### PR TITLE
Use .tmp extension for in-flight message writes

### DIFF
--- a/packages/core/src/connection/fileSyncConnection.ts
+++ b/packages/core/src/connection/fileSyncConnection.ts
@@ -812,10 +812,6 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
           `${message.length} bytes`,
       );
       this.log.debug(`[${this.role}] writing message ${tempFile}`);
-      // Track the .tmp before the write so cleanup() can sweep it if the
-      // process dies between put() and rename(); the rename removes the .tmp
-      // entry and replaces it with the final .json name.
-      this.responsibleFiles.add(tempFile);
       await this.client.put(Buffer.from(message), tempPath, {
         flags: "w",
         encoding: null,
@@ -823,11 +819,9 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
 
       this.log.debug(`[${this.role}] renaming ${tempFile} to ${this.id}.json`);
       await this.client.rename(tempPath, outPath);
-      this.responsibleFiles.delete(tempFile);
       this.responsibleFiles.add(`${this.id}.json`);
     } catch (err: unknown) {
       await this.client.safeDelete(tempPath);
-      this.responsibleFiles.delete(tempFile);
       if (err instanceof Error && err.cause === "usage") delete err.cause;
       throw err instanceof Error ? err : new Error(errMessage(err));
     }

--- a/packages/core/src/connection/fileSyncConnection.ts
+++ b/packages/core/src/connection/fileSyncConnection.ts
@@ -770,9 +770,8 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
       throw new Error("not connected");
 
     const outPath = `${this.path}/${this.id}.json`;
-    // The in-flight write uses a `.tmp` extension, not `.json`, so a sync tool
-    // configured to watch `*.json` never matches the partial write before the
-    // atomic rename to the final `.json` name completes.
+    // A `.tmp` extension (not `.json`) keeps this in-flight write from matching
+    // a `*.json` sync-tool watch before the rename to the final name lands.
     const tempFile = `temp-${uuidv4()}.tmp`;
     const tempPath = `${this.path}/${tempFile}`;
 

--- a/packages/core/src/connection/fileSyncConnection.ts
+++ b/packages/core/src/connection/fileSyncConnection.ts
@@ -770,7 +770,10 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
       throw new Error("not connected");
 
     const outPath = `${this.path}/${this.id}.json`;
-    const tempFile = `temp-${uuidv4()}.json`;
+    // The in-flight write uses a `.tmp` extension, not `.json`, so a sync tool
+    // configured to watch `*.json` never matches the partial write before the
+    // atomic rename to the final `.json` name completes.
+    const tempFile = `temp-${uuidv4()}.tmp`;
     const tempPath = `${this.path}/${tempFile}`;
 
     try {
@@ -809,6 +812,10 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
           `${message.length} bytes`,
       );
       this.log.debug(`[${this.role}] writing message ${tempFile}`);
+      // Track the .tmp before the write so cleanup() can sweep it if the
+      // process dies between put() and rename(); the rename removes the .tmp
+      // entry and replaces it with the final .json name.
+      this.responsibleFiles.add(tempFile);
       await this.client.put(Buffer.from(message), tempPath, {
         flags: "w",
         encoding: null,
@@ -816,9 +823,11 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
 
       this.log.debug(`[${this.role}] renaming ${tempFile} to ${this.id}.json`);
       await this.client.rename(tempPath, outPath);
+      this.responsibleFiles.delete(tempFile);
       this.responsibleFiles.add(`${this.id}.json`);
     } catch (err: unknown) {
       await this.client.safeDelete(tempPath);
+      this.responsibleFiles.delete(tempFile);
       if (err instanceof Error && err.cause === "usage") delete err.cause;
       throw err instanceof Error ? err : new Error(errMessage(err));
     }

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -389,41 +389,14 @@ test("send writes the in-flight file with a .tmp extension and renames to .json"
   expect(renameTargets).toEqual([`/test/${conn.id}.json`]);
 });
 
-test("send tracks the .tmp file in responsibleFiles until the rename completes", async () => {
-  // The .tmp must be listed in responsibleFiles before the write so cleanup()
-  // can sweep it if the process dies before the rename; once the rename
-  // succeeds the entry is replaced by the final .json name.
-  const { client } = makeMockClient();
-  const conn = makeConnectedConn(client);
-  const responsible = (conn as unknown as { responsibleFiles: Set<string> })
-    .responsibleFiles;
-
-  let tmpTrackedDuringPut: string | undefined;
-  const origPut = client.put.bind(client);
-  client.put = async (src, dest, opts) => {
-    const tmpName = dest.slice("/test/".length);
-    if (responsible.has(tmpName)) tmpTrackedDuringPut = tmpName;
-    return origPut(src, dest, opts);
-  };
-
-  await conn.send({ hello: "world" });
-
-  // The .tmp was tracked while the write was in flight ...
-  expect(tmpTrackedDuringPut).toBeDefined();
-  expect(tmpTrackedDuringPut!.endsWith(".tmp")).toBe(true);
-  // ... and is replaced by the final .json name once the rename completes.
-  expect(responsible.has(tmpTrackedDuringPut!)).toBe(false);
-  expect(responsible.has(`${conn.id}.json`)).toBe(true);
-});
-
-test("send cleans up the .tmp file and its responsibleFiles entry when the rename fails", async () => {
-  // If the rename throws (e.g. transport failure), the catch block must delete
-  // the orphaned .tmp file and drop it from responsibleFiles so a later
-  // cleanup() does not attempt to re-delete a name that no longer exists.
+test("send removes the .tmp file in-process when the rename fails", async () => {
+  // If the rename throws (e.g. transport failure) the catch block must delete
+  // the orphaned .tmp file so it is not left behind for the failed exchange.
+  // This is a best-effort in-process sweep through the still-live client; it
+  // is the only cleanup path for an in-flight write, so the .tmp name is
+  // deliberately not tracked in responsibleFiles (see send()).
   const { client, files } = makeMockClient();
   const conn = makeConnectedConn(client);
-  const responsible = (conn as unknown as { responsibleFiles: Set<string> })
-    .responsibleFiles;
 
   client.rename = async () => {
     throw new Error("synthetic rename failure");
@@ -433,11 +406,9 @@ test("send cleans up the .tmp file and its responsibleFiles entry when the renam
     "synthetic rename failure",
   );
 
-  // No .tmp residue on disk and nothing tracked for cleanup.
+  // No .tmp residue on disk.
   const tmpFiles = [...files.keys()].filter((p) => p.endsWith(".tmp"));
   expect(tmpFiles).toEqual([]);
-  const tracked = [...responsible].filter((n) => n.endsWith(".tmp"));
-  expect(tracked).toEqual([]);
 });
 
 // --- Race condition: consecutive sends ---------------------------------------

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -398,6 +398,22 @@ test("send removes the .tmp file in-process when the rename fails", async () => 
   const { client, files } = makeMockClient();
   const conn = makeConnectedConn(client);
 
+  // Capture the temp path the write actually produced so the cleanup
+  // assertion cannot pass vacuously: if a refactor stopped writing the temp
+  // file, tempPath stays undefined and the "was written" check below fails.
+  let tempPath: string | undefined;
+  const origPut = client.put.bind(client);
+  client.put = async (src, dest, opts) => {
+    await origPut(src, dest, opts);
+    tempPath = dest;
+  };
+  const safeDeleted: string[] = [];
+  const origSafeDelete = client.safeDelete.bind(client);
+  client.safeDelete = async (p) => {
+    safeDeleted.push(p);
+    return origSafeDelete(p);
+  };
+
   client.rename = async () => {
     throw new Error("synthetic rename failure");
   };
@@ -406,7 +422,13 @@ test("send removes the .tmp file in-process when the rename fails", async () => 
     "synthetic rename failure",
   );
 
-  // No .tmp residue on disk.
+  // The temp file was actually written (a .tmp, not a .json) ...
+  expect(tempPath).toBeDefined();
+  expect(tempPath!.endsWith(".tmp")).toBe(true);
+  // ... the catch swept exactly that file via safeDelete ...
+  expect(safeDeleted).toContain(tempPath!);
+  // ... and no .tmp residue remains on disk.
+  expect(files.has(tempPath!)).toBe(false);
   const tmpFiles = [...files.keys()].filter((p) => p.endsWith(".tmp"));
   expect(tmpFiles).toEqual([]);
 });

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -360,6 +360,86 @@ test("send writes the message file to the store", async () => {
   expect(files.has(`/test/${conn.id}.json`)).toBe(true);
 });
 
+test("send writes the in-flight file with a .tmp extension and renames to .json", async () => {
+  // A sync tool watching `*.json` must never match the partial write, so the
+  // temp file carries a `.tmp` extension; only the atomic rename target ends
+  // in `.json`.
+  const { client } = makeMockClient();
+  const conn = makeConnectedConn(client);
+
+  const putDests: string[] = [];
+  const origPut = client.put.bind(client);
+  client.put = async (src, dest, opts) => {
+    putDests.push(dest);
+    return origPut(src, dest, opts);
+  };
+  const renameTargets: string[] = [];
+  const origRename = client.rename.bind(client);
+  client.rename = async (from, to) => {
+    renameTargets.push(to);
+    return origRename(from, to);
+  };
+
+  await conn.send({ hello: "world" });
+
+  expect(putDests).toHaveLength(1);
+  expect(putDests[0].endsWith(".tmp")).toBe(true);
+  expect(putDests[0].endsWith(".json")).toBe(false);
+
+  expect(renameTargets).toEqual([`/test/${conn.id}.json`]);
+});
+
+test("send tracks the .tmp file in responsibleFiles until the rename completes", async () => {
+  // The .tmp must be listed in responsibleFiles before the write so cleanup()
+  // can sweep it if the process dies before the rename; once the rename
+  // succeeds the entry is replaced by the final .json name.
+  const { client } = makeMockClient();
+  const conn = makeConnectedConn(client);
+  const responsible = (conn as unknown as { responsibleFiles: Set<string> })
+    .responsibleFiles;
+
+  let tmpTrackedDuringPut: string | undefined;
+  const origPut = client.put.bind(client);
+  client.put = async (src, dest, opts) => {
+    const tmpName = dest.slice("/test/".length);
+    if (responsible.has(tmpName)) tmpTrackedDuringPut = tmpName;
+    return origPut(src, dest, opts);
+  };
+
+  await conn.send({ hello: "world" });
+
+  // The .tmp was tracked while the write was in flight ...
+  expect(tmpTrackedDuringPut).toBeDefined();
+  expect(tmpTrackedDuringPut!.endsWith(".tmp")).toBe(true);
+  // ... and is replaced by the final .json name once the rename completes.
+  expect(responsible.has(tmpTrackedDuringPut!)).toBe(false);
+  expect(responsible.has(`${conn.id}.json`)).toBe(true);
+});
+
+test("send cleans up the .tmp file and its responsibleFiles entry when the rename fails", async () => {
+  // If the rename throws (e.g. transport failure), the catch block must delete
+  // the orphaned .tmp file and drop it from responsibleFiles so a later
+  // cleanup() does not attempt to re-delete a name that no longer exists.
+  const { client, files } = makeMockClient();
+  const conn = makeConnectedConn(client);
+  const responsible = (conn as unknown as { responsibleFiles: Set<string> })
+    .responsibleFiles;
+
+  client.rename = async () => {
+    throw new Error("synthetic rename failure");
+  };
+
+  await expect(conn.send({ hello: "world" })).rejects.toThrow(
+    "synthetic rename failure",
+  );
+
+  // No .tmp residue on disk and nothing tracked for cleanup.
+  const tmpFiles = [...files.keys()].filter((p) => p.endsWith(".tmp"));
+  expect(tmpFiles).toEqual([]);
+  const tracked = [...responsible].filter((n) => n.endsWith(".tmp"));
+  expect(tracked).toEqual([]);
+});
+
 // --- Race condition: consecutive sends ---------------------------------------
 
 test("send waits for a previous unconsumed message before writing the next", async () => {


### PR DESCRIPTION
## Summary

`FileSyncConnection.send()` wrote each outgoing message to a `temp-<uuid>.json` file before renaming it to `<id>.json`. The `.json` extension on the temp file meant a sync tool configured to watch `*.json` could observe the partial write before the rename completed. This changes the in-flight file to a `.tmp` extension so a `*.json` glob never matches a partial write; only the rename target keeps `.json`.

A failed send still sweeps its own temp file in-process through `send()`'s existing `catch` (a best-effort `safeDelete` on the still-live client). The temp name is deliberately *not* tracked in `responsibleFiles`: that set is in-memory and reset per process, so it cannot survive a crash, and tracking it only introduced a teardown race (an error-driven `close()` could unlink the temp out from under an in-flight `put()`, failing the rename with a spurious ENOENT). A stray `.tmp` left by a crash or teardown race is benign litter -- it matches no `*.json` glob and the peer never polls for it. Robust cross-restart orphan recovery would need a `.tmp` sweep in `synchronize()` (mirroring the existing `.hello`/`.wave` orphan check) and is out of scope here.

Implemented on top of the UUID-only tiebreaker change (already in `staging`).

## Changes

- `packages/core/src/connection/fileSyncConnection.ts`: in-flight temp file extension `.json` -> `.tmp`; the final rename target is unchanged (`<id>.json`).
- `packages/core/test/fileSyncConnection.test.ts`: new tests covering the `.tmp` extension and `.json` rename target, and in-process cleanup of the temp file when the rename fails (asserting the temp was written and `safeDelete` removed exactly it).

## Testing

- `npm run build -w packages/core`
- `npm test -w packages/core` (19 files, 488 tests passing)
- `npm run lint` (clean), `npx prettier --check` (clean)