### PR TITLE
Self-manage web integration tests and gate the web deploy

### DIFF
--- a/.github/workflows/eb_build_and_test.yaml
+++ b/.github/workflows/eb_build_and_test.yaml
@@ -66,6 +66,13 @@ jobs:
       - name: Run tests
         run: |
           npm run -w packages/core test
+      # Web integration tests gate the web deploy on the app's own behavior,
+      # independent of the CLI (whose tests live in release.yaml). The suite is
+      # self-managing -- a vitest globalSetup spawns the dev server, waits for
+      # readiness, and tears it down -- and needs no Docker (it runs in the node
+      # environment and hits the HTTP/SSE routes), so a stock runner suffices.
+      - name: Web integration tests
+        run: npm run test:integration -w apps/web
       - name: Package for Elastic Beanstalk
         run: |
           cp -a apps/web/deploy/aws_eb/. apps/web/.output

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,10 +84,20 @@ default the Compose project name to the directory (`container`), colliding on
 the port. The `make-worktree` command gives each worktree a unique project and a
 free port, so checkouts can run the container concurrently.
 
-Web (requires the dev server, a foreground process on port 3000):
+Web (dev server managed automatically -- same pattern as the CLI container):
 
 ```sh
-npm run dev -w apps/web
+npm run test:integration -w apps/web    # auto-starts, waits for, and stops the dev server
+```
+
+For a faster inner loop you can keep a warm server running across many runs:
+`test:integration` detects an already-running server, reuses it, and leaves it
+up rather than stopping it.
+
+```sh
+npm run dev           -w apps/web    # start (and keep) the dev server in a terminal
+npm run test:integration -w apps/web    # reuses the running server
+# stop the dev server in the terminal when done (Ctrl-C)
 ```
 
 ## Code Conventions

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "type-check": "tsc --noEmit",
     "start": "node --env-file=.env .output/server/index.mjs",
     "cli_server": "node --import=tsx scripts/psi.ts",
-    "test": "vitest run",
+    "test": "vitest run --project unit",
     "test:browser": "vitest run --project browser",
     "test:unit": "vitest run --project unit",
     "test:integration": "vitest run --project integration"

--- a/apps/web/test/devServer/globalSetup.ts
+++ b/apps/web/test/devServer/globalSetup.ts
@@ -11,8 +11,8 @@ import { spawn } from "node:child_process";
 // The dev server runs on 127.0.0.1 (the Vite bind host -- not `localhost`,
 // which may resolve to ::1 and miss the IPv4 bind). The port comes from the
 // PORT env var (default 3000), matching vite.config.ts. The integration tests
-// hardcode http://127.0.0.1:3000; both derive from the same default, so they
-// stay in sync as long as PORT is not overridden.
+// derive their target from the same `process.env.PORT ?? "3000"`, so the
+// launched/probed port and the tested port cannot drift.
 //
 // If a server is already listening on 127.0.0.1:PORT when the suite starts,
 // it is reused and left running on teardown, so a developer's long-lived
@@ -24,10 +24,20 @@ const here = dirname(fileURLToPath(import.meta.url));
 const webRoot = resolve(here, "../..");
 
 const READY_TIMEOUT_MS = 60_000;
-const PROBE_INTERVAL_MS = 250;
+// Per-probe abort: how long a single readiness request waits for an HTTP
+// response when the server has accepted the TCP connection but is slow to
+// answer (e.g. Vite still compiling). A refused connection rejects near-
+// instantly, well before this fires.
+const PROBE_TIMEOUT_MS = 1_000;
+// Sleep between probes. With a refused connection returning immediately, this
+// is roughly the effective poll cadence while the server is still coming up.
+const PROBE_SLEEP_MS = 250;
 // Short probe to detect an already-running server so we reuse rather than
 // start a second one -- and, crucially, leave it running on teardown.
 const REUSE_PROBE_TIMEOUT_MS = 500;
+// After SIGTERM, how long to wait for the process group to exit before
+// escalating to SIGKILL, so teardown cannot hang on a stuck dev server.
+const STOP_TIMEOUT_MS = 5_000;
 
 function getPort(): number {
   return parseInt(process.env.PORT ?? "3000", 10);
@@ -51,14 +61,14 @@ async function httpAccepts(url: string, timeoutMs: number): Promise<boolean> {
 async function waitForServer(url: string): Promise<void> {
   const deadline = Date.now() + READY_TIMEOUT_MS;
   for (;;) {
-    if (await httpAccepts(url, PROBE_INTERVAL_MS)) return;
+    if (await httpAccepts(url, PROBE_TIMEOUT_MS)) return;
     if (Date.now() >= deadline)
       throw new Error(
         `Dev server did not become ready at ${url} within ` +
           `${READY_TIMEOUT_MS / 1000}s. Check that \`npm run dev\` starts ` +
           `cleanly from ${webRoot}.`,
       );
-    await new Promise((r) => setTimeout(r, PROBE_INTERVAL_MS));
+    await new Promise((r) => setTimeout(r, PROBE_SLEEP_MS));
   }
 }
 
@@ -98,14 +108,36 @@ export default async function setup(): Promise<() => Promise<void>> {
     launchError = err;
   });
 
-  const killGroup = () => {
-    if (child.pid !== undefined) {
+  // Sends SIGTERM to the whole process group, then waits for the child to exit
+  // before resolving -- otherwise a back-to-back run's reuse probe could see
+  // the still-dying server holding the port and treat it as a warm one, or the
+  // fresh spawn could fail with EADDRINUSE. Escalates to SIGKILL if the group
+  // does not exit within STOP_TIMEOUT_MS, so teardown cannot hang.
+  const stopServer = (): Promise<void> => {
+    if (child.pid === undefined || child.exitCode !== null)
+      return Promise.resolve();
+    const pid = child.pid;
+    return new Promise<void>((resolveStop) => {
+      const timer = setTimeout(() => {
+        try {
+          process.kill(-pid, "SIGKILL");
+        } catch {
+          // already gone
+        }
+      }, STOP_TIMEOUT_MS);
+      timer.unref();
+      child.once("exit", () => {
+        clearTimeout(timer);
+        resolveStop();
+      });
       try {
-        process.kill(-child.pid, "SIGTERM");
+        process.kill(-pid, "SIGTERM");
       } catch {
-        // already gone
+        // already gone -- the exit listener may never fire, so settle here.
+        clearTimeout(timer);
+        resolveStop();
       }
-    }
+    });
   };
 
   try {
@@ -114,7 +146,7 @@ export default async function setup(): Promise<() => Promise<void>> {
     if (launchError) throw launchError;
     await waitForServer(url);
   } catch (err) {
-    killGroup();
+    await stopServer();
     throw err;
   }
 
@@ -122,7 +154,6 @@ export default async function setup(): Promise<() => Promise<void>> {
 
   return () => {
     console.log("[dev-server] stopping dev server");
-    killGroup();
-    return Promise.resolve();
+    return stopServer();
   };
 }

--- a/apps/web/test/devServer/globalSetup.ts
+++ b/apps/web/test/devServer/globalSetup.ts
@@ -1,0 +1,128 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+// Vitest globalSetup for the `integration` project: brings the Vite/TanStack
+// dev server up before the suite and tears it down after, so `npm run
+// test:integration` is self-contained rather than requiring the operator to
+// start `npm run dev` first. Only the integration project references this file,
+// so the unit project (and `npm run test`) never touches the dev server.
+//
+// The dev server runs on 127.0.0.1 (the Vite bind host -- not `localhost`,
+// which may resolve to ::1 and miss the IPv4 bind). The port comes from the
+// PORT env var (default 3000), matching vite.config.ts. The integration tests
+// hardcode http://127.0.0.1:3000; both derive from the same default, so they
+// stay in sync as long as PORT is not overridden.
+//
+// If a server is already listening on 127.0.0.1:PORT when the suite starts,
+// it is reused and left running on teardown, so a developer's long-lived
+// `npm run dev` is not killed mid-session -- matching the CLI integration
+// suite's warm-container reuse behavior.
+
+const here = dirname(fileURLToPath(import.meta.url));
+// apps/web/test/devServer -> apps/web is two levels up.
+const webRoot = resolve(here, "../..");
+
+const READY_TIMEOUT_MS = 60_000;
+const PROBE_INTERVAL_MS = 250;
+// Short probe to detect an already-running server so we reuse rather than
+// start a second one -- and, crucially, leave it running on teardown.
+const REUSE_PROBE_TIMEOUT_MS = 500;
+
+function getPort(): number {
+  return parseInt(process.env.PORT ?? "3000", 10);
+}
+
+// Returns true if the server responds to an HTTP request within timeoutMs,
+// false on connection refusal or timeout. Any HTTP status code counts as ready.
+async function httpAccepts(url: string, timeoutMs: number): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    await fetch(url, { signal: controller.signal });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function waitForServer(url: string): Promise<void> {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  for (;;) {
+    if (await httpAccepts(url, PROBE_INTERVAL_MS)) return;
+    if (Date.now() >= deadline)
+      throw new Error(
+        `Dev server did not become ready at ${url} within ` +
+          `${READY_TIMEOUT_MS / 1000}s. Check that \`npm run dev\` starts ` +
+          `cleanly from ${webRoot}.`,
+      );
+    await new Promise((r) => setTimeout(r, PROBE_INTERVAL_MS));
+  }
+}
+
+export default async function setup(): Promise<() => Promise<void>> {
+  const port = getPort();
+  const url = `http://127.0.0.1:${port}/`;
+
+  // Reuse a server already listening on the port (manual `npm run dev`, or a
+  // warm one from a prior run): skip launch and leave it running on teardown.
+  if (await httpAccepts(url, REUSE_PROBE_TIMEOUT_MS)) {
+    console.log(`[dev-server] reusing server already listening on port ${port}`);
+    return () => Promise.resolve();
+  }
+
+  // Strip VITEST so vite.config.ts wires the dev-server-snagger and
+  // preview-server-snagger plugins (they are skipped when VITEST is set,
+  // since globalSetup runs inside the vitest process where VITEST=true).
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.VITEST;
+
+  console.log(`[dev-server] starting dev server on port ${port}`);
+  // detached: true groups npm and its children (sh -> vite) under one process
+  // group so teardown can kill the whole tree with process.kill(-pid, SIGTERM).
+  const child = spawn("npm", ["run", "dev"], {
+    cwd: webRoot,
+    env,
+    detached: true,
+    stdio: "ignore",
+  });
+  // unref so this process group does not prevent the vitest process from
+  // exiting if teardown is never reached (e.g. an uncaught exception before
+  // the return below).
+  child.unref();
+
+  let launchError: Error | undefined;
+  child.once("error", (err) => {
+    launchError = err;
+  });
+
+  const killGroup = () => {
+    if (child.pid !== undefined) {
+      try {
+        process.kill(-child.pid, "SIGTERM");
+      } catch {
+        // already gone
+      }
+    }
+  };
+
+  try {
+    // Yield one tick so the error handler can fire if npm is not found.
+    await new Promise<void>((r) => setImmediate(r));
+    if (launchError) throw launchError;
+    await waitForServer(url);
+  } catch (err) {
+    killGroup();
+    throw err;
+  }
+
+  console.log(`[dev-server] ready on port ${port}`);
+
+  return () => {
+    console.log("[dev-server] stopping dev server");
+    killGroup();
+    return Promise.resolve();
+  };
+}

--- a/apps/web/test/integration/sessionApi.test.ts
+++ b/apps/web/test/integration/sessionApi.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "vitest";
 
 import { EventSource } from "eventsource";
 
-const HOST = "http://127.0.0.1:3000";
+// Derive from PORT (default 3000) so this stays in sync with the dev server the
+// integration globalSetup launches on 127.0.0.1:PORT. Bind host is 127.0.0.1,
+// not localhost, which may resolve to ::1 and miss the IPv4 bind.
+const HOST = `http://127.0.0.1:${process.env.PORT ?? "3000"}`;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -64,6 +64,7 @@ export default defineConfig((_configEnv) => {
             ],
             name: "integration",
             environment: "node",
+            globalSetup: ["./test/devServer/globalSetup.ts"],
           },
         },
         {


### PR DESCRIPTION
## Summary

Make the apps/web integration suite self-managing -- it now starts the
Vite/TanStack dev server itself, waits for readiness, runs, and tears the server
down -- so `npm run test:integration -w apps/web` no longer needs a manual `npm
run dev` first, matching how the CLI suite manages its SFTP container. Pin
apps/web's `test` script to the unit project so the root `npm run test` stays
unit-only and cannot hang fanning into the integration project with no server
up. Because the suite is now Docker-free and self-contained, also gate the web
deploy on it in CI.

Implements Release item [196017736](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=196017736).

## Changes

- `apps/web/test/devServer/globalSetup.ts` (new) -- vitest globalSetup for the
  integration project. Spawns the dev server with VITEST stripped from the child
  env (so vite.config.ts's dev-server-snagger plugins wire the PeerJS relay as a
  real `npm run dev` would), probes `GET http://127.0.0.1:PORT/` until ready
  (127.0.0.1, not localhost, to match the IPv4 bind), then tears down. A server
  already listening is detected, reused, and left running on teardown (warm
  inner loop). Teardown awaits the process group exiting -- SIGTERM, escalating
  to SIGKILL after STOP_TIMEOUT_MS -- so a back-to-back run cannot reuse a dying
  server or fail its spawn with EADDRINUSE. Probe cadence split into
  PROBE_TIMEOUT_MS (per-probe abort) and PROBE_SLEEP_MS (inter-probe delay).
- `apps/web/vite.config.ts` -- wire `globalSetup` onto the `integration` project
  only.
- `apps/web/test/integration/sessionApi.test.ts` -- derive the target HOST from
  `process.env.PORT` (default 3000) so the launched/probed port and the tested
  port cannot drift.
- `apps/web/package.json` -- pin `test` to `vitest run --project unit` (matching
  apps/cli), so the root `npm run test` is unit-only and never pulls in the
  integration project with no dev server up.
- `CONTRIBUTING.md` -- Testing section: drop the manual-dev-server caveat;
  document the self-managing run and the warm-server reuse loop.
- `.github/workflows/eb_build_and_test.yaml` -- add a "Web integration tests"
  step (`npm run test:integration -w apps/web`) to the workflow feeding the web
  deploy. Docker-free, runs on the stock ubuntu-latest runner. The web pipeline
  already builds/tests only core and web, so this gates the web deploy on the
  web app's own behavior: a CLI regression cannot block it, and a web
  integration regression now does.

## Background

Three review-driven robustness points are baked into the globalSetup: ownership
is decided before launch (only the run that started the server stops it, so an
inner-loop developer's long-lived dev server is never killed); teardown waits
for the process group to actually exit rather than firing SIGTERM and returning;
and host/port are sourced from one PORT origin at both the launcher and the test
so they cannot drift. The CI step (the third commit) extends the item's scope --
the original task assumed web integration stays out of CI -- and is included
here because the self-managing, Docker-free suite makes it cheap to gate the
deploy on.

## Test plan

- [x] `npm run typecheck && npm run lint` clean
- [x] `npm run build -w packages/core`
- [x] `npm test -w apps/web` -- 70/70, unit project only (no dev server spawned)
- [x] `npm run test:integration -w apps/web` -- self-managed end to end: dev
  server started, readiness-probed, 11/11 integration tests passed, server torn
  down; exit status reflects the test result

This PR adds no new test cases; the change is test-lifecycle infrastructure. The
existing 11 integration tests now run without a manually started dev server, and
the root `npm run test` no longer fans into the integration project.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact.
- [x] `CHANGELOG.md` -- n/a. Test infrastructure and CI gating; no user-facing
  behavior change.
- [x] Cryptographic code changed? n/a -- no crypto touched.