### PR TITLE
Cancel inflight file sync waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to PSI-Link are documented here. The format follows [Keep a 
 
 - A malformed message from a peer is reported as a protocol error instead of crashing.
 - A failed exchange surfaces its original cause instead of a generic connection error.
+- Closing a file-sync connection now cancels any in-flight rendezvous or send wait promptly instead of letting the timer fire and resume against a connection that is tearing down. Internal hardening only: cancellation threads a single `AbortController` through every wait site, and a new internal `ConnectionClosedError` may appear in debug logs on a close-during-wait. Not a user-facing exit-code change (a deliberate close under a signal still exits 130/143).
 - Wave-path rendezvous: a party whose hello is deleted by a joiner that then fails mid-arrival no longer stalls until the peer timeout. The joiner now signals its arrival with a `<id>-joining.json` sentinel, and the waiting party recovers within a bounded window or aborts with a distinct transport error.
 - File-sync rendezvous now sweeps an orphaned in-flight temp file (`temp-*.tmp`) left in the exchange directory by a `send()`/`writeAck()` whose process was hard-killed between the temp write and its atomic rename. The artifact is deleted at rendezvous setup instead of accumulating as litter across crashed exchanges or aborting entry with a spurious usage error. Only `temp-*.tmp` is swept, never the `*.json` message files (so retain mode's transcript is untouched).
 

--- a/packages/core/src/connection/fileSyncConnection.ts
+++ b/packages/core/src/connection/fileSyncConnection.ts
@@ -8,13 +8,20 @@ import type {
   FileDropConnectionConfig,
 } from "../config/connection";
 import type { HandshakeRole } from "../types";
-import { UsageError, BilateralModeMismatchError } from "../errors";
+import {
+  UsageError,
+  BilateralModeMismatchError,
+  ConnectionClosedError,
+} from "../errors";
 import {
   HelloEnvelopeSchema,
   serializeEnvelope,
   type HelloEnvelope,
 } from "./controlEnvelope";
-import { ADVERTISE_HELLO_RETRY_ATTEMPTS } from "./fileSyncConstants";
+import {
+  ADVERTISE_HELLO_RETRY_ATTEMPTS,
+  cancellableDelay,
+} from "./fileSyncConstants";
 
 const errMessage = (err: unknown) =>
   err instanceof Error ? err.message : String(err);
@@ -141,9 +148,8 @@ async function readControlFileWithGate(
   timeToLive: Date,
   pollingFrequency: number,
   schema: z.ZodType<HelloEnvelope>,
+  signal: AbortSignal,
 ): Promise<HelloEnvelope> {
-  const delay = (ms: number) =>
-    new Promise<void>((resolve) => setTimeout(resolve, ms));
   // do-while guarantees at least one read attempt even when timeToLive has
   // already expired by the time the gate is entered (e.g. a slow polling loop
   // that exhausts the budget before reaching this call). Without this a fully-
@@ -154,7 +160,7 @@ async function readControlFileWithGate(
       raw = await client.get(filePath, { encoding: "utf-8" });
     } catch {
       // File may not be readable yet (TOCTOU or partial sync); retry.
-      await delay(pollingFrequency);
+      await cancellableDelay(pollingFrequency, signal);
       continue;
     }
     let parsed: unknown;
@@ -162,7 +168,7 @@ async function readControlFileWithGate(
       parsed = JSON.parse(raw.toString());
     } catch {
       // Partial write: body is not valid JSON yet; retry until fully synced.
-      await delay(pollingFrequency);
+      await cancellableDelay(pollingFrequency, signal);
       continue;
     }
     const result = schema.safeParse(parsed);
@@ -316,6 +322,14 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
   handshakeRole: HandshakeRole | undefined;
   private poller: NodeJS.Timeout | undefined;
   private pollerActive: boolean;
+  // Cancellation primitive threaded through every wait site (see wait() and
+  // cancellableDelay). close() aborts it so an in-flight sleep rejects
+  // promptly; synchronize() re-arms a fresh one per session. Constructed inline
+  // so a never-opened/never-synchronized instance is safe (close() before any
+  // session cannot NPE), and re-armed at session start rather than in
+  // resetSessionState() so a recovery reset mid-rendezvous cannot wipe a
+  // concurrent close()'s abort (see synchronize()).
+  private abortController = new AbortController();
   private responsibleFiles: Set<string>;
   // The name of the last message this party sent. Read by two consumers: the
   // delete-mode drain in close() (waits for the peer to consume this exact file
@@ -406,6 +420,15 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
     const e = this.bufferedError;
     this.bufferedError = undefined;
     return e;
+  }
+
+  // Cancellable replacement for `new Promise((r) => setTimeout(r, ms))` at every
+  // in-session wait site. Reads this.abortController.signal fresh per call. Do
+  // not hoist the signal: the controller is swapped at session start
+  // (synchronize()), so a cached `const signal = this.abortController.signal`
+  // above a loop would observe a stale controller and become uncancellable.
+  private wait(ms: number): Promise<void> {
+    return cancellableDelay(ms, this.abortController.signal);
   }
 
   /** Opens a connection from a typed config. Dispatches on `config.channel`. */
@@ -552,6 +575,19 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
   async close() {
     this.stop();
 
+    // Cancel any in-flight wait (a rendezvous/send sleep parked between polls)
+    // so it rejects promptly instead of resuming against a connection that is
+    // tearing down. stop() (above) already cleared pollerActive and the poller
+    // timer -- both synchronous -- so by the time an abort-induced rejection
+    // reaches poll()'s catch, the !pollerActive guard swallows it. The drain
+    // loop below stays on a plain setTimeout (it is the teardown wait itself;
+    // see its comment). INVARIANT: every abort() in this class passes a
+    // ConnectionClosedError reason -- cancellableDelay rejects with
+    // signal.reason, and the plain-Error (exit 69) classification depends on it.
+    this.abortController.abort(
+      new ConnectionClosedError("connection closed during wait"),
+    );
+
     if (this.path !== undefined) {
       // Drain the last sent file before sweeping: a clean close must not
       // delete a terminal frame the peer has not yet consumed. Uses a fresh
@@ -582,6 +618,12 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
               `[${this.role}] draining ${lastSentFile} before cleanup`,
             );
             while (Date.now() < deadline && (await filePresent())) {
+              // Deliberately a plain setTimeout, not this.wait(): this drain IS
+              // the teardown wait and runs after the session controller is
+              // already aborted (above), so wiring it to that signal would make
+              // it reject on the first iteration and skip its bounded wait. It
+              // is hard-bounded by `Date.now() < deadline` and its catch
+              // swallows failures, so a separate controller buys nothing.
               await new Promise((resolve) =>
                 setTimeout(resolve, this.options.pollingFrequency),
               );
@@ -671,6 +713,19 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
       throw new Error("not connected");
 
     if (this.peerId) throw new Error("already synchronized");
+
+    // Re-arm cancellation per session: each genuine rendezvous (including a
+    // retry on the same instance after a failed synchronize()) starts with a
+    // fresh signal. Placed here, after the re-entry guard, NOT in
+    // resetSessionState() -- that helper runs three times INSIDE a live
+    // synchronize() (the recovery resets), so re-arming there could wipe a
+    // concurrent close()'s abort mid-unwind. A no-op re-entry call throws at the
+    // guard above and never reaches this line, so it cannot swap a live
+    // session's controller. The teardown-stays-aborted invariant relies on a
+    // single, non-concurrent synchronize() caller per instance (the CLI drives
+    // exactly one at a time); a concurrent re-sync during a close() window is
+    // out of scope and not reachable in production.
+    this.abortController = new AbortController();
 
     // Library-level defense-in-depth: the schema refine and CLI imply cover the
     // config/CLI entry points, but a direct library consumer that constructs
@@ -853,6 +908,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
         this.options.timeToLive!,
         this.options.pollingFrequency,
         HelloEnvelopeSchema,
+        this.abortController.signal,
       );
 
       // Bilateral flag check. A mismatch here means the peer runs a different
@@ -913,9 +969,30 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
                   `${attempt}/${ADVERTISE_HELLO_RETRY_ATTEMPTS}); retrying: ` +
                   `${errMessage(writeErr)}`,
               );
-              await new Promise<void>((resolve) =>
-                setTimeout(resolve, this.options.pollingFrequency),
-              );
+              try {
+                await this.wait(this.options.pollingFrequency);
+              } catch {
+                // The only way this.wait rejects is an abort from a concurrent
+                // close() -- a plain delay never rejects -- so this catch cannot
+                // swallow a real put() failure (those are caught by the inner
+                // try and logged above). Stop retrying and fall through to the
+                // reset + `throw mismatch` below so the genuine
+                // BilateralModeMismatchError (exit 64) stays the surfaced root
+                // cause rather than the close's ConnectionClosedError (exit 69):
+                // the diverging flag is the actionable cause the operator must
+                // fix, and the close-during-mismatch case is unreachable except
+                // under a signal anyway (where neither code is the exit code).
+                // Log the cut-short retry so a close-during-mismatch is
+                // diagnosable in debug logs, mirroring the exhausted-budget
+                // path's degradation message in the else branch below.
+                this.log.debug(
+                  `[joiner] advertise-hello retry aborted by connection ` +
+                    `close after attempt ${attempt}/` +
+                    `${ADVERTISE_HELLO_RETRY_ATTEMPTS}; peer may time out ` +
+                    `instead of fast-failing`,
+                );
+                break;
+              }
             } else {
               this.log.debug(
                 `[joiner] could not advertise hello on mismatch after ` +
@@ -1073,8 +1150,6 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
       let ackPath: string | undefined;
 
       const waitForPeer = async () => {
-        const delay = (ms: number) =>
-          new Promise((resolve) => setTimeout(resolve, ms));
         if (this.options.locklessRendezvous) {
           // Lockless ack-handshake barrier: completes rendezvous using neither
           // createExclusive nor delete. Each party writes a hello, then an ack
@@ -1102,7 +1177,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
 
             if (peerHellos.length === 0) {
               this.log.trace(`[${this.role}] no peer hello found; polling`);
-              await delay(this.options.pollingFrequency);
+              await this.wait(this.options.pollingFrequency);
               continue;
             }
 
@@ -1129,6 +1204,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
                 this.options.timeToLive!,
                 this.options.pollingFrequency,
                 HelloEnvelopeSchema,
+                this.abortController.signal,
               );
 
               // Bilateral flag check before writing our ack. On mismatch throw:
@@ -1189,7 +1265,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
               this.log.trace(
                 `[${this.role}] waiting for peer ack ${peerAckName}`,
               );
-              await delay(this.options.pollingFrequency);
+              await this.wait(this.options.pollingFrequency);
               continue;
             }
 
@@ -1337,7 +1413,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
               joiningSeenName = undefined;
               this.log.trace(`[${this.role}] no peer hello found; polling`);
             }
-            await delay(this.options.pollingFrequency);
+            await this.wait(this.options.pollingFrequency);
             continue;
           }
 
@@ -1444,6 +1520,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
               this.options.timeToLive!,
               this.options.pollingFrequency,
               HelloEnvelopeSchema,
+              this.abortController.signal,
             );
 
             // Bilateral flag check before committing roles and before the
@@ -1512,6 +1589,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
               this.options.timeToLive!,
               this.options.pollingFrequency,
               HelloEnvelopeSchema,
+              this.abortController.signal,
             );
 
             // Bilateral flag check before deleting the peer hello. Defense-in-
@@ -1574,6 +1652,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
               this.options.timeToLive!,
               this.options.pollingFrequency,
               HelloEnvelopeSchema,
+              this.abortController.signal,
             );
             const mismatch = this.bilateralMismatch(peerEnvelope);
             if (mismatch) throw mismatch;
@@ -1829,9 +1908,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
                 `timed out waiting for ack ${expectedAck} from ${this.peerId}`,
               );
             }
-            await new Promise((resolve) =>
-              setTimeout(resolve, this.options.pollingFrequency),
-            );
+            await this.wait(this.options.pollingFrequency);
           }
         }
       } else {
@@ -1846,9 +1923,7 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
                 `timed out waiting for message from ${this.id} to be consumed`,
               );
             }
-            await new Promise((resolve) =>
-              setTimeout(resolve, this.options.pollingFrequency),
-            );
+            await this.wait(this.options.pollingFrequency);
           }
         }
       }
@@ -1892,6 +1967,12 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
       // cannot block on a message that was never written.
       this.seq = seq + 1;
     } catch (err: unknown) {
+      // tempPath may never have been written: both pre-write gate loops above
+      // (the retain ack-wait and the delete-mode consume-wait) can throw before
+      // the put -- a UsageError on timeout, or a ConnectionClosedError if
+      // close() aborts the wait. safeDelete is idempotent over an absent file,
+      // so the unconditional sweep is correct; the call on an unwritten temp is
+      // a harmless no-op (the abort case is new, the timeout case pre-existing).
       await this.client.safeDelete(tempPath);
       throw err instanceof Error ? err : new Error(errMessage(err));
     }
@@ -2376,9 +2457,15 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
             try {
               await this.client.delete(inPath);
             } catch {
-              await new Promise((resolve) =>
-                setTimeout(resolve, this.options.pollingFrequency),
-              );
+              // First delete failed; retry once after a backoff. On abort
+              // (close() mid-poll) this.wait rejects here, unwinding past the
+              // emit("data") below into poll()'s catch, where the !pollerActive
+              // guard swallows it (see below). The second delete AND the emit
+              // are both skipped, so the message is left undelivered for this
+              // session -- but it is still on disk (this first delete failed),
+              // so a fresh connection re-reads it. Teardown defers delivery; it
+              // does not lose the message.
+              await this.wait(this.options.pollingFrequency);
               try {
                 await this.client.delete(inPath);
               } catch (deleteErr: unknown) {
@@ -2404,6 +2491,23 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
       }
       this.consecutiveEnoentCount = 0;
     } catch (err: unknown) {
+      // Shutdown guard (by state, not error type): close() aborts the session
+      // controller, so a wait parked in the delete-retry backoff above rejects
+      // with a ConnectionClosedError that lands here. Swallow it -- close()
+      // already cleared pollerActive (synchronously, before this rejection
+      // could surface), so the guard is true only during teardown. A genuine
+      // error during active polling reaches here with pollerActive still true
+      // (the pollerActive = false assignments below run later), so this cannot
+      // suppress a real failure; and it is robust to a transport client that
+      // wraps/rethrows the rejection, which an `instanceof` check would miss.
+      // The finally then sees pollerActive === false and does not reschedule.
+      // pollerActive is also cleared by the public stop(), so this guard is
+      // really "stop() or close() ran" -- but stop() is only ever called from
+      // close() in this codebase, so the guard still means teardown. Were a
+      // future caller to invoke stop() independently mid-poll, a concurrent
+      // real error would be swallowed here; that is an accepted limitation of
+      // the deliberate by-state (not by-error-type) choice.
+      if (!this.pollerActive) return;
       if ((err as NodeJS.ErrnoException).code === "ENOENT" && reachedGet) {
         // TOCTOU race: list() surfaced the file but get() found it gone,
         // meaning the peer cleaned up between the two calls. After a single
@@ -2436,9 +2540,13 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
       } else {
         // Non-TOCTOU failure: either a non-ENOENT error from any operation, or
         // any error where reachedGet is false (e.g., exists() or message
-        // parsing). Note: delete() errors cannot reach here — delete() has its
-        // own inner try/catch (see above) that handles and swallows them.
-        // All cases are propagated immediately as hard failures.
+        // parsing). Note: a delete() FAILURE cannot reach here -- delete() has
+        // its own inner try/catch (see above) that handles and swallows it. The
+        // one rejection the delete-retry block can now propagate is an abort
+        // (close() firing during its this.wait backoff), but that is a
+        // ConnectionClosedError caught by the !pollerActive guard at the top of
+        // this catch and never reaches this branch. All other cases are
+        // propagated immediately as hard failures.
         this.consecutiveEnoentCount = 0;
         // A UsageError reaching this catch is terminal -- re-reading the same
         // bytes cannot help: a fully-synced message that fails to parse or

--- a/packages/core/src/connection/fileSyncConstants.ts
+++ b/packages/core/src/connection/fileSyncConstants.ts
@@ -22,3 +22,43 @@
 // site in synchronize()'s joiner fast-path.
 /** @internal */
 export const ADVERTISE_HELLO_RETRY_ATTEMPTS = 5;
+
+// Leak-safe cancellable sleep: resolves after `ms`, or rejects with
+// `signal.reason` if the signal aborts first. Every in-session wait site in
+// fileSyncConnection.ts uses it (the module-level readControlFileWithGate
+// directly, the class via its wait() delegate) so an in-flight sleep cancels
+// promptly when close() aborts the session controller. It lives here, in this
+// non-barrelled module, rather than in fileSyncConnection.ts (which IS
+// barrelled via main.ts's `export *`) so the unit test can deep-import it
+// without leaking it into the package's public runtime surface -- the same
+// reason ADVERTISE_HELLO_RETRY_ATTEMPTS lives here.
+//
+// Exactly one of {timer fires, abort fires} ever runs, and each tears down the
+// other: a pre-aborted signal returns an already-rejected promise with no timer
+// or listener allocated (the awaiter still observes it on the next microtask, as
+// with any rejected promise); a timer fire removes the listener before
+// resolving; an abort clears the timer
+// and the `{ once: true }` listener auto-detaches. (onAbort closes over `timer`,
+// a binding declared textually below it -- a safe forward reference, not a TDZ
+// hazard: the listener that can invoke onAbort is registered only after
+// `const timer` has been initialized, so onAbort can never run while `timer` is
+// still in its temporal dead zone.) It always rejects on abort, so the
+// surrounding poll loop unwinds into its next statement and propagates.
+/** @internal */
+export function cancellableDelay(
+  ms: number,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -38,3 +38,36 @@ export class BilateralModeMismatchError extends UsageError {
     this.name = "BilateralModeMismatchError";
   }
 }
+
+/**
+ * Thrown into an in-flight {@link FileSyncConnection} wait when the connection
+ * is closed mid-rendezvous or mid-send. `close()` aborts a shared
+ * `AbortController` whose `reason` is an instance of this class, so any wait
+ * parked between polls/retries rejects promptly instead of resuming against a
+ * connection that is tearing down.
+ *
+ * Unlike {@link UsageError}, this is a plain `Error`: a deliberate local
+ * teardown is a transport-availability condition, so the CLI's
+ * `instanceof UsageError` check classifies it as exit 69 (EX_UNAVAILABLE),
+ * not the 64 (EX_USAGE) reserved for caller misconfiguration. In practice it
+ * almost never surfaces as the process exit code -- `close()` only races an
+ * in-flight wait under a signal, where `signalReceived` owns the code
+ * (130/143) and this rejection is logged and swallowed.
+ *
+ * It lives here in `errors.ts` -- and is therefore re-exported on the package's
+ * public surface by main.ts's `export *` -- deliberately: this file is the
+ * single home for the connection error taxonomy ({@link UsageError},
+ * {@link BilateralModeMismatchError}), and splitting one error type out into a
+ * non-barrelled module to hide it would be the more surprising inconsistency.
+ * (`cancellableDelay` is hidden in the non-barrelled fileSyncConstants.ts for
+ * the opposite reason: it is an internal helper with no taxonomy home.) Treat
+ * this class as an internal teardown signal, not a stability contract -- the
+ * plain-`Error`/exit-69 classification above is the contract; consumers should
+ * not depend on catching it by type.
+ */
+export class ConnectionClosedError extends Error {
+  constructor(message = "connection closed during wait") {
+    super(message);
+    this.name = "ConnectionClosedError";
+  }
+}

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -1,7 +1,10 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 
 import { FileSyncConnection } from "../src/connection/fileSyncConnection";
-import { ADVERTISE_HELLO_RETRY_ATTEMPTS } from "../src/connection/fileSyncConstants";
+import {
+  ADVERTISE_HELLO_RETRY_ATTEMPTS,
+  cancellableDelay,
+} from "../src/connection/fileSyncConstants";
 import type {
   FileTransportClient,
   FileInfo,
@@ -10,7 +13,11 @@ import type {
   SFTPConnectionConfig,
   FileDropConnectionConfig,
 } from "../src/config/connection";
-import { UsageError, BilateralModeMismatchError } from "../src/errors";
+import {
+  UsageError,
+  BilateralModeMismatchError,
+  ConnectionClosedError,
+} from "../src/errors";
 import { withCapturedLogs } from "../src/testing";
 
 // Minimal in-memory FileTransportClient mock.  Only the methods called by
@@ -6208,4 +6215,294 @@ test("poll(): an ack-shaped foreign file whose target is not a real protocol fil
   expect((conn as unknown as { pollerActive: boolean }).pollerActive).toBe(
     false,
   );
+});
+
+// --- cancellable waits: close() cancels in-flight waits (D1-D6) ---------------
+
+test("close() cancels an in-flight retain ack-wait promptly (site 4)", async () => {
+  const { client } = makeMockClient();
+  const HUGE_TTL = 60_000;
+  const conn = makeRetainConn(client, "me", "peer", HUGE_TTL);
+  // seq>0 with a recorded lastSentFile drives send() into the ack-wait loop; the
+  // peer never writes the ack, so it parks in this.wait (site 4).
+  conn.seq = 1;
+  (conn as unknown as { lastSentFile: string }).lastSentFile =
+    "me-20260101T000000-000-10.json";
+
+  // Barrier: resolve once the ack-wait has polled list() at least once, so we
+  // close() with the loop committed to the wait rather than before it begins.
+  let parked!: () => void;
+  const reachedWait = new Promise<void>((r) => (parked = r));
+  const origList = client.list;
+  client.list = async (p: string) => {
+    const result = await origList(p);
+    parked();
+    return result;
+  };
+
+  const start = Date.now();
+  const outcome = conn.send({ blocked: true }).then(
+    () => null,
+    (err: unknown) => err,
+  );
+
+  await reachedWait;
+  await conn.close();
+
+  const err = await outcome;
+  expect(err).toBeInstanceOf(ConnectionClosedError);
+  // Cancellation, not the deadline, unblocked the wait.
+  expect(Date.now() - start).toBeLessThan(HUGE_TTL / 2);
+});
+
+test("close() cancels an in-flight delete-mode consume-wait promptly (site 5)", async () => {
+  const { client, files } = makeMockClient();
+  const HUGE_TTL = 60_000;
+  const conn = await makeConnectedConn(client, {
+    pollingFrequency: 10,
+    timeToLiveMs: HUGE_TTL,
+    peerTimeoutMs: 50,
+  });
+  conn.peerId = "peer";
+  // An outstanding message nobody consumes drives send() into the consume-wait.
+  files.set(
+    `/test/${conn.id}-99.json`,
+    Buffer.from(JSON.stringify({ stale: true })),
+  );
+
+  let parked!: () => void;
+  const reachedWait = new Promise<void>((r) => (parked = r));
+  const origList = client.list;
+  client.list = async (p: string) => {
+    const result = await origList(p);
+    parked();
+    return result;
+  };
+
+  const start = Date.now();
+  const outcome = conn.send({ blocked: true }).then(
+    () => null,
+    (err: unknown) => err,
+  );
+
+  await reachedWait;
+  await conn.close();
+
+  const err = await outcome;
+  expect(err).toBeInstanceOf(ConnectionClosedError);
+  expect(Date.now() - start).toBeLessThan(HUGE_TTL / 2);
+});
+
+test("close() cancels a parked rendezvous wait promptly (site 3)", async () => {
+  const { client } = makeMockClient();
+  const HUGE_TTL = 60_000;
+  const conn = await makeConnectedConn(client, {
+    pollingFrequency: 10,
+    timeToLiveMs: HUGE_TTL,
+    peerTimeoutMs: 50,
+  });
+
+  // The peer hello never appears, so waitForPeer parks in this.wait every poll.
+  let parked!: () => void;
+  const reachedWait = new Promise<void>((r) => (parked = r));
+  let listCalls = 0;
+  client.list = async () => {
+    listCalls++;
+    // entry list (1) + first waitForPeer poll (2): now parked in this.wait.
+    if (listCalls >= 2) parked();
+    return [];
+  };
+
+  const start = Date.now();
+  const outcome = conn.synchronize().then(
+    () => null,
+    (err: unknown) => err,
+  );
+
+  await reachedWait;
+  await conn.close();
+
+  const err = await outcome;
+  expect(err).toBeInstanceOf(ConnectionClosedError);
+  // Not the TTL "synchronization timed out" path.
+  expect((err as Error).message).not.toContain("timed out");
+  expect(Date.now() - start).toBeLessThan(HUGE_TTL / 2);
+});
+
+test("close() during a parked poll delete-retry emits no spurious error (site 6 + D5)", async () => {
+  const errors: unknown[] = [];
+  const [, logs] = await withCapturedLogs(async () => {
+    const { client, files } = makeMockClient();
+    // Large polling frequency so the site-6 backoff parks until the abort,
+    // never elapsing into the second delete attempt on its own.
+    const conn = await makeConnectedConn(client, {
+      pollingFrequency: 10_000,
+      timeToLiveMs: 60_000,
+      peerTimeoutMs: 50,
+    });
+    const peerId = "peer";
+    conn.peerId = peerId;
+
+    // A valid peer message the poller reads and then tries to delete.
+    const body = Buffer.from(
+      JSON.stringify({ ts: 1, seq: 0, type: "Object", payload: { hi: 1 } }),
+    );
+    files.set(`/test/${peerId}-${body.length}.json`, body);
+
+    // The first delete attempt fails AND signals the test, guaranteeing close()
+    // fires while the loop is parked inside the site-6 wait (not at list/get).
+    let reachedDeleteRetry!: () => void;
+    const parked = new Promise<void>((r) => (reachedDeleteRetry = r));
+    client.delete = async () => {
+      reachedDeleteRetry();
+      throw new Error("delete failed");
+    };
+
+    conn.on("error", (err) => errors.push(err));
+    conn.start();
+
+    await parked;
+    await conn.close();
+    // Let any erroneously-rescheduled poll cycle run (it must not).
+    await new Promise((r) => setTimeout(r, 30));
+
+    // (b) nothing buffered either.
+    expect(conn.takeBufferedError()).toBeUndefined();
+  });
+
+  // (a) no error surfaced on the event channel.
+  expect(errors).toHaveLength(0);
+  // (c) the second delete was skipped, so its warn never fired.
+  expect(logs.some((l) => l.message.includes("failed to delete"))).toBe(false);
+});
+
+test("cancellableDelay resolves after the delay when never aborted", async () => {
+  const controller = new AbortController();
+  const start = Date.now();
+  await expect(
+    cancellableDelay(20, controller.signal),
+  ).resolves.toBeUndefined();
+  expect(Date.now() - start).toBeGreaterThanOrEqual(15);
+});
+
+test("cancellableDelay rejects synchronously when the signal is already aborted", async () => {
+  const controller = new AbortController();
+  const reason = new ConnectionClosedError("already aborted");
+  controller.abort(reason);
+  await expect(cancellableDelay(1_000, controller.signal)).rejects.toBe(reason);
+});
+
+test("cancellableDelay rejects with signal.reason and clears its timer when aborted mid-wait", async () => {
+  const controller = new AbortController();
+  const reason = new ConnectionClosedError("aborted mid-wait");
+  const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+  try {
+    const pending = cancellableDelay(10_000, controller.signal);
+    controller.abort(reason);
+    await expect(pending).rejects.toBe(reason);
+    // The pending timer was cleared on abort (no dangling handle).
+    expect(clearSpy).toHaveBeenCalled();
+  } finally {
+    clearSpy.mockRestore();
+  }
+});
+
+test("synchronize() re-arms a fresh controller per session so a retry's waits stay live (D1)", async () => {
+  const { client, files } = makeMockClient();
+  const conn = await makeConnectedConn(client, {
+    pollingFrequency: 10,
+    timeToLiveMs: 60_000,
+    peerTimeoutMs: 50,
+  });
+  conn.id = "starter";
+
+  // Simulate a controller left aborted by a prior life (the state a failed-then-
+  // retried session must recover from). Without the re-arm at synchronize()
+  // entry, waitForPeer's first this.wait would observe this aborted signal and
+  // reject immediately instead of polling for the peer.
+  (
+    conn as unknown as { abortController: AbortController }
+  ).abortController.abort(new ConnectionClosedError("stale"));
+
+  // The peer hello appears after a few empty polls, so the rendezvous parks in
+  // this.wait (against the re-armed controller) before completing.
+  setTimeout(() => {
+    files.set("/test/other-hello.json", LOCK_HELLO_BODY);
+  }, 40);
+
+  await expect(conn.synchronize()).resolves.toBeUndefined();
+  expect(conn.peerId).toBe("other");
+});
+
+test("wait() reads the controller fresh per call so a swapped-in controller is independent (do-not-hoist, D4)", async () => {
+  // Weak but cheap proxy for the do-not-hoist invariant: the real regression is
+  // a hoisted `const signal` above a loop, which a unit test cannot fully catch
+  // (the guard is the comment on wait()); this pins "fresh signal per call".
+  const { client } = makeMockClient();
+  const conn = await makeConnectedConn(client, { pollingFrequency: 10 });
+  const internals = conn as unknown as {
+    wait(ms: number): Promise<void>;
+    abortController: AbortController;
+  };
+
+  const controllerA = internals.abortController;
+  // Swap in a fresh controller, as synchronize() does at session start.
+  internals.abortController = new AbortController();
+
+  // A wait started against the NEW controller must not be cancelled by aborting
+  // the OLD one -- proving wait() did not cache controllerA's signal.
+  const waitB = internals.wait(20);
+  controllerA.abort(new ConnectionClosedError("old controller"));
+  await expect(waitB).resolves.toBeUndefined();
+
+  // And a wait against the current controller still cancels when IT aborts.
+  const waitC = internals.wait(10_000);
+  internals.abortController.abort(new ConnectionClosedError("current"));
+  await expect(waitC).rejects.toBeInstanceOf(ConnectionClosedError);
+});
+
+test("close() during a parked rendezvous gate read completes teardown cleanly despite the sweep (site 1b)", async () => {
+  const errors: unknown[] = [];
+  const { client, files } = makeMockClient();
+  const conn = new FileSyncConnection(client, {
+    // Large frequency: the gate's retry backoff parks until the abort.
+    pollingFrequency: 10_000,
+    timeToLive: new Date(Date.now() + 60_000),
+    verbose: -1,
+    locklessRendezvous: true,
+  });
+  conn.id = "me";
+  conn.connected = true;
+  conn.path = "/test";
+  conn.on("error", (err) => errors.push(err));
+
+  // A peer hello is present (so the lockless barrier enters the gate read at
+  // site 1b), but get() always fails, so the gate retries via cancellableDelay
+  // and parks. This read IS under the rendezvous outer catch, so an abort drives
+  // its safeDelete sweep during teardown. The hello body is never read (get()
+  // always throws), so its contents are irrelevant.
+  files.set("/test/peer-hello.json", LOCK_HELLO_BODY);
+  let reachedGate!: () => void;
+  const parked = new Promise<void>((r) => (reachedGate = r));
+  client.get = async () => {
+    reachedGate();
+    throw new Error("partial sync; retry");
+  };
+
+  const outcome = conn.synchronize().then(
+    () => null,
+    (err: unknown) => err,
+  );
+
+  await parked;
+  // (a) close() resolves without throwing even though the aborted rendezvous
+  // issues its sweep safeDelete()s concurrently.
+  await expect(conn.close()).resolves.toBeUndefined();
+
+  const err = await outcome;
+  expect(err).toBeInstanceOf(ConnectionClosedError);
+  // (c) no spurious error surfaced/buffered despite the teardown-side
+  // safeDeletes.
+  expect(errors).toHaveLength(0);
+  expect(conn.takeBufferedError()).toBeUndefined();
 });


### PR DESCRIPTION
## Summary

Cancel in-flight file-sync waits when the connection closes. FileSyncConnection
polled rendezvous and the steady-state message loop with uncancellable
setTimeout-backed sleeps; if close() landed while one was parked, the timer
still fired, the loop resumed, and the next transport call ran against a
connection that was tearing down. Thread a single AbortController through every
in-session wait site so an in-flight wait, and the poll loop around it, unwinds
promptly on close(). Internal robustness hardening with no observable change on
non-close paths.

Implements Product item [196402163](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=196402163).

## Changes

- `packages/core/src/connection/fileSyncConnection.ts` -- thread one
  AbortController through the in-session wait sites. close() aborts it right
  after stop() (both synchronous); synchronize() re-arms a fresh controller per
  session after the re-entry guard rather than in resetSessionState(), so a
  recovery reset mid-rendezvous cannot wipe a concurrent close()'s abort. A
  wait() delegate reads the signal fresh per call (must not be hoisted, since
  the controller is swapped at session start). The poll() delete-retry backoff
  is now cancellable, with a shutdown guard at the top of poll()'s catch
  (`!pollerActive`, keyed on state not error type) that swallows the resulting
  rejection so close() emits no spurious transport error. The advertise-hello
  retry treats an abort as "stop retrying" and still throws
  BilateralModeMismatchError (exit 64). The close() drain loop is deliberately
  left on a plain setTimeout -- it is the teardown wait itself and runs after
  the abort.
- `packages/core/src/errors.ts` -- add `ConnectionClosedError`, the typed abort
  reason. A plain Error (not UsageError), so a deliberate local teardown
  classifies as exit 69; in practice it is essentially unreachable as a process
  exit code, since close() only races an in-flight wait under a signal where
  signalReceived owns the code. Lives here with the rest of the connection
  error taxonomy, so it is re-exported on the package surface by main.ts.
- `packages/core/src/connection/fileSyncConstants.ts` -- add the leak-safe
  `cancellableDelay` helper. Defined here, not in the barrelled
  fileSyncConnection.ts, so the unit test can deep-import it without leaking it
  onto the published surface.
- `packages/core/test/fileSyncConnection.test.ts` -- ten new tests (see below).
- `CHANGELOG.md` -- `[Unreleased] > Fixed` line.

## Background

The hazard is a close() racing a parked sleep: the abort must reject the sleep
and the awaiting loop must unwind rather than issue its next transport call. Two
subtleties: the controller is re-armed at synchronize() entry (not in
resetSessionState()) so a recovery reset cannot clear a concurrent close()'s
abort; and the poll-loop cancellation is swallowed by a poller-state guard, not
by matching the error type, so no spurious transport error is emitted on close.
The teardown-stays-aborted property relies on a single, non-concurrent
synchronize() caller per instance, which the CLI guarantees.

## Out of scope / follow-on

- Document the clean-close drain-vs-discard contract in COMMUNICATION.md:
  [196423018](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=196423018).

## Test plan

- [x] `npm run typecheck && npm run lint` clean
- [x] `npm run build -w packages/core`
- [x] `npm test -w packages/core` (675/675)

New tests cover:
- close() cancels a parked retain ack-wait and a delete-mode consume-wait
  promptly (sites 4, 5).
- close() cancels a parked rendezvous wait (site 3) and completes teardown
  cleanly when an aborted rendezvous runs its safeDelete sweep (site 1b).
- close() during a parked poll delete-retry emits no spurious error (site 6).
- cancellableDelay resolves after the delay, rejects synchronously when
  pre-aborted, rejects with signal.reason and clears its timer mid-wait.
- synchronize() re-arms a fresh controller per session so a retry's waits stay
  live; wait() reads the controller fresh per call (do-not-hoist).

## Checklist

- [x] Ran `ls docs/` and checked each file for impact.
- [x] `CHANGELOG.md` `[Unreleased]` updated.
- [x] Cryptographic code changed? n/a -- no crypto touched.