### PR TITLE
Generalize wave filename to tolerate arbitrary ids

### DIFF
--- a/packages/core/src/connection/fileSyncConnection.ts
+++ b/packages/core/src/connection/fileSyncConnection.ts
@@ -742,38 +742,35 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
             const otherFile = otherFiles[0];
             const thisFile = theseFiles[0];
 
-            const waveRegex = new RegExp(
-              [
-                /^/,
-                /([0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12})/,
-                /-/,
-                /([0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12})/,
-                /\.wave/,
-                /$/,
-              ]
-                .map((r) => r.source)
-                .join(""),
-              "i",
-            );
-            const waveMatches = waveFile.name.match(waveRegex);
-            if (!waveMatches || waveMatches.length !== 3)
-              throw new Error("wave file name not in expected format");
-            // The two capture groups are bare UUIDs, but theseFiles /
-            // otherFiles entries carry the HELLO_SUFFIX; strip it before
-            // comparing so the cross-checks can succeed.
             const thisId = thisFile.name.slice(0, -HELLO_SUFFIX.length);
             const otherId = otherFile.name.slice(0, -HELLO_SUFFIX.length);
-            if (waveMatches[1] !== thisId && waveMatches[2] !== thisId)
+
+            // Use hello filename order -- the same tiebreak the wave producer
+            // uses (I7) -- to reconstruct the expected wave name. Do NOT fall
+            // back to a raw `thisId < otherId` compare: for ids where one is a
+            // prefix of the other (e.g. "Agency" / "Agency A"), space (U+0020)
+            // sorts before "-" (U+002D), so hello-filename order and id-order
+            // can diverge, causing a false "wave does not reference this
+            // connection" throw that UUID tests would never catch.
+            const arrivedFirst = thisFile.name < otherFile.name;
+            const expectedWaveName = arrivedFirst
+              ? `${thisId}-${otherId}.wave`
+              : `${otherId}-${thisId}.wave`;
+
+            // Pair validation via reconstruct-and-compare. A stale wave from a
+            // different id-pair that happens to concatenate to the same
+            // <a>-<b>.wave string is a theoretical residual; the single-wave
+            // guard above (waveFiles.length > 1) is the primary protection, so
+            // the peer_id charset is left unrestricted rather than working
+            // around this edge case here.
+            if (waveFile.name !== expectedWaveName)
               throw new Error("wave file does not reference this connection");
-            if (waveMatches[1] !== otherId && waveMatches[2] !== otherId)
-              throw new Error("wave file does not reference other connection");
 
             // first to arrive => should wait for first message
-            this.handshakeRole =
-              waveMatches[1] === this.id ? "responder" : "initiator";
+            this.handshakeRole = arrivedFirst ? "responder" : "initiator";
             this.role =
               this.handshakeRole === "initiator" ? "joiner" : "starter";
-            this.peerId = otherFile.name.slice(0, -HELLO_SUFFIX.length);
+            this.peerId = otherId;
 
             this.log.debug(`[${this.role}] parsed ${waveFile.name}`);
 
@@ -832,13 +829,13 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
 
             const thisFile = theseFiles[0];
 
-            // Tiebreak on UUID lexicographic order alone, never modifyTime:
-            // both hello UUIDs are identical on each side, so this comparison
-            // is deterministic and symmetric regardless of which party runs
-            // it. modifyTime is unreliable here -- sync tools stamp files with
-            // the transfer time rather than the original creation time, so the
-            // two parties may observe different (even contradictory) timestamps
-            // for the same files.
+            // Tiebreak on hello filename order alone, never modifyTime: both
+            // parties compute the identical hello filenames, so this comparison
+            // is deterministic and symmetric regardless of which party runs it.
+            // modifyTime is unreliable here -- sync tools stamp files with the
+            // transfer time rather than the original creation time, so the two
+            // parties may observe different (even contradictory) timestamps for
+            // the same files.
             const arrivedFirst = thisFile.name < otherFile.name;
             this.handshakeRole = arrivedFirst ? "responder" : "initiator";
             this.role = arrivedFirst ? "starter" : "joiner";

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -1125,6 +1125,144 @@ test("synchronize() resolves cleanly when it observes a wave file already create
   expect(files.has(`${conn.path}/${myHelloName}`)).toBe(false);
 });
 
+// --- synchronize(): wave-detection with arbitrary-string ids -----------------
+
+test("synchronize() wave-detection branch completes rendezvous with arbitrary string ids", async () => {
+  // Acceptance criterion: a two-party unit test with arbitrary string ids
+  // (not UUIDs) completes the wave handshake and assigns roles deterministically.
+  //
+  // "Agency A-hello.json" < "Agency B-hello.json" lexicographically, so
+  // "Agency A" arrived first. The wave producer (the winner of the wave race,
+  // which is unmodelled here -- we plant the wave directly) creates
+  // "Agency A-Agency B.wave". This connection is "Agency B" and observes both
+  // hellos plus the peer-created wave, triggering the wave-detection branch.
+  const myId = "Agency B";
+  const peerId = "Agency A";
+  const { client, files } = makeMockClient();
+  const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
+  conn.id = myId;
+
+  const myHelloName = `${myId}-hello.json`;
+  const peerHelloName = `${peerId}-hello.json`;
+  // Peer arrived first (sorts lower) so the wave name is `${peerId}-${myId}`.
+  const waveName = `${peerId}-${myId}.wave`;
+  const wavePath = `${conn.path}/${waveName}`;
+
+  files.set(`${conn.path}/${myHelloName}`, Buffer.alloc(0));
+  files.set(`${conn.path}/${peerHelloName}`, Buffer.alloc(0));
+  files.set(wavePath, Buffer.alloc(0));
+
+  const mtime = Date.now();
+  let listCallCount = 0;
+  client.list = async () => {
+    listCallCount++;
+    if (listCallCount === 1) return [];
+    return [
+      { name: myHelloName, modifyTime: mtime, size: 0 },
+      { name: peerHelloName, modifyTime: mtime, size: 0 },
+      { name: waveName, modifyTime: mtime, size: 0 },
+    ];
+  };
+
+  await conn.synchronize();
+
+  // Peer arrived first => this connection is initiator/joiner.
+  expect(conn.handshakeRole).toBe("initiator");
+  expect(conn.role).toBe("joiner");
+  expect(conn.peerId).toBe(peerId);
+  expect(files.has(wavePath)).toBe(false);
+  expect(files.has(`${conn.path}/${peerHelloName}`)).toBe(false);
+  expect(files.has(`${conn.path}/${myHelloName}`)).toBe(false);
+});
+
+test("synchronize() wave-detection branch uses filename order (I7), not id order, for prefix-related ids", async () => {
+  // Acceptance criterion: with prefix-related ids where filename order and raw
+  // id-compare diverge, roles are derived from filename order (I7) and the
+  // wave-detection branch does NOT throw.
+  //
+  // "Agency A-hello.json" < "Agency-hello.json" because space (U+0020) sorts
+  // before "-" (U+002D). So "Agency A" arrived first by filename order.
+  // A raw `"Agency" < "Agency A"` id-compare would say "Agency" arrived first,
+  // producing the wrong expected wave name and a false rejection. Filename order
+  // is the source of truth (I7) and must win.
+  const myId = "Agency";
+  const peerId = "Agency A";
+  const { client, files } = makeMockClient();
+  const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
+  conn.id = myId;
+
+  const myHelloName = `${myId}-hello.json`;
+  const peerHelloName = `${peerId}-hello.json`;
+  // "Agency A-hello.json" < "Agency-hello.json" => peer arrived first.
+  // Wave name is `${peerId}-${myId}.wave`, matching what the producer wrote.
+  const waveName = `${peerId}-${myId}.wave`;
+  const wavePath = `${conn.path}/${waveName}`;
+
+  files.set(`${conn.path}/${myHelloName}`, Buffer.alloc(0));
+  files.set(`${conn.path}/${peerHelloName}`, Buffer.alloc(0));
+  files.set(wavePath, Buffer.alloc(0));
+
+  const mtime = Date.now();
+  let listCallCount = 0;
+  client.list = async () => {
+    listCallCount++;
+    if (listCallCount === 1) return [];
+    return [
+      { name: myHelloName, modifyTime: mtime, size: 0 },
+      { name: peerHelloName, modifyTime: mtime, size: 0 },
+      { name: waveName, modifyTime: mtime, size: 0 },
+    ];
+  };
+
+  // Must not throw "wave does not reference this connection".
+  await conn.synchronize();
+
+  expect(conn.handshakeRole).toBe("initiator");
+  expect(conn.role).toBe("joiner");
+  expect(conn.peerId).toBe(peerId);
+  expect(files.has(wavePath)).toBe(false);
+});
+
+test("synchronize() wave-detection branch rejects a stale wave from a different id-pair", async () => {
+  // Acceptance criterion: a stale .wave from a different id-pair, present
+  // alongside the current pair's hellos, fails the pair-validation check.
+  //
+  // The current pair is "Agency B" + "Agency A". A stale wave file
+  // "StaleX-StaleY.wave" from a prior session of a different pair is present.
+  // Reconstruct-and-compare produces "Agency A-Agency B.wave" (peer arrived
+  // first by filename order), which does not match the stale name.
+  const myId = "Agency B";
+  const peerId = "Agency A";
+  const { client, files } = makeMockClient();
+  const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
+  conn.id = myId;
+
+  const myHelloName = `${myId}-hello.json`;
+  const peerHelloName = `${peerId}-hello.json`;
+  const staleWaveName = "StaleX-StaleY.wave";
+  const staleWavePath = `${conn.path}/${staleWaveName}`;
+
+  files.set(`${conn.path}/${myHelloName}`, Buffer.alloc(0));
+  files.set(`${conn.path}/${peerHelloName}`, Buffer.alloc(0));
+  files.set(staleWavePath, Buffer.alloc(0));
+
+  const mtime = Date.now();
+  let listCallCount = 0;
+  client.list = async () => {
+    listCallCount++;
+    if (listCallCount === 1) return [];
+    return [
+      { name: myHelloName, modifyTime: mtime, size: 0 },
+      { name: peerHelloName, modifyTime: mtime, size: 0 },
+      { name: staleWaveName, modifyTime: mtime, size: 0 },
+    ];
+  };
+
+  await expect(conn.synchronize()).rejects.toThrow(
+    "wave file does not reference this connection",
+  );
+});
+
 // --- synchronize(): createExclusive winner retains responsibleFiles --------
 
 test("synchronize() createExclusive winner: leaves own hello and wave name in responsibleFiles so cleanup() can sweep them if peer never arrives", async () => {


### PR DESCRIPTION
## Summary

- Replaces the UUID-anchored regex in `FileSyncConnection`'s wave-detection branch with reconstruct-and-compare, so any `peer_id` (not just a UUID) completes wave rendezvous without throwing "wave file name not in expected format."
- Role assignment now derives `arrivedFirst` from hello filename order (invariant I7) rather than from regex capture groups, fixing a latent bug where prefix-related ids (`"Agency"` / `"Agency A"`) could cause filename order and raw id-compare to diverge and produce a false rejection.
- Behavior is fully preserved for UUID ids: existing rendezvous completes and roles are assigned identically.

Closes / implements board item [194002650](https://github.com/orgs/georgetown-mdi/projects/9/views/2?pane=issue&itemId=194002650).

## Test plan

- [x] All pre-existing wave-race and wave-detection tests pass unchanged (UUID ids)
- [x] New test: arbitrary string ids (`"Agency A"` / `"Agency B"`) complete rendezvous and assign roles correctly
- [x] New test: prefix-related ids (`"Agency"` / `"Agency A"`) use filename order (I7) and do NOT throw
- [x] New test: stale `.wave` from a different id-pair is rejected by reconstruct-and-compare
- [x] Full core test suite passes (`npx vitest run packages/core/test/fileSyncConnection.test.ts` — 66 tests)
- [x] Full CLI test suite passes (`npm test -w apps/cli` — 137 tests)