### PR TITLE
Contract-test non-throwing data-consumer (I8)

### DIFF
--- a/packages/core/src/connection/messageConnection.ts
+++ b/packages/core/src/connection/messageConnection.ts
@@ -257,6 +257,14 @@ export class QueuedMessageConnection implements MessageConnection {
     for (const waiter of pending) waiter.reject(error);
   }
 
+  // deliver() is the consumer of FileSyncConnection's "data" event in
+  // production (bridged via fromEventConnection's onData closure). It MUST NOT
+  // throw synchronously on any failure mode it handles -- notably the inbound
+  // overflow below, which latches a non-throwing fail() rather than throwing.
+  // FileSyncConnection's retain-mode poll() advances recvSeq only after
+  // emit("data", ...) returns, so a synchronous throw here would re-poll the
+  // same never-deleted message until peer_timeout_ms (docs/FILE_SYNC.md I8).
+  // messageConnection.test.ts pins this non-throwing contract.
   private deliver(message: unknown): void {
     // Once a half-close is pending, ignore further inbound: drain exactly what
     // was buffered at close time, then fail. PeerJS will not deliver after a

--- a/packages/core/src/connection/messageConnection.ts
+++ b/packages/core/src/connection/messageConnection.ts
@@ -283,8 +283,8 @@ export class QueuedMessageConnection implements MessageConnection {
     if (this.queue.length >= this.capacity) {
       this.fail(
         new ConnectionError(
-          `inbound buffer overflow: more than ${this.capacity} unconsumed ` +
-            "messages; the peer is sending out of turn",
+          `inbound buffer overflow: at capacity (${this.capacity} unconsumed ` +
+            "messages); the peer is sending out of turn",
           "protocol",
         ),
       );

--- a/packages/core/test/messageConnection.test.ts
+++ b/packages/core/test/messageConnection.test.ts
@@ -289,6 +289,74 @@ test("createMessagePipe: receive has no inactivity deadline", async () => {
   await parked;
 });
 
+// --- I8 contract: the production `data` consumer never throws synchronously ---
+//
+// docs/FILE_SYNC.md invariant I8 makes a non-throwing `data` consumer
+// load-bearing for FileSyncConnection's retain-mode poll(): the emit("data",
+// ...) hand-off sits inside the try whose catch reprocesses the never-deleted
+// message, and recvSeq advances only after the emit returns. A consumer that
+// threw synchronously would re-poll the same message until peer_timeout_ms and
+// then surface a generic peer-silence error. The sole production consumer is
+// deliver() (this file's QueuedMessageConnection, wired as fromEventConnection's
+// onData closure `(data) => controls.deliver(data)`); these tests pin that it
+// latches every failure mode it handles via a non-throwing fail() rather than
+// throwing back into emit. They lock the contract for the consumer that exists
+// today: a regression making deliver() throw on a handled mode would fail them.
+// They do NOT, and cannot, exercise a second `data` consumer that does not yet
+// exist -- a new throwing listener would be its own code path. The load-bearing
+// comment at deliver() and I8 itself, not this test, are what put a future
+// author adding such a consumer on notice. The eventB.emit("data", ...) call
+// below is structurally the same call FileSyncConnection.poll() makes at the
+// retain-mode emit site.
+
+test("data consumer (deliver): inbound overflow latches without throwing into emit", async () => {
+  const [, eventB] = makeEventConnections();
+  const connB = fromEventConnection(eventB, { capacity: 2 });
+
+  // Fill the inbound buffer to capacity with no parked receive: each delivery
+  // enqueues and must not throw.
+  expect(() => eventB.emit("data", "1")).not.toThrow();
+  expect(() => eventB.emit("data", "2")).not.toThrow();
+
+  // The capacity+1 frame is I8's named overflow mode. The consumer must absorb
+  // it as a non-throwing fail(), so emit("data", ...) returns normally rather
+  // than throwing back into the retain-mode poll loop.
+  expect(() => eventB.emit("data", "3")).not.toThrow();
+
+  // The absorbed overflow surfaces only as a sticky terminal protocol error on
+  // the next receive() -- confirming the consumer latched rather than threw.
+  const err = await connB.receive().catch((e: unknown) => e);
+  expect(err).toBeInstanceOf(ConnectionError);
+  expect((err as ConnectionError).kind).toBe("protocol");
+
+  // The frames buffered before the overflow ("1"/"2") are discarded by the
+  // latch, not replayed: a further receive() yields the same terminal error
+  // rather than a stale frame. (This is fail()'s documented discard semantics;
+  // asserted here so the drop reads as intended, not an untested side effect.)
+  await expect(connB.receive()).rejects.toBe(err);
+});
+
+test("data consumer (deliver): a frame after a terminal latch is a non-throwing no-op", async () => {
+  const [, eventB] = makeEventConnections();
+  const connB = fromEventConnection(eventB);
+
+  // A terminal failure has already latched the connection. In production this
+  // would be a transport drop from an earlier poll cycle; here it is emitted
+  // inline -- the test models the latched-then-late-frame ordering, not the
+  // timing.
+  eventB.emit("error", new Error("earlier transport drop"));
+
+  // A late data frame from a subsequent emit("data", ...) must be silently
+  // absorbed by the consumer, never thrown back into the poll loop.
+  expect(() => eventB.emit("data", "late")).not.toThrow();
+
+  // The connection is unchanged: still the original terminal transport error,
+  // with the late frame dropped rather than surfaced.
+  const err = await connB.receive().catch((e: unknown) => e);
+  expect(err).toBeInstanceOf(ConnectionError);
+  expect((err as ConnectionError).kind).toBe("transport");
+});
+
 // --- per-receive timeout -----------------------------------------------------
 
 test("receive(timeoutMs) shorter than the connection default fires and latches", async () => {


### PR DESCRIPTION
## Summary

Lock in `docs/FILE_SYNC.md` invariant I8 -- the non-throwing `data`-consumer
contract -- with two contract tests, so a regression that made the production
consumer throw synchronously back into `FileSyncConnection`'s retain-mode
`poll()` (stalling receive until `peer_timeout_ms`, then surfacing a generic
peer-silence error) is caught at unit-test time. Also corrects an off-by-one in
the inbound-overflow error text surfaced by review. No logic or protocol
behavior changes.

Implements Product item [194986348](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=194986348).

## Changes

- `packages/core/test/messageConnection.test.ts` -- two contract tests pinning
  that the bridged `data` consumer (`deliver()`, wired as `fromEventConnection`'s
  `onData` closure) latches the failure modes it handles -- inbound overflow, and
  a frame after a terminal latch -- through a non-throwing `fail()` rather than
  throwing back into `emit("data", ...)`. A block comment ties the tests to I8
  and is explicit that they pin the consumer that exists today, not a
  hypothetical future second consumer.
- `packages/core/src/connection/messageConnection.ts` -- two unrelated edits, no
  logic change: (1) a comment at `deliver()` marking the non-throwing contract as
  load-bearing for retain-mode `poll()` (the non-obvious cross-file WHY: `recvSeq`
  advances only after `emit` returns); (2) correct the inbound-overflow error text
  from "more than N unconsumed messages" to "at capacity (N unconsumed messages)"
  -- the guard trips at exactly `capacity` buffered frames, so the old wording
  overstated the count by one. Pre-existing, surfaced by review; kept as its own
  commit.

## Background

Retain-mode `poll()` emits `data` inside the try whose catch reprocesses the
never-deleted message, and advances `recvSeq` only after the emit returns. A
consumer that threw synchronously would re-poll the same message until
`peer_timeout_ms`. This is unreachable today: the sole consumer, `deliver()`,
absorbs inbound overflow as a non-throwing `fail()` and never throws back into
`emit` (the web app is WebRTC-only and never touches `FileSyncConnection`). The
tests pin that contract for the current consumer; the load-bearing comment and
I8 itself put a future author adding a second consumer on notice, since a test
cannot anticipate a code path that does not yet exist. Per the issue, no
retry-bound or wall-clock-budget machinery is added (nothing reachable to
bound) and delete-mode behavior is unchanged.

## Test plan

- [x] `npm run typecheck && npm run lint` clean
- [x] `npm test -w packages/core` (648/648)
- [x] `npm run test:unit -w apps/cli` (137/137) and `apps/web` (70/70)
- [x] Regression-guard (negative control): temporarily making `deliver()` `throw`
      on overflow fails both new Test 1 and the pre-existing capacity test;
      reverted. Confirms a real guard, not a smoke test.
- [x] CLI integration tests (`npm run test:integration -w apps/cli`): 9/9 passed
      (self-managed SFTP container).

New tests cover: the production `data` consumer (`deliver()`) does not throw
synchronously on the failure modes it handles -- (1) inbound buffer overflow
latches a terminal `protocol` error and discards buffered frames rather than
throwing into `emit`; (2) a `data` frame after a terminal latch is a
non-throwing no-op, leaving the original `transport` error intact.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact; none needed -- I8 in
      `docs/FILE_SYNC.md` already states the contract and the issue requires no
      wording change.
- [x] `CHANGELOG.md` `[Unreleased]`: n/a -- test, internal comment, and a
      precision fix to one protocol-error diagnostic string; no functional or
      protocol behavior change.
- [x] Cryptographic code changed? n/a -- no crypto touched.
