### PR TITLE
Encode byte count in file-sync message filenames

### DIFF
--- a/apps/cli/src/connection/localFSClient.ts
+++ b/apps/cli/src/connection/localFSClient.ts
@@ -83,7 +83,11 @@ export class LocalFSClient implements FileTransportClient {
       fileEntries.map(async ({ name }) => {
         try {
           const stat = await fs.stat(path.join(dir, name));
-          return { name, modifyTime: Math.floor(stat.mtimeMs) } as FileInfo;
+          return {
+            name,
+            modifyTime: Math.floor(stat.mtimeMs),
+            size: stat.size,
+          } as FileInfo;
         } catch (err: unknown) {
           if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
           throw err;

--- a/docs/EXCHANGE_SPEC.md
+++ b/docs/EXCHANGE_SPEC.md
@@ -564,6 +564,27 @@ These options apply to both `sftp` and `filedrop` channels.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `poll_interval_ms` | integer | 100 | Milliseconds between checks for the partner's uploaded file. The default is tuned for local-network mounts and CI; raise it (for example, to 1000-5000 ms) for public SFTP servers to reduce request load. |
+| `timestamp_in_filename` | boolean | false | When `true`, each outgoing message filename also encodes a UTC timestamp and a per-session sequence number (see [Message filenames](#message-filenames)). Useful for filename-based logging in sync-mediated environments where the sync tool stamps files with the transfer time rather than the original creation time. |
+
+#### Message filenames
+
+On the `sftp` and `filedrop` channels each party writes its outgoing messages as files in the shared directory; the partner polls for them. Every message filename ends in `.json`, and the last `-`-delimited segment before the extension is a decimal byte count: the exact size of the serialized message. The receiver compares that declared count against the file's on-disk size and reads the file only once the two match, so a partially synced file is never read as a complete message. Because the byte count is always the final segment, parsing is right-anchored and a party id containing hyphens does not affect extraction.
+
+With `timestamp_in_filename` unset (the default), the format is:
+
+```
+<id>-<byteCount>.json
+```
+
+With `timestamp_in_filename: true`, the filename additionally carries a timestamp and counter:
+
+```
+<id>-<YYYYMMDDTHHMMSS>-<NNN>-<byteCount>.json
+```
+
+`<YYYYMMDDTHHMMSS>` is the UTC write time in compact ISO 8601 form (no colons or hyphens, so it is Windows-safe and sorts lexicographically by time). `<NNN>` is a per-session counter that starts at `000`, is zero-padded to three digits, and increments with each message sent; it widens to four or more digits only after the 1000th message of a session.
+
+In-flight writes use a temporary `.tmp` file that is renamed to the final `.json` name only once the write completes, so a sync tool watching `*.json` never observes a partial file under its final name. Handshake files (`.hello`, `.wave`) are separate from message files and are documented in [PROTOCOL.md](PROTOCOL.md).
 
 ### `connection.provider_options`
 

--- a/packages/core/src/config/connection.ts
+++ b/packages/core/src/config/connection.ts
@@ -328,11 +328,21 @@ export interface FileSyncOptions extends SharedOptions {
    * 100.
    */
   pollIntervalMs?: number;
+  /**
+   * When `true`, each outgoing message filename also encodes a UTC timestamp
+   * and a per-session sequence number, so filename-based logging can capture
+   * when a file was written even in sync-mediated environments where the sync
+   * tool stamps files with the transfer time rather than the original creation
+   * time; default: `false`. With it unset, message filenames carry only the
+   * declared byte count (`<id>-<byteCount>.json`).
+   */
+  timestampInFilename?: boolean;
 }
 
 const FileSyncOptionsSchema: z.ZodType<FileSyncOptions> = z.object({
   ...sharedOptionsFields,
   pollIntervalMs: z.int().nonnegative().optional(),
+  timestampInFilename: z.boolean().optional(),
 });
 
 // --- Connection config -------------------------------------------------------

--- a/packages/core/src/connection/fileSyncConnection.ts
+++ b/packages/core/src/connection/fileSyncConnection.ts
@@ -12,6 +12,18 @@ import type { HandshakeRole } from "../types";
 const errMessage = (err: unknown) =>
   err instanceof Error ? err.message : String(err);
 
+// Extracts the declared byte count from a message filename by reading the last
+// `-`-delimited segment before `.json`. Parsing is right-anchored so an id
+// containing hyphens (a UUID, or a configured peer id) cannot corrupt the
+// result regardless of how many segments precede the count. Returns undefined
+// when that segment is not a non-negative integer.
+const parseMessageByteCount = (name: string): number | undefined => {
+  const stem = name.slice(0, -".json".length);
+  const lastSegment = stem.slice(stem.lastIndexOf("-") + 1);
+  if (!/^\d+$/.test(lastSegment)) return undefined;
+  return Number(lastSegment);
+};
+
 /**
  * Default peer-inactivity budget (1 hour) used when `peerTimeoutMs` is not
  * supplied in the connection options. Bounds how long this side waits for the
@@ -22,18 +34,18 @@ const errMessage = (err: unknown) =>
 export const DEFAULT_PEER_TIMEOUT_MS = 1000 * 60 * 60;
 const DEFAULT_POLLING_FREQUENCY_MS = 100;
 const DEFAULT_VERBOSITY = 1;
-// Consecutive ENOENT from get() after exists() returned true indicates a
+// Consecutive ENOENT from get() after list() surfaced the file indicates a
 // filesystem state that is unlikely to self-resolve: emit an error rather
 // than looping silently until the peer timeout fires.
 //
 // 3 is structural rather than performance-tuning, so it is not exposed as a
-// config option: one ENOENT after exists()=true is the expected TOCTOU race
-// when the peer's cleanup runs between the two calls (a single race per
-// message-consumption cycle); two more in a row indicates the directory
-// listing is not converging, which is pathological. A smaller threshold
-// (1-2) produces false positives on slow filesystems where one peer's
-// cleanup may briefly overlap with our next poll; a larger threshold (>5)
-// approaches the peer timeout and gives no practical benefit.
+// config option: one ENOENT after the file appeared in list() is the expected
+// TOCTOU race when the peer's cleanup runs between the listing and the get()
+// (a single race per message-consumption cycle); two more in a row indicates
+// the directory listing is not converging, which is pathological. A smaller
+// threshold (1-2) produces false positives on slow filesystems where one
+// peer's cleanup may briefly overlap with our next poll; a larger threshold
+// (>5) approaches the peer timeout and gives no practical benefit.
 const MAX_CONSECUTIVE_ENOENT = 3;
 
 interface Events {
@@ -48,6 +60,7 @@ interface Options {
   timeToLive?: Date;
   pollingFrequency: number;
   verbose: number;
+  timestampInFilename: boolean;
 }
 
 const Message = z.object({
@@ -61,6 +74,7 @@ const getDefaultOptions = (): Options => {
   return {
     pollingFrequency: DEFAULT_POLLING_FREQUENCY_MS,
     verbose: DEFAULT_VERBOSITY,
+    timestampInFilename: false,
   };
 };
 
@@ -70,6 +84,10 @@ export interface FileInfo {
   // rendezvous tiebreaker (see waitForPeer), which orders on UUID alone
   // because sync tools stamp transfer time rather than creation time.
   modifyTime: number;
+  // On-disk byte count, populated by every FileTransportClient.list(). poll()
+  // compares it against the declared count encoded in a message filename so a
+  // partially synced file is not read as a complete message.
+  size: number;
 }
 
 export interface PutOptions {
@@ -220,6 +238,8 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
   ): Promise<void> {
     if (config.options?.pollIntervalMs !== undefined)
       this.options.pollingFrequency = config.options.pollIntervalMs;
+    if (config.options?.timestampInFilename !== undefined)
+      this.options.timestampInFilename = config.options.timestampInFilename;
     // timeToLive is computed after a successful connect (below) so that
     // retry latency during connection setup does not eat into the
     // peer-waiting budget. Applies to both peerTimeoutMs-supplied and
@@ -769,18 +789,29 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
     if (!this.connected || this.path === undefined)
       throw new Error("not connected");
 
-    const outPath = `${this.path}/${this.id}.json`;
+    const path = this.path;
     // A `.tmp` extension (not `.json`) keeps this in-flight write from matching
     // a `*.json` sync-tool watch before the rename to the final name lands.
     const tempFile = `temp-${uuidv4()}.tmp`;
-    const tempPath = `${this.path}/${tempFile}`;
+    const tempPath = `${path}/${tempFile}`;
+
+    // Each message carries a distinct filename (the byte count, and optionally
+    // a counter, differ per send), so a previous message the peer has not yet
+    // consumed cannot be found by an exact name. Scan for any `<id>-*.json` we
+    // still own and wait for it to clear, preserving the one-outstanding-
+    // message-at-a-time invariant the peer's poll() relies on.
+    const hasOutstandingMessage = async () =>
+      (await this.client.list(path)).some(
+        (file) =>
+          file.name.startsWith(`${this.id}-`) && file.name.endsWith(".json"),
+      );
 
     try {
-      if (await this.client.exists(outPath)) {
+      if (await hasOutstandingMessage()) {
         this.log.debug(
           `[${this.role}] waiting for previous message to be consumed`,
         );
-        while (await this.client.exists(outPath)) {
+        while (await hasOutstandingMessage()) {
           // open() set timeToLive before send() can run; assertion is safe.
           if (Date.now() > this.options.timeToLive!.getTime()) {
             throw new Error(
@@ -800,30 +831,59 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
         type = "Uint8Array";
       }
 
-      const message = JSON.stringify({
-        ts: Date.now(),
-        seq: this.seq++,
-        type,
-        payload: data,
-      });
+      const ts = Date.now();
+      const seq = this.seq++;
+      // Serialize before constructing the filename so the encoded byte count is
+      // the exact on-disk size; the peer waits until the synced file reaches
+      // that many bytes before reading it, so a partial sync delivery is never
+      // read as a complete message.
+      const payload = Buffer.from(
+        JSON.stringify({ ts, seq, type, payload: data }),
+      );
+      const outName = this.messageFilename(payload.byteLength, seq, ts);
+      const outPath = `${path}/${outName}`;
+
       this.log.trace(
-        `[${this.role}] message seq=${this.seq - 1}, type=${type}, ` +
-          `${message.length} bytes`,
+        `[${this.role}] message seq=${seq}, type=${type}, ` +
+          `${payload.byteLength} bytes`,
       );
       this.log.debug(`[${this.role}] writing message ${tempFile}`);
-      await this.client.put(Buffer.from(message), tempPath, {
+      await this.client.put(payload, tempPath, {
         flags: "w",
         encoding: null,
       });
 
-      this.log.debug(`[${this.role}] renaming ${tempFile} to ${this.id}.json`);
+      this.log.debug(`[${this.role}] renaming ${tempFile} to ${outName}`);
       await this.client.rename(tempPath, outPath);
-      this.responsibleFiles.add(`${this.id}.json`);
+      this.responsibleFiles.add(outName);
     } catch (err: unknown) {
       await this.client.safeDelete(tempPath);
       if (err instanceof Error && err.cause === "usage") delete err.cause;
       throw err instanceof Error ? err : new Error(errMessage(err));
     }
+  }
+
+  // Builds an outgoing message filename. The byte count is always the final
+  // `-`-delimited segment before `.json` so the receiver can extract it with a
+  // right-anchored parse (see parseMessageByteCount). When timestampInFilename
+  // is set, a compact UTC timestamp and a zero-padded per-session counter are
+  // inserted so sync-mediated logging can recover write order even when the
+  // sync tool rewrites file mtimes.
+  private messageFilename(byteCount: number, seq: number, ts: number): string {
+    if (!this.options.timestampInFilename)
+      return `${this.id}-${byteCount}.json`;
+    // YYYYMMDDTHHMMSS in UTC: no colons or hyphens, so it is Windows-safe,
+    // lexicographically time-sortable, and occupies one hyphen-delimited
+    // segment.
+    const timestamp = new Date(ts)
+      .toISOString()
+      .replace(/[-:]/g, "")
+      .slice(0, 15);
+    // Zero-padded to three digits for the common case; widens to four or more
+    // past message 999, which keeps names unique (the byte count is still the
+    // final segment) at the cost of strict three-digit width on long sessions.
+    const counter = String(seq).padStart(3, "0");
+    return `${this.id}-${timestamp}-${counter}-${byteCount}.json`;
   }
 
   private async poll() {
@@ -834,62 +894,111 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
 
     if (!this.peerId) throw new Error("not synchronized");
 
-    const inPath = `${this.path}/${this.peerId}.json`;
+    const path = this.path;
+    const peerId = this.peerId;
 
     let reachedGet = false;
     try {
-      this.log.trace(`[${this.role}] polling for message from ${this.peerId}`);
-      const messageFile = await this.client.exists(inPath);
-      if (messageFile) {
-        this.log.debug(
-          `[${this.role}] getting message from ${this.peerId}.json`,
+      this.log.trace(`[${this.role}] polling for message from ${peerId}`);
+      // Detect via a pattern scan rather than an exact-name exists(): the
+      // message filename now encodes a per-message byte count (and optionally
+      // a timestamp and counter), so the receiver cannot predict the exact
+      // name. `<peerId>-*.json` matches only the peer's message files - its
+      // `.hello`/`.wave` handshake files and our own `<id>-*.json` writes are
+      // excluded by prefix or extension.
+      //
+      // A name that matches the prefix but whose final segment is not a byte
+      // count (e.g. a leftover `<peerId>-backup.json`) is ignored, not treated
+      // as an error: the previous exact-name lookup never matched such a file,
+      // so failing the exchange over an unrelated file would be a regression.
+      const messages: Array<{ file: FileInfo; declaredSize: number }> = [];
+      const ignored: string[] = [];
+      for (const file of await this.client.list(path)) {
+        if (!file.name.startsWith(`${peerId}-`) || !file.name.endsWith(".json"))
+          continue;
+        const declaredSize = parseMessageByteCount(file.name);
+        if (declaredSize === undefined) ignored.push(file.name);
+        else messages.push({ file, declaredSize });
+      }
+      if (ignored.length > 0)
+        this.log.trace(
+          `[${this.role}] ignoring ${ignored.length} non-message file(s) ` +
+            `matching ${peerId}-*.json: ${ignored.join(", ")}`,
         );
 
-        reachedGet = true;
-        const message = await this.client.get(inPath, { encoding: "utf-8" });
-        reachedGet = false;
+      if (messages.length > 1) {
+        // Emitted (not thrown to a caller), so no "usage" sentinel: the bridge
+        // classifies every poll-loop error as a transport failure.
+        throw new Error(
+          `more than one message file from ${peerId} in ${path} - are there ` +
+            "other sessions using this path?",
+        );
+      }
 
-        this.log.debug(`[${this.role}] deleting message ${this.peerId}.json`);
-        try {
-          await this.client.delete(inPath);
-        } catch {
-          await new Promise((resolve) =>
-            setTimeout(resolve, this.options.pollingFrequency),
+      if (messages.length === 1) {
+        const { file: messageFile, declaredSize } = messages[0];
+
+        if (messageFile.size < declaredSize) {
+          // The file has appeared but the sync tool has not finished
+          // transferring it. Leave it untouched and re-check next cycle rather
+          // than reading a truncated message. For a direct transport (SFTP),
+          // the atomic rename means the size already matches on the first poll.
+          this.log.trace(
+            `[${this.role}] ${messageFile.name} is ${messageFile.size}/` +
+              `${declaredSize} bytes; waiting for full sync`,
           );
+        } else {
+          const inPath = `${path}/${messageFile.name}`;
+          this.log.debug(`[${this.role}] getting message ${messageFile.name}`);
+
+          reachedGet = true;
+          const message = await this.client.get(inPath, { encoding: "utf-8" });
+          reachedGet = false;
+
+          this.log.debug(`[${this.role}] deleting message ${messageFile.name}`);
           try {
             await this.client.delete(inPath);
-          } catch (deleteErr: unknown) {
-            this.log.warn(
-              `[${this.role}] failed to delete ${this.peerId}.json; ` +
-                "please notify the administrator that manual cleanup " +
-                `may be required: ${errMessage(deleteErr)}`,
+          } catch {
+            await new Promise((resolve) =>
+              setTimeout(resolve, this.options.pollingFrequency),
             );
+            try {
+              await this.client.delete(inPath);
+            } catch (deleteErr: unknown) {
+              this.log.warn(
+                `[${this.role}] failed to delete ${messageFile.name}; ` +
+                  "please notify the administrator that manual cleanup " +
+                  `may be required: ${errMessage(deleteErr)}`,
+              );
+            }
           }
-        }
 
-        const validatedMessage = Message.parse(JSON.parse(message.toString()));
-        this.log.trace(
-          `[${this.role}] received message seq=${validatedMessage.seq}, ` +
-            `type=${validatedMessage.type}`,
-        );
-
-        if (validatedMessage.type === "Uint8Array") {
-          const bytes = Buffer.from(
-            validatedMessage.payload as string,
-            "base64",
+          const validatedMessage = Message.parse(
+            JSON.parse(message.toString()),
           );
-          this.emit("data", bytes);
-        } else {
-          this.emit("data", validatedMessage.payload);
+          this.log.trace(
+            `[${this.role}] received message seq=${validatedMessage.seq}, ` +
+              `type=${validatedMessage.type}`,
+          );
+
+          if (validatedMessage.type === "Uint8Array") {
+            const bytes = Buffer.from(
+              validatedMessage.payload as string,
+              "base64",
+            );
+            this.emit("data", bytes);
+          } else {
+            this.emit("data", validatedMessage.payload);
+          }
         }
       }
       this.consecutiveEnoentCount = 0;
     } catch (err: unknown) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT" && reachedGet) {
-        // TOCTOU race: exists() returned true but get() found the file gone,
-        // meaning the peer cleaned up between our two calls. After a single
-        // race the file is genuinely gone and subsequent exists() calls return
-        // false, resetting the counter on the next clean poll cycle.
+        // TOCTOU race: list() surfaced the file but get() found it gone,
+        // meaning the peer cleaned up between the two calls. After a single
+        // race the file is genuinely gone and subsequent list() cycles no
+        // longer match it, resetting the counter on the next clean poll.
         // Consecutive ENOENTs that keep incrementing the counter indicate a
         // pathological filesystem state that will not self-resolve; emit an
         // error after MAX_CONSECUTIVE_ENOENT rather than looping silently
@@ -906,8 +1015,8 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
           );
         } else {
           this.log.warn(
-            `[${this.role}] ${this.peerId}.json disappeared between exists and ` +
-              "get; assuming peer cleaned up",
+            `[${this.role}] message from ${peerId} disappeared between list ` +
+              "and get; assuming peer cleaned up",
           );
         }
       } else {

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -17,7 +17,22 @@ function makeMockClient(): {
   const client: FileTransportClient = {
     connect: async () => {},
     end: async () => {},
-    list: async (): Promise<FileInfo[]> => [],
+    // Reflect the in-memory store so send()/poll(), which now detect files via
+    // list() pattern scans, see the same state exists()/get() do. Returns
+    // direct children of `dir`, with `size` taken from the buffer length.
+    list: async (dir: string): Promise<FileInfo[]> => {
+      const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+      return [...files.entries()]
+        .filter(
+          ([p]) =>
+            p.startsWith(prefix) && !p.slice(prefix.length).includes("/"),
+        )
+        .map(([p, buf]) => ({
+          name: p.slice(prefix.length),
+          modifyTime: 0,
+          size: buf.length,
+        }));
+    },
     get: async (path: string) => {
       const data = files.get(path);
       if (!data) throw new Error(`${path}: not found`);
@@ -108,13 +123,16 @@ test("close() sweeps responsible files and ends the client, idempotently", async
   const conn = makeConnectedConn(client);
   // send() records the outbound file as one this side is responsible for.
   await conn.send({ hello: 1 });
-  expect(files.has(`/test/${conn.id}.json`)).toBe(true);
+  const messagePath = [...files.keys()].find((p) =>
+    new RegExp(`^/test/${conn.id}-\\d+\\.json$`).test(p),
+  );
+  expect(messagePath).toBeDefined();
 
   await conn.close();
 
   expect(ended).toBe(true);
-  expect(deleted).toContain(`/test/${conn.id}.json`);
-  expect(files.has(`/test/${conn.id}.json`)).toBe(false);
+  expect(deleted).toContain(messagePath);
+  expect(files.has(messagePath!)).toBe(false);
 
   // A second close neither throws nor re-ends the client.
   ended = false;
@@ -124,11 +142,11 @@ test("close() sweeps responsible files and ends the client, idempotently", async
 
 test("close() stops a running poller", async () => {
   const { client } = makeMockClient();
-  let existsCalls = 0;
-  const origExists = client.exists;
-  client.exists = async (p: string) => {
-    existsCalls++;
-    return origExists(p);
+  let listCalls = 0;
+  const origList = client.list;
+  client.list = async (p: string) => {
+    listCalls++;
+    return origList(p);
   };
   const conn = makeConnectedConn(client, { pollingFrequency: 5 });
   conn.peerId = "peer-test";
@@ -136,9 +154,9 @@ test("close() stops a running poller", async () => {
   await new Promise((r) => setTimeout(r, 25));
   await conn.close();
 
-  const callsAfterClose = existsCalls;
+  const callsAfterClose = listCalls;
   await new Promise((r) => setTimeout(r, 25));
-  expect(existsCalls).toBe(callsAfterClose);
+  expect(listCalls).toBe(callsAfterClose);
 });
 
 // --- buffered error ----------------------------------------------------------
@@ -357,7 +375,26 @@ test("send writes the message file to the store", async () => {
 
   await conn.send({ hello: "world" });
 
-  expect(files.has(`/test/${conn.id}.json`)).toBe(true);
+  // Default (timestampInFilename unset): `<id>-<byteCount>.json`.
+  const written = [...files.keys()].filter((p) =>
+    new RegExp(`^/test/${conn.id}-\\d+\\.json$`).test(p),
+  );
+  expect(written).toHaveLength(1);
+});
+
+test("send encodes the exact serialized byte count in the filename", async () => {
+  const { client, files } = makeMockClient();
+  const conn = makeConnectedConn(client);
+
+  await conn.send({ hello: "world" });
+
+  const [written] = [...files.entries()].filter(([p]) =>
+    new RegExp(`^/test/${conn.id}-\\d+\\.json$`).test(p),
+  );
+  expect(written).toBeDefined();
+  const [path, buf] = written;
+  const declared = Number(path.slice(0, -".json".length).split("-").at(-1));
+  expect(declared).toBe(buf.length);
 });
 
 test("send writes the in-flight file with a .tmp extension and renames to .json", async () => {
@@ -386,7 +423,10 @@ test("send writes the in-flight file with a .tmp extension and renames to .json"
   expect(putDests[0].endsWith(".tmp")).toBe(true);
   expect(putDests[0].endsWith(".json")).toBe(false);
 
-  expect(renameTargets).toEqual([`/test/${conn.id}.json`]);
+  expect(renameTargets).toHaveLength(1);
+  expect(renameTargets[0]).toMatch(
+    new RegExp(`^/test/${conn.id}-\\d+\\.json$`),
+  );
 });
 
 test("send removes the .tmp file in-process when the rename fails", async () => {
@@ -440,8 +480,9 @@ test("send waits for a previous unconsumed message before writing the next", asy
   const conn = makeConnectedConn(client);
 
   // Simulate a message from this connection already sitting in the store
-  // (e.g. the peer's poller hasn't run yet).
-  const outPath = `/test/${conn.id}.json`;
+  // (e.g. the peer's poller hasn't run yet). The exact byte count is
+  // irrelevant; send() detects any `<id>-*.json` it still owns.
+  const outPath = `/test/${conn.id}-99.json`;
   files.set(outPath, Buffer.from(JSON.stringify({ stale: true })));
 
   // After 50 ms, simulate the peer consuming (deleting) the stale message.
@@ -466,7 +507,7 @@ test("send times out when the previous message is never consumed", async () => {
   });
 
   // Plant a stale message that nobody will ever delete.
-  const outPath = `/test/${conn.id}.json`;
+  const outPath = `/test/${conn.id}-99.json`;
   files.set(outPath, Buffer.from(JSON.stringify({ stale: true })));
 
   await expect(conn.send({ next: true })).rejects.toThrow("timed out");
@@ -474,55 +515,58 @@ test("send times out when the previous message is never consumed", async () => {
 
 // --- TOCTOU race: ENOENT from get() ------------------------------------------
 
-test("poll does not emit error when get() throws ENOENT after a successful exists()", async () => {
-  // Simulate the TOCTOU window: exists() returns true, but by the time get()
-  // runs the peer has already deleted the file (their cleanup() raced with our
-  // poll()). The poller must swallow ENOENT and reschedule rather than
+test("poll does not emit error when get() throws ENOENT after list() surfaced the file", async () => {
+  // Simulate the TOCTOU window: list() surfaces the peer's message file, but by
+  // the time get() runs the peer has already deleted it (their cleanup() raced
+  // with our poll()). The poller must swallow ENOENT and reschedule rather than
   // emitting "error" and killing the connection.
   let getCount = 0;
   const { client } = makeMockClient();
-  const originalGet = client.get.bind(client);
-  let existsCount = 0;
-  client.exists = async () => {
-    existsCount++;
-    // Return true once so poll() attempts get(); false afterwards.
-    return existsCount === 1;
+  const peerId = "peer-test";
+  let listCount = 0;
+  // Surface a matching message file once (size matches the declared count so
+  // poll() proceeds to get()); empty afterwards.
+  client.list = async () => {
+    listCount++;
+    return listCount === 1
+      ? [{ name: `${peerId}-5.json`, modifyTime: 0, size: 5 }]
+      : [];
   };
-  client.get = async (p, opts) => {
+  client.get = async (p) => {
     if (++getCount === 1) {
       throw Object.assign(
         new Error(`ENOENT: no such file or directory, open '${p}'`),
         { code: "ENOENT" },
       );
     }
-    return originalGet(p, opts);
+    throw new Error("unexpected second get()");
   };
 
   const conn = makeConnectedConn(client, { pollingFrequency: 10 });
-  conn.peerId = "peer-test";
+  conn.peerId = peerId;
 
   const errors: unknown[] = [];
   conn.on("error", (err) => errors.push(err));
 
-  // Resolved by exists() on its 3rd call, confirming the poller rescheduled at
-  // least twice after the ENOENT — without relying on a fixed wall-clock wait.
-  let notifyThirdExists!: () => void;
-  const thirdExists = new Promise<void>((r) => {
-    notifyThirdExists = r;
+  // Resolved on list()'s 3rd call, confirming the poller rescheduled at least
+  // twice after the ENOENT — without relying on a fixed wall-clock wait.
+  let notifyThirdList!: () => void;
+  const thirdList = new Promise<void>((r) => {
+    notifyThirdList = r;
   });
-  const origExists = client.exists.bind(client);
-  client.exists = async (p: string) => {
-    const result = await origExists(p);
-    if (existsCount === 3) notifyThirdExists();
+  const origList = client.list.bind(client);
+  client.list = async (p: string) => {
+    const result = await origList(p);
+    if (listCount === 3) notifyThirdList();
     return result;
   };
 
   conn.start();
   await Promise.race([
-    thirdExists,
+    thirdList,
     new Promise<never>((_, reject) =>
       setTimeout(
-        () => reject(new Error("timed out waiting for 3rd exists() call")),
+        () => reject(new Error("timed out waiting for 3rd list() call")),
         2_000,
       ),
     ),
@@ -533,36 +577,38 @@ test("poll does not emit error when get() throws ENOENT after a successful exist
   // get() was called exactly once (on the ENOENT-throwing poll cycle).
   expect(getCount).toBe(1);
   // The poller rescheduled and ran additional cycles after the ENOENT.
-  expect(existsCount).toBeGreaterThan(1);
+  expect(listCount).toBeGreaterThan(1);
 });
 
 test("poll delivers a subsequent valid message after swallowing an ENOENT", async () => {
   const { client, files } = makeMockClient();
   const originalGet = client.get.bind(client);
-  let existsCallCount = 0;
   let getCount = 0;
   const peerId = "peer-test";
-  const peerPath = `/test/${peerId}.json`;
+  const validMessage = Buffer.from(
+    JSON.stringify({
+      ts: 1,
+      seq: 0,
+      type: "Object",
+      payload: { hello: "world" },
+    }),
+  );
+  const peerName = `${peerId}-${validMessage.length}.json`;
+  const peerPath = `/test/${peerName}`;
 
-  client.exists = async (p: string) => {
-    existsCallCount++;
-    if (existsCallCount === 1) return true; // triggers ENOENT on get()
-    if (existsCallCount === 3) {
-      // Plant a valid message on the third poll cycle, after the ENOENT.
-      files.set(
-        peerPath,
-        Buffer.from(
-          JSON.stringify({
-            ts: Date.now(),
-            seq: 0,
-            type: "Object",
-            payload: { hello: "world" },
-          }),
-        ),
-      );
-      return true;
+  let listCount = 0;
+  client.list = async () => {
+    listCount++;
+    // First cycle surfaces a phantom file (get() throws ENOENT); second cycle
+    // is empty (resets the consecutive-ENOENT counter); third cycle surfaces a
+    // real message whose on-disk size matches its declared byte count.
+    if (listCount === 1)
+      return [{ name: `${peerId}-1.json`, modifyTime: 0, size: 1 }];
+    if (listCount >= 3) {
+      if (!files.has(peerPath)) files.set(peerPath, validMessage);
+      return [{ name: peerName, modifyTime: 0, size: validMessage.length }];
     }
-    return files.has(p);
+    return [];
   };
   client.get = async (p: string, opts?: unknown) => {
     if (++getCount === 1)
@@ -604,11 +650,14 @@ test("poll delivers a subsequent valid message after swallowing an ENOENT", asyn
 });
 
 test("poll emits error when ENOENT threshold is reached on consecutive poll cycles", async () => {
-  // exists() always returns true; get() always throws ENOENT. After 3
-  // consecutive ENOENT cycles the poller must emit an error instead of
-  // warning indefinitely.
+  // list() always surfaces a matching file (size matches declared count);
+  // get() always throws ENOENT. After 3 consecutive ENOENT cycles the poller
+  // must emit an error instead of warning indefinitely.
   const { client } = makeMockClient();
-  client.exists = async () => true;
+  const peerId = "peer-test";
+  client.list = async () => [
+    { name: `${peerId}-5.json`, modifyTime: 0, size: 5 },
+  ];
   client.get = async (p) => {
     throw Object.assign(
       new Error(`ENOENT: no such file or directory, open '${p}'`),
@@ -617,7 +666,7 @@ test("poll emits error when ENOENT threshold is reached on consecutive poll cycl
   };
 
   const conn = makeConnectedConn(client, { pollingFrequency: 10 });
-  conn.peerId = "peer-test";
+  conn.peerId = peerId;
 
   const errors: unknown[] = [];
   // Resolved by the error handler so the test waits only as long as necessary
@@ -647,13 +696,14 @@ test("poll emits error when ENOENT threshold is reached on consecutive poll cycl
   expect(errors).toHaveLength(1);
 });
 
-test("poll emits error immediately when exists() throws ENOENT (not a TOCTOU race)", async () => {
-  // reachedGet is false when exists() throws, so ENOENT from exists() is a
-  // hard error that must be emitted immediately — not tolerated as a TOCTOU race.
+test("poll emits error immediately when list() throws ENOENT (not a TOCTOU race)", async () => {
+  // reachedGet is false when list() throws, so ENOENT from the detection scan
+  // is a hard error that must be emitted immediately — not tolerated as a
+  // TOCTOU race.
   const { client } = makeMockClient();
-  client.exists = async (p) => {
+  client.list = async (p) => {
     throw Object.assign(
-      new Error(`ENOENT: no such file or directory, open '${p}'`),
+      new Error(`ENOENT: no such file or directory, scandir '${p}'`),
       { code: "ENOENT" },
     );
   };
@@ -735,8 +785,8 @@ test("synchronize() cleans up hello and wave files when createExclusive() throws
     listCallCount++;
     if (listCallCount === 1) return []; // initial check: directory is clean
     return [
-      { name: myHelloName, modifyTime: mtime },
-      { name: peerHelloName, modifyTime: mtime },
+      { name: myHelloName, modifyTime: mtime, size: 0 },
+      { name: peerHelloName, modifyTime: mtime, size: 0 },
     ];
   };
 
@@ -791,8 +841,8 @@ test("synchronize() throws when createExclusive throws EEXIST but wave file is a
     listCallCount++;
     if (listCallCount === 1) return []; // initial check: directory is clean
     return [
-      { name: myHelloName, modifyTime: mtime },
-      { name: peerHelloName, modifyTime: mtime },
+      { name: myHelloName, modifyTime: mtime, size: 0 },
+      { name: peerHelloName, modifyTime: mtime, size: 0 },
     ];
   };
 
@@ -839,8 +889,8 @@ test("synchronize() rejects and cleans up hello and wave files when createExclus
     listCallCount++;
     if (listCallCount === 1) return [];
     return [
-      { name: myHelloName, modifyTime: mtime },
-      { name: peerHelloName, modifyTime: mtime },
+      { name: myHelloName, modifyTime: mtime, size: 0 },
+      { name: peerHelloName, modifyTime: mtime, size: 0 },
     ];
   };
 
@@ -888,8 +938,8 @@ test("synchronize() outer catch clears responsibleFiles so cleanup() makes no re
     listCallCount++;
     if (listCallCount === 1) return [];
     return [
-      { name: myHelloName, modifyTime: mtime },
-      { name: peerHelloName, modifyTime: mtime },
+      { name: myHelloName, modifyTime: mtime, size: 0 },
+      { name: peerHelloName, modifyTime: mtime, size: 0 },
     ];
   };
 
@@ -965,9 +1015,9 @@ test("synchronize() resolves cleanly when it observes a wave file already create
     // Subsequent listings expose the peer hello and the peer-created wave.
     if (listCallCount === 1) return [];
     return [
-      { name: myHelloName, modifyTime: mtime },
-      { name: peerHelloName, modifyTime: mtime },
-      { name: waveName, modifyTime: mtime },
+      { name: myHelloName, modifyTime: mtime, size: 0 },
+      { name: peerHelloName, modifyTime: mtime, size: 0 },
+      { name: waveName, modifyTime: mtime, size: 0 },
     ];
   };
 
@@ -1013,8 +1063,8 @@ test("synchronize() createExclusive winner: leaves own hello and wave name in re
     listCallCount++;
     if (listCallCount === 1) return []; // initial check
     return [
-      { name: myHelloName, modifyTime: mtime },
-      { name: peerHelloName, modifyTime: mtime },
+      { name: myHelloName, modifyTime: mtime, size: 0 },
+      { name: peerHelloName, modifyTime: mtime, size: 0 },
     ];
   };
   // Default mock createExclusive succeeds (no EEXIST) — this conn is the
@@ -1070,8 +1120,8 @@ test("synchronize() two-hellos branch: tiebreaker uses UUID order only, ignoring
       // This side's own hello carries the EARLIER timestamp; under a
       // modifyTime tiebreaker that would mark this side as "arrived first".
       return [
-        { name: myHelloName, modifyTime: 1000 },
-        { name: peerHelloName, modifyTime: 5000 },
+        { name: myHelloName, modifyTime: 1000, size: 0 },
+        { name: peerHelloName, modifyTime: 5000, size: 0 },
       ];
     };
 
@@ -1113,7 +1163,9 @@ test("synchronize() joiner branch: assigns initiator role and writes own hello a
   conn.id = "ffffffff-ffff-4fff-bfff-ffffffffffff";
   const peerHelloName = `${peerId}.hello`;
   files.set(`${conn.path}/${peerHelloName}`, Buffer.alloc(0));
-  client.list = async () => [{ name: peerHelloName, modifyTime: Date.now() }];
+  client.list = async () => [
+    { name: peerHelloName, modifyTime: Date.now(), size: 0 },
+  ];
 
   await conn.synchronize();
 
@@ -1137,7 +1189,9 @@ test("synchronize() joiner branch: leaves connection unsynchronized when put fai
   conn.id = "ffffffff-ffff-4fff-bfff-ffffffffffff";
   const peerHelloName = `${peerId}.hello`;
   files.set(`${conn.path}/${peerHelloName}`, Buffer.alloc(0));
-  client.list = async () => [{ name: peerHelloName, modifyTime: Date.now() }];
+  client.list = async () => [
+    { name: peerHelloName, modifyTime: Date.now(), size: 0 },
+  ];
   // delete succeeds (default mock behavior); put rejects with a synthetic
   // transport error.
   client.put = async () => {
@@ -1158,28 +1212,30 @@ test("ENOENT counter resets after a clean poll cycle, allowing a fresh set of re
   // resets), then two more ENOENTs. Four total ENOENTs — but split across two
   // groups — must never reach the threshold and must not emit an error.
   const { client } = makeMockClient();
-  let existsCallCount = 0;
+  const peerId = "peer-test";
+  let listCallCount = 0;
   let getCount = 0;
 
   let resolveDone!: () => void;
-  // Resolves once exists() is called a 6th time, confirming all 5 expected
-  // poll cycles (including both ENOENT groups and the reset cycle) are done.
+  // Resolves once list() is called a 6th time, confirming all 5 expected poll
+  // cycles (including both ENOENT groups and the reset cycle) are done.
   const cyclesDone = new Promise<void>((resolve) => {
     resolveDone = resolve;
   });
 
-  client.exists = async () => {
-    existsCallCount++;
-    // Cycles 1–2: true → ENOENT on get (count reaches 2, below threshold 3)
-    // Cycle 3: false → clean poll, counter resets to 0
-    // Cycles 4–5: true → ENOENT on get (count reaches 2 again, still below 3)
-    if (existsCallCount === 6) resolveDone();
-    return (
-      existsCallCount === 1 ||
-      existsCallCount === 2 ||
-      existsCallCount === 4 ||
-      existsCallCount === 5
-    );
+  const match = [{ name: `${peerId}-5.json`, modifyTime: 0, size: 5 }];
+  client.list = async () => {
+    listCallCount++;
+    // Cycles 1-2: match -> ENOENT on get (count reaches 2, below threshold 3)
+    // Cycle 3: empty -> clean poll, counter resets to 0
+    // Cycles 4-5: match -> ENOENT on get (count reaches 2 again, still below 3)
+    if (listCallCount === 6) resolveDone();
+    return listCallCount === 1 ||
+      listCallCount === 2 ||
+      listCallCount === 4 ||
+      listCallCount === 5
+      ? match
+      : [];
   };
   client.get = async (p) => {
     getCount++;
@@ -1190,7 +1246,7 @@ test("ENOENT counter resets after a clean poll cycle, allowing a fresh set of re
   };
 
   const conn = makeConnectedConn(client, { pollingFrequency: 10 });
-  conn.peerId = "peer-test";
+  conn.peerId = peerId;
 
   const errors: unknown[] = [];
   conn.on("error", (err) => errors.push(err));
@@ -1208,4 +1264,209 @@ test("ENOENT counter resets after a clean poll cycle, allowing a fresh set of re
   // consecutive ENOENTs occurred, so no error should be emitted.
   expect(getCount).toBe(4);
   expect(errors).toHaveLength(0);
+});
+
+// --- message filename format -------------------------------------------------
+
+// Drives a poller until `signal` resolves or a safety timeout fires, then
+// stops it. Keeps the message-format tests free of repeated race scaffolding.
+async function runPoller(
+  conn: FileSyncConnection,
+  signal: Promise<void>,
+): Promise<void> {
+  conn.start();
+  await Promise.race([signal, new Promise<void>((r) => setTimeout(r, 2_000))]);
+  conn.stop();
+}
+
+test("send filename is <id>-<byteCount>.json when timestampInFilename is unset", async () => {
+  const { client, files } = makeMockClient();
+  const conn = makeConnectedConn(client);
+
+  await conn.send({ hello: "world" });
+
+  const names = [...files.keys()].map((p) => p.slice("/test/".length));
+  expect(names).toHaveLength(1);
+  // Exactly two segments around the id: `<uuid>-<digits>.json`, no timestamp
+  // or counter inserted.
+  expect(names[0]).toMatch(new RegExp(`^${conn.id}-\\d+\\.json$`));
+});
+
+test("send filename encodes timestamp and zero-padded counter when timestampInFilename is true", async () => {
+  const { client, files } = makeMockClient();
+  const conn = new FileSyncConnection(client, {
+    pollingFrequency: 10,
+    timeToLive: new Date(Date.now() + 5_000),
+    verbose: -1,
+    timestampInFilename: true,
+  });
+  conn.connected = true;
+  conn.path = "/test";
+
+  await conn.send({ first: true });
+  const firstName = [...files.keys()][0].slice("/test/".length);
+  // <id>-<YYYYMMDDTHHMMSS>-<NNN>-<byteCount>.json; counter starts at 000.
+  expect(firstName).toMatch(
+    new RegExp(`^${conn.id}-\\d{8}T\\d{6}-000-\\d+\\.json$`),
+  );
+  // The last segment is the exact serialized byte count.
+  const firstBuf = files.get(`/test/${firstName}`)!;
+  expect(Number(firstName.slice(0, -".json".length).split("-").at(-1))).toBe(
+    firstBuf.length,
+  );
+
+  // Simulate the peer consuming the first message, then send again: the
+  // per-session counter advances to 001.
+  files.clear();
+  await conn.send({ second: true });
+  const secondName = [...files.keys()][0].slice("/test/".length);
+  expect(secondName).toMatch(
+    new RegExp(`^${conn.id}-\\d{8}T\\d{6}-001-\\d+\\.json$`),
+  );
+});
+
+test("poll waits while the file is partially synced and reads it once the size matches", async () => {
+  const { client, files } = makeMockClient();
+  const peerId = "peer-partial";
+  const message = Buffer.from(
+    JSON.stringify({ ts: 1, seq: 0, type: "Object", payload: { value: 42 } }),
+  );
+  const name = `${peerId}-${message.length}.json`;
+  const fullPath = `/test/${name}`;
+
+  let listCount = 0;
+  client.list = async () => {
+    listCount++;
+    // First two cycles: the file is present but not fully synced. It reports a
+    // smaller size and is deliberately absent from the store, so any premature
+    // get() would throw "not found" and surface as an error below.
+    if (listCount <= 2)
+      return [{ name, modifyTime: 0, size: message.length - 5 }];
+    files.set(fullPath, message);
+    return [{ name, modifyTime: 0, size: message.length }];
+  };
+
+  const conn = makeConnectedConn(client, { pollingFrequency: 10 });
+  conn.peerId = peerId;
+
+  const received: unknown[] = [];
+  const errors: unknown[] = [];
+  let notifyReceived!: () => void;
+  const delivered = new Promise<void>((r) => (notifyReceived = r));
+  conn.on("data", (msg) => {
+    received.push(msg);
+    notifyReceived();
+  });
+  conn.on("error", (err) => errors.push(err));
+
+  await runPoller(conn, delivered);
+
+  expect(errors).toHaveLength(0);
+  expect(received).toHaveLength(1);
+  expect((received[0] as Record<string, unknown>)["value"]).toBe(42);
+  // The reader did not act on either partial-sync cycle.
+  expect(listCount).toBeGreaterThanOrEqual(3);
+});
+
+test("poll ignores message files belonging to a different peer", async () => {
+  const { client } = makeMockClient();
+  const peerId = "peer-a";
+
+  let listCount = 0;
+  let notifyEnough!: () => void;
+  const enoughCycles = new Promise<void>((r) => (notifyEnough = r));
+  // Only a different peer's message file is present; it pattern-matches
+  // `*-<count>.json` but not our peer-scoped `<peerId>-` prefix.
+  client.list = async () => {
+    listCount++;
+    if (listCount >= 4) notifyEnough();
+    return [{ name: "peer-b-7.json", modifyTime: 0, size: 7 }];
+  };
+  let getCalled = false;
+  client.get = async () => {
+    getCalled = true;
+    return Buffer.alloc(0) as Buffer<ArrayBufferLike>;
+  };
+
+  const conn = makeConnectedConn(client, { pollingFrequency: 10 });
+  conn.peerId = peerId;
+
+  const received: unknown[] = [];
+  const errors: unknown[] = [];
+  conn.on("data", (msg) => received.push(msg));
+  conn.on("error", (err) => errors.push(err));
+
+  await runPoller(conn, enoughCycles);
+
+  expect(getCalled).toBe(false);
+  expect(received).toHaveLength(0);
+  expect(errors).toHaveLength(0);
+});
+
+test("poll extracts the byte count from the last segment when the filename has many segments", async () => {
+  const { client, files } = makeMockClient();
+  // A peer id containing hyphens plus an inserted timestamp and counter: the
+  // right-anchored parse must still read the byte count from the final segment.
+  const peerId = "00000000-0000-4000-8000-000000000abc";
+  const message = Buffer.from(
+    JSON.stringify({ ts: 1, seq: 7, type: "Object", payload: { ok: true } }),
+  );
+  const name = `${peerId}-20260529T142301-007-${message.length}.json`;
+  files.set(`/test/${name}`, message);
+
+  client.list = async () => [{ name, modifyTime: 0, size: message.length }];
+
+  const conn = makeConnectedConn(client, { pollingFrequency: 10 });
+  conn.peerId = peerId;
+
+  const received: unknown[] = [];
+  const errors: unknown[] = [];
+  let notifyReceived!: () => void;
+  const delivered = new Promise<void>((r) => (notifyReceived = r));
+  conn.on("data", (msg) => {
+    received.push(msg);
+    notifyReceived();
+  });
+  conn.on("error", (err) => errors.push(err));
+
+  await runPoller(conn, delivered);
+
+  expect(errors).toHaveLength(0);
+  expect(received).toHaveLength(1);
+  expect((received[0] as Record<string, unknown>)["ok"]).toBe(true);
+});
+
+test("poll ignores a prefix-matching file whose final segment is not a byte count", async () => {
+  // A leftover or foreign file sharing the peer's id prefix but not encoding a
+  // byte count (e.g. `<peerId>-backup.json`) must be ignored, not treated as a
+  // fatal protocol error: the exact-name lookup it replaced never matched such
+  // a file. The real message alongside it is still delivered.
+  const { client, files } = makeMockClient();
+  const peerId = "peer-leftover";
+  const message = Buffer.from(
+    JSON.stringify({ ts: 1, seq: 0, type: "Object", payload: { ok: true } }),
+  );
+  files.set(`/test/${peerId}-${message.length}.json`, message);
+  files.set(`/test/${peerId}-backup.json`, Buffer.from("not a message"));
+
+  const conn = makeConnectedConn(client, { pollingFrequency: 10 });
+  conn.peerId = peerId;
+
+  const received: unknown[] = [];
+  const errors: unknown[] = [];
+  let notifyReceived!: () => void;
+  const delivered = new Promise<void>((r) => (notifyReceived = r));
+  conn.on("data", (msg) => {
+    received.push(msg);
+    notifyReceived();
+  });
+  conn.on("error", (err) => errors.push(err));
+
+  await runPoller(conn, delivered);
+
+  expect(errors).toHaveLength(0);
+  expect(received).toHaveLength(1);
+  expect((received[0] as Record<string, unknown>)["ok"]).toBe(true);
+  // The non-message file is left untouched, not deleted or read.
+  expect(files.has(`/test/${peerId}-backup.json`)).toBe(true);
 });

--- a/packages/core/test/fromEventConnection.test.ts
+++ b/packages/core/test/fromEventConnection.test.ts
@@ -29,7 +29,21 @@ function makeMockClient(): {
   const client: FileTransportClient = {
     connect: async () => {},
     end: async () => {},
-    list: async (): Promise<FileInfo[]> => [],
+    // Reflect the in-memory store so send()/poll(), which detect files via
+    // list() pattern scans, observe the same state get() does.
+    list: async (dir: string): Promise<FileInfo[]> => {
+      const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+      return [...files.entries()]
+        .filter(
+          ([p]) =>
+            p.startsWith(prefix) && !p.slice(prefix.length).includes("/"),
+        )
+        .map(([p, buf]) => ({
+          name: p.slice(prefix.length),
+          modifyTime: 0,
+          size: buf.length,
+        }));
+    },
     get: async (path: string) => {
       const data = files.get(path);
       if (!data) throw new Error(`${path}: not found`);
@@ -99,7 +113,8 @@ test("fromEventConnection over FileSyncConnection: a polled message is delivered
   const { client, files } = makeMockClient();
   const conn = makeConnectedConn(client);
   conn.peerId = "peer-test";
-  files.set("/test/peer-test.json", envelope({ hello: "world" }));
+  const body = envelope({ hello: "world" });
+  files.set(`/test/peer-test-${body.length}.json`, body);
 
   const mc = fromEventConnection(conn);
   conn.start();
@@ -117,14 +132,21 @@ test("fromEventConnection over FileSyncConnection: send() writes the outbound me
   const mc = fromEventConnection(conn);
   await mc.send({ ping: 1 });
 
-  expect(files.has(`/test/${conn.id}.json`)).toBe(true);
+  const written = [...files.keys()].filter((p) =>
+    new RegExp(`^/test/${conn.id}-\\d+\\.json$`).test(p),
+  );
+  expect(written).toHaveLength(1);
 });
 
 test("fromEventConnection over FileSyncConnection: a poll-loop error surfaces as a sticky transport ConnectionError", async () => {
   const { client } = makeMockClient();
-  // exists() always true but get() always throws ENOENT: after
-  // MAX_CONSECUTIVE_ENOENT cycles the poller emits a terminal error.
-  client.exists = async () => true;
+  const peerId = "peer-test";
+  // list() always surfaces a matching file (size matches declared) but get()
+  // always throws ENOENT: after MAX_CONSECUTIVE_ENOENT cycles the poller emits
+  // a terminal error.
+  client.list = async () => [
+    { name: `${peerId}-5.json`, modifyTime: 0, size: 5 },
+  ];
   client.get = async (p) => {
     throw Object.assign(
       new Error(`ENOENT: no such file or directory, open '${p}'`),
@@ -132,7 +154,7 @@ test("fromEventConnection over FileSyncConnection: a poll-loop error surfaces as
     );
   };
   const conn = makeConnectedConn(client, { pollingFrequency: 10 });
-  conn.peerId = "peer-test";
+  conn.peerId = peerId;
 
   const mc = fromEventConnection(conn);
   conn.start();
@@ -171,7 +193,10 @@ test("fromEventConnection over FileSyncConnection: a send-time transport failure
   });
   // A previous unconsumed message blocks send(); with a short TTL the wait
   // times out and send() rejects, which the bridge latches as terminal.
-  files.set(`/test/${conn.id}.json`, Buffer.from(JSON.stringify({ stale: 1 })));
+  files.set(
+    `/test/${conn.id}-99.json`,
+    Buffer.from(JSON.stringify({ stale: 1 })),
+  );
 
   const mc = fromEventConnection(conn);
   const err = await mc.send({ next: true }).catch((e: unknown) => e);


### PR DESCRIPTION
## Summary

Message filenames on the `sftp` and `filedrop` channels now encode the serialized byte count as their final hyphen-delimited segment. The receiver extracts the declared count and waits until the on-disk file size matches before reading, so a partial sync delivery is never read as a complete message. An opt-in `timestamp_in_filename` option additionally encodes a UTC timestamp and a per-session sequence number so filename-based logging can recover write order in sync-mediated environments.

Implements project item [193204378](https://github.com/orgs/georgetown-mdi/projects/9/views/2?pane=issue&itemId=193204378) (Issue C of the file-sync hardening series; follows the `.tmp` extension change in #8).

## Changes

`send()` serializes the message to a `Buffer` before constructing the filename, so the encoded byte count is exact, then writes the `.tmp` temp file and renames to the final `.json`. `poll()` switches from an exact-name `exists()` lookup to a `list()`-based pattern scan of `<peerId>-*.json` with right-anchored byte-count parsing (robust to hyphens in party ids), and waits until the observed size matches the declared size before calling `get()`. `FileInfo` gains a `size` field populated by every transport's `list()` (free for SFTP, one `stat` for local FS). The TOCTOU/`consecutiveEnoent` machinery is preserved across the detection-step change.

Filename formats:

- default: `<id>-<byteCount>.json`
- `timestamp_in_filename: true`: `<id>-<YYYYMMDDTHHMMSS>-<NNN>-<byteCount>.json`

A prefix-matching file whose final segment is not a byte count (a leftover or foreign `<peerId>-*.json`) is ignored rather than treated as a fatal error, matching the tolerance of the exact-name lookup it replaces.

## Breaking change

Both parties must run the new filename format; old-format names (`<id>.json`) are no longer recognized. Handshake files keep the `.hello`/`.wave` extensions for now (the unified `-hello.json` convention lands with the ack-file mode issue).

## Testing

- `npm test -w packages/core` — 503 passing (existing mock-driven send/poll/handshake tests updated for the list-based detection and new naming; new tests cover both filename variants, the partial-sync size wait, foreign-peer filtering, right-anchored byte-count extraction, and the ignore-non-message-file path).
- `npm run test:unit -w apps/cli` — 129 passing.
- `npm run lint` and `prettier --check` (source files) clean.
- Real-filesystem round-trip over two `LocalFSClient`-backed connections (object and `Uint8Array` payloads, both filename modes) verified manually.

Docker-based integration tests could not run: the test container's SSH host-key generation fails at boot on this machine (pre-existing, unrelated to this change).

## Review round

This branch was code-reviewed and revised: the unparseable-foreign-file path was downgraded from fatal to ignored (with a covering test), the `<NNN>` counter's widening past message 999 is now documented in both the spec and an inline note, and an unintended whole-file Prettier reformat of `EXCHANGE_SPEC.md` was reverted so the doc diff is limited to the new option row and Message filenames section.
