### PR TITLE
Replace synchronize() cause sentinel with typed UsageError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to PSI-Link are documented here. The format follows [Keep a 
 - Library API: `runExchange` and `authenticateConnection` now take a `MessageConnection` instead of the event-based `Connection`. CLI exchanges are unaffected.
 - An exchange now fails with a clear error (bounded by `peer_timeout_ms`) when the partner stops responding, instead of hanging.
 - A peer sending messages out of turn is rejected rather than buffered without limit.
+- The CLI now exits with code 64 (EX_USAGE) instead of 69 (EX_UNAVAILABLE) when `synchronize()` or `send()` fails due to a configuration or usage problem: a dirty exchange directory (preexisting handshake files), multiple concurrent sessions on the same path, or a send timeout. Transport failures continue to exit with code 69.
 
 ### Fixed
 

--- a/apps/cli/src/commands/exchange.ts
+++ b/apps/cli/src/commands/exchange.ts
@@ -9,6 +9,7 @@ import {
   getLogger,
   loadCSVFile,
   prepareForExchange,
+  UsageError,
 } from "@psilink/core";
 import type { ExchangeDataSpec, PreparedExchange } from "@psilink/core";
 
@@ -284,7 +285,8 @@ export function loadConfig(
     peerId: options.peerId,
   });
 
-  if (options.locklessRendezvous === true &&
+  if (
+    options.locklessRendezvous === true &&
     connection.channel !== "sftp" &&
     connection.channel !== "filedrop"
   ) {
@@ -402,6 +404,6 @@ export async function handler(argv: Arguments): Promise<void> {
     await runProtocol(connection, prepared, output, verbosity, "exchange");
   } catch (err) {
     log.error(err instanceof Error ? err.message : String(err));
-    process.exit(69);
+    process.exit(err instanceof UsageError ? 64 : 69);
   }
 }

--- a/apps/cli/src/commands/zeroSetup.ts
+++ b/apps/cli/src/commands/zeroSetup.ts
@@ -4,7 +4,12 @@ import { fileURLToPath } from "node:url";
 import logLibrary from "loglevel";
 import { userInfo } from "node:os";
 
-import { getLogger, loadCSVFile, prepareForExchange } from "@psilink/core";
+import {
+  getLogger,
+  loadCSVFile,
+  prepareForExchange,
+  UsageError,
+} from "@psilink/core";
 import type {
   ConnectionConfig,
   FileDropConnectionConfig,
@@ -405,7 +410,7 @@ export async function handler(argv: Arguments): Promise<void> {
     );
   } catch (err) {
     log.error(err instanceof Error ? err.message : String(err));
-    process.exit(69);
+    process.exit(err instanceof UsageError ? 64 : 69);
   }
 
   if (!options.save) {

--- a/packages/core/src/connection/fileSyncConnection.ts
+++ b/packages/core/src/connection/fileSyncConnection.ts
@@ -8,6 +8,7 @@ import type {
   FileDropConnectionConfig,
 } from "../config/connection";
 import type { HandshakeRole } from "../types";
+import { UsageError } from "../errors";
 
 const errMessage = (err: unknown) =>
   err instanceof Error ? err.message : String(err);
@@ -470,9 +471,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
     this.responsibleFiles.forEach((fileName) => {
       if (!fileNames.includes(fileName)) this.responsibleFiles.delete(fileName);
     });
-    const helloFiles = files.filter((file) =>
-      file.name.endsWith(HELLO_SUFFIX),
-    );
+    const helloFiles = files.filter((file) => file.name.endsWith(HELLO_SUFFIX));
     const hasStaleAck = files.some((file) =>
       file.name.endsWith("-hello-ack.json"),
     );
@@ -491,7 +490,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
         )
         .map((f) => f.name)
         .join(", ");
-      throw new Error(
+      throw new UsageError(
         `path ${this.path} had preexisting hello, wave, or handshake-ack ` +
           `files (${leftover}); the directory must be empty of these files ` +
           "before executing the protocol. Most likely cause: a previous " +
@@ -645,10 +644,9 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
             }
 
             if (peerHellos.length > 1) {
-              throw new Error(
+              throw new UsageError(
                 `more than one peer hello file in ${this.path} - are there ` +
                   "other sessions using this path?",
-                { cause: "usage" },
               );
             }
 
@@ -661,14 +659,11 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
               ackPath = `${this.path}/${ackName}`;
               // Pre-track before writing so cleanup() sweeps it at close().
               this.responsibleFiles.add(ackName);
-              this.log.debug(
-                `[${this.role}] writing handshake ack ${ackName}`,
-              );
-              await this.client.put(
-                Buffer.from(new ArrayBuffer(0)),
-                ackPath,
-                { flags: "w", encoding: "utf-8" },
-              );
+              this.log.debug(`[${this.role}] writing handshake ack ${ackName}`);
+              await this.client.put(Buffer.from(new ArrayBuffer(0)), ackPath, {
+                flags: "w",
+                encoding: "utf-8",
+              });
               // Re-enter the loop so hasPeerAck is checked against a fresh
               // listing; the pre-ack-write snapshot from this iteration may
               // miss a peer ack that arrived in the window between list() and
@@ -696,8 +691,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
             // the same invariant as the joiner path (see above): if the ack
             // write fails before this point, this.peerId stays undefined and
             // the "already synchronized" guard allows a retry on this instance.
-            const arrivedFirst =
-              `${this.id}${HELLO_SUFFIX}` < peerHello.name;
+            const arrivedFirst = `${this.id}${HELLO_SUFFIX}` < peerHello.name;
             this.handshakeRole = arrivedFirst ? "responder" : "initiator";
             this.role = arrivedFirst ? "starter" : "joiner";
             this.peerId = peerId;
@@ -757,24 +751,21 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
              * This is B
              */
             if (waveFiles.length > 1) {
-              throw new Error(
+              throw new UsageError(
                 "more than one wave file - are there other sessions using " +
                   "this path?",
-                { cause: "usage" },
               );
             }
             if (otherFiles.length !== 1) {
-              throw new Error(
+              throw new UsageError(
                 "wave file detected but no peer hello - are there other " +
                   "sessions using this path?",
-                { cause: "usage" },
               );
             }
             if (theseFiles.length !== 1) {
-              throw new Error(
+              throw new UsageError(
                 "wave file detected but no self hello - are there other " +
                   "sessions using this path?",
-                { cause: "usage" },
               );
             }
 
@@ -824,10 +815,9 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
           }
 
           if (otherFiles.length > 1) {
-            throw new Error(
+            throw new UsageError(
               `more than one peer hello file in ${this.path} - are there ` +
                 "other sessions using this path?",
-              { cause: "usage" },
             );
           }
           const otherFile = otherFiles[0];
@@ -860,10 +850,9 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
             return;
           } else {
             if (theseFiles.length > 1) {
-              throw new Error(
+              throw new UsageError(
                 `more than one self hello file in ${this.path} - are there ` +
                   "other sessions using this path?",
-                { cause: "usage" },
               );
             }
 
@@ -945,11 +934,10 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
                 await this.client.safeDelete(`${this.path}/${otherFile.name}`);
                 await this.client.safeDelete(helloPath);
                 this.responsibleFiles.clear();
-                throw new Error(
+                throw new UsageError(
                   "peer appears to have abandoned the handshake: wave file " +
                     "was claimed by the peer but disappeared before this " +
                     "side could complete synchronization. Retry the exchange.",
-                  { cause: "usage" },
                 );
               } else {
                 this.log.debug(
@@ -987,11 +975,10 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
           this.peerId!.startsWith(this.id + "-") ||
           this.id.startsWith(this.peerId! + "-")
         )
-          throw new Error(
+          throw new UsageError(
             `peer id '${this.peerId}' and this party's id '${this.id}' share ` +
               "a prefix at a '-' boundary; ids must not be prefix-extensions " +
               "of each other (e.g. 'site' / 'site-2')",
-            { cause: "usage" },
           );
         return;
       } catch (err: unknown) {
@@ -1006,7 +993,6 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
         this.peerId = undefined;
         this.role = "unknown role";
         this.handshakeRole = undefined;
-        if (err instanceof Error && err.cause === "usage") delete err.cause;
         throw err instanceof Error ? err : new Error(errMessage(err));
       }
     }
@@ -1056,9 +1042,8 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
         while (await hasOutstandingMessage()) {
           // open() set timeToLive before send() can run; assertion is safe.
           if (Date.now() > this.options.timeToLive!.getTime()) {
-            throw new Error(
+            throw new UsageError(
               `timed out waiting for message from ${this.id} to be consumed`,
-              { cause: "usage" },
             );
           }
           await new Promise((resolve) =>
@@ -1101,7 +1086,6 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
       this.lastSentFile = outName;
     } catch (err: unknown) {
       await this.client.safeDelete(tempPath);
-      if (err instanceof Error && err.cause === "usage") delete err.cause;
       throw err instanceof Error ? err : new Error(errMessage(err));
     }
   }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Thrown by {@link FileSyncConnection} when the caller has supplied an
+ * invalid configuration or attempted an operation that violates usage
+ * constraints: wrong directory state, stale handshake files, multiple
+ * concurrent sessions sharing a path, or a send timeout. This is the
+ * public API contract for the 64-vs-69 exit-code split: callers outside
+ * `packages/core` -- notably the CLI -- check `instanceof UsageError` to
+ * distinguish a configuration problem from a transport failure and exit
+ * with 64 (EX_USAGE) rather than 69 (EX_UNAVAILABLE). Future throw sites
+ * added to `synchronize()` or `send()` should throw this class rather
+ * than a plain `Error` with `{ cause: "usage" }`.
+ */
+export class UsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UsageError";
+  }
+}

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -1,3 +1,4 @@
+export * from "./errors";
 export * from "./participant";
 export * from "./link";
 export * from "./protocolSetup";

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -9,6 +9,7 @@ import type {
   SFTPConnectionConfig,
   FileDropConnectionConfig,
 } from "../src/config/connection";
+import { UsageError } from "../src/errors";
 
 // Minimal in-memory FileTransportClient mock.  Only the methods called by
 // send() need real implementations; everything else is a no-op.
@@ -1760,9 +1761,7 @@ test("synchronize() preexisting -hello-ack.json causes an immediate rejection", 
   const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
   const staleAck = "some-peer-id-hello-ack.json";
   files.set(`${conn.path}/${staleAck}`, Buffer.alloc(0));
-  client.list = async () => [
-    { name: staleAck, modifyTime: 0, size: 0 },
-  ];
+  client.list = async () => [{ name: staleAck, modifyTime: 0, size: 0 }];
 
   await expect(conn.synchronize()).rejects.toThrow(/handshake-ack/);
 });
@@ -1840,10 +1839,7 @@ test("synchronize() lockless mode completes rendezvous when createExclusive and 
       if (!data) throw new Error(`${path}: not found`);
       return data as Buffer<ArrayBufferLike>;
     },
-    put: async (
-      src: string | Buffer | NodeJS.ReadableStream,
-      dest: string,
-    ) => {
+    put: async (src: string | Buffer | NodeJS.ReadableStream, dest: string) => {
       if (Buffer.isBuffer(src)) sharedFiles.set(dest, src);
     },
     delete: async () => {
@@ -1920,13 +1916,12 @@ test("synchronize() lockless mode role assignment matches the lexicographic rule
       if (!data) throw new Error(`${path}: not found`);
       return data as Buffer<ArrayBufferLike>;
     },
-    put: async (
-      src: string | Buffer | NodeJS.ReadableStream,
-      dest: string,
-    ) => {
+    put: async (src: string | Buffer | NodeJS.ReadableStream, dest: string) => {
       if (Buffer.isBuffer(src)) sharedFiles.set(dest, src);
     },
-    delete: async () => { throw new Error("delete not supported"); },
+    delete: async () => {
+      throw new Error("delete not supported");
+    },
     safeDelete: async () => {},
     rename: async (from: string, to: string) => {
       const data = sharedFiles.get(from);
@@ -1934,7 +1929,9 @@ test("synchronize() lockless mode role assignment matches the lexicographic rule
       sharedFiles.delete(from);
       sharedFiles.set(to, data);
     },
-    createExclusive: async () => { throw new Error("not supported"); },
+    createExclusive: async () => {
+      throw new Error("not supported");
+    },
     exists: async (path: string) => sharedFiles.has(path),
   });
 
@@ -2006,10 +2003,7 @@ test("synchronize() lockless mode joiner fast-path is skipped; lockless barrier 
       if (!data) throw new Error(`${path}: not found`);
       return data as Buffer<ArrayBufferLike>;
     },
-    put: async (
-      src: string | Buffer | NodeJS.ReadableStream,
-      dest: string,
-    ) => {
+    put: async (src: string | Buffer | NodeJS.ReadableStream, dest: string) => {
       if (Buffer.isBuffer(src)) sharedFiles.set(dest, src);
     },
     delete: async () => {
@@ -2260,4 +2254,74 @@ test("synchronize() joiner branch accepts space-containing ids", async () => {
 
   await conn.synchronize();
   expect(conn.peerId).toBe(peerId);
+});
+
+// --- UsageError taxonomy -------------------------------------------------------
+
+test("synchronize() throws UsageError when preexisting hello files are present", async () => {
+  const { client, files } = makeMockClient();
+  const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
+  // Two hello files in the directory trigger the preexisting-files guard.
+  files.set(`${conn.path}/peer-aaa-hello.json`, Buffer.alloc(0));
+  files.set(`${conn.path}/peer-bbb-hello.json`, Buffer.alloc(0));
+  await expect(conn.synchronize()).rejects.toBeInstanceOf(UsageError);
+});
+
+test("synchronize() throws UsageError when a stale lockless ack file is present", async () => {
+  // A -hello-ack.json left behind by a crashed lockless session trips the
+  // preexisting-files guard, which is classified as a usage/configuration error.
+  const { client, files } = makeMockClient();
+  const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
+  files.set(`${conn.path}/peer-aaa-hello-ack.json`, Buffer.alloc(0));
+  await expect(conn.synchronize()).rejects.toBeInstanceOf(UsageError);
+});
+
+test("synchronize() throws UsageError for multiple concurrent sessions detected in wave-race path", async () => {
+  // Trigger the "more than one peer hello" guard inside waitForPeer(). The
+  // initial list() returns empty (passes the preexisting check); subsequent
+  // calls return our own hello plus two peer hellos, simulating a third party
+  // joining the same directory mid-rendezvous.
+  const { client } = makeMockClient();
+  const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
+  const myHello = `${conn.id}-hello.json`;
+  let listCallCount = 0;
+  client.list = async () => {
+    listCallCount++;
+    if (listCallCount === 1) return []; // preexisting check: empty
+    return [
+      { name: myHello, modifyTime: 0, size: 0 },
+      { name: "peer-aaa-hello.json", modifyTime: 0, size: 0 },
+      { name: "peer-bbb-hello.json", modifyTime: 0, size: 0 },
+    ];
+  };
+  // put() must succeed (writing our hello); delete/safeDelete are no-ops.
+  client.put = async () => {};
+  client.safeDelete = async () => {};
+  await expect(conn.synchronize()).rejects.toBeInstanceOf(UsageError);
+});
+
+test("synchronize() transport failure is not a UsageError", async () => {
+  // A rejected list() (e.g. SFTP connection lost) is a transport failure and
+  // must NOT be identified as a UsageError.
+  const { client } = makeMockClient();
+  const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
+  client.list = async () => {
+    throw new Error("SFTP connection lost");
+  };
+  const err = await conn.synchronize().catch((e: unknown) => e);
+  expect(err).not.toBeInstanceOf(UsageError);
+  expect(err).toBeInstanceOf(Error);
+});
+
+test("send() message timeout throws UsageError", async () => {
+  // A stale unconsumed message that outlasts the TTL is a send-timeout usage
+  // error: the caller is responsible for ensuring the peer is polling.
+  const { client, files } = makeMockClient();
+  const conn = await makeConnectedConn(client, {
+    timeToLiveMs: 150,
+    pollingFrequency: 10,
+  });
+  // Plant a stale outbound message that nobody will consume.
+  files.set(`${conn.path}/${conn.id}-99.json`, Buffer.from("stale"));
+  await expect(conn.send({ next: true })).rejects.toBeInstanceOf(UsageError);
 });


### PR DESCRIPTION
## Summary

- Introduces `UsageError extends Error` in `packages/core/src/errors.ts`, exported from the package index, as the public API contract for the 64-vs-69 exit-code split.
- Replaces all `{ cause: "usage" }` throw sites in `FileSyncConnection` (preexisting handshake files, multiple concurrent sessions, abandoned handshake, prefix-at-dash id pairs, send timeout) with `throw new UsageError(...)`. Also converts the preexisting-files throw that was missing the sentinel but is required by the AC to be classified as a usage error.
- Removes both sentinel-stripping lines (`if (err instanceof Error && err.cause === "usage") delete err.cause;`) from the outer catches in `synchronize()` and `send()`.
- CLI `exchange` and `zero-setup` commands now exit 64 (EX_USAGE) when the caught error is `instanceof UsageError`, and 69 otherwise. The existing ENOENT-config branch is unaffected.
- `protocol.ts`: verified that the `runProtocol` catch re-throws unconditionally (unless a signal was received), so the `UsageError` identity is preserved from the throw site to the CLI command catch. No routing changes are needed in `protocol.ts`.

## Mechanism design rationale (from open question)

`UsageError extends Error` was chosen over `.code`-property and narrowing-helper alternatives:
- `instanceof` check at the CLI is collision-free and requires no string-literal coordination across the package boundary.
- `.code` is stringly typed across packages.
- A narrowing helper adds an abstraction before a second caller exists, which `CLAUDE.local.md` prohibits.

`UsageError` lives in `packages/core/src/errors.ts` and is re-exported from the package index so `apps/cli` imports it as `import { UsageError } from "@psilink/core"` without touching `fileSyncConnection` internals.

Future throw sites added by 193901017, 192785502, and 194304738 should throw `UsageError` from the start.

## Test plan

- [x] New tests in `packages/core/test/fileSyncConnection.test.ts`:
  - `synchronize()` throws `UsageError` for preexisting stale hello files
  - `synchronize()` throws `UsageError` for a stale lockless ack file
  - `synchronize()` throws `UsageError` for multiple concurrent sessions (wave-race path)
  - `synchronize()` transport failure (`list()` rejects) is **not** a `UsageError`
  - `send()` message timeout throws `UsageError`
- [x] All 767 tests across packages/core, apps/cli, and apps/web pass (`npm run test`)
- [x] TypeScript: zero errors (`npm run typecheck`)
- [x] Lint: zero errors on changed files (`npx eslint <changed files>`) -- full-repo lint has a pre-existing false-positive from a worktree in `.claude/worktrees/` confusing ESLint's parser-options resolution; unrelated to this PR
- [x] Prettier: all changed files formatted