### PR TITLE
Port web PSI exchange to MessageConnection

### DIFF
--- a/apps/web/src/psi/peerMessageConnection.ts
+++ b/apps/web/src/psi/peerMessageConnection.ts
@@ -1,0 +1,101 @@
+import {
+  ConnectionError,
+  QueuedMessageConnection,
+  asConnectionError,
+} from "@psilink/core";
+
+import { waitForConnectionOpen } from "./waitForOpen";
+
+import type { DataConnection } from "peerjs";
+import type { MessageConnection } from "@psilink/core";
+
+/**
+ * Parked-receive inactivity budget for the WebRTC transport. Hour-scale: the
+ * timer arms only while a receive waits on an empty queue, so it bounds the
+ * peer's per-step single-threaded WASM compute time (which sends no keepalive
+ * while running), and thus the workable dataset size.
+ *
+ * Deliberately a transport-local constant rather than core's file-sync
+ * `DEFAULT_PEER_TIMEOUT_MS`: the two govern unrelated transports (a file
+ * rendezvous TTL vs. a data-channel inactivity deadline) and only coincide in
+ * value today, so tuning one must not silently move the other.
+ */
+const DEFAULT_WEBRTC_INACTIVITY_TIMEOUT_MS = 60 * 60 * 1000;
+
+/**
+ * Returns a {@link MessageConnection} backed by the PeerJS data channel `conn`.
+ * The inbound `data` listener is attached synchronously, before the open
+ * handshake is awaited, so a frame the peer sends the instant the channel opens
+ * is queued rather than dropped: PeerJS does not replay events to a listener
+ * attached later, and the initiator sends its first frame unprompted - possibly
+ * before this side has finished loading its PSI WASM. A remote `error` fails the
+ * connection immediately with a `transport` {@link ConnectionError}; a remote
+ * `close` drains any buffered frames and then fails with a `transport` error;
+ * `send` writes to the channel; and `close` detaches the listeners and closes
+ * the channel, flushing buffered writes first on a clean close.
+ *
+ * If the channel never opens (timeout, or a pre-open `error`/`close`), the
+ * returned promise rejects and the half-open channel is torn down before the
+ * rejection propagates, since `peer.disconnect()` alone would not close it.
+ *
+ * @param conn     A PeerJS data connection, open or not yet open.
+ * @param options  `openTimeoutMs` bounds how long to wait for the channel to
+ *                 open (see {@link waitForConnectionOpen}); `inactivityTimeoutMs`
+ *                 overrides the {@link DEFAULT_WEBRTC_INACTIVITY_TIMEOUT_MS}
+ *                 parked-receive budget.
+ */
+export async function openPeerMessageConnection(
+  conn: DataConnection,
+  options?: { openTimeoutMs?: number; inactivityTimeoutMs?: number },
+): Promise<MessageConnection> {
+  const opened = waitForConnectionOpen(conn, options?.openTimeoutMs);
+  const mc = new QueuedMessageConnection(
+    (controls) => {
+      const onData = (data: unknown) => controls.deliver(data);
+      const onError = (err: unknown) =>
+        controls.fail(asConnectionError(err, "transport"));
+      // A clean remote close can carry the peer's final frame still queued, so
+      // it must drain that frame before failing - finish() defers the error
+      // until the queue empties. A genuine error (onError) instead discards
+      // buffered data, which is the intended stance for an abnormal drop.
+      const onClose = () =>
+        controls.finish(
+          new ConnectionError("peer connection closed", "transport"),
+        );
+      conn.on("data", onData);
+      conn.on("error", onError);
+      conn.on("close", onClose);
+      return {
+        send: (data) => conn.send(data),
+        close: (closeOptions) => {
+          conn.off("data", onData);
+          conn.off("error", onError);
+          conn.off("close", onClose);
+          // flush drains buffered outbound writes before closing, but PeerJS's
+          // flush path is a no-op on a channel that never opened: it queues a
+          // close sentinel and returns before tearing down the
+          // RTCPeerConnection. So only flush an open channel; otherwise
+          // hard-close, or an unopened channel leaks.
+          if (closeOptions?.flush && conn.open) {
+            conn.close({ flush: true });
+          } else {
+            conn.close();
+          }
+        },
+      };
+    },
+    {
+      inactivityTimeoutMs:
+        options?.inactivityTimeoutMs ?? DEFAULT_WEBRTC_INACTIVITY_TIMEOUT_MS,
+    },
+  );
+  try {
+    await opened;
+  } catch (err) {
+    // The open handshake failed; tear down the half-open channel and its
+    // listeners so it does not linger before re-throwing the open error.
+    await mc.close();
+    throw err;
+  }
+  return mc;
+}

--- a/apps/web/src/psi/waitForConnection.ts
+++ b/apps/web/src/psi/waitForConnection.ts
@@ -1,0 +1,32 @@
+import type { DataConnection } from "peerjs";
+import type Peer from "peerjs";
+
+/**
+ * Provisional ceiling for the invited party to dial in. The proper value (and
+ * the surrounding UX) belongs to the web connection-lifecycle consolidation;
+ * this exists so a peer that never connects surfaces an error rather than
+ * hanging the page indefinitely.
+ */
+export const DEFAULT_CONNECT_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Resolves with the first incoming {@link DataConnection} on `peer`, or rejects
+ * if none arrives within `timeoutMs`. The `connection` listener and the timer
+ * are torn down on whichever branch runs, so nothing outlives the wait.
+ */
+export function waitForIncomingConnection(
+  peer: Peer,
+  timeoutMs: number = DEFAULT_CONNECT_TIMEOUT_MS,
+): Promise<DataConnection> {
+  return new Promise<DataConnection>((resolve, reject) => {
+    const onConnection = (conn: DataConnection) => {
+      clearTimeout(timer);
+      resolve(conn);
+    };
+    const timer = setTimeout(() => {
+      peer.off("connection", onConnection);
+      reject(new Error("timed out waiting for the other party to connect"));
+    }, timeoutMs);
+    peer.once("connection", onConnection);
+  });
+}

--- a/apps/web/src/psi/waitForOpen.ts
+++ b/apps/web/src/psi/waitForOpen.ts
@@ -1,0 +1,47 @@
+import { withTimeout } from "@psilink/core";
+
+import type { DataConnection } from "peerjs";
+
+/**
+ * Default ceiling for a data channel to finish opening. Matches the order of
+ * magnitude of the PAKE handshake timeout: a channel that has not opened within
+ * this window is almost certainly never going to.
+ */
+const DEFAULT_OPEN_TIMEOUT_MS = 30_000;
+
+/**
+ * Resolves when `conn` emits `"open"`, or rejects with the first `"error"` or
+ * `"close"` that fires before `"open"`, or with a timeout error if none of
+ * those occurs within `timeoutMs`. Returns immediately if `conn.open` is
+ * already `true`. The three event listeners are torn down whichever branch
+ * runs - including the timeout - so nothing outlives the handshake.
+ *
+ * The timeout bounds connection setup: WebRTC negotiation does not always
+ * surface a stall as an `"error"` or `"close"`, so without it a peer stuck in
+ * ICE negotiation would hang this promise (and the exchange) indefinitely.
+ */
+export function waitForConnectionOpen(
+  conn: DataConnection,
+  timeoutMs: number = DEFAULT_OPEN_TIMEOUT_MS,
+): Promise<void> {
+  if (conn.open) return Promise.resolve();
+  let detach = () => {};
+  const opened = new Promise<void>((resolve, reject) => {
+    const onOpen = () => resolve();
+    const onError = (err: Error) => reject(err);
+    const onClose = () => reject(new Error("connection closed before open"));
+    conn.once("open", onOpen);
+    conn.once("error", onError);
+    conn.once("close", onClose);
+    detach = () => {
+      conn.off("open", onOpen);
+      conn.off("error", onError);
+      conn.off("close", onClose);
+    };
+  });
+  // withTimeout owns the deadline timer; detach() runs on every settle path
+  // (open, pre-open error/close, or timeout) so no listener is left attached.
+  return withTimeout(opened, timeoutMs, "connection open timed out").finally(
+    detach,
+  );
+}

--- a/apps/web/src/routes/psi.tsx
+++ b/apps/web/src/routes/psi.tsx
@@ -135,15 +135,24 @@ function Home() {
   const [submitted, setSubmitted] = useState(false);
   const [stageId, setStageById] = useState<string>("before start");
   const [resultURL, setResultURL] = useState<string>();
-  const [errorMessage, setErrorMessage] = useState<string>();
+  const [errorAlert, setErrorAlert] = useState<{
+    title: string;
+    message: string;
+  }>();
 
   const handleSubmit = () => {
     setSubmitted(true);
-    setErrorMessage(undefined);
+    setErrorAlert(undefined);
+
+    const describeError = (error: unknown) =>
+      error instanceof Error ? error.message : String(error);
 
     const handleFailure = (error: unknown) => {
       console.error(error);
-      setErrorMessage(error instanceof Error ? error.message : String(error));
+      setErrorAlert({
+        title: "Exchange failed",
+        message: describeError(error),
+      });
     };
 
     const finishExchange = (
@@ -175,6 +184,10 @@ function Home() {
       conn: DataConnection,
       exchangeRole: "initiator" | "responder",
       prepared: PreparedExchange,
+      // Either the still-loading library (server: passed before the WASM load
+      // resolves, so the inbound listener attaches first) or an already-loaded
+      // one (client: resolved before the connection handler runs). await covers
+      // both, so the union is intentional, not a dead branch.
       psi: PSILibrary | Promise<PSILibrary>,
       peer: Peer,
     ) => {
@@ -185,7 +198,21 @@ function Home() {
           psiLibrary: await psi,
           onStage: setStageById,
         });
-        finishExchange(exchangeResult, prepared);
+        // The privacy-sensitive exchange has completed by here; a failure
+        // building the local results file must not be reported as an exchange
+        // failure, or the user may needlessly re-run a PSI exchange that in
+        // fact already succeeded.
+        try {
+          finishExchange(exchangeResult, prepared);
+        } catch (error) {
+          console.error(error);
+          setErrorAlert({
+            title: "Results unavailable",
+            message:
+              "The linkage completed, but generating the results file failed: " +
+              describeError(error),
+          });
+        }
       } catch (error) {
         handleFailure(error);
       } finally {
@@ -286,9 +313,9 @@ function Home() {
             resultsFileURL={resultURL}
           />
         </Group>
-        {errorMessage && (
-          <Alert color="red" title="Exchange failed">
-            {errorMessage}
+        {errorAlert && (
+          <Alert color="red" title={errorAlert.title}>
+            {errorAlert.message}
           </Alert>
         )}
         {url && (

--- a/apps/web/src/routes/psi.tsx
+++ b/apps/web/src/routes/psi.tsx
@@ -35,6 +35,7 @@ import {
 import { openPeerConnection, waitForPeerId } from "@psi/server";
 import { createAndSharePeerId } from "@psi/client";
 import { openPeerMessageConnection } from "@psi/peerMessageConnection";
+import { waitForIncomingConnection } from "@psi/waitForConnection";
 
 import FileSelect from "@components/FileSelect";
 import SessionDetails from "@components/SessionDetails";
@@ -216,8 +217,19 @@ function Home() {
       } catch (error) {
         handleFailure(error);
       } finally {
-        peer.disconnect();
-        await mc?.close();
+        // Teardown must not throw: a rejection here would propagate past the
+        // handlers above and overwrite a more accurate alert (e.g. the
+        // "Results unavailable" set when only output generation failed).
+        try {
+          peer.disconnect();
+        } catch (teardownError) {
+          console.error(teardownError);
+        }
+        try {
+          await mc?.close();
+        } catch (teardownError) {
+          console.error(teardownError);
+        }
       }
     };
 
@@ -225,15 +237,14 @@ function Home() {
       setStageById("waiting for peer");
       waitForPeerId(session.uuid)
         .then(async (peerId) => {
-          // Start the WASM load now, but do not let it gate opening the channel:
-          // the responder must attach its inbound listener before the initiator
-          // sends, which can happen before this load finishes.
+          // Load and prepare before dialing the peer. Opening the connection
+          // resolves a live Peer/DataConnection that only runExchangeOn tears
+          // down, so a CSV or standardization failure must happen before it
+          // exists, not after, or the connection leaks. The WASM load still
+          // runs in parallel and is awaited (with the inbound listener already
+          // attached) inside runExchangeOn.
           const psi = PSI() as Promise<PSILibrary>;
-          const [csvResult, [peer, conn]] = await Promise.all([
-            loadCSVFile(files[0]),
-            openPeerConnection(peerId),
-          ]);
-
+          const csvResult = await loadCSVFile(files[0]);
           const rawRows = csvResult.data as Array<Record<string, string>>;
           const prepared = prepareForExchange(
             {}, // no explicit spec; infer from input
@@ -250,6 +261,7 @@ function Home() {
             doneStage,
           ]);
 
+          const [peer, conn] = await openPeerConnection(peerId);
           await runExchangeOn(conn, "responder", prepared, psi, peer);
         })
         .catch((error) => {
@@ -278,15 +290,19 @@ function Home() {
 
           const peer = await createAndSharePeerId(session);
 
-          // once, not on: a single exchange runs per session, so a duplicate
-          // incoming connection must not spawn a concurrent runExchange. The
-          // trailing catch guards against a teardown rejection in the helper's
-          // finally escaping as an unhandled rejection.
-          peer.once("connection", (conn) => {
-            void runExchangeOn(conn, "initiator", prepared, psi, peer).catch(
-              handleFailure,
-            );
-          });
+          try {
+            // A single exchange runs per session: take the first incoming
+            // connection, bounded so a peer that never dials in surfaces an
+            // error instead of hanging on "Confirming protocol" forever.
+            const conn = await waitForIncomingConnection(peer);
+            await runExchangeOn(conn, "initiator", prepared, psi, peer);
+          } catch (error) {
+            // Reached only when no peer dialed in within the deadline;
+            // runExchangeOn handles and tears down its own failures. Drop the
+            // peer we created so the timed-out attempt does not leak it.
+            handleFailure(error);
+            peer.disconnect();
+          }
         })
         .catch((error) => {
           handleFailure(error);

--- a/apps/web/src/routes/psi.tsx
+++ b/apps/web/src/routes/psi.tsx
@@ -42,6 +42,9 @@ import { Status } from "@components/Status";
 
 import type { PSILibrary } from "@openmined/psi.js/implementation/psi.d.ts";
 
+import type { DataConnection } from "peerjs";
+import type Peer from "peerjs";
+
 import type {
   ExchangeResult,
   MessageConnection,
@@ -163,12 +166,43 @@ function Home() {
       setStageById("done");
     };
 
+    // Shared per-connection lifecycle for both roles: open a MessageConnection,
+    // run the exchange, surface the result or the failure, and always tear down.
+    // `psi` may still be loading - opening the connection first attaches the
+    // inbound listener (so the initiator's unprompted first frame is not
+    // dropped) while the WASM library finishes in parallel.
+    const runExchangeOn = async (
+      conn: DataConnection,
+      exchangeRole: "initiator" | "responder",
+      prepared: PreparedExchange,
+      psi: PSILibrary | Promise<PSILibrary>,
+      peer: Peer,
+    ) => {
+      let mc: MessageConnection | undefined;
+      try {
+        mc = await openPeerMessageConnection(conn);
+        const exchangeResult = await runExchange(mc, exchangeRole, prepared, {
+          psiLibrary: await psi,
+          onStage: setStageById,
+        });
+        finishExchange(exchangeResult, prepared);
+      } catch (error) {
+        handleFailure(error);
+      } finally {
+        peer.disconnect();
+        await mc?.close();
+      }
+    };
+
     if (role === "server") {
       setStageById("waiting for peer");
       waitForPeerId(session.uuid)
         .then(async (peerId) => {
-          const [psi, csvResult, [peer, conn]] = await Promise.all([
-            PSI() as Promise<PSILibrary>,
+          // Start the WASM load now, but do not let it gate opening the channel:
+          // the responder must attach its inbound listener before the initiator
+          // sends, which can happen before this load finishes.
+          const psi = PSI() as Promise<PSILibrary>;
+          const [csvResult, [peer, conn]] = await Promise.all([
             loadCSVFile(files[0]),
             openPeerConnection(peerId),
           ]);
@@ -189,25 +223,7 @@ function Home() {
             doneStage,
           ]);
 
-          let mc: MessageConnection | undefined;
-          try {
-            mc = await openPeerMessageConnection(conn);
-            const exchangeResult = await runExchange(
-              mc,
-              "responder",
-              prepared,
-              {
-                psiLibrary: psi,
-                onStage: setStageById,
-              },
-            );
-            finishExchange(exchangeResult, prepared);
-          } catch (error) {
-            handleFailure(error);
-          } finally {
-            peer.disconnect();
-            await mc?.close();
-          }
+          await runExchangeOn(conn, "responder", prepared, psi, peer);
         })
         .catch((error) => {
           handleFailure(error);
@@ -235,25 +251,14 @@ function Home() {
 
           const peer = await createAndSharePeerId(session);
 
-          peer.on("connection", (conn) => {
-            void (async () => {
-              let mc: MessageConnection | undefined;
-              try {
-                mc = await openPeerMessageConnection(conn);
-                const exchangeResult = await runExchange(
-                  mc,
-                  "initiator",
-                  prepared,
-                  { psiLibrary: psi, onStage: setStageById },
-                );
-                finishExchange(exchangeResult, prepared);
-              } catch (error) {
-                handleFailure(error);
-              } finally {
-                peer.disconnect();
-                await mc?.close();
-              }
-            })();
+          // once, not on: a single exchange runs per session, so a duplicate
+          // incoming connection must not spawn a concurrent runExchange. The
+          // trailing catch guards against a teardown rejection in the helper's
+          // finally escaping as an unhandled rejection.
+          peer.once("connection", (conn) => {
+            void runExchangeOn(conn, "initiator", prepared, psi, peer).catch(
+              handleFailure,
+            );
           });
         })
         .catch((error) => {

--- a/apps/web/src/routes/psi.tsx
+++ b/apps/web/src/routes/psi.tsx
@@ -33,6 +33,7 @@ import {
 } from "@psilink/core";
 import { openPeerConnection, waitForPeerId } from "@psi/server";
 import { createAndSharePeerId } from "@psi/client";
+import { openPeerMessageConnection } from "@psi/peerMessageConnection";
 
 import FileSelect from "@components/FileSelect";
 import SessionDetails from "@components/SessionDetails";
@@ -40,8 +41,11 @@ import { Status } from "@components/Status";
 
 import type { PSILibrary } from "@openmined/psi.js/implementation/psi.d.ts";
 
-import type { ExchangeResult, PreparedExchange } from "@psilink/core";
-import type { DataConnection } from "peerjs";
+import type {
+  ExchangeResult,
+  MessageConnection,
+  PreparedExchange,
+} from "@psilink/core";
 import type { LinkSession } from "@utils/sessions";
 
 export const Route = createFileRoute("/psi")({
@@ -132,11 +136,9 @@ function Home() {
     setSubmitted(true);
 
     const finishExchange = (
-      conn: DataConnection,
       { associationTable, partnerPayload }: ExchangeResult,
       prepared: PreparedExchange,
     ) => {
-      conn.close();
       log.info("linkage complete, generating results file");
       const { headers, rows } = buildOutputTable(
         associationTable,
@@ -162,7 +164,6 @@ function Home() {
             loadCSVFile(files[0]),
             openPeerConnection(peerId),
           ]);
-          conn.once("data", () => peer.disconnect());
 
           const rawRows = csvResult.data as Array<Record<string, string>>;
           const prepared = prepareForExchange(
@@ -180,16 +181,25 @@ function Home() {
             doneStage,
           ]);
 
-          const exchangeResult = await runExchange(
-            conn,
-            "responder",
-            prepared,
-            {
-              psiLibrary: psi,
-              onStage: setStageById,
-            },
-          );
-          finishExchange(conn, exchangeResult, prepared);
+          let mc: MessageConnection | undefined;
+          try {
+            mc = await openPeerMessageConnection(conn);
+            const exchangeResult = await runExchange(
+              mc,
+              "responder",
+              prepared,
+              {
+                psiLibrary: psi,
+                onStage: setStageById,
+              },
+            );
+            finishExchange(exchangeResult, prepared);
+          } catch (error) {
+            console.error(error);
+          } finally {
+            peer.disconnect();
+            await mc?.close();
+          }
         })
         .catch((error) => {
           console.error(error);
@@ -218,20 +228,24 @@ function Home() {
           const peer = await createAndSharePeerId(session);
 
           peer.on("connection", (conn) => {
-            conn.on("open", async () => {
-              conn.once("data", () => peer.disconnect());
+            void (async () => {
+              let mc: MessageConnection | undefined;
               try {
+                mc = await openPeerMessageConnection(conn);
                 const exchangeResult = await runExchange(
-                  conn,
+                  mc,
                   "initiator",
                   prepared,
                   { psiLibrary: psi, onStage: setStageById },
                 );
-                finishExchange(conn, exchangeResult, prepared);
+                finishExchange(exchangeResult, prepared);
               } catch (error) {
                 console.error(error);
+              } finally {
+                peer.disconnect();
+                await mc?.close();
               }
-            });
+            })();
           });
         })
         .catch((error) => {

--- a/apps/web/src/routes/psi.tsx
+++ b/apps/web/src/routes/psi.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 
 import {
   ActionIcon,
+  Alert,
   Code,
   Container,
   CopyButton,
@@ -131,9 +132,16 @@ function Home() {
   const [submitted, setSubmitted] = useState(false);
   const [stageId, setStageById] = useState<string>("before start");
   const [resultURL, setResultURL] = useState<string>();
+  const [errorMessage, setErrorMessage] = useState<string>();
 
   const handleSubmit = () => {
     setSubmitted(true);
+    setErrorMessage(undefined);
+
+    const handleFailure = (error: unknown) => {
+      console.error(error);
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+    };
 
     const finishExchange = (
       { associationTable, partnerPayload }: ExchangeResult,
@@ -195,14 +203,14 @@ function Home() {
             );
             finishExchange(exchangeResult, prepared);
           } catch (error) {
-            console.error(error);
+            handleFailure(error);
           } finally {
             peer.disconnect();
             await mc?.close();
           }
         })
         .catch((error) => {
-          console.error(error);
+          handleFailure(error);
         });
     } else {
       // role is client
@@ -240,7 +248,7 @@ function Home() {
                 );
                 finishExchange(exchangeResult, prepared);
               } catch (error) {
-                console.error(error);
+                handleFailure(error);
               } finally {
                 peer.disconnect();
                 await mc?.close();
@@ -249,7 +257,7 @@ function Home() {
           });
         })
         .catch((error) => {
-          console.error(error);
+          handleFailure(error);
         });
     }
   };
@@ -273,6 +281,11 @@ function Home() {
             resultsFileURL={resultURL}
           />
         </Group>
+        {errorMessage && (
+          <Alert color="red" title="Exchange failed">
+            {errorMessage}
+          </Alert>
+        )}
         {url && (
           <Paper>
             <Title order={2}>Sharable Link</Title>

--- a/apps/web/test/browser/invitedPSI.test.ts
+++ b/apps/web/test/browser/invitedPSI.test.ts
@@ -8,6 +8,8 @@ import { prepareForExchange, runExchange } from "@psilink/core";
 // @ts-ignore this is really there
 import PSI from "@openmined/psi.js/psi_wasm_web";
 
+import { openPeerMessageConnection } from "../../src/psi/peerMessageConnection.js";
+
 import { sortAssociationTable } from "../utils/associationTable.js";
 
 import type { DataConnection } from "peerjs";
@@ -174,10 +176,12 @@ const clientPrepared = prepareForExchange(
   ["first_name"],
 );
 
+const serverMc = await openPeerMessageConnection(serverConn);
+const clientMc = await openPeerMessageConnection(clientConn);
+
 const runServerPSI = async () => {
-  serverConn.once("data", () => serverPeer.disconnect());
   const { associationTable } = await runExchange(
-    serverConn,
+    serverMc,
     "responder",
     serverPrepared,
     { psiLibrary },
@@ -186,9 +190,8 @@ const runServerPSI = async () => {
 };
 
 const runClientPSI = async () => {
-  clientConn.once("data", () => clientPeer.disconnect());
   const { associationTable } = await runExchange(
-    clientConn,
+    clientMc,
     "initiator",
     clientPrepared,
     { psiLibrary },
@@ -201,8 +204,10 @@ let [serverResult, clientResult] = await Promise.all([
   runClientPSI(),
 ]);
 
-serverConn.close();
-clientConn.close();
+await serverMc.close();
+await clientMc.close();
+serverPeer.disconnect();
+clientPeer.disconnect();
 
 serverResult = sortAssociationTable(serverResult);
 clientResult = sortAssociationTable(clientResult, true);

--- a/apps/web/test/unit/peerMessageConnection.test.ts
+++ b/apps/web/test/unit/peerMessageConnection.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { default as EventEmitter } from "eventemitter3";
+
+import { ConnectionError } from "@psilink/core";
+
+import { openPeerMessageConnection } from "../../src/psi/peerMessageConnection.js";
+
+import type { DataConnection } from "peerjs";
+
+class FakeDataConnection extends EventEmitter {
+  open: boolean;
+  send = vi.fn();
+  // Mirrors PeerJS: a flush close on a channel that never opened only queues a
+  // close sentinel and returns without tearing down the RTCPeerConnection, so
+  // it does not count as a teardown. Any other close does.
+  torndown = false;
+  close = vi.fn((options?: { flush?: boolean }) => {
+    if (options?.flush && !this.open) return;
+    this.torndown = true;
+  });
+
+  constructor(open = true) {
+    super();
+    this.open = open;
+  }
+}
+
+function makeConn(open = true): {
+  fake: FakeDataConnection;
+  conn: DataConnection;
+} {
+  const fake = new FakeDataConnection(open);
+  return { fake, conn: fake as unknown as DataConnection };
+}
+
+describe("openPeerMessageConnection", () => {
+  test("round-trips an inbound frame to receive()", async () => {
+    const { fake, conn } = makeConn();
+    const mc = await openPeerMessageConnection(conn);
+
+    fake.emit("data", { hello: "world" });
+
+    expect(await mc.receive()).toEqual({ hello: "world" });
+  });
+
+  test("delegates send to the underlying channel", async () => {
+    const { fake, conn } = makeConn();
+    const mc = await openPeerMessageConnection(conn);
+
+    await mc.send("payload");
+
+    expect(fake.send).toHaveBeenCalledWith("payload");
+  });
+
+  test("a remote close while a receive is parked rejects it as transport", async () => {
+    const { fake, conn } = makeConn();
+    const mc = await openPeerMessageConnection(conn);
+
+    const parked = mc.receive();
+    fake.emit("close");
+
+    const err = await parked.catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ConnectionError);
+    expect((err as ConnectionError).kind).toBe("transport");
+  });
+
+  test("a remote close drains a buffered frame before failing", async () => {
+    // The discard regression: a frame buffered with no parked receive must
+    // survive a clean close. finish() defers the transport error until the
+    // queue empties, so the buffered frame is returned and only the next
+    // receive() rejects.
+    const { fake, conn } = makeConn();
+    const mc = await openPeerMessageConnection(conn);
+
+    fake.emit("data", "final frame"); // buffered, no waiter
+    fake.emit("close");
+
+    expect(await mc.receive()).toBe("final frame");
+    const err = await mc.receive().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ConnectionError);
+    expect((err as ConnectionError).kind).toBe("transport");
+  });
+
+  test("a remote error fails the connection as transport and preserves the cause", async () => {
+    const { fake, conn } = makeConn();
+    const mc = await openPeerMessageConnection(conn);
+
+    const cause = new Error("ICE failure");
+    fake.emit("error", cause);
+
+    const err = await mc.receive().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ConnectionError);
+    expect((err as ConnectionError).kind).toBe("transport");
+    expect((err as ConnectionError).message).toBe("ICE failure");
+    expect((err as ConnectionError).cause).toBe(cause);
+  });
+
+  test("send after close rejects and does not reach the channel", async () => {
+    const { fake, conn } = makeConn();
+    const mc = await openPeerMessageConnection(conn);
+
+    await mc.close();
+
+    await expect(mc.send("x")).rejects.toBeInstanceOf(ConnectionError);
+    expect(fake.send).not.toHaveBeenCalled();
+  });
+
+  test("an intentional close is quiet: it closes the channel once and silences the close event", async () => {
+    const { fake, conn } = makeConn();
+    const mc = await openPeerMessageConnection(conn);
+
+    await expect(mc.close()).resolves.toBeUndefined();
+    expect(fake.close).toHaveBeenCalledTimes(1);
+
+    // The onClose listener was detached, so a late channel close fires no
+    // spurious failure.
+    expect(() => fake.emit("close")).not.toThrow();
+  });
+
+  test("rejects if the channel closes before it opens", async () => {
+    const { fake, conn } = makeConn(false);
+
+    const promise = openPeerMessageConnection(conn);
+    fake.emit("close");
+
+    await expect(promise).rejects.toThrow("connection closed before open");
+  });
+
+  test("attaches the inbound listener before the channel opens", async () => {
+    // The dropped-first-frame regression: the initiator sends Message 1 the
+    // instant the channel opens, before this side resolves the open handshake.
+    // The listener must already be attached, since PeerJS does not replay a
+    // frame emitted before a listener exists.
+    const { fake, conn } = makeConn(false);
+    const promise = openPeerMessageConnection(conn);
+
+    fake.emit("open");
+    fake.emit("data", "first frame"); // arrives in the same tick as open
+
+    const mc = await promise;
+    expect(await mc.receive()).toBe("first frame");
+  });
+
+  test("tears down the channel on a pre-open close", async () => {
+    // peer.disconnect() would not close a half-open data channel, so a failed
+    // open must close it here or it leaks its RTCPeerConnection.
+    const { fake, conn } = makeConn(false);
+    const promise = openPeerMessageConnection(conn);
+
+    fake.emit("close");
+
+    await expect(promise).rejects.toThrow("connection closed before open");
+    expect(fake.torndown).toBe(true);
+  });
+
+  test("hard-closes a never-opening channel on timeout instead of leaking it", async () => {
+    // An open timeout emits no pre-open error/close to route through fail(), so
+    // the catch closes the channel itself. A flush close would no-op on an
+    // unopened channel, so this must be a hard close or the channel leaks - the
+    // regression the open-state guard in the close hook prevents.
+    const { fake, conn } = makeConn(false); // never opens, never errors
+
+    const promise = openPeerMessageConnection(conn, { openTimeoutMs: 10 });
+
+    await expect(promise).rejects.toThrow("connection open timed out");
+    expect(fake.torndown).toBe(true);
+  });
+
+  test("a clean close flushes buffered writes before tearing down", async () => {
+    const { fake, conn } = makeConn();
+    const mc = await openPeerMessageConnection(conn);
+
+    await mc.close();
+
+    expect(fake.close).toHaveBeenCalledWith({ flush: true });
+  });
+
+  test("an error teardown closes the channel without flushing", async () => {
+    const { fake, conn } = makeConn();
+    const mc = await openPeerMessageConnection(conn);
+
+    fake.emit("error", new Error("boom"));
+    await mc.receive().catch(() => undefined);
+
+    expect(fake.close).toHaveBeenCalledWith();
+  });
+});

--- a/apps/web/test/unit/waitForConnection.test.ts
+++ b/apps/web/test/unit/waitForConnection.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import { default as EventEmitter } from "eventemitter3";
+
+import { waitForIncomingConnection } from "../../src/psi/waitForConnection.js";
+
+import type { DataConnection } from "peerjs";
+import type Peer from "peerjs";
+
+class FakePeer extends EventEmitter {}
+
+function makePeer(): { fake: FakePeer; peer: Peer } {
+  const fake = new FakePeer();
+  return { fake, peer: fake as unknown as Peer };
+}
+
+describe("waitForIncomingConnection", () => {
+  test("resolves with the first incoming connection", async () => {
+    const { fake, peer } = makePeer();
+    const promise = waitForIncomingConnection(peer, 1000);
+
+    const conn = { id: "c1" } as unknown as DataConnection;
+    fake.emit("connection", conn);
+
+    expect(await promise).toBe(conn);
+  });
+
+  test("rejects if no connection arrives within the timeout", async () => {
+    const { peer } = makePeer();
+
+    await expect(waitForIncomingConnection(peer, 10)).rejects.toThrow(
+      "timed out waiting for the other party to connect",
+    );
+  });
+
+  test("detaches the connection listener on timeout", async () => {
+    const { fake, peer } = makePeer();
+
+    await waitForIncomingConnection(peer, 10).catch(() => undefined);
+
+    expect(fake.listenerCount("connection")).toBe(0);
+  });
+});

--- a/apps/web/test/unit/waitForOpen.test.ts
+++ b/apps/web/test/unit/waitForOpen.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { default as EventEmitter } from "eventemitter3";
+
+import { waitForConnectionOpen } from "../../src/psi/waitForOpen.js";
+
+import type { DataConnection } from "peerjs";
+
+class FakeConn extends EventEmitter {}
+
+function makeConn(): { fake: FakeConn; conn: DataConnection } {
+  const fake = new FakeConn();
+  return { fake, conn: fake as unknown as DataConnection };
+}
+
+describe("waitForConnectionOpen", () => {
+  test("resolves immediately when the connection is already open", async () => {
+    class FakeConnOpen extends EventEmitter {
+      readonly open = true;
+    }
+    const fake = new FakeConnOpen();
+    await expect(
+      waitForConnectionOpen(fake as unknown as DataConnection),
+    ).resolves.toBeUndefined();
+    expect(fake.listenerCount("open")).toBe(0);
+    expect(fake.listenerCount("error")).toBe(0);
+  });
+
+  test("resolves when 'open' fires", async () => {
+    const { fake, conn } = makeConn();
+    const p = waitForConnectionOpen(conn);
+    fake.emit("open");
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  test("rejects with the error when 'error' fires before 'open'", async () => {
+    const { fake, conn } = makeConn();
+    const err = new Error("pre-open ICE failure");
+    const p = waitForConnectionOpen(conn);
+    fake.emit("error", err);
+    await expect(p).rejects.toBe(err);
+  });
+
+  test("error listener is removed after 'open' fires", async () => {
+    const { fake, conn } = makeConn();
+    const p = waitForConnectionOpen(conn);
+    fake.emit("open");
+    await p;
+    expect(fake.listenerCount("error")).toBe(0);
+    expect(fake.listenerCount("close")).toBe(0);
+  });
+
+  test("open listener is removed after 'error' fires", async () => {
+    const { fake, conn } = makeConn();
+    const err = new Error("pre-open ICE failure");
+    const p = waitForConnectionOpen(conn);
+    fake.emit("error", err);
+    await p.catch(() => {});
+    expect(fake.listenerCount("open")).toBe(0);
+    expect(fake.listenerCount("close")).toBe(0);
+  });
+
+  test("rejects when 'close' fires before 'open'", async () => {
+    const { fake, conn } = makeConn();
+    const p = waitForConnectionOpen(conn);
+    fake.emit("close");
+    await expect(p).rejects.toBeInstanceOf(Error);
+  });
+
+  test("open and error listeners are removed after 'close' fires", async () => {
+    const { fake, conn } = makeConn();
+    const p = waitForConnectionOpen(conn);
+    fake.emit("close");
+    await p.catch(() => {});
+    expect(fake.listenerCount("open")).toBe(0);
+    expect(fake.listenerCount("error")).toBe(0);
+  });
+
+  test("rejects and removes all listeners after the timeout elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const { fake, conn } = makeConn();
+      const p = waitForConnectionOpen(conn, 5000);
+      p.catch(() => {});
+      await vi.advanceTimersByTimeAsync(5000);
+      await expect(p).rejects.toThrow("connection open timed out");
+      expect(fake.listenerCount("open")).toBe(0);
+      expect(fake.listenerCount("error")).toBe(0);
+      expect(fake.listenerCount("close")).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("does not reject after the timeout once 'open' has fired", async () => {
+    vi.useFakeTimers();
+    try {
+      const { fake, conn } = makeConn();
+      const p = waitForConnectionOpen(conn, 5000);
+      fake.emit("open");
+      await expect(p).resolves.toBeUndefined();
+      // Advancing past the timeout must not produce a late rejection: the
+      // timer is cleared when 'open' fires.
+      await vi.advanceTimersByTimeAsync(10000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/core/src/connection/messageConnection.ts
+++ b/packages/core/src/connection/messageConnection.ts
@@ -40,8 +40,12 @@ export class ConnectionError extends Error {
   }
 }
 
-/** Wraps an arbitrary thrown value as a {@link ConnectionError}. */
-function asConnectionError(
+/**
+ * Wraps an arbitrary thrown value as a {@link ConnectionError}, passing an
+ * existing {@link ConnectionError} through unchanged. Shared by the bridges so
+ * every transport classifies a raw transport failure the same way.
+ */
+export function asConnectionError(
   err: unknown,
   kind: ConnectionErrorKind,
 ): ConnectionError {
@@ -96,12 +100,29 @@ export interface TransportControls {
   deliver: (message: unknown) => void;
   /** Latch a terminal error; idempotent after the first call. */
   fail: (error: ConnectionError) => void;
+  /**
+   * Half-close: latch a terminal error that surfaces only once any already
+   * buffered messages have been drained by {@link MessageConnection.receive}.
+   * If the queue is already empty it behaves exactly like {@link fail}. Use
+   * for a clean remote close that may arrive with the peer's final frame still
+   * queued, where {@link fail} would discard it. Idempotent once a terminal
+   * state is reached.
+   */
+  finish: (error: ConnectionError) => void;
 }
 
 /** The transport-specific operations the queue drives. */
 export interface TransportHooks {
   send: (data: unknown) => void | Promise<void>;
-  close: () => void | Promise<void>;
+  /**
+   * Tears down the transport. `options.flush` is set on a deliberate clean
+   * close ({@link MessageConnection.close}) and unset on error teardown (via
+   * {@link TransportControls.fail}). A transport that buffers outbound writes
+   * should drain them before closing when `flush` is set, so a final frame
+   * still in flight is not lost, and close immediately otherwise; a transport
+   * without an outbound buffer may ignore it.
+   */
+  close: (options?: { flush?: boolean }) => void | Promise<void>;
   /**
    * Run once after wiring is complete; safe to call {@link TransportControls}
    * here.
@@ -146,6 +167,10 @@ export class QueuedMessageConnection implements MessageConnection {
   private readonly inactivityTimeoutMs: number | undefined;
   private readonly hooks: TransportHooks;
   private error: ConnectionError | undefined;
+  // Deferred terminal error from a half-close (finish): held while the queue
+  // still has buffered frames and promoted to a real error by receive() once
+  // the queue drains, so a clean remote close surfaces after its final frame.
+  private pendingError: ConnectionError | undefined;
   private closed = false;
   // Guards the single transport teardown shared by close() and fail().
   private terminated = false;
@@ -162,6 +187,7 @@ export class QueuedMessageConnection implements MessageConnection {
     this.hooks = connect({
       deliver: (message) => this.deliver(message),
       fail: (error) => this.fail(error),
+      finish: (error) => this.finish(error),
     });
     this.hooks.start?.();
   }
@@ -207,7 +233,11 @@ export class QueuedMessageConnection implements MessageConnection {
   }
 
   private deliver(message: unknown): void {
-    if (this.error || this.closed) return;
+    // Once a half-close is pending, ignore further inbound: drain exactly what
+    // was buffered at close time, then fail. PeerJS will not deliver after a
+    // close, so this is belt-and-suspenders, but it keeps the half-closed
+    // semantics crisp.
+    if (this.error || this.closed || this.pendingError !== undefined) return;
     const waiter = this.waiters.shift();
     if (waiter) {
       // A message just arrived: the peer is alive, so reset the idle clock,
@@ -242,11 +272,50 @@ export class QueuedMessageConnection implements MessageConnection {
     }
   }
 
+  // Half-close: latch a terminal error to be surfaced only after the queue
+  // drains. A genuine error uses fail() (discarding buffered frames is the
+  // intended stance); a clean remote close that may have left the peer's final
+  // frame queued uses this so receive() returns that frame before failing.
+  private finish(error: ConnectionError): void {
+    // Idempotent once a half-close is already pending: a second finish() (a
+    // duplicate transport close, or a transport that finishes on both a close
+    // and a timeout) must not overwrite the first deferred error. Mirrors the
+    // pendingError guard in deliver().
+    if (this.error || this.closed || this.pendingError !== undefined) return;
+    if (this.queue.length > 0) {
+      this.pendingError = error;
+    } else {
+      // Nothing buffered to drain (a parked waiter implies an empty queue), so
+      // there is nothing to wait for: fail now, exactly like fail().
+      this.fail(error);
+    }
+  }
+
   receive(timeoutMs?: number): Promise<unknown> {
     if (this.error) return Promise.reject(this.error);
     // Drain buffered messages even after a clean close, but never after an
     // error: a latched error may mean the buffered data is untrustworthy.
-    if (this.queue.length > 0) return Promise.resolve(this.queue.shift());
+    if (this.queue.length > 0) {
+      const message = this.queue.shift();
+      // The just-drained frame was the last one a half-close was waiting on, so
+      // promote its deferred error through fail() (not a bare this.error
+      // assignment) to keep terminated/hooks.close() in sync with every other
+      // error path. The next receive() then rejects with it.
+      if (this.queue.length === 0 && this.pendingError !== undefined) {
+        const deferred = this.pendingError;
+        this.pendingError = undefined;
+        // fail() no-ops once closed, so a close() that raced ahead of this final
+        // drain would otherwise drop the deferred error and leave the next
+        // receive() reporting a generic close. Latch it directly in that case;
+        // teardown already ran in close().
+        if (this.closed) {
+          this.error = deferred;
+        } else {
+          this.fail(deferred);
+        }
+      }
+      return Promise.resolve(message);
+    }
     if (this.closed)
       return Promise.reject(new ConnectionError("connection closed", "usage"));
     return new Promise<unknown>((resolve, reject) => {
@@ -257,6 +326,9 @@ export class QueuedMessageConnection implements MessageConnection {
 
   async send(data: unknown): Promise<void> {
     if (this.error) throw this.error;
+    // A half-close has latched a terminal error behind still-buffered inbound
+    // frames; the peer is gone, so reject rather than write into the void.
+    if (this.pendingError) throw this.pendingError;
     if (this.closed)
       throw new ConnectionError("cannot send on a closed connection", "usage");
     try {
@@ -276,7 +348,10 @@ export class QueuedMessageConnection implements MessageConnection {
     // A waiter parked before this deliberate close did nothing wrong, so reject
     // it as "closed" (a cancelled operation), not "usage" (caller misuse).
     this.rejectWaiters(new ConnectionError("connection closed", "closed"));
-    await this.hooks.close();
+    // Deliberate close: ask the transport to drain buffered outbound writes
+    // before tearing down. fail() closes without flush, since an error means
+    // the link is already unusable.
+    await this.hooks.close({ flush: true });
   }
 }
 

--- a/packages/core/test/messageConnection.test.ts
+++ b/packages/core/test/messageConnection.test.ts
@@ -1,12 +1,15 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { z } from "zod";
 
 import {
   ConnectionError,
+  QueuedMessageConnection,
   createMessagePipe,
   fromEventConnection,
   receiveParsed,
 } from "../src/connection/messageConnection";
+
+import type { TransportControls } from "../src/connection/messageConnection";
 
 import { PassthroughConnection } from "./utils/passthroughConnection";
 
@@ -88,6 +91,120 @@ test("exceeding capacity fails the connection as a protocol violation", async ()
   const err = await b.receive().catch((e: unknown) => e);
   expect(err).toBeInstanceOf(ConnectionError);
   expect((err as ConnectionError).kind).toBe("protocol");
+});
+
+// --- finish (drain-then-fail half-close) -------------------------------------
+
+function makeQueued(options?: {
+  capacity?: number;
+  inactivityTimeoutMs?: number;
+}): {
+  conn: QueuedMessageConnection;
+  controls: TransportControls;
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+} {
+  let controls!: TransportControls;
+  const send = vi.fn();
+  const close = vi.fn();
+  const conn = new QueuedMessageConnection((c) => {
+    controls = c;
+    return { send, close };
+  }, options);
+  return { conn, controls, send, close };
+}
+
+test("finish drains a buffered frame before surfacing the transport error", async () => {
+  const { conn, controls, close } = makeQueued();
+  controls.deliver("final"); // buffered, no parked waiter
+  controls.finish(new ConnectionError("peer closed", "transport"));
+
+  // The buffered frame is still delivered...
+  expect(await conn.receive()).toBe("final");
+  // ...and only the next receive surfaces the deferred transport error.
+  const err = await conn.receive().catch((e: unknown) => e);
+  expect(err).toBeInstanceOf(ConnectionError);
+  expect((err as ConnectionError).kind).toBe("transport");
+  // Teardown runs exactly once, on promotion.
+  expect(close).toHaveBeenCalledTimes(1);
+});
+
+test("finish with an empty queue fails immediately, like fail", async () => {
+  const { conn, controls, close } = makeQueued();
+  controls.finish(new ConnectionError("peer closed", "transport"));
+  const err = await conn.receive().catch((e: unknown) => e);
+  expect(err).toBeInstanceOf(ConnectionError);
+  expect((err as ConnectionError).kind).toBe("transport");
+  expect(close).toHaveBeenCalledTimes(1);
+});
+
+test("finish rejects a parked receive immediately", async () => {
+  const { conn, controls } = makeQueued();
+  const parked = conn.receive();
+  controls.finish(new ConnectionError("peer closed", "transport"));
+  const err = await parked.catch((e: unknown) => e);
+  expect(err).toBeInstanceOf(ConnectionError);
+  expect((err as ConnectionError).kind).toBe("transport");
+});
+
+test("inbound after finish is ignored; the drained frame is the last one", async () => {
+  const { conn, controls } = makeQueued();
+  controls.deliver("keep");
+  controls.finish(new ConnectionError("peer closed", "transport"));
+  controls.deliver("dropped"); // a half-close is pending: ignored
+  expect(await conn.receive()).toBe("keep");
+  const err = await conn.receive().catch((e: unknown) => e);
+  expect((err as ConnectionError).kind).toBe("transport");
+});
+
+test("a second finish is ignored; the first deferred error wins", async () => {
+  const { conn, controls } = makeQueued();
+  controls.deliver("final");
+  controls.finish(new ConnectionError("first", "transport"));
+  controls.finish(new ConnectionError("second", "security")); // ignored
+
+  expect(await conn.receive()).toBe("final");
+  const err = await conn.receive().catch((e: unknown) => e);
+  expect((err as ConnectionError).kind).toBe("transport");
+  expect((err as ConnectionError).message).toBe("first");
+});
+
+test("send is rejected while a half-close is pending, without writing", async () => {
+  const { conn, controls, send } = makeQueued();
+  controls.deliver("final"); // buffered, half-close pending behind it
+  controls.finish(new ConnectionError("peer closed", "transport"));
+
+  const err = await conn.send("x").catch((e: unknown) => e);
+  expect(err).toBeInstanceOf(ConnectionError);
+  expect((err as ConnectionError).kind).toBe("transport");
+  expect(send).not.toHaveBeenCalled();
+  // The buffered frame is still drainable after the rejected send.
+  expect(await conn.receive()).toBe("final");
+});
+
+test("a close racing the final drain still surfaces the transport error", async () => {
+  const { conn, controls } = makeQueued();
+  controls.deliver("final");
+  controls.finish(new ConnectionError("peer closed", "transport"));
+  await conn.close(); // races ahead of draining the final frame
+
+  // The buffered frame still drains...
+  expect(await conn.receive()).toBe("final");
+  // ...and the deferred error surfaces as transport, not a generic close/usage.
+  const err = await conn.receive().catch((e: unknown) => e);
+  expect(err).toBeInstanceOf(ConnectionError);
+  expect((err as ConnectionError).kind).toBe("transport");
+});
+
+test("a clean close requests a flush; an error teardown does not", async () => {
+  const clean = makeQueued();
+  await clean.conn.close();
+  expect(clean.close).toHaveBeenCalledWith({ flush: true });
+
+  const failed = makeQueued();
+  failed.controls.fail(new ConnectionError("boom", "transport"));
+  await failed.conn.receive().catch(() => undefined);
+  expect(failed.close).toHaveBeenCalledWith();
 });
 
 // --- fromEventConnection bridge ----------------------------------------------


### PR DESCRIPTION
The web app's PSI exchange previously drove the protocol over raw PeerJS
`DataConnection` callbacks rather than the pull-based `MessageConnection`
interface the CLI uses. This branch bridges the two, fixes several
lifecycle and teardown bugs uncovered along the way, and improves the UI
when things go wrong.

## Changes

- `QueuedMessageConnection` gains a `finish()` half-close: a clean remote
  close can arrive while the peer's final frame is still buffered, so
  `finish()` defers the terminal error until the queue drains rather than
  dropping that frame immediately (distinct from `fail()`, which discards
  buffered frames).

- `openPeerMessageConnection` / `waitForOpen` bridge a PeerJS
  `DataConnection` to `QueuedMessageConnection`. The inbound listener
  attaches synchronously before `waitForOpen` awaits the channel's open
  event, so a frame sent the instant the channel opens is queued rather
  than dropped. The open phase rejects and tears down on pre-open error,
  close, or timeout; an open timeout hard-closes rather than flushing
  (flushing a never-opened channel leaks the underlying
  `RTCPeerConnection` in PeerJS).

- `psi.tsx` now opens a `MessageConnection` and drives `runExchange`
  through it rather than reading raw DataConnection frames. A
  `runExchangeOn` helper shared by both roles owns the full lifecycle:
  data preparation, connection open, exchange, result surfacing, and
  teardown in a single `try/finally`.

- Output failures are caught separately from exchange failures. A CSV or
  standardization error during `finishExchange` now surfaces as "Results
  unavailable" rather than "Exchange failed", since the PSI exchange
  itself succeeded and a re-run would be unnecessary.

- The server path prepares its data before dialing the peer, so a
  pre-dial CSV failure can no longer strand a live connection that only
  the `runExchangeOn` finally would tear down. The client waits for an
  incoming connection through `waitForIncomingConnection` with a
  deadline, so a peer that never dials surfaces an error instead of
  hanging indefinitely.

- Failed exchanges now show a red alert in the UI with a descriptive
  message instead of silently logging to the console and leaving the page
  stuck on its last stage.

## Testing

`QueuedMessageConnection` half-close, `waitForOpen`,
`waitForIncomingConnection`, and `PeerMessageConnection` are each covered
by new unit-test suites. The existing invited-PSI browser integration test
is updated to use `openPeerMessageConnection`.