### PR TITLE
Fix open() overwriting constructor timeToLive

### DIFF
--- a/packages/core/src/connection/fileSyncConnection.ts
+++ b/packages/core/src/connection/fileSyncConnection.ts
@@ -311,17 +311,20 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
     this.connected = true;
     // Compute timeToLive only after connect() has resolved so that retry
     // latency during connection setup does not eat into the peer-waiting
-    // budget. An explicit timeToLive passed to the constructor (test path)
-    // wins over both peerTimeoutMs and the default.
+    // budget. Three cases:
+    //   1. No constructor timeToLive, no config peerTimeoutMs: use the default
+    //      budget for both timeToLive and peerTimeoutMs.
+    //   2. No constructor timeToLive, config peerTimeoutMs present: derive
+    //      timeToLive from config peerTimeoutMs and store the raw duration.
+    //   3. Constructor timeToLive present: it wins - do not recompute timeToLive.
+    //      Still store config peerTimeoutMs when provided so close() can use a
+    //      fresh drain deadline independent of the exchange duration.
     if (this.options.timeToLive === undefined) {
       const ttlMs = config.options?.peerTimeoutMs ?? DEFAULT_PEER_TIMEOUT_MS;
       this.options.peerTimeoutMs = ttlMs;
       this.options.timeToLive = new Date(Date.now() + ttlMs);
     } else if (config.options?.peerTimeoutMs !== undefined) {
       this.options.peerTimeoutMs = config.options.peerTimeoutMs;
-      this.options.timeToLive = new Date(
-        Date.now() + config.options.peerTimeoutMs,
-      );
     }
     this.log.debug(`[${this.role}] connected`);
   }

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -249,6 +249,61 @@ test("open maps pollIntervalMs to pollingFrequency for sftp config", async () =>
   expect(conn.options.pollingFrequency).toBe(15_000);
 });
 
+test("open preserves constructor timeToLive and stores config peerTimeoutMs when both are supplied", async () => {
+  // Constructor timeToLive wins; open() must not recompute it from
+  // config.options.peerTimeoutMs. The raw duration is still stored in
+  // peerTimeoutMs so close() can use a fresh drain deadline.
+  const { client } = makeMockClient();
+  const constructorTtl = new Date(Date.now() + 9_999_999);
+  const conn = new FileSyncConnection(client, {
+    verbose: -1,
+    timeToLive: constructorTtl,
+  });
+  await conn.open({
+    channel: "sftp",
+    server: { host: "sftp.example.org" },
+    options: { peerTimeoutMs: 30_000 },
+  });
+  expect(conn.options.timeToLive).toBe(constructorTtl);
+  expect(conn.options.peerTimeoutMs).toBe(30_000);
+});
+
+test("open preserves constructor timeToLive and leaves peerTimeoutMs undefined when config has none", async () => {
+  // Constructor timeToLive wins; when no config peerTimeoutMs is provided
+  // peerTimeoutMs stays undefined so close() falls back to DEFAULT_PEER_TIMEOUT_MS.
+  const { client } = makeMockClient();
+  const constructorTtl = new Date(Date.now() + 9_999_999);
+  const conn = new FileSyncConnection(client, {
+    verbose: -1,
+    timeToLive: constructorTtl,
+  });
+  await conn.open({
+    channel: "sftp",
+    server: { host: "sftp.example.org" },
+  });
+  expect(conn.options.timeToLive).toBe(constructorTtl);
+  expect(conn.options.peerTimeoutMs).toBeUndefined();
+});
+
+test("open derives timeToLive from config peerTimeoutMs when no constructor timeToLive is set", async () => {
+  // Existing behavior: no constructor timeToLive, config peerTimeoutMs present
+  // -> timeToLive is computed as Date.now() + peerTimeoutMs and peerTimeoutMs
+  // is stored.
+  const { client } = makeMockClient();
+  const conn = new FileSyncConnection(client, { verbose: -1 });
+  const before = Date.now();
+  await conn.open({
+    channel: "sftp",
+    server: { host: "sftp.example.org" },
+    options: { peerTimeoutMs: 45_000 },
+  });
+  const after = Date.now();
+  const ttl = conn.options.timeToLive!.getTime();
+  expect(ttl).toBeGreaterThanOrEqual(before + 45_000);
+  expect(ttl).toBeLessThanOrEqual(after + 45_000);
+  expect(conn.options.peerTimeoutMs).toBe(45_000);
+});
+
 // --- open (filedrop) ---------------------------------------------------------
 
 test("open sets path and marks connected for filedrop config", async () => {


### PR DESCRIPTION
## Summary

- The `else if` arm in `open()` was recomputing `timeToLive` from `config.options.peerTimeoutMs` even when the constructor had already supplied a `timeToLive`, contradicting the comment that said the constructor value wins.
- Removed the `timeToLive = new Date(...)` line from the `else if` arm. The `peerTimeoutMs` assignment is kept so `close()` can derive a fresh drain deadline from the config value.
- Updated the inline comment to enumerate all three cases (no TTL/no config; no TTL/config present; constructor TTL present).
- Added three unit tests covering each case, including a regression guard confirming the no-constructor-TTL path is unchanged.

## Test plan

- [x] `npm run build -w packages/core` passes
- [x] `npx vitest run packages/core/test/fileSyncConnection.test.ts` passes (56 tests)
- [x] New test 1: constructor TTL + config `peerTimeoutMs` — `timeToLive` equals constructor value, `peerTimeoutMs` equals config value
- [x] New test 2: constructor TTL + no config `peerTimeoutMs` — `timeToLive` equals constructor value, `peerTimeoutMs` is `undefined`
- [x] New test 3: no constructor TTL + config `peerTimeoutMs` — `timeToLive` derived from config value, `peerTimeoutMs` stored
