### PR TITLE
Add opt-in lockless rendezvous to FileSyncConnection

### DIFF
--- a/apps/cli/src/commands/exchange.ts
+++ b/apps/cli/src/commands/exchange.ts
@@ -90,6 +90,14 @@ export function builder(cmd: Argv): Argv {
       type: "string",
       describe: "silent | error | warn | info | debug | trace; default=info",
     })
+    .option("lockless-rendezvous", {
+      type: "boolean",
+      describe:
+        "use the ack-handshake rendezvous instead of the atomic wave-file " +
+        "race; required on sync-mediated transports that lack atomic " +
+        "exclusive-create or deletion visibility during rendezvous. Both " +
+        "parties must set this flag identically",
+    })
     .option("verbose", {
       alias: "v",
       type: "count",
@@ -114,6 +122,7 @@ interface ExchangeArgs {
   connectionTimeout?: number;
   peerTimeout?: number;
   maxReconnectAttempts?: number;
+  locklessRendezvous?: boolean;
   logLevel: logLibrary.LogLevelNumbers;
   verbosity: number;
 }
@@ -148,6 +157,7 @@ function parseArgs(argv: Arguments): ExchangeArgs {
     connectionTimeout: argv["connection-timeout"] as number | undefined,
     peerTimeout: argv["peer-timeout"] as number | undefined,
     maxReconnectAttempts: argv["max-reconnect-attempts"] as number | undefined,
+    locklessRendezvous: argv["lockless-rendezvous"] as boolean | undefined,
     logLevel,
     verbosity: (argv["verbose"] as number | undefined) ?? 0,
   };
@@ -261,6 +271,7 @@ export function loadConfig(
     serverPassword: options.serverPassword,
     serverPrivateKey: options.serverPrivateKey,
     serverPort: options.serverPort,
+    locklessRendezvous: options.locklessRendezvous,
   });
 
   if (connection.channel !== "sftp" && connection.channel !== "filedrop")

--- a/apps/cli/src/commands/exchange.ts
+++ b/apps/cli/src/commands/exchange.ts
@@ -274,7 +274,7 @@ export function loadConfig(
     locklessRendezvous: options.locklessRendezvous,
   });
 
-  if (options.locklessRendezvous !== undefined &&
+  if (options.locklessRendezvous === true &&
     connection.channel !== "sftp" &&
     connection.channel !== "filedrop"
   ) {

--- a/apps/cli/src/commands/exchange.ts
+++ b/apps/cli/src/commands/exchange.ts
@@ -274,6 +274,16 @@ export function loadConfig(
     locklessRendezvous: options.locklessRendezvous,
   });
 
+  if (options.locklessRendezvous !== undefined &&
+    connection.channel !== "sftp" &&
+    connection.channel !== "filedrop"
+  ) {
+    log.warn(
+      `--lockless-rendezvous has no effect on the ${connection.channel} ` +
+        "channel and will be ignored; it is only supported on sftp and filedrop",
+    );
+  }
+
   if (connection.channel !== "sftp" && connection.channel !== "filedrop")
     throw new Error(
       `the ${connection.channel} channel is not yet supported in the CLI`,

--- a/apps/cli/src/commands/zeroSetup.ts
+++ b/apps/cli/src/commands/zeroSetup.ts
@@ -339,7 +339,7 @@ export async function handler(argv: Arguments): Promise<void> {
 
   // Warn before createConnection can throw so the user sees the flag issue
   // even if the channel is not yet supported.
-  if (options.locklessRendezvous !== undefined) {
+  if (options.locklessRendezvous === true) {
     try {
       const ch = channelFromURL(server);
       if (ch !== "sftp" && ch !== "filedrop") {

--- a/apps/cli/src/commands/zeroSetup.ts
+++ b/apps/cli/src/commands/zeroSetup.ts
@@ -88,6 +88,14 @@ export function builder(cmd: Argv): Argv {
       type: "string",
       describe: "silent | error | warn | info | debug | trace; default=info",
     })
+    .option("lockless-rendezvous", {
+      type: "boolean",
+      describe:
+        "use the ack-handshake rendezvous instead of the atomic wave-file " +
+        "race; required on sync-mediated transports that lack atomic " +
+        "exclusive-create or deletion visibility during rendezvous. Both " +
+        "parties must set this flag identically",
+    })
     .option("verbose", {
       alias: "v",
       type: "count",
@@ -113,6 +121,7 @@ interface ZeroSetupArgs {
   connectionTimeout?: number;
   peerTimeout?: number;
   maxReconnectAttempts?: number;
+  locklessRendezvous?: boolean;
   logLevel: logLibrary.LogLevelNumbers;
   verbosity: number;
 }
@@ -147,6 +156,7 @@ function parseArgs(argv: Arguments): ZeroSetupArgs {
     connectionTimeout: argv["connection-timeout"] as number | undefined,
     peerTimeout: argv["peer-timeout"] as number | undefined,
     maxReconnectAttempts: argv["max-reconnect-attempts"] as number | undefined,
+    locklessRendezvous: argv["lockless-rendezvous"] as boolean | undefined,
     logLevel,
     verbosity: (argv["verbose"] as number | undefined) ?? 0,
   };
@@ -249,6 +259,7 @@ export function createConnection(
       connectionTimeout: options.connectionTimeout,
       peerTimeout: options.peerTimeout,
       maxReconnectAttempts: options.maxReconnectAttempts,
+      locklessRendezvous: options.locklessRendezvous,
     });
   }
 
@@ -274,6 +285,7 @@ export function createConnection(
     serverPassword: options.serverPassword,
     serverPrivateKey: options.serverPrivateKey,
     serverPort: options.serverPort,
+    locklessRendezvous: options.locklessRendezvous,
   });
 }
 

--- a/apps/cli/src/commands/zeroSetup.ts
+++ b/apps/cli/src/commands/zeroSetup.ts
@@ -337,6 +337,22 @@ export async function handler(argv: Arguments): Promise<void> {
 
   const { server, input, output } = resolved;
 
+  // Warn before createConnection can throw so the user sees the flag issue
+  // even if the channel is not yet supported.
+  if (options.locklessRendezvous !== undefined) {
+    try {
+      const ch = channelFromURL(server);
+      if (ch !== "sftp" && ch !== "filedrop") {
+        log.warn(
+          `--lockless-rendezvous has no effect on the ${ch} channel and ` +
+            "will be ignored; it is only supported on sftp and filedrop",
+        );
+      }
+    } catch {
+      // Unknown URL scheme; createConnection handles this.
+    }
+  }
+
   if (options.save) {
     log.warn(
       "--save: bootstrapping a shared secret is not yet implemented; " +

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -31,8 +31,7 @@ export function applyConnectionOverrides(
   if (
     overrides.peerTimeout !== undefined ||
     overrides.connectionTimeout !== undefined ||
-    overrides.maxReconnectAttempts !== undefined ||
-    overrides.locklessRendezvous !== undefined
+    overrides.maxReconnectAttempts !== undefined
   ) {
     result.options = {
       ...result.options,
@@ -45,9 +44,19 @@ export function applyConnectionOverrides(
       ...(overrides.maxReconnectAttempts !== undefined && {
         maxReconnectAttempts: overrides.maxReconnectAttempts,
       }),
-      ...(overrides.locklessRendezvous !== undefined && {
-        locklessRendezvous: overrides.locklessRendezvous,
-      }),
+    };
+  }
+
+  // locklessRendezvous is a FileSyncOptions field; only apply it on channels
+  // that use FileSyncConnection. The other overrides above (peerTimeout etc.)
+  // are SharedOptions that apply to all channels including webrtc.
+  if (
+    (result.channel === "sftp" || result.channel === "filedrop") &&
+    overrides.locklessRendezvous !== undefined
+  ) {
+    result.options = {
+      ...result.options,
+      locklessRendezvous: overrides.locklessRendezvous,
     };
   }
 

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -8,6 +8,7 @@ export interface ConnectionOverrides {
   serverPassword?: string;
   serverPrivateKey?: string;
   serverPort?: number;
+  locklessRendezvous?: boolean;
 }
 
 export function applyConnectionOverrides(
@@ -30,7 +31,8 @@ export function applyConnectionOverrides(
   if (
     overrides.peerTimeout !== undefined ||
     overrides.connectionTimeout !== undefined ||
-    overrides.maxReconnectAttempts !== undefined
+    overrides.maxReconnectAttempts !== undefined ||
+    overrides.locklessRendezvous !== undefined
   ) {
     result.options = {
       ...result.options,
@@ -42,6 +44,9 @@ export function applyConnectionOverrides(
       }),
       ...(overrides.maxReconnectAttempts !== undefined && {
         maxReconnectAttempts: overrides.maxReconnectAttempts,
+      }),
+      ...(overrides.locklessRendezvous !== undefined && {
+        locklessRendezvous: overrides.locklessRendezvous,
       }),
     };
   }

--- a/apps/cli/test/integration/mixedConnection.test.ts
+++ b/apps/cli/test/integration/mixedConnection.test.ts
@@ -91,19 +91,19 @@ test("wave synchronization with race condition", async () => {
 test("basic synchronization", async () => {
   await sftpAdapter.put(
     Buffer.from(new ArrayBuffer(0)),
-    `${SFTP_PATH}/${localConn.id}.hello`,
+    `${SFTP_PATH}/${localConn.id}-hello.json`,
   );
 
   await sftpConn.synchronize();
 
   const currentFiles = await sftpAdapter.list(SFTP_PATH);
-  await sftpAdapter.safeDelete(`${SFTP_PATH}/${sftpConn.id}.hello`);
+  await sftpAdapter.safeDelete(`${SFTP_PATH}/${sftpConn.id}-hello.json`);
 
   expect(sftpConn.peerId).toBe(localConn.id);
   expect(sftpConn.handshakeRole).toBe("initiator");
 
   expect(currentFiles.length).toBe(1);
-  expect(currentFiles[0].name).toBe(`${sftpConn.id}.hello`);
+  expect(currentFiles[0].name).toBe(`${sftpConn.id}-hello.json`);
 
   desynchronize(sftpConn);
 });

--- a/apps/cli/test/integration/sftpConnection.test.ts
+++ b/apps/cli/test/integration/sftpConnection.test.ts
@@ -99,20 +99,20 @@ test("wave synchronization with race condition", async () => {
 test("basic synchronization", async () => {
   await serverSFTP.put(
     Buffer.from(new ArrayBuffer(0)),
-    `${SFTP_PATH}/${clientConn.id}.hello`,
+    `${SFTP_PATH}/${clientConn.id}-hello.json`,
   );
 
   await serverConn.synchronize();
 
   const currentFiles = await serverSFTP.list(SFTP_PATH);
 
-  await serverSFTP.safeDelete(`${SFTP_PATH}/${serverConn.id}.hello`);
+  await serverSFTP.safeDelete(`${SFTP_PATH}/${serverConn.id}-hello.json`);
 
   expect(serverConn.peerId).toBe(clientConn.id);
   expect(serverConn.handshakeRole).toBe("initiator");
 
   expect(currentFiles.length).toBe(1);
-  expect(currentFiles[0].name === `${serverConn.id}.hello`).toBe(true);
+  expect(currentFiles[0].name === `${serverConn.id}-hello.json`).toBe(true);
 
   desynchronize(serverConn);
 });

--- a/apps/cli/test/unit/protocol.test.ts
+++ b/apps/cli/test/unit/protocol.test.ts
@@ -1017,7 +1017,7 @@ test("SIGINT mid-synchronize exits with 130 and cleans up the hello file (starte
       () => {
         const entries = fs
           .readdirSync(dropDir)
-          .filter((f) => f.endsWith(".hello"));
+          .filter((f) => f.endsWith("-hello.json"));
         expect(entries.length).toBeGreaterThanOrEqual(1);
       },
       { timeout: 5_000 },
@@ -1032,7 +1032,7 @@ test("SIGINT mid-synchronize exits with 130 and cleans up the hello file (starte
     // After cleanup runs the hello file must be gone — otherwise a retry
     // would trip the "preexisting hello or wave files" guard.
     expect(
-      fs.readdirSync(dropDir).filter((f) => f.endsWith(".hello")),
+      fs.readdirSync(dropDir).filter((f) => f.endsWith("-hello.json")),
     ).toHaveLength(0);
   } finally {
     exitSpy.mockRestore();
@@ -1225,7 +1225,7 @@ test.skipIf(process.platform === "win32")(
     );
 
     // Poll for B's rendezvous file rather than sleeping a fixed amount. B
-    // writes its .hello file to dropDir during open()/synchronize(); its
+    // writes its -hello.json file to dropDir during open()/synchronize(); its
     // presence is the deterministic signal that B has reached synchronize() and
     // is waiting for a peer. A only starts after this loop exits, guaranteeing
     // B is already in the drop directory before A's open() runs.

--- a/docs/EXCHANGE_SPEC.md
+++ b/docs/EXCHANGE_SPEC.md
@@ -587,6 +587,12 @@ With `timestamp_in_filename: true`, the filename additionally carries a timestam
 
 In-flight writes use a temporary `.tmp` file that is renamed to the final `.json` name only once the write completes, so a sync tool watching `*.json` never observes a partial file under its final name. Handshake files (`<id>-hello.json`, `<id1>-<id2>.wave`, `<id>-hello-ack.json`) are separate from message files and are documented in [PROTOCOL.md](PROTOCOL.md).
 
+#### Directory exclusivity
+
+The shared directory (SFTP path or local filedrop path) must be **dedicated exclusively** to a single active exchange between exactly two parties. Both channels treat the directory as a private communication channel: each party reads and deletes files written by the other, and the rendezvous protocol uses filename presence as a synchronization signal.
+
+A third process writing `<id>-hello.json`, `.wave`, `-hello-ack.json`, or `<id>-*.json` files into the same path during an active session will cause the exchange to abort with a diagnostic error. Separate concurrent exchanges must use separate directories.
+
 #### Filename grammar
 
 Every protocol file on `sftp` and `filedrop` channels is named `<id>-...-<token>.json`, where `<token>` is the final `-`-delimited segment before `.json`:

--- a/docs/EXCHANGE_SPEC.md
+++ b/docs/EXCHANGE_SPEC.md
@@ -591,7 +591,7 @@ In-flight writes use a temporary `.tmp` file that is renamed to the final `.json
 
 The shared directory (SFTP path or local filedrop path) must be **dedicated exclusively** to a single active exchange between exactly two parties. Both channels treat the directory as a private communication channel: each party reads and deletes files written by the other, and the rendezvous protocol uses filename presence as a synchronization signal.
 
-A third process writing `<id>-hello.json`, `.wave`, `-hello-ack.json`, or `<id>-*.json` files into the same path during an active session will cause the exchange to abort with a diagnostic error. Separate concurrent exchanges must use separate directories.
+A third process writing `<id>-hello.json`, `<id1>-<id2>.wave`, `<id>-hello-ack.json`, or `<id>-*.json` files into the same path during an active session will cause the exchange to abort with a diagnostic error. Separate concurrent exchanges must use separate directories.
 
 #### Filename grammar
 

--- a/docs/EXCHANGE_SPEC.md
+++ b/docs/EXCHANGE_SPEC.md
@@ -565,6 +565,7 @@ These options apply to both `sftp` and `filedrop` channels.
 |-------|------|---------|-------------|
 | `poll_interval_ms` | integer | 100 | Milliseconds between checks for the partner's uploaded file. The default is tuned for local-network mounts and CI; raise it (for example, to 1000-5000 ms) for public SFTP servers to reduce request load. |
 | `timestamp_in_filename` | boolean | false | When `true`, each outgoing message filename also encodes a UTC timestamp and a per-session sequence number (see [Message filenames](#message-filenames)). Useful for filename-based logging in sync-mediated environments where the sync tool stamps files with the transfer time rather than the original creation time. |
+| `lockless_rendezvous` | boolean | false | When `true`, the rendezvous handshake uses an ack-handshake barrier (`<id>-hello.json` + `<id>-hello-ack.json`) instead of the default atomic wave-file race (`<id>-hello.json` + `<id1>-<id2>.wave`). Required on sync-mediated transports that lack atomic exclusive-create or deletion visibility during rendezvous (e.g. a cloud sync service reconciling two local mirrors where both sides "win" a local create). Both parties must set this identically; a mismatch causes rendezvous to time out. The operational sync glob in lockless mode is `<myId>-*` (upload) / `<partnerId>-*` (download), which covers hello, ack, and message files while excluding in-flight `temp-*.tmp` writes. |
 
 #### Message filenames
 
@@ -584,7 +585,16 @@ With `timestamp_in_filename: true`, the filename additionally carries a timestam
 
 `<YYYYMMDDTHHMMSS>` is the UTC write time in compact ISO 8601 form (no colons or hyphens, so it is Windows-safe and sorts lexicographically by time). `<NNN>` is a per-session counter that starts at `000`, is zero-padded to three digits, and increments with each message sent; it widens to four or more digits only after the 1000th message of a session.
 
-In-flight writes use a temporary `.tmp` file that is renamed to the final `.json` name only once the write completes, so a sync tool watching `*.json` never observes a partial file under its final name. Handshake files (`.hello`, `.wave`) are separate from message files and are documented in [PROTOCOL.md](PROTOCOL.md).
+In-flight writes use a temporary `.tmp` file that is renamed to the final `.json` name only once the write completes, so a sync tool watching `*.json` never observes a partial file under its final name. Handshake files (`<id>-hello.json`, `<id1>-<id2>.wave`, `<id>-hello-ack.json`) are separate from message files and are documented in [PROTOCOL.md](PROTOCOL.md).
+
+#### Filename grammar
+
+Every protocol file on `sftp` and `filedrop` channels is named `<id>-...-<token>.json`, where `<token>` is the final `-`-delimited segment before `.json`:
+
+- If `<token>` is all digits, the file is a **message** and `<token>` is its declared byte count. Parsing is right-anchored so a party id containing hyphens does not affect extraction.
+- Otherwise `<token>` is a **type word** naming the file kind: `hello` (rendezvous hello), `ack` (lockless-mode handshake ack). A typed file is never read as a message; the receiver's message scan ignores any file whose terminal segment is non-numeric.
+
+The receiver only reads files whose on-disk size matches the declared byte count, so a partially synced message file is never consumed prematurely.
 
 ### `connection.provider_options`
 

--- a/packages/core/src/config/connection.ts
+++ b/packages/core/src/config/connection.ts
@@ -340,10 +340,18 @@ export interface FileSyncOptions extends SharedOptions {
   /**
    * When `true`, the rendezvous handshake uses an ack-handshake barrier
    * instead of the atomic-exclusive-create wave-file race. Both parties must
-   * set this identically; a mismatch causes rendezvous to time out. Use on
-   * transports that lack atomic exclusive-create (`createExclusive`) or
-   * deletion visibility during rendezvous (e.g. sync-mediated directories
-   * where both sides "win" a local create). Default: `false`.
+   * set this identically; a mismatch causes rendezvous to time out.
+   *
+   * Intended for sync-mediated transports (e.g. a cloud-sync service
+   * reconciling two local directories) where `createExclusive` lacks
+   * atomicity or deletion has high propagation latency. Delete still works
+   * on these transports — cleanup via `safeDelete` succeeds eventually —
+   * but arrival order cannot be determined by an atomic exclusive-create.
+   * This option is **not** intended for transports that genuinely cannot
+   * delete; handshake files must be removable at `close()` time or they
+   * accumulate and block future sessions.
+   *
+   * Default: `false`.
    */
   locklessRendezvous?: boolean;
 }

--- a/packages/core/src/config/connection.ts
+++ b/packages/core/src/config/connection.ts
@@ -337,12 +337,22 @@ export interface FileSyncOptions extends SharedOptions {
    * declared byte count (`<id>-<byteCount>.json`).
    */
   timestampInFilename?: boolean;
+  /**
+   * When `true`, the rendezvous handshake uses an ack-handshake barrier
+   * instead of the atomic-exclusive-create wave-file race. Both parties must
+   * set this identically; a mismatch causes rendezvous to time out. Use on
+   * transports that lack atomic exclusive-create (`createExclusive`) or
+   * deletion visibility during rendezvous (e.g. sync-mediated directories
+   * where both sides "win" a local create). Default: `false`.
+   */
+  locklessRendezvous?: boolean;
 }
 
 const FileSyncOptionsSchema: z.ZodType<FileSyncOptions> = z.object({
   ...sharedOptionsFields,
   pollIntervalMs: z.int().nonnegative().optional(),
   timestampInFilename: z.boolean().optional(),
+  locklessRendezvous: z.boolean().optional(),
 });
 
 // --- Connection config -------------------------------------------------------
@@ -481,6 +491,18 @@ export const ConnectionConfigSchema: z.ZodType<ConnectionConfig> = z
         (conn.stun !== undefined || conn.turn !== undefined)
       ),
     { message: "iceProvision is mutually exclusive with stun and turn" },
+  )
+  // Defense-in-depth: locklessRendezvous is a FileSyncOptions field and
+  // cannot be expressed on a webrtc config through the discriminated union
+  // (webrtc uses SharedOptions, not FileSyncOptions). This refine guards the
+  // path anyway so a future schema change cannot silently accept it.
+  .refine(
+    (conn) =>
+      !(
+        conn.channel === "webrtc" &&
+        (conn.options as FileSyncOptions | undefined)?.locklessRendezvous
+      ),
+    { message: "locklessRendezvous is not valid for the webrtc channel" },
   );
 
 // --- Parse -------------------------------------------------------------------

--- a/packages/core/src/connection/fileSyncConnection.ts
+++ b/packages/core/src/connection/fileSyncConnection.ts
@@ -474,8 +474,12 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
           "before executing the protocol. Most likely cause: a previous " +
           "exchange was terminated by SIGKILL/OOM/power loss before its " +
           "cleanup ran (a handshake-ack file indicates a crashed lockless " +
-          "session). Remove the listed files manually after verifying that " +
-          "no other session is concurrently using this path.",
+          "session). A handshake-ack can also appear when a live lockless " +
+          "peer wrote its ack and this party timed out and retried before " +
+          "the peer finished or cleaned up; in that case wait for the peer " +
+          "to complete or time out before retrying. Remove the listed files " +
+          "manually after verifying that no other session is concurrently " +
+          "using this path.",
       );
     }
 
@@ -586,13 +590,13 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
                 this.responsibleFiles.delete(fileName);
             });
 
-            const peerHello = currentFiles.find(
+            const peerHellos = currentFiles.filter(
               (file) =>
                 file.name !== `${this.id}${HELLO_SUFFIX}` &&
                 file.name.endsWith(HELLO_SUFFIX),
             );
 
-            if (peerHello === undefined) {
+            if (peerHellos.length === 0) {
               this.log.trace(`[${this.role}] no peer hello found; polling`);
               const delay = (ms: number) =>
                 new Promise((resolve) => setTimeout(resolve, ms));
@@ -600,6 +604,15 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
               continue;
             }
 
+            if (peerHellos.length > 1) {
+              throw new Error(
+                `more than one peer hello file in ${this.path} - are there ` +
+                  "other sessions using this path?",
+                { cause: "usage" },
+              );
+            }
+
+            const peerHello = peerHellos[0];
             const peerId = peerHello.name.slice(0, -HELLO_SUFFIX.length);
 
             // Write our ack once on the first sighting of the peer's hello.
@@ -616,13 +629,16 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
                 ackPath,
                 { flags: "w", encoding: "utf-8" },
               );
+              // Re-enter the loop so hasPeerAck is checked against a fresh
+              // listing; the pre-ack-write snapshot from this iteration may
+              // miss a peer ack that arrived in the window between list() and
+              // put(), adding up to pollIntervalMs of unnecessary latency on
+              // slow-sync transports.
+              continue;
             }
 
-            // Barrier completes when the peer's ack is visible in the
-            // current listing. The listing was taken before we wrote our
-            // ack, so the peer's ack may not appear until the next poll;
-            // that is fine -- the barrier is correct as long as each party
-            // writes its ack before declaring completion.
+            // Barrier completes when the peer's ack is visible in the current
+            // listing (always a fresh one because of the continue above).
             const peerAckName = `${peerId}-hello-ack.json`;
             const hasPeerAck = currentFiles.some(
               (file) => file.name === peerAckName,

--- a/packages/core/src/connection/fileSyncConnection.ts
+++ b/packages/core/src/connection/fileSyncConnection.ts
@@ -572,6 +572,8 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
       let ackPath: string | undefined;
 
       const waitForPeer = async () => {
+        const delay = (ms: number) =>
+          new Promise((resolve) => setTimeout(resolve, ms));
         if (this.options.locklessRendezvous) {
           // Lockless ack-handshake barrier: completes rendezvous using neither
           // createExclusive nor delete. Each party writes a hello, then an ack
@@ -598,8 +600,6 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
 
             if (peerHellos.length === 0) {
               this.log.trace(`[${this.role}] no peer hello found; polling`);
-              const delay = (ms: number) =>
-                new Promise((resolve) => setTimeout(resolve, ms));
               await delay(this.options.pollingFrequency);
               continue;
             }
@@ -648,8 +648,6 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
               this.log.trace(
                 `[${this.role}] waiting for peer ack ${peerAckName}`,
               );
-              const delay = (ms: number) =>
-                new Promise((resolve) => setTimeout(resolve, ms));
               await delay(this.options.pollingFrequency);
               continue;
             }
@@ -703,8 +701,6 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
 
           if (otherFiles.length === 0) {
             this.log.trace(`[${this.role}] no peer hello found; polling`);
-            const delay = (ms: number) =>
-              new Promise((resolve) => setTimeout(resolve, ms));
             await delay(this.options.pollingFrequency);
             continue;
           }

--- a/packages/core/src/connection/fileSyncConnection.ts
+++ b/packages/core/src/connection/fileSyncConnection.ts
@@ -48,6 +48,10 @@ const DEFAULT_VERBOSITY = 1;
 // (>5) approaches the peer timeout and gives no practical benefit.
 const MAX_CONSECUTIVE_ENOENT = 3;
 
+// Suffix shared by all hello files. Using a named constant avoids repeating
+// magic strings and numbers at the multiple slice/endsWith sites below.
+const HELLO_SUFFIX = "-hello.json";
+
 interface Events {
   data: (data: unknown) => void;
   error: (err: unknown) => void;
@@ -61,6 +65,7 @@ interface Options {
   pollingFrequency: number;
   verbose: number;
   timestampInFilename: boolean;
+  locklessRendezvous: boolean;
 }
 
 const Message = z.object({
@@ -75,6 +80,7 @@ const getDefaultOptions = (): Options => {
     pollingFrequency: DEFAULT_POLLING_FREQUENCY_MS,
     verbose: DEFAULT_VERBOSITY,
     timestampInFilename: false,
+    locklessRendezvous: false,
   };
 };
 
@@ -136,9 +142,9 @@ export interface FileTransportClient {
 
 /**
  * File-based rendezvous and message-passing connection. Implements the
- * `.hello`/`.wave` handshake and `.json` polling protocol over any
- * {@link FileTransportClient} — an SFTP server via
- * {@link SSH2SFTPClientAdapter} or a locally-mounted folder via
+ * `-hello.json`/`.wave` handshake (or the lockless ack-handshake barrier) and
+ * `.json` polling protocol over any {@link FileTransportClient} — an SFTP
+ * server via {@link SSH2SFTPClientAdapter} or a locally-mounted folder via
  * `LocalFSClient`.
  */
 export class FileSyncConnection extends EventEmitter<Events, never> {
@@ -242,6 +248,8 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
       this.options.pollingFrequency = config.options.pollIntervalMs;
     if (config.options?.timestampInFilename !== undefined)
       this.options.timestampInFilename = config.options.timestampInFilename;
+    if (config.options?.locklessRendezvous !== undefined)
+      this.options.locklessRendezvous = config.options.locklessRendezvous;
     this.config = config;
     // timeToLive is computed after a successful connect (below) so that
     // retry latency during connection setup does not eat into the
@@ -406,9 +414,10 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
   }
 
   /**
-   * Negotiates rendezvous with the peer by exchanging `.hello` and `.wave`
-   * files in the shared directory, assigning `peerId` and `handshakeRole` on
-   * success.
+   * Negotiates rendezvous with the peer by exchanging `-hello.json` and
+   * `.wave` files (wave-race mode) or `-hello.json` and `-hello-ack.json`
+   * files (lockless mode) in the shared directory, assigning `peerId` and
+   * `handshakeRole` on success.
    *
    * Failures throw synchronously rather than being emitted on the `error`
    * channel: the `error` event is reserved for asynchronous failures from the
@@ -438,29 +447,41 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
     this.responsibleFiles.forEach((fileName) => {
       if (!fileNames.includes(fileName)) this.responsibleFiles.delete(fileName);
     });
-    const helloFiles = files.filter((file) => file.name.endsWith(".hello"));
+    const helloFiles = files.filter((file) =>
+      file.name.endsWith(HELLO_SUFFIX),
+    );
+    const hasStaleAck = files.some((file) =>
+      file.name.endsWith("-hello-ack.json"),
+    );
 
     if (
       helloFiles.length > 1 ||
-      files.some((file) => file.name.endsWith(".wave"))
+      files.some((file) => file.name.endsWith(".wave")) ||
+      hasStaleAck
     ) {
       const leftover = files
-        .filter((f) => f.name.endsWith(".hello") || f.name.endsWith(".wave"))
+        .filter(
+          (f) =>
+            f.name.endsWith(HELLO_SUFFIX) ||
+            f.name.endsWith(".wave") ||
+            f.name.endsWith("-hello-ack.json"),
+        )
         .map((f) => f.name)
         .join(", ");
       throw new Error(
-        `path ${this.path} had preexisting hello or wave files ` +
-          `(${leftover}); the directory must be empty of .hello and .wave ` +
-          "files before executing the protocol. Most likely cause: a " +
-          "previous exchange was terminated by SIGKILL/OOM/power loss " +
-          "before its cleanup ran. Remove the listed files manually after " +
-          "verifying that no other session is concurrently using this path.",
+        `path ${this.path} had preexisting hello, wave, or handshake-ack ` +
+          `files (${leftover}); the directory must be empty of these files ` +
+          "before executing the protocol. Most likely cause: a previous " +
+          "exchange was terminated by SIGKILL/OOM/power loss before its " +
+          "cleanup ran (a handshake-ack file indicates a crashed lockless " +
+          "session). Remove the listed files manually after verifying that " +
+          "no other session is concurrently using this path.",
       );
     }
 
-    const helloPath = `${this.path}/${this.id}.hello`;
+    const helloPath = `${this.path}/${this.id}${HELLO_SUFFIX}`;
 
-    if (helloFiles.length === 1) {
+    if (helloFiles.length === 1 && !this.options.locklessRendezvous) {
       /**
        * A list
        * A hello
@@ -475,11 +496,11 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
 
       const otherFile = helloFiles[0];
       const otherPath = `${this.path}/${otherFile.name}`;
-      const peerId = otherFile.name.slice(0, -6);
+      const peerId = otherFile.name.slice(0, -HELLO_SUFFIX.length);
 
       this.log.debug(
-        `[joiner] creating response ${this.id}.hello and deleting ` +
-          `discovered ${otherFile.name}`,
+        `[joiner] creating response ${this.id}${HELLO_SUFFIX} and ` +
+          `deleting discovered ${otherFile.name}`,
       );
 
       // Partial-failure note: if delete(otherPath) succeeds but put(helloPath)
@@ -496,7 +517,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
           flags: "w",
           encoding: "utf-8",
         });
-        this.responsibleFiles.add(`${this.id}.hello`);
+        this.responsibleFiles.add(`${this.id}${HELLO_SUFFIX}`);
       } catch (err: unknown) {
         throw err instanceof Error ? err : new Error(errMessage(err));
       }
@@ -525,17 +546,122 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
        * A ~ B hello
        * A ~ B list
        * A ~ B wave
+       *
+       * or (lockless mode, joiner fast-path bypassed):
+       *
+       * A list
+       * A hello
+       * B list (sees A hello)
+       * B hello (does not delete A hello)
+       * A ~ B ack-handshake barrier
        */
 
-      this.log.debug(`[${this.role}] creating initial ${this.id}.hello`);
+      this.log.debug(
+        `[${this.role}] creating initial ${this.id}${HELLO_SUFFIX}`,
+      );
       await this.client.put(Buffer.from(new ArrayBuffer(0)), helloPath, {
         flags: "w",
         encoding: "utf-8",
       });
-      this.responsibleFiles.add(`${this.id}.hello`);
+      this.responsibleFiles.add(`${this.id}${HELLO_SUFFIX}`);
       let wavePath: string | undefined;
+      let ackPath: string | undefined;
 
       const waitForPeer = async () => {
+        if (this.options.locklessRendezvous) {
+          // Lockless ack-handshake barrier: completes rendezvous using neither
+          // createExclusive nor delete. Each party writes a hello, then an ack
+          // on seeing the peer's hello, then completes when it sees the peer's
+          // ack. A peer hello already present before entering this loop (joiner
+          // fast-path bypassed) satisfies the condition on the first iteration.
+          //
+          // open() set timeToLive before synchronize() can run, so the
+          // non-null assertion is safe here.
+          while (Date.now() <= this.options.timeToLive!.getTime()) {
+            const currentFiles = await this.client.list(this.path!);
+
+            const fileNames = currentFiles.map((file) => file.name);
+            this.responsibleFiles.forEach((fileName) => {
+              if (!fileNames.includes(fileName))
+                this.responsibleFiles.delete(fileName);
+            });
+
+            const peerHello = currentFiles.find(
+              (file) =>
+                file.name !== `${this.id}${HELLO_SUFFIX}` &&
+                file.name.endsWith(HELLO_SUFFIX),
+            );
+
+            if (peerHello === undefined) {
+              this.log.trace(`[${this.role}] no peer hello found; polling`);
+              const delay = (ms: number) =>
+                new Promise((resolve) => setTimeout(resolve, ms));
+              await delay(this.options.pollingFrequency);
+              continue;
+            }
+
+            const peerId = peerHello.name.slice(0, -HELLO_SUFFIX.length);
+
+            // Write our ack once on the first sighting of the peer's hello.
+            if (ackPath === undefined) {
+              const ackName = `${this.id}-hello-ack.json`;
+              ackPath = `${this.path}/${ackName}`;
+              // Pre-track before writing so cleanup() sweeps it at close().
+              this.responsibleFiles.add(ackName);
+              this.log.debug(
+                `[${this.role}] writing handshake ack ${ackName}`,
+              );
+              await this.client.put(
+                Buffer.from(new ArrayBuffer(0)),
+                ackPath,
+                { flags: "w", encoding: "utf-8" },
+              );
+            }
+
+            // Barrier completes when the peer's ack is visible in the
+            // current listing. The listing was taken before we wrote our
+            // ack, so the peer's ack may not appear until the next poll;
+            // that is fine -- the barrier is correct as long as each party
+            // writes its ack before declaring completion.
+            const peerAckName = `${peerId}-hello-ack.json`;
+            const hasPeerAck = currentFiles.some(
+              (file) => file.name === peerAckName,
+            );
+
+            if (!hasPeerAck) {
+              this.log.trace(
+                `[${this.role}] waiting for peer ack ${peerAckName}`,
+              );
+              const delay = (ms: number) =>
+                new Promise((resolve) => setTimeout(resolve, ms));
+              await delay(this.options.pollingFrequency);
+              continue;
+            }
+
+            // Peer ack confirmed -- commit roles and peerId as the last step,
+            // the same invariant as the joiner path (see above): if the ack
+            // write fails before this point, this.peerId stays undefined and
+            // the "already synchronized" guard allows a retry on this instance.
+            const arrivedFirst =
+              `${this.id}${HELLO_SUFFIX}` < peerHello.name;
+            this.handshakeRole = arrivedFirst ? "responder" : "initiator";
+            this.role = arrivedFirst ? "starter" : "joiner";
+            this.peerId = peerId;
+
+            this.log.debug(
+              `[${this.role}] lockless rendezvous complete with ${peerId}`,
+            );
+
+            // Do NOT clear responsibleFiles: hello and ack remain so
+            // cleanup() can sweep them at close() time, the same as the
+            // wave-winner path.
+            return;
+          }
+
+          throw new Error(`[${this.role}] synchronization has timed out`);
+        }
+
+        // Wave-race path.
         // open() set timeToLive before synchronize() can run, so the non-null
         // assertion is safe here.
         while (Date.now() <= this.options.timeToLive!.getTime()) {
@@ -549,10 +675,11 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
 
           const otherFiles = currentFiles.filter(
             (file) =>
-              file.name !== `${this.id}.hello` && file.name.endsWith(".hello"),
+              file.name !== `${this.id}${HELLO_SUFFIX}` &&
+              file.name.endsWith(HELLO_SUFFIX),
           );
           const theseFiles = currentFiles.filter(
-            (file) => file.name === `${this.id}.hello`,
+            (file) => file.name === `${this.id}${HELLO_SUFFIX}`,
           );
           const waveFiles = currentFiles.filter((file) =>
             file.name.endsWith(".wave"),
@@ -620,10 +747,10 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
             if (!waveMatches || waveMatches.length !== 3)
               throw new Error("wave file name not in expected format");
             // The two capture groups are bare UUIDs, but theseFiles /
-            // otherFiles entries carry the ".hello" suffix; strip it before
+            // otherFiles entries carry the HELLO_SUFFIX; strip it before
             // comparing so the cross-checks can succeed.
-            const thisId = thisFile.name.slice(0, -".hello".length);
-            const otherId = otherFile.name.slice(0, -".hello".length);
+            const thisId = thisFile.name.slice(0, -HELLO_SUFFIX.length);
+            const otherId = otherFile.name.slice(0, -HELLO_SUFFIX.length);
             if (waveMatches[1] !== thisId && waveMatches[2] !== thisId)
               throw new Error("wave file does not reference this connection");
             if (waveMatches[1] !== otherId && waveMatches[2] !== otherId)
@@ -634,7 +761,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
               waveMatches[1] === this.id ? "responder" : "initiator";
             this.role =
               this.handshakeRole === "initiator" ? "joiner" : "starter";
-            this.peerId = otherFile.name.slice(0, -6);
+            this.peerId = otherFile.name.slice(0, -HELLO_SUFFIX.length);
 
             this.log.debug(`[${this.role}] parsed ${waveFile.name}`);
 
@@ -671,7 +798,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
             // arrived first, should wait for a message
             this.handshakeRole = "responder";
             this.role = "starter";
-            this.peerId = otherFile.name.slice(0, -6);
+            this.peerId = otherFile.name.slice(0, -HELLO_SUFFIX.length);
 
             this.log.debug(
               `[${this.role}] detected ${otherFile.name}; deleting it`,
@@ -703,7 +830,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
             const arrivedFirst = thisFile.name < otherFile.name;
             this.handshakeRole = arrivedFirst ? "responder" : "initiator";
             this.role = arrivedFirst ? "starter" : "joiner";
-            this.peerId = otherFile.name.slice(0, -6);
+            this.peerId = otherFile.name.slice(0, -HELLO_SUFFIX.length);
 
             const waveName =
               `${arrivedFirst ? this.id : this.peerId}-` +
@@ -797,15 +924,16 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
       try {
         await waitForPeer();
         // No clear() here: branches that finish their own cleanup
-        // (responder, wave-detection, EEXIST loser) clear explicitly
-        // before returning. The createExclusive-winner path is the
-        // exception — it leaves `${this.id}.hello` and waveName in
-        // responsibleFiles so the eventual cleanup() can sweep them
-        // if the loser never arrives (e.g. crash before reaching the
-        // wave file). Clearing here would lose that safety net.
+        // (responder, wave-detection, EEXIST loser, lockless) clear or retain
+        // explicitly before returning. The createExclusive-winner and lockless
+        // paths are the exception -- they leave hello (and wave or ack) in
+        // responsibleFiles so cleanup() can sweep them if the peer never
+        // arrives (e.g. crash before reaching the handshake files). Clearing
+        // here would lose that safety net.
         return;
       } catch (err: unknown) {
         if (wavePath) await this.client.safeDelete(wavePath);
+        if (ackPath) await this.client.safeDelete(ackPath);
         await this.client.safeDelete(helloPath);
         this.responsibleFiles.clear();
         if (err instanceof Error && err.cause === "usage") delete err.cause;
@@ -838,10 +966,16 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
     // consumed cannot be found by an exact name. Scan for any `<id>-*.json` we
     // still own and wait for it to clear, preserving the one-outstanding-
     // message-at-a-time invariant the peer's poll() relies on.
+    // Typed protocol files (hello, ack, receipt) share the `<id>-` prefix and
+    // `.json` extension but have a non-numeric terminal segment. Exclude them
+    // via parseMessageByteCount so a renamed hello does not cause send() to
+    // spin waiting for a protocol file to disappear.
     const hasOutstandingMessage = async () =>
       (await this.client.list(path)).some(
         (file) =>
-          file.name.startsWith(`${this.id}-`) && file.name.endsWith(".json"),
+          file.name.startsWith(`${this.id}-`) &&
+          file.name.endsWith(".json") &&
+          parseMessageByteCount(file.name) !== undefined,
       );
 
     try {

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -1668,9 +1668,14 @@ test("synchronize() wave path writes hello as <id>-hello.json and self-hello det
 // --- synchronize(): lockless mode ---------------------------------------------
 
 test("synchronize() lockless mode completes rendezvous when createExclusive and delete both throw", async () => {
-  // Two-party test using an inline client where createExclusive and delete
-  // always throw, simulating a transport that supports neither. The
-  // ack-handshake barrier must complete rendezvous using neither capability.
+  // Robustness proof: the ack-handshake barrier must complete rendezvous even
+  // when createExclusive and delete both throw. This is the most extreme
+  // constraint possible and is here to prove the protocol is sound under it.
+  // Real lockless deployments target sync-mediated transports where
+  // createExclusive lacks atomicity or deletion has high propagation latency
+  // -- delete itself works, just asynchronously. Cleanup therefore succeeds
+  // eventually on real transports; the pure no-op safeDelete here is not
+  // representative of a real storage backend.
   const idA = "00000000-0000-4000-8000-000000000001"; // sorts lower
   const idB = "ffffffff-ffff-4fff-bfff-ffffffffffff"; // sorts higher
 
@@ -1749,8 +1754,9 @@ test("synchronize() lockless mode completes rendezvous when createExclusive and 
 });
 
 test("synchronize() lockless mode role assignment matches the lexicographic rule for the same id pair as the wave path", async () => {
-  // idA < idB so A "arrived first" and is the responder/starter; B is
-  // the initiator/joiner. This must hold in lockless mode without any race.
+  // Role must be determined by lexicographic id order regardless of arrival
+  // timing. The throwing delete/createExclusive is robustness scaffolding
+  // (see the previous test); real lockless transports support delete.
   const idA = "00000000-0000-4000-8000-000000000001";
   const idB = "ffffffff-ffff-4fff-bfff-ffffffffffff";
   const sharedFiles = new Map<string, Buffer>();
@@ -1824,6 +1830,10 @@ test("synchronize() lockless mode role assignment matches the lexicographic rule
 });
 
 test("synchronize() lockless mode joiner fast-path is skipped; lockless barrier is entered even with peer hello already present", async () => {
+  // The throwing delete proves the joiner fast-path (which calls delete) is
+  // not taken in lockless mode. The no-op safeDelete is robustness scaffolding
+  // only; real lockless transports support delete (see the first lockless test).
+  //
   // When locklessRendezvous is set and a single peer hello is found on the
   // initial list(), the party must NOT take the joiner shortcut (which would
   // call delete(peer hello), unsupported on a lockless transport). It must

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -852,7 +852,7 @@ test("createExclusive creates an empty entry and does not affect other files", a
 test("synchronize() cleans up hello and wave files when createExclusive() throws EEXIST", async () => {
   // Simulates the losing party in the wave-file race: createExclusive() throws
   // because the peer already claimed the wave slot, and all three residue files
-  // (.hello x2, .wave) must be deleted before synchronize() returns.
+  // (-hello.json x2, .wave) must be deleted before synchronize() returns.
   const peerId = "00000000-0000-4000-8000-000000000001";
   const { client, files } = makeMockClient();
   const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
@@ -861,8 +861,8 @@ test("synchronize() cleans up hello and wave files when createExclusive() throws
   conn.id = "ffffffff-ffff-4fff-bfff-ffffffffffff";
   const myId = conn.id;
 
-  const myHelloName = `${myId}.hello`;
-  const peerHelloName = `${peerId}.hello`;
+  const myHelloName = `${myId}-hello.json`;
+  const peerHelloName = `${peerId}-hello.json`;
   // peerId < myId (pinned to max), so peer "arrived first" by name tiebreak.
   // Wave name: peer-mine.
   const waveName = `${peerId}-${myId}.wave`;
@@ -913,8 +913,8 @@ test("synchronize() throws when createExclusive throws EEXIST but wave file is a
   conn.id = "ffffffff-ffff-4fff-bfff-ffffffffffff";
   const myId = conn.id;
 
-  const myHelloName = `${myId}.hello`;
-  const peerHelloName = `${peerId}.hello`;
+  const myHelloName = `${myId}-hello.json`;
+  const peerHelloName = `${peerId}-hello.json`;
   // peerId < myId (pinned to max), so peer "arrived first" by name tiebreak.
   // Wave name would be peer-mine.
 
@@ -967,8 +967,8 @@ test("synchronize() rejects and cleans up hello and wave files when createExclus
   conn.id = "ffffffff-ffff-4fff-bfff-ffffffffffff";
   const myId = conn.id;
 
-  const myHelloName = `${myId}.hello`;
-  const peerHelloName = `${peerId}.hello`;
+  const myHelloName = `${myId}-hello.json`;
+  const peerHelloName = `${peerId}-hello.json`;
   // peerId < myId (pinned to max), so peer arrived first.
   const waveName = `${peerId}-${myId}.wave`;
   const wavePath = `${conn.path}/${waveName}`;
@@ -1017,8 +1017,8 @@ test("synchronize() outer catch clears responsibleFiles so cleanup() makes no re
   conn.id = "ffffffff-ffff-4fff-bfff-ffffffffffff";
   const myId = conn.id;
 
-  const myHelloName = `${myId}.hello`;
-  const peerHelloName = `${peerId}.hello`;
+  const myHelloName = `${myId}-hello.json`;
+  const peerHelloName = `${peerId}-hello.json`;
   const waveName = `${peerId}-${myId}.wave`;
   const wavePath = `${conn.path}/${waveName}`;
 
@@ -1072,22 +1072,22 @@ test("synchronize() outer catch clears responsibleFiles so cleanup() makes no re
 test("synchronize() resolves cleanly when it observes a wave file already created by the peer", async () => {
   // Regression guard: the wave-detection branch
   // (waitForPeer's "waveFiles.length > 0" arm) used to compare bare UUIDs
-  // from the wave filename against .hello entries, which never matched, so
-  // any party that observed a peer-created wave file threw
+  // from the wave filename against -hello.json entries, which never matched,
+  // so any party that observed a peer-created wave file threw
   // "wave file does not reference this connection" instead of completing
   // the rendezvous.
   //
-  // Scenario reproduced here: peer arrived first, both wrote .hello, peer
-  // won the wave race and created `${peerId}-${myId}.wave`. This party
-  // observes peer.hello + my.hello + wave file on its next list().
+  // Scenario reproduced here: peer arrived first, both wrote -hello.json,
+  // peer won the wave race and created `${peerId}-${myId}.wave`. This party
+  // observes peer-hello.json + my-hello.json + wave file on its next list().
   const peerId = "00000000-0000-4000-8000-000000000001";
   const { client, files } = makeMockClient();
   const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
   conn.id = "ffffffff-ffff-4fff-bfff-ffffffffffff";
   const myId = conn.id;
 
-  const myHelloName = `${myId}.hello`;
-  const peerHelloName = `${peerId}.hello`;
+  const myHelloName = `${myId}-hello.json`;
+  const peerHelloName = `${peerId}-hello.json`;
   // Peer arrived first (sorted lower) so the wave name is `${peer}-${my}`.
   const waveName = `${peerId}-${myId}.wave`;
   const wavePath = `${conn.path}/${waveName}`;
@@ -1141,8 +1141,8 @@ test("synchronize() createExclusive winner: leaves own hello and wave name in re
   const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
   conn.id = "ffffffff-ffff-4fff-bfff-ffffffffffff";
   const myId = conn.id;
-  const myHelloName = `${myId}.hello`;
-  const peerHelloName = `${peerId}.hello`;
+  const myHelloName = `${myId}-hello.json`;
+  const peerHelloName = `${peerId}-hello.json`;
   // peerId < myId so the peer "arrived first" by name tiebreak; wave name
   // is `${peerId}-${myId}.wave` and is created by THIS connection.
   const waveName = `${peerId}-${myId}.wave`;
@@ -1200,8 +1200,8 @@ test("synchronize() two-hellos branch: tiebreaker uses UUID order only, ignoring
     const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
     conn.id = myId;
     const base = conn.path ?? "";
-    const myHelloName = `${myId}.hello`;
-    const peerHelloName = `${peerId}.hello`;
+    const myHelloName = `${myId}-hello.json`;
+    const peerHelloName = `${peerId}-hello.json`;
 
     let listCallCount = 0;
     client.list = async () => {
@@ -1251,7 +1251,7 @@ test("synchronize() joiner branch: assigns initiator role and writes own hello a
   const { client, files } = makeMockClient();
   const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
   conn.id = "ffffffff-ffff-4fff-bfff-ffffffffffff";
-  const peerHelloName = `${peerId}.hello`;
+  const peerHelloName = `${peerId}-hello.json`;
   files.set(`${conn.path}/${peerHelloName}`, Buffer.alloc(0));
   client.list = async () => [
     { name: peerHelloName, modifyTime: Date.now(), size: 0 },
@@ -1263,7 +1263,7 @@ test("synchronize() joiner branch: assigns initiator role and writes own hello a
   expect(conn.peerId).toBe(peerId);
   // Peer's hello was deleted; our own hello was written.
   expect(files.has(`${conn.path}/${peerHelloName}`)).toBe(false);
-  expect(files.has(`${conn.path}/${conn.id}.hello`)).toBe(true);
+  expect(files.has(`${conn.path}/${conn.id}-hello.json`)).toBe(true);
 });
 
 test("synchronize() joiner branch: leaves connection unsynchronized when put fails after delete succeeds", async () => {
@@ -1277,7 +1277,7 @@ test("synchronize() joiner branch: leaves connection unsynchronized when put fai
   const { client, files } = makeMockClient();
   const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
   conn.id = "ffffffff-ffff-4fff-bfff-ffffffffffff";
-  const peerHelloName = `${peerId}.hello`;
+  const peerHelloName = `${peerId}-hello.json`;
   files.set(`${conn.path}/${peerHelloName}`, Buffer.alloc(0));
   client.list = async () => [
     { name: peerHelloName, modifyTime: Date.now(), size: 0 },
@@ -1611,4 +1611,326 @@ test("close() drains the last sent file before cleanup, preventing premature del
   await closePromise;
 
   expect(deletedBeforeConsumed).toBe(false);
+});
+
+// --- synchronize(): unconditional hello rename --------------------------------
+
+test("synchronize() preexisting -hello-ack.json causes an immediate rejection", async () => {
+  // A stale ack file indicates a crashed lockless session. The preexisting-file
+  // guard must reject regardless of whether locklessRendezvous is set.
+  const { client, files } = makeMockClient();
+  const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
+  const staleAck = "some-peer-id-hello-ack.json";
+  files.set(`${conn.path}/${staleAck}`, Buffer.alloc(0));
+  client.list = async () => [
+    { name: staleAck, modifyTime: 0, size: 0 },
+  ];
+
+  await expect(conn.synchronize()).rejects.toThrow(/handshake-ack/);
+});
+
+test("synchronize() wave path writes hello as <id>-hello.json and self-hello detection still works", async () => {
+  // Regression guard: the unconditional hello rename must not break the
+  // self-hello filter inside waitForPeer (the pair of checks that prevents a
+  // party from treating its own hello as the peer's).
+  const peerId = "00000000-0000-4000-8000-000000000001";
+  const { client, files } = makeMockClient();
+  const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
+  conn.id = "ffffffff-ffff-4fff-bfff-ffffffffffff";
+  const myId = conn.id;
+  const myHelloName = `${myId}-hello.json`;
+  const peerHelloName = `${peerId}-hello.json`;
+
+  const mtime = Date.now();
+  let listCallCount = 0;
+  client.list = async () => {
+    listCallCount++;
+    if (listCallCount === 1) return [];
+    return [
+      { name: myHelloName, modifyTime: mtime, size: 0 },
+      { name: peerHelloName, modifyTime: mtime, size: 0 },
+    ];
+  };
+
+  await conn.synchronize();
+
+  // The wave-race winner (this conn: wave created by createExclusive)
+  // committed peerId correctly from the -hello.json filename.
+  expect(conn.peerId).toBe(peerId);
+  expect(conn.handshakeRole).toBe("initiator");
+  // Our hello is named with the new convention and was written to the store.
+  const helloInStore = [...files.keys()].find((p) =>
+    p.endsWith(`/${myHelloName}`),
+  );
+  expect(helloInStore).toBeDefined();
+});
+
+// --- synchronize(): lockless mode ---------------------------------------------
+
+test("synchronize() lockless mode completes rendezvous when createExclusive and delete both throw", async () => {
+  // Two-party test using an inline client where createExclusive and delete
+  // always throw, simulating a transport that supports neither. The
+  // ack-handshake barrier must complete rendezvous using neither capability.
+  const idA = "00000000-0000-4000-8000-000000000001"; // sorts lower
+  const idB = "ffffffff-ffff-4fff-bfff-ffffffffffff"; // sorts higher
+
+  const sharedFiles = new Map<string, Buffer>();
+
+  const makeThrowingClient = (): FileTransportClient => ({
+    connect: async () => {},
+    end: async () => {},
+    list: async (dir: string): Promise<FileInfo[]> => {
+      const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+      return [...sharedFiles.entries()]
+        .filter(
+          ([p]) =>
+            p.startsWith(prefix) && !p.slice(prefix.length).includes("/"),
+        )
+        .map(([p, buf]) => ({
+          name: p.slice(prefix.length),
+          modifyTime: 0,
+          size: buf.length,
+        }));
+    },
+    get: async (path: string) => {
+      const data = sharedFiles.get(path);
+      if (!data) throw new Error(`${path}: not found`);
+      return data as Buffer<ArrayBufferLike>;
+    },
+    put: async (
+      src: string | Buffer | NodeJS.ReadableStream,
+      dest: string,
+    ) => {
+      if (Buffer.isBuffer(src)) sharedFiles.set(dest, src);
+    },
+    delete: async () => {
+      throw new Error("delete not supported on this transport");
+    },
+    safeDelete: async () => {
+      // Swallow silently: transport cannot delete.
+    },
+    rename: async (from: string, to: string) => {
+      const data = sharedFiles.get(from);
+      if (data === undefined) throw new Error(`${from}: no such file`);
+      sharedFiles.delete(from);
+      sharedFiles.set(to, data);
+    },
+    createExclusive: async () => {
+      throw new Error("createExclusive not supported on this transport");
+    },
+    exists: async (path: string) => sharedFiles.has(path),
+  });
+
+  const connA = new FileSyncConnection(makeThrowingClient(), {
+    pollingFrequency: 10,
+    timeToLive: new Date(Date.now() + 5_000),
+    verbose: -1,
+    locklessRendezvous: true,
+  });
+  connA.id = idA;
+  connA.connected = true;
+  connA.path = "/shared";
+
+  const connB = new FileSyncConnection(makeThrowingClient(), {
+    pollingFrequency: 10,
+    timeToLive: new Date(Date.now() + 5_000),
+    verbose: -1,
+    locklessRendezvous: true,
+  });
+  connB.id = idB;
+  connB.connected = true;
+  connB.path = "/shared";
+
+  await Promise.all([connA.synchronize(), connB.synchronize()]);
+
+  // Both parties must be synchronized.
+  expect(connA.peerId).toBe(idB);
+  expect(connB.peerId).toBe(idA);
+});
+
+test("synchronize() lockless mode role assignment matches the lexicographic rule for the same id pair as the wave path", async () => {
+  // idA < idB so A "arrived first" and is the responder/starter; B is
+  // the initiator/joiner. This must hold in lockless mode without any race.
+  const idA = "00000000-0000-4000-8000-000000000001";
+  const idB = "ffffffff-ffff-4fff-bfff-ffffffffffff";
+  const sharedFiles = new Map<string, Buffer>();
+
+  const makeClient = (): FileTransportClient => ({
+    connect: async () => {},
+    end: async () => {},
+    list: async (dir: string): Promise<FileInfo[]> => {
+      const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+      return [...sharedFiles.entries()]
+        .filter(
+          ([p]) =>
+            p.startsWith(prefix) && !p.slice(prefix.length).includes("/"),
+        )
+        .map(([p, buf]) => ({
+          name: p.slice(prefix.length),
+          modifyTime: 0,
+          size: buf.length,
+        }));
+    },
+    get: async (path: string) => {
+      const data = sharedFiles.get(path);
+      if (!data) throw new Error(`${path}: not found`);
+      return data as Buffer<ArrayBufferLike>;
+    },
+    put: async (
+      src: string | Buffer | NodeJS.ReadableStream,
+      dest: string,
+    ) => {
+      if (Buffer.isBuffer(src)) sharedFiles.set(dest, src);
+    },
+    delete: async () => { throw new Error("delete not supported"); },
+    safeDelete: async () => {},
+    rename: async (from: string, to: string) => {
+      const data = sharedFiles.get(from);
+      if (!data) throw new Error(`${from}: no such file`);
+      sharedFiles.delete(from);
+      sharedFiles.set(to, data);
+    },
+    createExclusive: async () => { throw new Error("not supported"); },
+    exists: async (path: string) => sharedFiles.has(path),
+  });
+
+  const connA = new FileSyncConnection(makeClient(), {
+    pollingFrequency: 10,
+    timeToLive: new Date(Date.now() + 5_000),
+    verbose: -1,
+    locklessRendezvous: true,
+  });
+  connA.id = idA;
+  connA.connected = true;
+  connA.path = "/shared";
+
+  const connB = new FileSyncConnection(makeClient(), {
+    pollingFrequency: 10,
+    timeToLive: new Date(Date.now() + 5_000),
+    verbose: -1,
+    locklessRendezvous: true,
+  });
+  connB.id = idB;
+  connB.connected = true;
+  connB.path = "/shared";
+
+  await Promise.all([connA.synchronize(), connB.synchronize()]);
+
+  // idA < idB: A arrived "first" by lexicographic order.
+  expect(connA.handshakeRole).toBe("responder");
+  expect(connA.role).toBe("starter");
+  expect(connB.handshakeRole).toBe("initiator");
+  expect(connB.role).toBe("joiner");
+});
+
+test("synchronize() lockless mode joiner fast-path is skipped; lockless barrier is entered even with peer hello already present", async () => {
+  // When locklessRendezvous is set and a single peer hello is found on the
+  // initial list(), the party must NOT take the joiner shortcut (which would
+  // call delete(peer hello), unsupported on a lockless transport). It must
+  // write its own hello and enter the lockless ack-handshake barrier instead.
+  const idA = "00000000-0000-4000-8000-000000000001";
+  const idB = "ffffffff-ffff-4fff-bfff-ffffffffffff";
+  const sharedFiles = new Map<string, Buffer>();
+
+  // Pre-plant A's hello so B's initial list() sees it (simulating A having
+  // arrived first and written its hello before B calls synchronize()).
+  sharedFiles.set(`/shared/${idA}-hello.json`, Buffer.alloc(0));
+
+  let deleteCalled = false;
+  const makeClient = (): FileTransportClient => ({
+    connect: async () => {},
+    end: async () => {},
+    list: async (dir: string): Promise<FileInfo[]> => {
+      const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+      return [...sharedFiles.entries()]
+        .filter(
+          ([p]) =>
+            p.startsWith(prefix) && !p.slice(prefix.length).includes("/"),
+        )
+        .map(([p, buf]) => ({
+          name: p.slice(prefix.length),
+          modifyTime: 0,
+          size: buf.length,
+        }));
+    },
+    get: async (path: string) => {
+      const data = sharedFiles.get(path);
+      if (!data) throw new Error(`${path}: not found`);
+      return data as Buffer<ArrayBufferLike>;
+    },
+    put: async (
+      src: string | Buffer | NodeJS.ReadableStream,
+      dest: string,
+    ) => {
+      if (Buffer.isBuffer(src)) sharedFiles.set(dest, src);
+    },
+    delete: async () => {
+      deleteCalled = true;
+      throw new Error("delete not supported");
+    },
+    safeDelete: async () => {},
+    rename: async (from: string, to: string) => {
+      const data = sharedFiles.get(from);
+      if (!data) throw new Error(`${from}: no such file`);
+      sharedFiles.delete(from);
+      sharedFiles.set(to, data);
+    },
+    createExclusive: async () => {
+      throw new Error("createExclusive not supported");
+    },
+    exists: async (path: string) => sharedFiles.has(path),
+  });
+
+  const connA = new FileSyncConnection(makeClient(), {
+    pollingFrequency: 10,
+    timeToLive: new Date(Date.now() + 5_000),
+    verbose: -1,
+    locklessRendezvous: true,
+  });
+  connA.id = idA;
+  connA.connected = true;
+  connA.path = "/shared";
+
+  const connB = new FileSyncConnection(makeClient(), {
+    pollingFrequency: 10,
+    timeToLive: new Date(Date.now() + 5_000),
+    verbose: -1,
+    locklessRendezvous: true,
+  });
+  connB.id = idB;
+  connB.connected = true;
+  connB.path = "/shared";
+
+  // Simulate A entering the lockless barrier (A's hello is pre-planted; A
+  // must poll for B's hello). Run A and B concurrently.
+  await Promise.all([connA.synchronize(), connB.synchronize()]);
+
+  // Neither party should have called delete (unsupported on lockless transport).
+  expect(deleteCalled).toBe(false);
+  // Both are synchronized.
+  expect(connA.peerId).toBe(idB);
+  expect(connB.peerId).toBe(idA);
+  // A's hello was NOT deleted (still in sharedFiles).
+  expect(sharedFiles.has(`/shared/${idA}-hello.json`)).toBe(true);
+});
+
+// --- send(): hasOutstandingMessage excludes typed protocol files ---------------
+
+test("send() completes without spinning when a <id>-hello.json file is present in the store", async () => {
+  // Regression guard: after the hello rename, <id>-hello.json matches the
+  // `startsWith(<id>-) && endsWith(.json)` scan in hasOutstandingMessage.
+  // Without the parseMessageByteCount fix, send() would spin waiting for the
+  // hello file to be consumed. Verify it completes immediately instead.
+  const { client, files } = makeMockClient();
+  const conn = await makeConnectedConn(client);
+
+  // Plant the hello file as it would appear after synchronize().
+  const helloPath = `/test/${conn.id}-hello.json`;
+  files.set(helloPath, Buffer.alloc(0));
+
+  // send() must complete without looping on the hello file.
+  await expect(conn.send({ check: true })).resolves.toBeUndefined();
+
+  // The hello file must still be present (send() is not responsible for it).
+  expect(files.has(helloPath)).toBe(true);
 });

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -1934,3 +1934,35 @@ test("send() completes without spinning when a <id>-hello.json file is present i
   // The hello file must still be present (send() is not responsible for it).
   expect(files.has(helloPath)).toBe(true);
 });
+
+test("synchronize() lockless mode throws when more than one peer hello is detected during the poll loop", async () => {
+  // Regression guard for the multi-peer-hello guard added to the lockless
+  // loop: mirrors the wave path's otherFiles.length > 1 check and catches a
+  // third party that slipped in after the initial synchronize() guard.
+  const { client } = makeMockClient();
+  const conn = new FileSyncConnection(client, {
+    pollingFrequency: 10,
+    timeToLive: new Date(Date.now() + 5_000),
+    verbose: -1,
+    locklessRendezvous: true,
+  });
+  conn.id = "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa";
+  conn.connected = true;
+  conn.path = "/test";
+
+  const peerId1 = "00000000-0000-4000-8000-000000000001";
+  const peerId2 = "00000000-0000-4000-8000-000000000002";
+  let listCallCount = 0;
+  client.list = async () => {
+    listCallCount++;
+    if (listCallCount === 1) return []; // initial synchronize() guard: clean
+    // Second call (inside waitForPeer): two peer hellos are present.
+    return [
+      { name: `${conn.id}-hello.json`, modifyTime: 0, size: 0 },
+      { name: `${peerId1}-hello.json`, modifyTime: 0, size: 0 },
+      { name: `${peerId2}-hello.json`, modifyTime: 0, size: 0 },
+    ];
+  };
+
+  await expect(conn.synchronize()).rejects.toThrow(/more than one peer hello/);
+});


### PR DESCRIPTION
## Summary

- Renames the hello file unconditionally from `<id>.hello` to `<id>-hello.json` so rendezvous discovery is uniform across both rendezvous paths and the future mode-mismatch fast-fail (193901017) can detect mismatches from the filename alone
- Adds `lockless_rendezvous` option to `FileSyncOptions` (config schema, Zod, JSDoc, CLI flags); when set, both parties run an ack-handshake barrier instead of the wave-file race — requires neither `createExclusive` nor `delete`
- Fixes `send()` `hasOutstandingMessage` to exclude typed protocol files (non-numeric terminal segment) so the renamed hello file does not block message sends
- Wires `--lockless-rendezvous` through the `exchange` and `zero-setup` CLI commands; documents the option, the canonical filename grammar, and a new Directory Exclusivity section in `EXCHANGE_SPEC.md`

Closes (implements) board item [194002643](https://github.com/orgs/georgetown-mdi/projects/9/views/2?pane=issue&itemId=194002643). Depends on merged [193204005](https://github.com/orgs/georgetown-mdi/projects/9/views/2?pane=issue&itemId=193204005). Note for whoever implements [194002650](https://github.com/orgs/georgetown-mdi/projects/9/views/2?pane=issue&itemId=194002650) (wave-filename generalization): this PR lands first — rebase on top of it.

## Code-review fixes (commits 2 and 3)

Four correctness findings from independent review, then three from a second review round:

**Round 1:**
- Multi-peer-hello guard added to the lockless loop — `peerHellos.length > 1` throws on every iteration, mirroring the wave path
- `applyConnectionOverrides` channel-guards `locklessRendezvous` to sftp/filedrop only
- `continue` after ack write so `hasPeerAck` always uses a fresh `list()` snapshot
- Stale-ack guard error message extended to describe the live-peer retry false-positive

**Round 2:**
- `locklessRendezvous` JSDoc and test comments clarify that the option targets transports with slow/async deletion (cloud-sync), not transports that genuinely cannot delete; the no-op `safeDelete` in tests is robustness scaffolding, not a model of a real backend
- `--lockless-rendezvous` now emits a `warn`-level log when passed for a channel that does not support it (`exchange` checks after config resolution; `zero-setup` checks before `createConnection` can throw so the message is always visible)

Follow-on: board item [194304738](https://github.com/orgs/georgetown-mdi/projects/9/views/2?pane=issue&itemId=194304738) tracks binding the ack filename to the target peer ID (deferred; depends on [193901017](https://github.com/orgs/georgetown-mdi/projects/9/views/2?pane=issue&itemId=193901017)).

## Test plan

- [x] All `fileSyncConnection.test.ts` tests pass with updated hello filenames (63 tests including new ones)
- [x] New unit tests cover: stale-ack guard, preexisting ack rejection, wave-path hello rename, two-party lockless rendezvous, lockless role assignment, joiner fast-path skip, `send()` non-blocking with hello file present, lockless multi-peer-hello guard
- [x] `apps/cli/test/unit/protocol.test.ts` filter updated from `.endsWith(".hello")` to `.endsWith("-hello.json")`
- [x] Integration tests (SFTP + mixed, against Docker): 8/8 passing