### PR TITLE
Consolidate the web PSI connection lifecycle and teardown

### DIFF
--- a/apps/web/src/psi/client.ts
+++ b/apps/web/src/psi/client.ts
@@ -5,14 +5,40 @@ import { getLogger } from "@psilink/core";
 import { ConfigManager } from "@utils/clientConfig";
 
 import type { LinkSession } from "@utils/sessions";
+import type { PeerOptions } from "peerjs";
 
 const log = getLogger("client");
 
 const configManager = new ConfigManager();
 const config = await configManager.load();
 
-/** Connects to peer server, gets a peer id, and posts to API. Returns Peer. */
-export function createAndSharePeerId(session: LinkSession): Promise<Peer> {
+/** Constructs a PeerJS {@link Peer}; injectable so the destroy-on-failure path
+ * is unit-testable without a real broker connection. */
+export type PeerFactory = (options: PeerOptions) => Peer;
+
+const defaultPeerFactory: PeerFactory = (options) => new Peer(options);
+
+/**
+ * Connects to the peer server, obtains a peer id, posts it to the rendezvous
+ * API, and resolves the {@link Peer} once the id is published.
+ *
+ * The constructed {@link Peer} only surfaces on success: any pre-resolve
+ * failure - a pre-open `error`, or the post-open id-POST failing (a non-OK
+ * response or a rejected fetch) - destroys it (freeing the broker id) before
+ * rejecting, rather than leaving an open, broker-registered peer the caller
+ * never receives. A `destroy()` is right here - no data channel has carried a
+ * frame yet, so there is nothing to flush.
+ *
+ * @param session  The rendezvous session whose `uuid` the peer id is posted to.
+ * @param options  `peerFactory` injects the {@link Peer} constructor for testing
+ *                 the destroy-on-failure path without a real broker.
+ */
+export function createAndSharePeerId(
+  session: LinkSession,
+  options?: { peerFactory?: PeerFactory },
+): Promise<Peer> {
+  const makePeer = options?.peerFactory ?? defaultPeerFactory;
+
   return new Promise((resolve, reject) => {
     let host = window.location.hostname;
     if (host === "localhost") host = "127.0.0.1";
@@ -22,7 +48,7 @@ export function createAndSharePeerId(session: LinkSession): Promise<Peer> {
       parseInt(window.location.port) ||
       (window.location.protocol == "http" ? 80 : 443);
 
-    const peer = new Peer({
+    const peer = makePeer({
       host: host,
       path: "/api/",
       port: port,
@@ -51,10 +77,21 @@ export function createAndSharePeerId(session: LinkSession): Promise<Peer> {
       },
     });
 
-    peer.once("open", function (id: string) {
+    let settled = false;
+
+    // Pre-resolve failure: this Peer never reached the caller, so destroy it
+    // (freeing the broker id) before rejecting rather than leaking it.
+    const fail = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      peer.destroy();
+      reject(err);
+    };
+
+    peer.once("open", (id: string) => {
       log.info(`got peer id ${id} from peer server; posting to server`);
 
-      fetch(`/api/psi/${session["uuid"]}`, {
+      fetch(`/api/psi/${session.uuid}`, {
         headers: {
           "Content-Type": "application/json",
         },
@@ -62,25 +99,31 @@ export function createAndSharePeerId(session: LinkSession): Promise<Peer> {
         body: JSON.stringify({
           invitedPeerId: id,
         }),
-      }).then((response) => {
-        if (!response.ok) {
-          log.error(
-            `error posting peer id: ${response.status}, text: ${response.statusText}`,
-          );
-          reject(
-            new Error(
+      })
+        .then((response) => {
+          if (!response.ok) {
+            log.error(
               `error posting peer id: ${response.status}, text: ${response.statusText}`,
-            ),
-          );
-        } else {
-          resolve(peer);
-        }
-      });
+            );
+            fail(
+              new Error(
+                `error posting peer id: ${response.status}, text: ${response.statusText}`,
+              ),
+            );
+          } else if (!settled) {
+            settled = true;
+            resolve(peer);
+          }
+        })
+        .catch((err: unknown) => {
+          log.error("error posting peer id:", err);
+          fail(err instanceof Error ? err : new Error(String(err)));
+        });
     });
 
-    peer.on("error", function (err: Error) {
+    peer.on("error", (err: Error) => {
       log.error("error getting peer connection:", err);
-      reject(err);
+      fail(err);
     });
   });
 }

--- a/apps/web/src/psi/exchangeLifecycle.ts
+++ b/apps/web/src/psi/exchangeLifecycle.ts
@@ -1,0 +1,246 @@
+import { getLogger, runExchange } from "@psilink/core";
+
+import { openPeerMessageConnection } from "./peerMessageConnection";
+
+import type { DataConnection } from "peerjs";
+import type Peer from "peerjs";
+
+import type {
+  ExchangeResult,
+  MessageConnection,
+  PreparedExchange,
+  ProcessState,
+} from "@psilink/core";
+import type { PSILibrary } from "@openmined/psi.js/implementation/psi.d.ts";
+
+const log = getLogger("exchangeLifecycle");
+
+/** A single rendered stage in the progress UI (a superset of core's
+ * `ExchangeStageDefinition`, adding the UI {@link ProcessState}). */
+export interface StageDefinition {
+  id: string;
+  label: string;
+  state: ProcessState;
+}
+
+/** Which half of the lifecycle a failure came from, so the UI can choose its
+ * alert: an `"exchange"` failure (acquire/open/run) invites a re-run, whereas an
+ * `"output"` failure means the privacy-sensitive exchange already succeeded and
+ * only local results-file generation failed - the user must not re-run it. This
+ * is an owner-local discriminant, deliberately not {@link ConnectionError} kind:
+ * an output-generation failure is not a connection error. */
+export type ExchangeErrorCategory = "exchange" | "output";
+
+/** The live resources an {@link Acquire} hands the owner on success. */
+export interface AcquiredExchange {
+  peer: Peer;
+  conn: DataConnection;
+  /** The PSI WASM library. Resolved already for the client (it awaits early, to
+   * fail before publishing its peer id); still pending for the server (the
+   * responder must attach its inbound listener before the library resolves), so
+   * the owner does a single uniform `await` that is instant for the client and
+   * real for the server. */
+  psi: Promise<PSILibrary>;
+  prepared: PreparedExchange;
+}
+
+/** The seams an {@link Acquire} drives while it loads/prepares and draws in the
+ * peer. All no-op once the owner's signal aborts. */
+export interface AcquireContext {
+  signal: AbortSignal;
+  /** Activate a stage (e.g. "waiting for peer" immediately before a wait). */
+  onStage: (stageId: string) => void;
+  /** Emit the full per-exchange stage tree, once, after load/prepare. */
+  onStages: (stages: Array<StageDefinition>) => void;
+}
+
+/**
+ * Role-specific acquisition: load/prepare locally, then draw in the peer (last
+ * step), returning the live resources. The only role difference in the
+ * lifecycle. Must be atomic: a failure inside acquisition tears down anything it
+ * built (e.g. `peer.destroy()`) before rejecting, so the owner's teardown latch
+ * only ever covers a successfully-returned `{peer, conn}`.
+ */
+export type Acquire = (context: AcquireContext) => Promise<AcquiredExchange>;
+
+/** Pure output-generation step: build the local results file from the exchange
+ * result and return a URL for it. May throw (classified as `"output"`); runs
+ * inside the owner after the exchange and before teardown. */
+export type GenerateOutput = (
+  result: ExchangeResult,
+  prepared: PreparedExchange,
+) => string;
+
+/** Options for {@link runExchangeLifecycle}. */
+export interface RunExchangeLifecycleOptions {
+  acquire: Acquire;
+  /** This party's PSI handshake role: the web client is the `"initiator"`, the
+   * web server the `"responder"`. */
+  exchangeRole: "initiator" | "responder";
+  signal: AbortSignal;
+  generateOutput: GenerateOutput;
+  onStages: (stages: Array<StageDefinition>) => void;
+  onStage: (stageId: string) => void;
+  onResult: (url: string) => void;
+  onError: (failure: {
+    category: ExchangeErrorCategory;
+    error: unknown;
+  }) => void;
+}
+
+/**
+ * Single owner of the per-exchange lifecycle for both roles. Acquires the
+ * resource (the role's only difference, via `acquire`), runs the exchange, and
+ * guarantees teardown regardless of where a failure lands or whether an unmount
+ * aborts mid-flight.
+ *
+ * Guarantees:
+ * - **Teardown always runs, exactly once, and never throws** (F1, F2). It is a
+ *   run-once latch: even when two triggers race (a wait timeout and an
+ *   unmount-abort), the effect runs once. A teardown-only failure is logged and
+ *   surfaces no alert - the results are available and it is not user-actionable.
+ * - **The exchange-vs-output distinction survives** (F2). A failure from
+ *   acquire/open/run is `"exchange"`; a `generateOutput` throw (the exchange
+ *   already succeeded) is `"output"`; a teardown-only throw raises neither.
+ * - **The broker socket drops on the first inbound frame** (F4), while the data
+ *   channel stays open for the exchange. Best-effort: a throw in that listener
+ *   cannot fail the exchange.
+ * - **Abort tears down in any phase** (F1, F3). On abort the owner closes the
+ *   connection regardless of phase; an in-flight `runExchange` then rejects with
+ *   a `closed` ConnectionError and lands in the same latched teardown. Every
+ *   owner-driven seam no-ops once aborted, so no setState fires after unmount on
+ *   any path (success, progress, or error).
+ */
+export async function runExchangeLifecycle(
+  options: RunExchangeLifecycleOptions,
+): Promise<void> {
+  const {
+    acquire,
+    exchangeRole,
+    signal,
+    generateOutput,
+    onStages,
+    onStage,
+    onResult,
+    onError,
+  } = options;
+
+  // Every owner-driven React seam is a no-op once the signal aborts, so an
+  // unmount that lands in the same tick as a resolving stage/result/error
+  // cannot setState on an unmounted component.
+  const ifLive =
+    <TArgs extends Array<unknown>>(fn: (...args: TArgs) => void) =>
+    (...args: TArgs) => {
+      if (!signal.aborted) fn(...args);
+    };
+  const emitStages = ifLive(onStages);
+  const emitStage = ifLive(onStage);
+  const emitResult = ifLive(onResult);
+  const emitError = ifLive(onError);
+
+  let acquired: AcquiredExchange;
+  try {
+    acquired = await acquire({
+      signal,
+      onStage: emitStage,
+      onStages: emitStages,
+    });
+  } catch (error) {
+    // acquire is atomic: it has already torn down anything it built, so there is
+    // nothing here for the owner to release. On abort, emitError no-ops.
+    emitError({ category: "exchange", error });
+    return;
+  }
+
+  const { peer, conn, psi, prepared } = acquired;
+  let mc: MessageConnection | undefined;
+
+  // F4 trigger: drop the broker signaling socket on the first inbound frame,
+  // keeping the data channel (already open and bidirectional by the time a frame
+  // flows) alive for the exchange. Best-effort and non-throwing: it fires from a
+  // PeerJS listener the run's try/finally cannot catch, and a failed early
+  // disconnect must not fail an otherwise-successful exchange - the end-of-life
+  // latch still drops the peer.
+  const dropBrokerOnFirstFrame = () => {
+    try {
+      peer.disconnect();
+    } catch (err) {
+      log.error("early broker disconnect failed:", err);
+    }
+  };
+
+  // Run-once teardown latch (stronger than idempotent): the effect runs exactly
+  // once even if the function is invoked twice by a timeout/abort race, and it
+  // never throws, so it cannot clobber a more accurate alert.
+  let toreDown = false;
+  const teardown = async () => {
+    if (toreDown) return;
+    toreDown = true;
+    // A late inbound frame must not fire a stray disconnect post-teardown.
+    conn.off("data", dropBrokerOnFirstFrame);
+    try {
+      if (mc !== undefined) {
+        // Flushing close: drains the final outbound frame and detaches the
+        // channel listeners. This is the teardown-exclusive effect.
+        await mc.close();
+      } else {
+        // The wrapper never materialized (abort/timeout before the open await
+        // resolved); hard-close the raw channel so a pending open rejects.
+        conn.close();
+      }
+    } catch (err) {
+      log.error("teardown: closing the connection failed:", err);
+    }
+    // Interim teardown for this item: disconnect() frees the broker id without
+    // abruptly killing the still-flushing channel. The disconnect() -> destroy()
+    // upgrade is a separate follow-up gated on an awaitable flush.
+    try {
+      peer.disconnect();
+    } catch (err) {
+      log.error("teardown: disconnecting the peer failed:", err);
+    }
+  };
+
+  // Already aborted between acquire resolving and here: addEventListener would
+  // never fire post-abort, so tear down what acquire handed us and leave.
+  if (signal.aborted) {
+    await teardown();
+    return;
+  }
+  const onAbort = () => {
+    void teardown();
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  conn.once("data", dropBrokerOnFirstFrame);
+
+  try {
+    // Fixed order, load-bearing for the server's listener-first guarantee (F6):
+    // openPeerMessageConnection attaches the QueuedMessageConnection's inbound
+    // `data` listener synchronously in its constructor, and the server returns
+    // the still-unresolved psi, so `await psi` must stay AFTER the open or the
+    // responder would have no listener during the WASM load and drop the
+    // initiator's unprompted first frame.
+    mc = await openPeerMessageConnection(conn);
+    const psiLibrary = await psi;
+    const result = await runExchange(mc, exchangeRole, prepared, {
+      psiLibrary,
+      onStage: emitStage,
+    });
+    // The privacy-sensitive exchange has succeeded here. A failure building the
+    // local results file is an "output" failure, never an "exchange" one, so the
+    // user is not told to re-run a PSI exchange that in fact already completed.
+    let url: string;
+    try {
+      url = generateOutput(result, prepared);
+    } catch (error) {
+      emitError({ category: "output", error });
+      return;
+    }
+    emitResult(url);
+  } catch (error) {
+    emitError({ category: "exchange", error });
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    await teardown();
+  }
+}

--- a/apps/web/src/psi/peerMessageConnection.ts
+++ b/apps/web/src/psi/peerMessageConnection.ts
@@ -95,7 +95,12 @@ export async function openPeerMessageConnection(
     // The open handshake failed; tear down the half-open channel and its
     // listeners so it does not linger before re-throwing the open error.
     await mc.close();
-    throw err;
+    // waitForConnectionOpen rejects with a bare Error (timeout, pre-open
+    // error/close), so tag it as a `transport` ConnectionError at the boundary;
+    // otherwise a consumer that branches on ConnectionError.kind cannot classify
+    // an open-time failure (F5). asConnectionError passes an existing
+    // ConnectionError through unchanged.
+    throw asConnectionError(err, "transport");
   }
   return mc;
 }

--- a/apps/web/src/psi/server.ts
+++ b/apps/web/src/psi/server.ts
@@ -4,58 +4,178 @@ import { getLogger } from "@psilink/core";
 
 import { ConfigManager } from "@utils/clientConfig";
 
-import type { DataConnection } from "peerjs";
+import { DEFAULT_PEER_WAIT_TIMEOUT_MS } from "./waitForConnection";
+
+import type { DataConnection, PeerOptions } from "peerjs";
 
 const log = getLogger("server");
 
 const configManager = new ConfigManager();
 const config = await configManager.load();
 
-export function waitForPeerId(uuid: string): Promise<string> {
-  return new Promise((resolve, reject) => {
+/** WHATWG `EventSource.CLOSED`, inlined so this module does not depend on the
+ * `EventSource` global (absent under the node unit environment, which injects a
+ * fake via the factory). */
+const EVENT_SOURCE_CLOSED = 2;
+
+/** Constructs a PeerJS `EventSource`; injectable so the timeout/abort path is
+ * unit-testable under `environment: "node"`, where there is no reliable global. */
+export type EventSourceFactory = (
+  url: string,
+  init?: EventSourceInit,
+) => EventSource;
+
+/** Constructs a PeerJS {@link Peer}; injectable so the destroy-on-failure path
+ * is unit-testable without a real broker connection. */
+export type PeerFactory = (options: PeerOptions) => Peer;
+
+const defaultEventSourceFactory: EventSourceFactory = (url, init) =>
+  new EventSource(url, init);
+
+const defaultPeerFactory: PeerFactory = (options) => new Peer(options);
+
+/**
+ * Waits, via the server-sent-events `/wait` stream, for the invited peer to
+ * publish its peer id, resolving with that id.
+ *
+ * The wait is bounded so an operator who never shows up surfaces an error
+ * rather than hanging the page. A settle-once guard makes the first of
+ * {peer id, `{error}` frame, `CLOSED` stream, timeout, abort} win: it closes
+ * the `EventSource`, clears the timer, and detaches the abort listener exactly
+ * once, then settles. This is the helper's own guarantee, independent of any
+ * caller's teardown latch, so cleanup still runs exactly once even when the
+ * timer and an abort fire in the same tick.
+ *
+ * A transient network `error` is tolerated: `EventSource` auto-reconnects
+ * (`readyState === CONNECTING`) and the `/wait` handler re-polls the persisted
+ * session on the fresh request, so only a `CLOSED` stream (or the bound
+ * timeout) is fatal. The application-level `{error}` frame the handler pushes on
+ * session-TTL expiry is recognized explicitly and rejected as "session
+ * expired", distinct from the generic unexpected-message path.
+ *
+ * @param uuid     The rendezvous session id.
+ * @param options  `timeoutMs` overrides the {@link DEFAULT_PEER_WAIT_TIMEOUT_MS}
+ *                 bound; `signal` lets the owner cancel the wait and close the
+ *                 stream promptly on unmount; `eventSourceFactory` injects the
+ *                 `EventSource` constructor for testing.
+ */
+export function waitForPeerId(
+  uuid: string,
+  options?: {
+    timeoutMs?: number;
+    signal?: AbortSignal;
+    eventSourceFactory?: EventSourceFactory;
+  },
+): Promise<string> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_PEER_WAIT_TIMEOUT_MS;
+  const signal = options?.signal;
+  const makeEventSource =
+    options?.eventSourceFactory ?? defaultEventSourceFactory;
+
+  return new Promise<string>((resolve, reject) => {
     log.info(`opening event source at: /api/psi/${uuid}/wait`);
-    const eventSource = new EventSource(`/api/psi/${uuid}/wait`, {
+    const eventSource = makeEventSource(`/api/psi/${uuid}/wait`, {
       withCredentials: true,
     });
-    log.info("created event source at", eventSource.url);
+
+    let settled = false;
+    const settle = (action: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      eventSource.close();
+      action();
+    };
+
+    const onAbort = () =>
+      settle(() => reject(new Error("waiting for the peer id was aborted")));
+
+    const timer = setTimeout(
+      () =>
+        settle(() =>
+          reject(new Error("timed out waiting for the other party to connect")),
+        ),
+      timeoutMs,
+    );
 
     eventSource.addEventListener("message", (event) => {
+      let messageData: unknown;
       try {
-        const messageData = event.data && JSON.parse(event.data);
-        if (!("invitedPeerId" in messageData)) {
-          log.error(
-            "received unexpected message from server:",
-            messageData,
-            "; closing event source",
-          );
-
-          eventSource.close();
-          reject("unexpected message from server: " + event.data);
-        } else {
-          const invitedPeerId = messageData["invitedPeerId"];
-          log.info(`received peer id ${invitedPeerId}`);
-
-          eventSource.close();
-          resolve(invitedPeerId);
-        }
+        messageData = event.data ? JSON.parse(event.data) : undefined;
       } catch (err) {
         log.error("error parsing message:", err);
-        eventSource.close();
-        reject(err);
+        settle(() =>
+          reject(err instanceof Error ? err : new Error(String(err))),
+        );
+        return;
+      }
+
+      const record =
+        typeof messageData === "object" && messageData !== null
+          ? (messageData as Record<string, unknown>)
+          : undefined;
+
+      if (record && "invitedPeerId" in record) {
+        const invitedPeerId = String(record["invitedPeerId"]);
+        log.info(`received peer id ${invitedPeerId}`);
+        settle(() => resolve(invitedPeerId));
+      } else if (record && "error" in record) {
+        // Application-level TTL-expiry frame: the session record is gone, so
+        // continuing to wait is pointless. Fatal, but recognized explicitly so
+        // the operator sees a clear cause rather than the generic path.
+        log.error("session expired while waiting for peer:", record["error"]);
+        settle(() =>
+          reject(new Error("session expired: " + String(record["error"]))),
+        );
+      } else {
+        log.error("received unexpected message from server:", messageData);
+        settle(() =>
+          reject(new Error("unexpected message from server: " + event.data)),
+        );
       }
     });
 
-    eventSource.addEventListener("error", (event) => {
-      log.error("EventSource error: ", event);
-      eventSource.close();
-      reject(new Error("EventSource connection error:" + event.type));
+    eventSource.addEventListener("error", () => {
+      // EventSource auto-reconnects on a transient drop (readyState CONNECTING),
+      // and the /wait handler re-polls the session on the reissued request; only
+      // a CLOSED stream is fatal. Collapsing the reconnect into a reject would
+      // kill a multi-minute human-timescale wait on a brief network blip.
+      if (eventSource.readyState === EVENT_SOURCE_CLOSED) {
+        log.error("EventSource closed while waiting for peer");
+        settle(() => reject(new Error("event source connection closed")));
+      }
     });
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    signal?.addEventListener("abort", onAbort);
   });
 }
 
+/**
+ * Connects to the peer server, obtains a local peer id, and dials `peerId`,
+ * resolving `[peer, conn]` once this side is registered with the broker. The
+ * returned `DataConnection` is not necessarily open yet; the caller bounds the
+ * channel-open handshake separately.
+ *
+ * The constructed {@link Peer} only surfaces on success: a pre-resolve `error`
+ * destroys it (freeing the broker id) before rejecting, rather than leaking a
+ * registered peer the caller never receives. A `destroy()` is right here - no
+ * data channel has carried a frame yet, so there is nothing to flush.
+ *
+ * @param peerId   The invited peer's id to dial.
+ * @param options  `peerFactory` injects the {@link Peer} constructor for testing
+ *                 the destroy-on-failure path without a real broker.
+ */
 export function openPeerConnection(
   peerId: string,
+  options?: { peerFactory?: PeerFactory },
 ): Promise<[Peer, DataConnection]> {
+  const makePeer = options?.peerFactory ?? defaultPeerFactory;
+
   return new Promise((resolve, reject) => {
     let host = window.location.hostname;
     if (host === "localhost") host = "127.0.0.1";
@@ -65,7 +185,7 @@ export function openPeerConnection(
       parseInt(window.location.port) ||
       (window.location.protocol == "http" ? 80 : 443);
 
-    const peer = new Peer({
+    const peer = makePeer({
       host: host,
       path: "/api/",
       port: port,
@@ -95,7 +215,11 @@ export function openPeerConnection(
       },
     });
 
+    let settled = false;
+
     peer.once("open", (id) => {
+      if (settled) return;
+      settled = true;
       log.info(
         `got peer id ${id} from peer server; connecting to peer ${peerId}`,
       );
@@ -104,7 +228,12 @@ export function openPeerConnection(
     });
 
     peer.on("error", (err) => {
+      if (settled) return;
+      settled = true;
       log.error("error getting peer connection:", err);
+      // Pre-resolve failure: this Peer never reached the caller, so destroy it
+      // (freeing the broker id) before rejecting rather than leaking it.
+      peer.destroy();
       reject(err);
     });
   });

--- a/apps/web/src/psi/waitForConnection.ts
+++ b/apps/web/src/psi/waitForConnection.ts
@@ -2,31 +2,69 @@ import type { DataConnection } from "peerjs";
 import type Peer from "peerjs";
 
 /**
- * Provisional ceiling for the invited party to dial in. The proper value (and
- * the surrounding UX) belongs to the web connection-lifecycle consolidation;
- * this exists so a peer that never connects surfaces an error rather than
- * hanging the page indefinitely.
+ * Human-timescale ceiling for one operator to wait for the other party to show
+ * up. Shared by both roles' browsers: the client role's
+ * {@link waitForIncomingConnection} and the server role's browser-side bound on
+ * its SSE wait (`waitForPeerId`). It exists so an abandoned wait surfaces an
+ * error instead of hanging the page.
+ *
+ * It sits *under* the rendezvous session TTL (15 min by default), which is the
+ * true outer bound on a wait, so this is a secondary cap. It is distinct from
+ * the 30s channel-open bound in `waitForOpen.ts`, which times the WebRTC
+ * handshake once both peers are already dialing.
  */
-export const DEFAULT_CONNECT_TIMEOUT_MS = 5 * 60 * 1000;
+export const DEFAULT_PEER_WAIT_TIMEOUT_MS = 10 * 60 * 1000;
 
 /**
  * Resolves with the first incoming {@link DataConnection} on `peer`, or rejects
- * if none arrives within `timeoutMs`. The `connection` listener and the timer
- * are torn down on whichever branch runs, so nothing outlives the wait.
+ * if none arrives within `timeoutMs`, or if `signal` aborts first.
+ *
+ * A settle-once guard makes the first of {connection, timeout, abort} win: it
+ * runs the helper-local cleanup (drop the `connection` listener, clear the
+ * timer, detach the abort listener) exactly once and settles the promise; the
+ * rest are no-ops. The guard is the helper's own, independent of any caller's
+ * teardown latch, so cleanup still runs exactly once even when the timer and an
+ * abort fire in the same tick.
+ *
+ * @param peer     The local PeerJS peer awaiting an inbound connection.
+ * @param options  `timeoutMs` overrides the {@link DEFAULT_PEER_WAIT_TIMEOUT_MS}
+ *                 bound; `signal` lets the owner cancel the wait (on unmount or
+ *                 a sibling teardown) and settle it promptly rather than leaving
+ *                 the promise pending until the timer fires.
  */
 export function waitForIncomingConnection(
   peer: Peer,
-  timeoutMs: number = DEFAULT_CONNECT_TIMEOUT_MS,
+  options?: { timeoutMs?: number; signal?: AbortSignal },
 ): Promise<DataConnection> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_PEER_WAIT_TIMEOUT_MS;
+  const signal = options?.signal;
   return new Promise<DataConnection>((resolve, reject) => {
-    const onConnection = (conn: DataConnection) => {
-      clearTimeout(timer);
-      resolve(conn);
-    };
-    const timer = setTimeout(() => {
+    let settled = false;
+    const settle = (action: () => void) => {
+      if (settled) return;
+      settled = true;
       peer.off("connection", onConnection);
-      reject(new Error("timed out waiting for the other party to connect"));
-    }, timeoutMs);
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      action();
+    };
+    const onConnection = (conn: DataConnection) => settle(() => resolve(conn));
+    const onAbort = () =>
+      settle(() =>
+        reject(new Error("waiting for the other party to connect was aborted")),
+      );
+    const timer = setTimeout(
+      () =>
+        settle(() =>
+          reject(new Error("timed out waiting for the other party to connect")),
+        ),
+      timeoutMs,
+    );
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
     peer.once("connection", onConnection);
+    signal?.addEventListener("abort", onAbort);
   });
 }

--- a/apps/web/src/routes/psi.tsx
+++ b/apps/web/src/routes/psi.tsx
@@ -2,7 +2,7 @@ import log from "loglevel";
 
 import { createFileRoute, useSearch } from "@tanstack/react-router";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
   ActionIcon,
@@ -28,13 +28,13 @@ import {
   ProcessState,
   buildOutputTable,
   describeExchangeStages,
+  errorMessage,
   loadCSVFile,
   prepareForExchange,
-  runExchange,
 } from "@psilink/core";
 import { openPeerConnection, waitForPeerId } from "@psi/server";
 import { createAndSharePeerId } from "@psi/client";
-import { openPeerMessageConnection } from "@psi/peerMessageConnection";
+import { runExchangeLifecycle } from "@psi/exchangeLifecycle";
 import { waitForIncomingConnection } from "@psi/waitForConnection";
 
 import FileSelect from "@components/FileSelect";
@@ -43,14 +43,8 @@ import { Status } from "@components/Status";
 
 import type { PSILibrary } from "@openmined/psi.js/implementation/psi.d.ts";
 
-import type { DataConnection } from "peerjs";
-import type Peer from "peerjs";
-
-import type {
-  ExchangeResult,
-  MessageConnection,
-  PreparedExchange,
-} from "@psilink/core";
+import type { Acquire, StageDefinition } from "@psi/exchangeLifecycle";
+import type { ExchangeResult, PreparedExchange } from "@psilink/core";
 import type { LinkSession } from "@utils/sessions";
 
 export const Route = createFileRoute("/psi")({
@@ -77,8 +71,6 @@ export const Route = createFileRoute("/psi")({
   component: Home,
 });
 
-type StageDefinition = { id: string; label: string; state: ProcessState };
-
 const serverPreStages: Array<StageDefinition> = [
   {
     id: "before start",
@@ -98,6 +90,11 @@ const clientPreStages: Array<StageDefinition> = [
     label: "Before start",
     state: ProcessState.BeforeStart,
   },
+  {
+    id: "waiting for peer",
+    label: "Waiting for peer",
+    state: ProcessState.Waiting,
+  },
 ];
 
 const doneStage: StageDefinition = {
@@ -106,15 +103,35 @@ const doneStage: StageDefinition = {
   state: ProcessState.Done,
 };
 
+function preStagesFor(role: "server" | "client"): Array<StageDefinition> {
+  return role === "server" ? serverPreStages : clientPreStages;
+}
+
 function buildInitialStages(role: "server" | "client"): Array<StageDefinition> {
-  const preStages = role === "server" ? serverPreStages : clientPreStages;
   return [
-    ...preStages,
+    ...preStagesFor(role),
     {
       id: CONFIRMING_PROTOCOL_STAGE_ID,
       label: "Confirming protocol",
       state: ProcessState.Working,
     },
+    doneStage,
+  ];
+}
+
+/** Full per-exchange stage tree, emitted once after load/prepare via `onStages`:
+ * the role's pre-stages, the protocol stages derived from the prepared exchange,
+ * and the terminal done stage. */
+function buildStageList(
+  role: "server" | "client",
+  prepared: PreparedExchange,
+): Array<StageDefinition> {
+  return [
+    ...preStagesFor(role),
+    ...describeExchangeStages(prepared).map((stage) => ({
+      ...stage,
+      state: ProcessState.Working as const,
+    })),
     doneStage,
   ];
 }
@@ -141,173 +158,121 @@ function Home() {
     message: string;
   }>();
 
+  // Drives the lifecycle's AbortSignal. A useEffect cleanup aborts it on
+  // unmount, so the owner tears down any in-flight wait or exchange and every
+  // owner-driven seam stops firing (no setState after unmount).
+  const abortRef = useRef<AbortController | undefined>(undefined);
+  useEffect(() => () => abortRef.current?.abort(), []);
+
   const handleSubmit = () => {
     setSubmitted(true);
     setErrorAlert(undefined);
 
-    const describeError = (error: unknown) =>
-      error instanceof Error ? error.message : String(error);
+    const controller = new AbortController();
+    abortRef.current = controller;
 
-    const handleFailure = (error: unknown) => {
-      console.error(error);
-      setErrorAlert({
-        title: "Exchange failed",
-        message: describeError(error),
-      });
-    };
-
-    const finishExchange = (
-      { associationTable, partnerPayload }: ExchangeResult,
+    // Pure output-generation half of the former finishExchange: build the local
+    // results file and return its URL. No React state and no previous-URL revoke
+    // (a fresh session sets the URL at most once per component lifetime).
+    const generateOutput = (
+      result: ExchangeResult,
       prepared: PreparedExchange,
-    ) => {
+    ): string => {
       log.info("linkage complete, generating results file");
       const { headers, rows } = buildOutputTable(
-        associationTable,
+        result.associationTable,
         prepared.rawRows,
         prepared.metadata,
-        partnerPayload,
+        result.partnerPayload,
       );
       const csv =
         headers.join(",") + "\n" + rows.map((r) => r.join(",") + "\n").join("");
       const fileData = new Blob([csv], { type: "text/csv" });
-      const newResultURL = window.URL.createObjectURL(fileData);
-      if (resultURL !== undefined) window.URL.revokeObjectURL(resultURL);
-      setResultURL(newResultURL);
-      setStageById("done");
+      return window.URL.createObjectURL(fileData);
     };
 
-    // Shared per-connection lifecycle for both roles: open a MessageConnection,
-    // run the exchange, surface the result or the failure, and always tear down.
-    // `psi` may still be loading - opening the connection first attaches the
-    // inbound listener (so the initiator's unprompted first frame is not
-    // dropped) while the WASM library finishes in parallel.
-    const runExchangeOn = async (
-      conn: DataConnection,
-      exchangeRole: "initiator" | "responder",
-      prepared: PreparedExchange,
-      // Either the still-loading library (server: passed before the WASM load
-      // resolves, so the inbound listener attaches first) or an already-loaded
-      // one (client: resolved before the connection handler runs). await covers
-      // both, so the union is intentional, not a dead branch.
-      psi: PSILibrary | Promise<PSILibrary>,
-      peer: Peer,
-    ) => {
-      let mc: MessageConnection | undefined;
+    // Server (PSI responder, PeerJS dialer): load/prepare, emit the stage tree,
+    // then wait for the invited peer id over SSE and dial. The WASM library
+    // stays pending - the responder must attach its inbound listener before it
+    // resolves - so it is returned unresolved and awaited late inside the owner.
+    const serverAcquire: Acquire = async ({ signal, onStage, onStages }) => {
+      const psi = PSI() as Promise<PSILibrary>;
+      const csvResult = await loadCSVFile(files[0]);
+      const rawRows = csvResult.data as Array<Record<string, string>>;
+      const prepared = prepareForExchange(
+        {}, // no explicit spec; infer from input
+        session.initiatedName,
+        rawRows,
+        csvResult.meta.fields ?? [],
+      );
+      onStages(buildStageList("server", prepared));
+
+      onStage("waiting for peer");
+      const peerId = await waitForPeerId(session.uuid, { signal });
+      const [peer, conn] = await openPeerConnection(peerId);
+      return { peer, conn, psi, prepared };
+    };
+
+    // Client (PSI initiator, PeerJS receiver): load/prepare, emit the stage
+    // tree, await the WASM early (fail before publishing the peer id), publish
+    // the id, then wait for the incoming connection. A wait failure destroys the
+    // published peer so acquisition stays atomic.
+    const clientAcquire: Acquire = async ({ signal, onStage, onStages }) => {
+      const psi = PSI() as Promise<PSILibrary>;
+      const csvResult = await loadCSVFile(files[0]);
+      const rawRows = csvResult.data as Array<Record<string, string>>;
+      const prepared = prepareForExchange(
+        {}, // no explicit spec; infer from input
+        session.invitedName,
+        rawRows,
+        csvResult.meta.fields ?? [],
+      );
+      onStages(buildStageList("client", prepared));
+
+      await psi;
+      const peer = await createAndSharePeerId(session);
       try {
-        mc = await openPeerMessageConnection(conn);
-        const exchangeResult = await runExchange(mc, exchangeRole, prepared, {
-          psiLibrary: await psi,
-          onStage: setStageById,
-        });
-        // The privacy-sensitive exchange has completed by here; a failure
-        // building the local results file must not be reported as an exchange
-        // failure, or the user may needlessly re-run a PSI exchange that in
-        // fact already succeeded.
-        try {
-          finishExchange(exchangeResult, prepared);
-        } catch (error) {
-          console.error(error);
+        onStage("waiting for peer");
+        const conn = await waitForIncomingConnection(peer, { signal });
+        return { peer, conn, psi, prepared };
+      } catch (error) {
+        // The peer was published but no data channel ever opened, so destroy it
+        // (freeing the broker id) before propagating - acquisition is atomic.
+        peer.destroy();
+        throw error;
+      }
+    };
+
+    void runExchangeLifecycle({
+      acquire: role === "server" ? serverAcquire : clientAcquire,
+      exchangeRole: role === "server" ? "responder" : "initiator",
+      signal: controller.signal,
+      generateOutput,
+      onStages: setStages,
+      onStage: setStageById,
+      onResult: (url) => {
+        setResultURL(url);
+        setStageById("done");
+      },
+      onError: ({ category, error }) => {
+        console.error(error);
+        if (category === "output") {
+          // The exchange succeeded; only results-file generation failed. The
+          // user must not be told to re-run a privacy-sensitive exchange.
           setErrorAlert({
             title: "Results unavailable",
             message:
               "The linkage completed, but generating the results file failed: " +
-              describeError(error),
+              errorMessage(error),
+          });
+        } else {
+          setErrorAlert({
+            title: "Exchange failed",
+            message: errorMessage(error),
           });
         }
-      } catch (error) {
-        handleFailure(error);
-      } finally {
-        // Teardown must not throw: a rejection here would propagate past the
-        // handlers above and overwrite a more accurate alert (e.g. the
-        // "Results unavailable" set when only output generation failed).
-        try {
-          peer.disconnect();
-        } catch (teardownError) {
-          console.error(teardownError);
-        }
-        try {
-          await mc?.close();
-        } catch (teardownError) {
-          console.error(teardownError);
-        }
-      }
-    };
-
-    if (role === "server") {
-      setStageById("waiting for peer");
-      waitForPeerId(session.uuid)
-        .then(async (peerId) => {
-          // Load and prepare before dialing the peer. Opening the connection
-          // resolves a live Peer/DataConnection that only runExchangeOn tears
-          // down, so a CSV or standardization failure must happen before it
-          // exists, not after, or the connection leaks. The WASM load still
-          // runs in parallel and is awaited (with the inbound listener already
-          // attached) inside runExchangeOn.
-          const psi = PSI() as Promise<PSILibrary>;
-          const csvResult = await loadCSVFile(files[0]);
-          const rawRows = csvResult.data as Array<Record<string, string>>;
-          const prepared = prepareForExchange(
-            {}, // no explicit spec; infer from input
-            session.initiatedName,
-            rawRows,
-            csvResult.meta.fields ?? [],
-          );
-          setStages([
-            ...serverPreStages,
-            ...describeExchangeStages(prepared).map((s) => ({
-              ...s,
-              state: ProcessState.Working as const,
-            })),
-            doneStage,
-          ]);
-
-          const [peer, conn] = await openPeerConnection(peerId);
-          await runExchangeOn(conn, "responder", prepared, psi, peer);
-        })
-        .catch((error) => {
-          handleFailure(error);
-        });
-    } else {
-      // role is client
-      setStageById("before start");
-      Promise.all([PSI() as Promise<PSILibrary>, loadCSVFile(files[0])])
-        .then(async ([psi, csvResult]) => {
-          const rawRows = csvResult.data as Array<Record<string, string>>;
-          const prepared = prepareForExchange(
-            {}, // no explicit spec; infer from input
-            session.invitedName,
-            rawRows,
-            csvResult.meta.fields ?? [],
-          );
-          setStages([
-            ...clientPreStages,
-            ...describeExchangeStages(prepared).map((s) => ({
-              ...s,
-              state: ProcessState.Working as const,
-            })),
-            doneStage,
-          ]);
-
-          const peer = await createAndSharePeerId(session);
-
-          try {
-            // A single exchange runs per session: take the first incoming
-            // connection, bounded so a peer that never dials in surfaces an
-            // error instead of hanging on "Confirming protocol" forever.
-            const conn = await waitForIncomingConnection(peer);
-            await runExchangeOn(conn, "initiator", prepared, psi, peer);
-          } catch (error) {
-            // Reached only when no peer dialed in within the deadline;
-            // runExchangeOn handles and tears down its own failures. Drop the
-            // peer we created so the timed-out attempt does not leak it.
-            handleFailure(error);
-            peer.disconnect();
-          }
-        })
-        .catch((error) => {
-          handleFailure(error);
-        });
-    }
+      },
+    });
   };
 
   let url: URL | undefined;

--- a/apps/web/test/unit/client.test.ts
+++ b/apps/web/test/unit/client.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { default as EventEmitter } from "eventemitter3";
+
+import { createAndSharePeerId } from "../../src/psi/client.js";
+
+import type Peer from "peerjs";
+
+import type { LinkSession } from "../../src/utils/sessions.js";
+
+const session = { uuid: "test-uuid" } as unknown as LinkSession;
+
+class FakePeer extends EventEmitter {
+  destroy = vi.fn();
+  disconnect = vi.fn();
+  connect = vi.fn();
+}
+
+describe("createAndSharePeerId destroy-on-failure", () => {
+  beforeEach(() => {
+    vi.stubGlobal("window", {
+      location: { hostname: "localhost", port: "3000", protocol: "http:" },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("resolves the Peer once the id POST succeeds, without destroying it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ ok: true, status: 200, statusText: "OK" })),
+    );
+    const fake = new FakePeer();
+    const promise = createAndSharePeerId(session, {
+      peerFactory: () => fake as unknown as Peer,
+    });
+
+    fake.emit("open", "my-peer-id");
+
+    expect(await promise).toBe(fake as unknown as Peer);
+    expect(fake.destroy).not.toHaveBeenCalled();
+  });
+
+  test("destroys the Peer and rejects when the id POST returns a non-OK response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({ ok: false, status: 500, statusText: "boom" }),
+      ),
+    );
+    const fake = new FakePeer();
+    const promise = createAndSharePeerId(session, {
+      peerFactory: () => fake as unknown as Peer,
+    });
+
+    fake.emit("open", "my-peer-id");
+
+    await expect(promise).rejects.toThrow("error posting peer id");
+    expect(fake.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test("destroys the Peer and rejects when the id POST fetch is rejected", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("network down"))),
+    );
+    const fake = new FakePeer();
+    const promise = createAndSharePeerId(session, {
+      peerFactory: () => fake as unknown as Peer,
+    });
+
+    fake.emit("open", "my-peer-id");
+
+    await expect(promise).rejects.toThrow("network down");
+    expect(fake.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test("destroys the Peer and rejects on a pre-open error", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+    const fake = new FakePeer();
+    const promise = createAndSharePeerId(session, {
+      peerFactory: () => fake as unknown as Peer,
+    });
+
+    fake.emit("error", new Error("broker unreachable"));
+
+    await expect(promise).rejects.toThrow("broker unreachable");
+    expect(fake.destroy).toHaveBeenCalledTimes(1);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/test/unit/exchangeLifecycle.test.ts
+++ b/apps/web/test/unit/exchangeLifecycle.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { default as EventEmitter } from "eventemitter3";
+
+import { ConnectionError, runExchange } from "@psilink/core";
+
+import { openPeerMessageConnection } from "../../src/psi/peerMessageConnection.js";
+import { runExchangeLifecycle } from "../../src/psi/exchangeLifecycle.js";
+
+import type {
+  Acquire,
+  AcquiredExchange,
+} from "../../src/psi/exchangeLifecycle.js";
+
+import type { DataConnection } from "peerjs";
+import type Peer from "peerjs";
+
+import type {
+  ExchangeResult,
+  MessageConnection,
+  PreparedExchange,
+} from "@psilink/core";
+import type { PSILibrary } from "@openmined/psi.js/implementation/psi.d.ts";
+
+// runExchange and the open-handshake are the two heavy operations the owner runs
+// uniformly; mock them so the contract (teardown, abort, error classification,
+// first-frame disconnect) is observable without a real peer or WASM library.
+vi.mock("../../src/psi/peerMessageConnection.js", () => ({
+  openPeerMessageConnection: vi.fn(),
+}));
+vi.mock("@psilink/core", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, runExchange: vi.fn() };
+});
+
+const mockedOpen = vi.mocked(openPeerMessageConnection);
+const mockedRunExchange = vi.mocked(runExchange);
+
+/** Flush pending microtasks (and any queued macrotask) so the owner advances. */
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+class FakeConn extends EventEmitter {
+  close = vi.fn();
+}
+
+class FakePeer extends EventEmitter {
+  disconnect = vi.fn();
+  destroy = vi.fn();
+}
+
+/** A MessageConnection whose parked `receive` is rejected with a `closed`
+ * ConnectionError by `close`, mirroring how a deliberate teardown unwinds an
+ * in-flight `runExchange`. */
+function makeFakeMc() {
+  let rejectParked: ((reason: unknown) => void) | undefined;
+  const close = vi.fn((): Promise<void> => {
+    rejectParked?.(new ConnectionError("connection closed", "closed"));
+    return Promise.resolve();
+  });
+  const receive = vi.fn(
+    () =>
+      new Promise((_resolve, reject) => {
+        rejectParked = reject;
+      }),
+  );
+  const send = vi.fn((): Promise<void> => Promise.resolve());
+  return {
+    mc: { close, receive, send } as unknown as MessageConnection,
+    close,
+  };
+}
+
+function makeResources(overrides?: { peer?: FakePeer; conn?: FakeConn }) {
+  const peer = overrides?.peer ?? new FakePeer();
+  const conn = overrides?.conn ?? new FakeConn();
+  const acquired: AcquiredExchange = {
+    peer: peer as unknown as Peer,
+    conn: conn as unknown as DataConnection,
+    psi: Promise.resolve({} as PSILibrary),
+    prepared: {} as PreparedExchange,
+  };
+  return { acquired, peer, conn };
+}
+
+function seams() {
+  return {
+    onStages: vi.fn(),
+    onStage: vi.fn(),
+    onResult: vi.fn(),
+    onError: vi.fn(),
+    generateOutput: vi.fn(() => "blob:results"),
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runExchangeLifecycle", () => {
+  beforeEach(() => {
+    // Default happy mocks; individual tests override as needed.
+    mockedRunExchange.mockResolvedValue({} as ExchangeResult);
+  });
+
+  test("success: reports the result, then tears down", async () => {
+    const { mc, close } = makeFakeMc();
+    mockedOpen.mockResolvedValue(mc);
+    const { acquired, peer } = makeResources();
+    const acquire: Acquire = () => Promise.resolve(acquired);
+    const s = seams();
+
+    await runExchangeLifecycle({
+      acquire,
+      exchangeRole: "initiator",
+      signal: new AbortController().signal,
+      ...s,
+    });
+
+    expect(s.generateOutput).toHaveBeenCalledTimes(1);
+    expect(s.onResult).toHaveBeenCalledWith("blob:results");
+    expect(s.onError).not.toHaveBeenCalled();
+    // Teardown ran: the flushing close (teardown-exclusive) once, and the peer
+    // was disconnected.
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(peer.disconnect).toHaveBeenCalled();
+  });
+
+  test("an acquire failure is category 'exchange' and needs no owner teardown", async () => {
+    const acquire: Acquire = () => Promise.reject(new Error("CSV load failed"));
+    const s = seams();
+
+    await runExchangeLifecycle({
+      acquire,
+      exchangeRole: "responder",
+      signal: new AbortController().signal,
+      ...s,
+    });
+
+    expect(s.onError).toHaveBeenCalledWith({
+      category: "exchange",
+      error: expect.any(Error),
+    });
+    expect(s.onResult).not.toHaveBeenCalled();
+    expect(mockedOpen).not.toHaveBeenCalled();
+  });
+
+  test("a runExchange failure is classified as category 'exchange'", async () => {
+    const { mc } = makeFakeMc();
+    mockedOpen.mockResolvedValue(mc);
+    mockedRunExchange.mockRejectedValue(new Error("protocol blew up"));
+    const { acquired } = makeResources();
+    const acquire: Acquire = () => Promise.resolve(acquired);
+    const s = seams();
+
+    await runExchangeLifecycle({
+      acquire,
+      exchangeRole: "initiator",
+      signal: new AbortController().signal,
+      ...s,
+    });
+
+    expect(s.onError).toHaveBeenCalledWith({
+      category: "exchange",
+      error: expect.any(Error),
+    });
+    expect(s.onResult).not.toHaveBeenCalled();
+  });
+
+  test("a generateOutput failure is category 'output' (the exchange succeeded)", async () => {
+    const { mc } = makeFakeMc();
+    mockedOpen.mockResolvedValue(mc);
+    const { acquired } = makeResources();
+    const acquire: Acquire = () => Promise.resolve(acquired);
+    const s = seams();
+    s.generateOutput.mockImplementation(() => {
+      throw new Error("could not build CSV");
+    });
+
+    await runExchangeLifecycle({
+      acquire,
+      exchangeRole: "initiator",
+      signal: new AbortController().signal,
+      ...s,
+    });
+
+    expect(s.onError).toHaveBeenCalledWith({
+      category: "output",
+      error: expect.any(Error),
+    });
+    expect(s.onResult).not.toHaveBeenCalled();
+  });
+
+  test("a teardown-only failure preserves the result and raises no alert", async () => {
+    const { mc, close } = makeFakeMc();
+    close.mockImplementation(() => Promise.reject(new Error("close blew up")));
+    mockedOpen.mockResolvedValue(mc);
+    const { acquired } = makeResources();
+    const acquire: Acquire = () => Promise.resolve(acquired);
+    const s = seams();
+
+    await runExchangeLifecycle({
+      acquire,
+      exchangeRole: "initiator",
+      signal: new AbortController().signal,
+      ...s,
+    });
+
+    // The exchange and output both succeeded; only teardown threw, so the
+    // success state survives and neither alert is shown (F2).
+    expect(s.onResult).toHaveBeenCalledWith("blob:results");
+    expect(s.onError).not.toHaveBeenCalled();
+  });
+
+  test("drops the broker on the first inbound frame, armed before the open await", async () => {
+    const { acquired, peer, conn } = makeResources();
+    const opened = deferred<MessageConnection>();
+    mockedOpen.mockReturnValue(opened.promise);
+    const acquire: Acquire = () => Promise.resolve(acquired);
+    const s = seams();
+
+    const run = runExchangeLifecycle({
+      acquire,
+      exchangeRole: "initiator",
+      signal: new AbortController().signal,
+      ...s,
+    });
+
+    // Let acquire resolve so the owner has attached conn.once("data") and is now
+    // parked on the (still pending) open await.
+    await tick();
+    expect(peer.disconnect).not.toHaveBeenCalled();
+    conn.emit("data", "first frame");
+    expect(peer.disconnect).toHaveBeenCalledTimes(1);
+
+    // Finish opening so the run can complete cleanly.
+    opened.resolve(makeFakeMc().mc);
+    await run;
+    expect(s.onResult).toHaveBeenCalled();
+  });
+
+  test("a throw in the first-frame disconnect does not fail the exchange", async () => {
+    const peer = new FakePeer();
+    peer.disconnect.mockImplementationOnce(() => {
+      throw new Error("disconnect boom");
+    });
+    const { acquired, conn } = makeResources({ peer });
+    mockedOpen.mockResolvedValue(makeFakeMc().mc);
+    const acquire: Acquire = () => Promise.resolve(acquired);
+    const s = seams();
+
+    const run = runExchangeLifecycle({
+      acquire,
+      exchangeRole: "initiator",
+      signal: new AbortController().signal,
+      ...s,
+    });
+    await tick();
+    conn.emit("data", "first frame");
+    await run;
+
+    expect(s.onResult).toHaveBeenCalled();
+    expect(s.onError).not.toHaveBeenCalled();
+  });
+
+  test("abort mid-run closes the connection, the run rejects, teardown runs once, no alert", async () => {
+    const { mc, close } = makeFakeMc();
+    mockedOpen.mockResolvedValue(mc);
+    // runExchange parks on a receive that the teardown close() will reject.
+    mockedRunExchange.mockImplementation(
+      async (c) => (await c.receive()) as ExchangeResult,
+    );
+    const controller = new AbortController();
+    const { acquired, peer } = makeResources();
+    const acquire: Acquire = () => Promise.resolve(acquired);
+    const s = seams();
+
+    const run = runExchangeLifecycle({
+      acquire,
+      exchangeRole: "initiator",
+      signal: controller.signal,
+      ...s,
+    });
+    await tick(); // reach the parked receive inside runExchange
+    controller.abort();
+    await run;
+
+    expect(close).toHaveBeenCalledTimes(1); // teardown-exclusive effect, once
+    expect(peer.disconnect).toHaveBeenCalled();
+    expect(s.onError).not.toHaveBeenCalled(); // abort is silent
+    expect(s.onResult).not.toHaveBeenCalled();
+  });
+
+  test("abort during a wait settles silently and tears down nothing it never held", async () => {
+    const controller = new AbortController();
+    // acquire models a wait that settles (rejects) when the owner's signal aborts.
+    const acquire: Acquire = ({ signal }) =>
+      new Promise<AcquiredExchange>((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => reject(new Error("wait aborted")),
+          { once: true },
+        );
+      });
+    const s = seams();
+
+    const run = runExchangeLifecycle({
+      acquire,
+      exchangeRole: "responder",
+      signal: controller.signal,
+      ...s,
+    });
+    await tick();
+    controller.abort();
+    await run;
+
+    // The aborted wait is a deliberate user-leave, not a failure: no alert.
+    expect(s.onError).not.toHaveBeenCalled();
+    expect(s.onResult).not.toHaveBeenCalled();
+    expect(mockedOpen).not.toHaveBeenCalled();
+  });
+
+  test("already-aborted before the run starts tears down the acquired resources", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const { acquired, peer, conn } = makeResources();
+    const acquire: Acquire = () => Promise.resolve(acquired);
+    const s = seams();
+
+    await runExchangeLifecycle({
+      acquire,
+      exchangeRole: "initiator",
+      signal: controller.signal,
+      ...s,
+    });
+
+    // acquire resolved but the signal was already aborted: tear down what it
+    // handed us (no mc yet -> hard close the raw channel) and stay silent.
+    expect(conn.close).toHaveBeenCalled();
+    expect(peer.disconnect).toHaveBeenCalled();
+    expect(mockedOpen).not.toHaveBeenCalled();
+    expect(s.onError).not.toHaveBeenCalled();
+    expect(s.onResult).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/test/unit/peerMessageConnection.test.ts
+++ b/apps/web/test/unit/peerMessageConnection.test.ts
@@ -154,6 +154,22 @@ describe("openPeerMessageConnection", () => {
     expect(fake.torndown).toBe(true);
   });
 
+  test("tags an open-handshake failure as a transport ConnectionError", async () => {
+    // F5: waitForConnectionOpen rejects with a bare Error, but the boundary must
+    // surface a kind-tagged ConnectionError so a consumer can classify it.
+    const { fake, conn } = makeConn(false);
+    const promise = openPeerMessageConnection(conn);
+
+    fake.emit("close");
+
+    const err = await promise.catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ConnectionError);
+    expect((err as ConnectionError).kind).toBe("transport");
+    expect((err as ConnectionError).message).toBe(
+      "connection closed before open",
+    );
+  });
+
   test("hard-closes a never-opening channel on timeout instead of leaking it", async () => {
     // An open timeout emits no pre-open error/close to route through fail(), so
     // the catch closes the channel itself. A flush close would no-op on an

--- a/apps/web/test/unit/server.test.ts
+++ b/apps/web/test/unit/server.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { default as EventEmitter } from "eventemitter3";
+
+import { openPeerConnection, waitForPeerId } from "../../src/psi/server.js";
+
+import type Peer from "peerjs";
+
+// --- waitForPeerId -----------------------------------------------------------
+
+type MessageEventLike = { data: string };
+
+class FakeEventSource {
+  url: string;
+  readyState = 0; // CONNECTING
+  close = vi.fn(() => {
+    this.readyState = 2; // CLOSED
+  });
+  private listeners: Record<string, Array<(ev: unknown) => void>> = {};
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  addEventListener(type: string, handler: (ev: unknown) => void) {
+    (this.listeners[type] ??= []).push(handler);
+  }
+
+  emit(type: string, ev?: unknown) {
+    for (const handler of this.listeners[type] ?? []) handler(ev);
+  }
+}
+
+function withFakeEventSource(): {
+  factory: (url: string) => EventSource;
+  current: () => FakeEventSource;
+} {
+  let fake: FakeEventSource | undefined;
+  return {
+    factory: (url: string) => {
+      fake = new FakeEventSource(url);
+      return fake as unknown as EventSource;
+    },
+    current: () => {
+      if (!fake) throw new Error("event source not yet constructed");
+      return fake;
+    },
+  };
+}
+
+describe("waitForPeerId", () => {
+  test("resolves with the invited peer id", async () => {
+    const es = withFakeEventSource();
+    const promise = waitForPeerId("uuid", { eventSourceFactory: es.factory });
+
+    es.current().emit("message", {
+      data: JSON.stringify({ invitedPeerId: "peer-123" }),
+    } satisfies MessageEventLike);
+
+    expect(await promise).toBe("peer-123");
+    expect(es.current().close).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects with 'session expired' on the application-level error frame", async () => {
+    const es = withFakeEventSource();
+    const promise = waitForPeerId("uuid", { eventSourceFactory: es.factory });
+
+    es.current().emit("message", {
+      data: JSON.stringify({ error: "session uuid timed-out waiting" }),
+    } satisfies MessageEventLike);
+
+    await expect(promise).rejects.toThrow("session expired");
+  });
+
+  test("rejects on a genuinely unexpected message", async () => {
+    const es = withFakeEventSource();
+    const promise = waitForPeerId("uuid", { eventSourceFactory: es.factory });
+
+    es.current().emit("message", {
+      data: JSON.stringify({ something: "else" }),
+    } satisfies MessageEventLike);
+
+    await expect(promise).rejects.toThrow("unexpected message from server");
+  });
+
+  test("tolerates a transient reconnect (CONNECTING) and resolves on a later id", async () => {
+    const es = withFakeEventSource();
+    const promise = waitForPeerId("uuid", { eventSourceFactory: es.factory });
+
+    // readyState is CONNECTING (the browser is reconnecting): not fatal.
+    es.current().emit("error");
+    es.current().emit("message", {
+      data: JSON.stringify({ invitedPeerId: "peer-after-blip" }),
+    } satisfies MessageEventLike);
+
+    expect(await promise).toBe("peer-after-blip");
+  });
+
+  test("rejects when the stream is CLOSED", async () => {
+    const es = withFakeEventSource();
+    const promise = waitForPeerId("uuid", { eventSourceFactory: es.factory });
+
+    es.current().readyState = 2; // CLOSED
+    es.current().emit("error");
+
+    await expect(promise).rejects.toThrow("event source connection closed");
+  });
+
+  test("rejects and closes the stream on timeout", async () => {
+    const es = withFakeEventSource();
+    const promise = waitForPeerId("uuid", {
+      timeoutMs: 10,
+      eventSourceFactory: es.factory,
+    });
+
+    await expect(promise).rejects.toThrow("timed out");
+    expect(es.current().close).toHaveBeenCalled();
+  });
+
+  test("rejects and closes the stream when the signal aborts", async () => {
+    const es = withFakeEventSource();
+    const controller = new AbortController();
+    const promise = waitForPeerId("uuid", {
+      timeoutMs: 10_000,
+      signal: controller.signal,
+      eventSourceFactory: es.factory,
+    });
+
+    controller.abort();
+
+    await expect(promise).rejects.toThrow("aborted");
+    expect(es.current().close).toHaveBeenCalledTimes(1);
+  });
+
+  test("settles exactly once when an abort follows a resolution", async () => {
+    const es = withFakeEventSource();
+    const controller = new AbortController();
+    const promise = waitForPeerId("uuid", {
+      timeoutMs: 10_000,
+      signal: controller.signal,
+      eventSourceFactory: es.factory,
+    });
+
+    es.current().emit("message", {
+      data: JSON.stringify({ invitedPeerId: "peer-1" }),
+    } satisfies MessageEventLike);
+    controller.abort(); // races the already-settled resolution
+
+    expect(await promise).toBe("peer-1");
+    expect(es.current().close).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- openPeerConnection (destroy-on-failure) ---------------------------------
+
+class FakePeer extends EventEmitter {
+  destroy = vi.fn();
+  disconnect = vi.fn();
+  connect = vi.fn(() => ({ id: "data-conn" }));
+}
+
+describe("openPeerConnection destroy-on-failure", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("destroys the constructed Peer and rejects on a pre-open error", async () => {
+    vi.stubGlobal("window", {
+      location: { hostname: "localhost", port: "3000", protocol: "http:" },
+    });
+    const fake = new FakePeer();
+    const promise = openPeerConnection("remote-id", {
+      peerFactory: () => fake as unknown as Peer,
+    });
+
+    fake.emit("error", new Error("broker unreachable"));
+
+    await expect(promise).rejects.toThrow("broker unreachable");
+    expect(fake.destroy).toHaveBeenCalledTimes(1);
+    expect(fake.connect).not.toHaveBeenCalled();
+  });
+
+  test("does not destroy the Peer once it has opened (the caller owns it)", async () => {
+    vi.stubGlobal("window", {
+      location: { hostname: "localhost", port: "3000", protocol: "http:" },
+    });
+    const fake = new FakePeer();
+    const promise = openPeerConnection("remote-id", {
+      peerFactory: () => fake as unknown as Peer,
+    });
+
+    fake.emit("open", "my-id");
+    const [peer] = await promise;
+    expect(peer).toBe(fake as unknown as Peer);
+
+    // A late error after the handle was surfaced belongs to the caller's Peer.
+    fake.emit("error", new Error("late drop"));
+    expect(fake.destroy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/test/unit/waitForConnection.test.ts
+++ b/apps/web/test/unit/waitForConnection.test.ts
@@ -17,7 +17,7 @@ function makePeer(): { fake: FakePeer; peer: Peer } {
 describe("waitForIncomingConnection", () => {
   test("resolves with the first incoming connection", async () => {
     const { fake, peer } = makePeer();
-    const promise = waitForIncomingConnection(peer, 1000);
+    const promise = waitForIncomingConnection(peer, { timeoutMs: 1000 });
 
     const conn = { id: "c1" } as unknown as DataConnection;
     fake.emit("connection", conn);
@@ -28,16 +28,59 @@ describe("waitForIncomingConnection", () => {
   test("rejects if no connection arrives within the timeout", async () => {
     const { peer } = makePeer();
 
-    await expect(waitForIncomingConnection(peer, 10)).rejects.toThrow(
-      "timed out waiting for the other party to connect",
-    );
+    await expect(
+      waitForIncomingConnection(peer, { timeoutMs: 10 }),
+    ).rejects.toThrow("timed out waiting for the other party to connect");
   });
 
   test("detaches the connection listener on timeout", async () => {
     const { fake, peer } = makePeer();
 
-    await waitForIncomingConnection(peer, 10).catch(() => undefined);
+    await waitForIncomingConnection(peer, { timeoutMs: 10 }).catch(
+      () => undefined,
+    );
 
     expect(fake.listenerCount("connection")).toBe(0);
+  });
+
+  test("rejects and tears down when the signal aborts", async () => {
+    const { fake, peer } = makePeer();
+    const controller = new AbortController();
+
+    const promise = waitForIncomingConnection(peer, {
+      timeoutMs: 10_000,
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    await expect(promise).rejects.toThrow("aborted");
+    expect(fake.listenerCount("connection")).toBe(0);
+  });
+
+  test("rejects immediately if the signal is already aborted", async () => {
+    const { fake, peer } = makePeer();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      waitForIncomingConnection(peer, { signal: controller.signal }),
+    ).rejects.toThrow("aborted");
+    expect(fake.listenerCount("connection")).toBe(0);
+  });
+
+  test("settles exactly once when a connection arrives after an abort", async () => {
+    const { fake, peer } = makePeer();
+    const controller = new AbortController();
+
+    const promise = waitForIncomingConnection(peer, {
+      timeoutMs: 10_000,
+      signal: controller.signal,
+    });
+    controller.abort();
+    // A connection arriving after the abort must not overturn the settled
+    // rejection: the settle-once guard already removed the listener.
+    fake.emit("connection", { id: "late" });
+
+    await expect(promise).rejects.toThrow("aborted");
   });
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,6 +19,20 @@ const config = await configManager.load({ dotenv: true });
 
 logLibrary.setDefaultLevel(config.LOG_LEVEL);
 
+// Vite resolution for the `@`-prefixed imports the app uses, shared so the
+// inline vitest projects (which do not inherit the root `resolve`) resolve them
+// too. tsconfig provides these via explicit `paths` plus a `@*` -> `./src/*`
+// catch-all; `@psi` here stands in for that catch-all, which the unit project
+// needs because its `src/psi` sources pull in `@utils/*`.
+const srcAliases = {
+  "@components": path.resolve(__dirname, "src/components"),
+  "@utils": path.resolve(__dirname, "src/utils"),
+  "@util": path.resolve(__dirname, "src/util"),
+  "@peerjs-server": path.resolve(__dirname, "src/contrib/peerjs-server"),
+  "@psi": path.resolve(__dirname, "src/psi"),
+  "@": path.resolve(__dirname, "src"),
+};
+
 export default defineConfig((_configEnv) => {
   return {
     server: {
@@ -36,6 +50,7 @@ export default defineConfig((_configEnv) => {
             name: "unit",
             environment: "node",
           },
+          resolve: { alias: srcAliases },
         },
         {
           test: {
@@ -89,12 +104,7 @@ export default defineConfig((_configEnv) => {
     ],
     resolve: {
       tsconfigPaths: true,
-      alias: {
-        "@components": path.resolve(__dirname, "src/components"),
-        "@util": path.resolve(__dirname, "src/util"),
-        "@peerjs-server": path.resolve(__dirname, "src/contrib/peerjs-server"),
-        "@": path.resolve(__dirname, "src"),
-      },
+      alias: srcAliases,
     },
   };
 });

--- a/packages/core/src/connection/messageConnection.ts
+++ b/packages/core/src/connection/messageConnection.ts
@@ -41,6 +41,18 @@ export class ConnectionError extends Error {
 }
 
 /**
+ * Extracts a human-readable message from an arbitrary thrown value. The single
+ * shared rule for turning an `unknown` error into display text: an `Error`'s
+ * `message`, falling back to `String(err)` when that message is empty (so an
+ * `Error` with no message yields `"Error"` rather than a blank string), and
+ * `String(err)` for any non-`Error` value (so `null`/`undefined` become
+ * `"null"`/`"undefined"` rather than throwing on a `.message` dereference).
+ */
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message || String(err) : String(err);
+}
+
+/**
  * Wraps an arbitrary thrown value as a {@link ConnectionError}, passing an
  * existing {@link ConnectionError} through unchanged. Shared by the bridges so
  * every transport classifies a raw transport failure the same way.
@@ -50,11 +62,7 @@ export function asConnectionError(
   kind: ConnectionErrorKind,
 ): ConnectionError {
   if (err instanceof ConnectionError) return err;
-  return new ConnectionError(
-    err instanceof Error ? err.message : String(err),
-    kind,
-    { cause: err },
-  );
+  return new ConnectionError(errorMessage(err), kind, { cause: err });
 }
 
 /**

--- a/packages/core/test/messageConnection.test.ts
+++ b/packages/core/test/messageConnection.test.ts
@@ -4,7 +4,9 @@ import { z } from "zod";
 import {
   ConnectionError,
   QueuedMessageConnection,
+  asConnectionError,
   createMessagePipe,
+  errorMessage,
   fromEventConnection,
   receiveParsed,
 } from "../src/connection/messageConnection";
@@ -352,4 +354,35 @@ test("receiveParsed: a transport drop surfaces as transport, not protocol", asyn
   const err = await parked.catch((e: unknown) => e);
   expect(err).toBeInstanceOf(ConnectionError);
   expect((err as ConnectionError).kind).toBe("transport");
+});
+
+// --- errorMessage / asConnectionError ----------------------------------------
+
+test("errorMessage returns an Error's message", () => {
+  expect(errorMessage(new Error("boom"))).toBe("boom");
+});
+
+test("errorMessage falls back to String(err) for an empty-message Error", () => {
+  // Non-blank guarantee: an empty message never yields a blank alert.
+  expect(errorMessage(new Error(""))).toBe("Error");
+});
+
+test("errorMessage stringifies non-Error values without throwing", () => {
+  expect(errorMessage(null)).toBe("null");
+  expect(errorMessage(undefined)).toBe("undefined");
+  expect(errorMessage("plain string")).toBe("plain string");
+  expect(errorMessage(42)).toBe("42");
+});
+
+test("asConnectionError routes its message through errorMessage", () => {
+  // The deliberate behavior change: an empty-message Error becomes "Error".
+  const err = asConnectionError(new Error(""), "transport");
+  expect(err).toBeInstanceOf(ConnectionError);
+  expect(err.kind).toBe("transport");
+  expect(err.message).toBe("Error");
+});
+
+test("asConnectionError passes an existing ConnectionError through unchanged", () => {
+  const original = new ConnectionError("nope", "security");
+  expect(asConnectionError(original, "transport")).toBe(original);
 });


### PR DESCRIPTION
## Summary

Extracts a single per-exchange lifecycle owner for the web PSI exchange so that acquisition and teardown are no longer scattered across `psi.tsx`, `runExchangeOn`'s `finally`, and the connection helpers. The new owner (`runExchangeLifecycle` in `apps/web/src/psi/exchangeLifecycle.ts`) acquires the `Peer`/`DataConnection`/`MessageConnection`, runs the exchange, and guarantees teardown wherever a failure lands or whenever an unmount aborts mid-flight. App-layer refactor; no protocol change.

This supersedes the interim band-aids from "Harden web exchange teardown and connect wait" and addresses findings F1-F7 from round 4 of the web-transport-port review.

## What changed

- **Single lifecycle owner (F1, F2, F4, F6).** `psi.tsx` becomes a thin caller that picks the role's `acquire`, supplies a `generateOutput` callback, and wires the `onStages`/`onStage`/`onResult`/`onError` seams. Teardown is a run-once, non-throwing latch, so a teardown failure can't clobber a more accurate alert and the exchange-vs-output distinction survives (an output-generation failure stays "Results unavailable", never "Exchange failed"). The broker socket drops on the first inbound frame while the data channel stays open. An `AbortController` + `useEffect` cleanup tears the owner down on unmount in any phase; every owner-driven seam no-ops once aborted, so no `setState` fires after unmount.
- **Bounded, cancellable waits (F3).** Both waits share `DEFAULT_PEER_WAIT_TIMEOUT_MS` (10 min, renamed from `DEFAULT_CONNECT_TIMEOUT_MS`) and take an `AbortSignal` with a settle-once guard. `waitForPeerId` gains an injectable `EventSource` factory, tolerates a transient reconnect (fatal only on a `CLOSED` stream), and rejects the session-TTL `{error}` frame as "session expired". The client gains a "Waiting for peer" stage mirroring the server's.
- **Atomic acquisition (F1).** A `Peer` factory makes the `peer.destroy()`-on-failure path in `openPeerConnection`/`createAndSharePeerId` unit-testable; a client wait failure destroys the published peer.
- **Boundary cleanups (F5, F7).** Open-handshake failures are tagged as `transport` `ConnectionError`s. A new exported `errorMessage(err)` helper in core is the single display-text extractor, used by `asConnectionError` and the UI.

## Deliberate behavior change (F7)

Routing `asConnectionError` (and the UI) through `errorMessage` changes the message for an *empty-message* `Error` from `""` to `"Error"`. This is intentional: the rule (`err instanceof Error ? (err.message || String(err)) : String(err)`) is nullish-safe and non-blank, so an alert is never blank.

## Out of scope / deferred

- Teardown ships as `mc.close()` (flushing) + `peer.disconnect()`. The `disconnect()` -> `destroy()` upgrade is gated on an awaitable flush and tracked separately (board item 193800518).
- The unmount -> `abort()` `useEffect` wiring is covered at the contract level by the node owner test; an automated React effect-cleanup test awaits a component-test harness (board item 193886235).

## Commits

1. `Add errorMessage helper to core connection module` (F7)
2. `Consolidate web PSI lifecycle and teardown` (F1-F4, F6)
3. `Tag open-handshake failures as ConnectionErrors` (F5)

## Test plan

- `npm run build` (all workspaces): pass
- `npm run lint`: clean; `tsc --noEmit` (web): clean
- `npm test -w packages/core`: 508/508
- `npm run test:unit -w apps/web`: 70/70 (new: owner contract, wait-helper abort/settle-once/reconnect/`{error}`, destroy-on-failure via injected `Peer` factory, open-handshake tagging, `errorMessage`)
- `npm run test:unit -w apps/cli`: 129/129
