### PR TITLE
Pass connection.provider_options keys through verbatim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to PSI-Link are documented here. The format follows [Keep a 
 
 ### Fixed
 
-- `connection.provider_options` keys are now passed verbatim, as the spec documents. Previously the config reader case-normalized them to camelCase (and the config writer back to snake_case), so a key authored in the casing the transport library expects -- e.g. ssh2's `readyTimeout` -- could be rewritten (`ready_timeout`) rather than preserved. The map's contents are excluded from key-case transformation on both the read and write paths; all other schema fields, including function `params`, are normalized as before.
+- `connection.provider_options` keys are now passed verbatim, as the spec documents. Previously the config writer snakeized them to disk and the reader camelized them back, so a key authored in the casing the transport library expects -- e.g. ssh2's `readyTimeout` -- could be rewritten (`ready_timeout`) rather than preserved. The map's contents are excluded from key-case transformation on both the write and read paths; all other schema fields, including function `params`, are normalized as before.
 - A malformed message from a peer is reported as a protocol error instead of crashing.
 - A failed exchange surfaces its original cause instead of a generic connection error.
 - Closing a file-sync connection now cancels any in-flight rendezvous or send wait promptly instead of letting the timer fire and resume against a connection that is tearing down. Internal hardening only: cancellation threads a single `AbortController` through every wait site, and a new internal `ConnectionClosedError` may appear in debug logs on a close-during-wait. Not a user-facing exit-code change (a deliberate close under a signal still exits 130/143).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to PSI-Link are documented here. The format follows [Keep a 
 
 ### Fixed
 
-- `connection.provider_options` keys are now passed verbatim, as the spec documents. Previously the config writer snakeized them to disk and the reader camelized them back, so a key authored in the casing the transport library expects -- e.g. ssh2's `readyTimeout` -- could be rewritten (`ready_timeout`) rather than preserved. The map's contents are excluded from key-case transformation on both the write and read paths; all other schema fields, including function `params`, are normalized as before.
+- `connection.provider_options` keys are now passed verbatim, as the spec now documents. Previously the config writer snakeized them to disk and the reader camelized them back, so a key authored in the casing the transport library expects -- e.g. ssh2's `readyTimeout` -- was rewritten (`ready_timeout`) rather than preserved. The map's contents are excluded from key-case transformation on both the write and read paths; all other schema fields, including function `params`, are normalized as before.
 - A malformed message from a peer is reported as a protocol error instead of crashing.
 - A failed exchange surfaces its original cause instead of a generic connection error.
 - Closing a file-sync connection now cancels any in-flight rendezvous or send wait promptly instead of letting the timer fire and resume against a connection that is tearing down. Internal hardening only: cancellation threads a single `AbortController` through every wait site, and a new internal `ConnectionClosedError` may appear in debug logs on a close-during-wait. Not a user-facing exit-code change (a deliberate close under a signal still exits 130/143).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to PSI-Link are documented here. The format follows [Keep a 
 
 ### Fixed
 
+- `connection.provider_options` keys are now passed verbatim, as the spec documents. Previously the config reader case-normalized them to camelCase (and the config writer back to snake_case), so a key authored in the casing the transport library expects -- e.g. ssh2's `readyTimeout` -- could be rewritten (`ready_timeout`) rather than preserved. The map's contents are excluded from key-case transformation on both the read and write paths; all other schema fields, including function `params`, are normalized as before.
 - A malformed message from a peer is reported as a protocol error instead of crashing.
 - A failed exchange surfaces its original cause instead of a generic connection error.
 - Closing a file-sync connection now cancels any in-flight rendezvous or send wait promptly instead of letting the timer fire and resume against a connection that is tearing down. Internal hardening only: cancellation threads a single `AbortController` through every wait site, and a new internal `ConnectionClosedError` may appear in debug logs on a close-during-wait. Not a user-facing exit-code change (a deliberate close under a signal still exits 130/143).

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -156,6 +156,13 @@ function camelToSnake(s: string): string {
   return s.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
 }
 
+// Mirrors core's private `snakeToCamel`. Used only to normalize a key to its
+// canonical camelCase form before consulting the camelCase-keyed
+// `OPAQUE_VALUE_KEYS`; it is a no-op on an already-camelCase key.
+function snakeToCamel(s: string): string {
+  return s.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
 /**
  * Recursively rewrites object keys from camelCase to snake_case. The inverse of
  * core's `camelizeKeys` for the keys the exchange schema uses: every config key
@@ -172,13 +179,20 @@ function camelToSnake(s: string): string {
  * keeps the read and write paths excluding exactly the same subtrees, preserving
  * the write -> read round-trip invariant. Function-specific `params` blocks are
  * NOT opaque -- they are psilink's own vocabulary and stay normalized.
+ *
+ * The opaque check normalizes each key to its canonical camelCase form first
+ * (`OPAQUE_VALUE_KEYS` is camelCase-keyed), so it matches regardless of the
+ * input key's casing -- symmetric with `camelizeKeys`, which also normalizes
+ * before consulting the set. In practice this writer only ever sees a camelCase
+ * `ExchangeSpec`, but normalizing removes the silent precondition that the guard
+ * would otherwise depend on.
  */
 function snakeizeKeys(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(snakeizeKeys);
   if (value !== null && typeof value === "object")
     return Object.fromEntries(
       Object.entries(value).map(([k, v]) =>
-        OPAQUE_VALUE_KEYS.has(k)
+        OPAQUE_VALUE_KEYS.has(snakeToCamel(k))
           ? [camelToSnake(k), v]
           : [camelToSnake(k), snakeizeKeys(v)],
       ),

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -156,13 +156,6 @@ function camelToSnake(s: string): string {
   return s.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
 }
 
-// Mirrors core's private `snakeToCamel`. Used only to normalize a key to its
-// canonical camelCase form before consulting the camelCase-keyed
-// `OPAQUE_VALUE_KEYS`; it is a no-op on an already-camelCase key.
-function snakeToCamel(s: string): string {
-  return s.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
-}
-
 /**
  * Recursively rewrites object keys from camelCase to snake_case. The inverse of
  * core's `camelizeKeys` for the keys the exchange schema uses: every config key
@@ -180,19 +173,31 @@ function snakeToCamel(s: string): string {
  * the write -> read round-trip invariant. Function-specific `params` blocks are
  * NOT opaque -- they are psilink's own vocabulary and stay normalized.
  *
- * The opaque check normalizes each key to its canonical camelCase form first
- * (`OPAQUE_VALUE_KEYS` is camelCase-keyed), so it matches regardless of the
- * input key's casing -- symmetric with `camelizeKeys`, which also normalizes
- * before consulting the set. In practice this writer only ever sees a camelCase
- * `ExchangeSpec`, but normalizing removes the silent precondition that the guard
- * would otherwise depend on.
+ * The opaque check consults the raw key directly (`OPAQUE_VALUE_KEYS.has(k)`),
+ * with no casing normalization. This is correct, and the asymmetry with
+ * `camelizeKeys` -- which normalizes via its own `snakeToCamel` before the same
+ * check -- is deliberate, because the two functions have different input
+ * domains. `camelizeKeys` reads user YAML whose key casing is unknown
+ * (conventionally snake_case), so it must normalize to the canonical camelCase
+ * form first. `snakeizeKeys` is only ever called by `saveConfig` on a typed
+ * `ExchangeSpec`, whose opaque key is always the camelCase `providerOptions`, so
+ * the raw key already matches the camelCase-keyed set and normalizing would be
+ * dead code. Re-introducing a `snakeToCamel` helper here to force symmetry would
+ * duplicate core's private copy across the package boundary -- the CLI builds
+ * against core's dist, so the two cannot share a private helper without widening
+ * core's export surface -- and a silent drift between the copies would break the
+ * very round-trip invariant the shared set exists to guarantee.
  */
 function snakeizeKeys(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(snakeizeKeys);
   if (value !== null && typeof value === "object")
     return Object.fromEntries(
       Object.entries(value).map(([k, v]) =>
-        OPAQUE_VALUE_KEYS.has(snakeToCamel(k))
+        // Raw-key check: `k` is already canonical camelCase here (a typed
+        // ExchangeSpec from saveConfig), so the opaque key matches the
+        // camelCase-keyed set as-is -- see the note above on why this writer
+        // does not normalize.
+        OPAQUE_VALUE_KEYS.has(k)
           ? [camelToSnake(k), v]
           : [camelToSnake(k), snakeizeKeys(v)],
       ),

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -1,6 +1,10 @@
 import YAML from "yaml";
 import type { ConnectionConfig, ExchangeSpec } from "@psilink/core";
-import { safeParseFileSyncOptions, UsageError } from "@psilink/core";
+import {
+  OPAQUE_VALUE_KEYS,
+  safeParseFileSyncOptions,
+  UsageError,
+} from "@psilink/core";
 
 import { writeFileOwnerOnly } from "./keyFile";
 
@@ -161,19 +165,23 @@ function camelToSnake(s: string): string {
  * occurs in the schema. Only keys are rewritten; string values (e.g. the
  * `firstName` in `type: firstName`) are left verbatim, matching the read path.
  *
- * Like the read path's `camelizeKeys`, this recurses into every nested object,
- * including opaque maps such as `connection.provider_options` and transform
- * `params`. A literal camelCase key a user placed in such a map would be
- * normalized to snake_case here. That mirrors `camelizeKeys` (which already
- * camelCases those keys on read), so the write/read round-trip stays stable;
- * making either side skip opaque subtrees must be done symmetrically in core
- * (tracked separately).
+ * Opaque-value maps (`OPAQUE_VALUE_KEYS`, currently `connection.provider_options`)
+ * are skipped symmetrically with `camelizeKeys`: the map's own key is snakeized,
+ * but its contents are left verbatim so a user-authored key (snake or camel)
+ * survives byte-for-byte to disk and back. The shared `OPAQUE_VALUE_KEYS` set
+ * keeps the read and write paths excluding exactly the same subtrees, preserving
+ * the write -> read round-trip invariant. Function-specific `params` blocks are
+ * NOT opaque -- they are psilink's own vocabulary and stay normalized.
  */
 function snakeizeKeys(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(snakeizeKeys);
   if (value !== null && typeof value === "object")
     return Object.fromEntries(
-      Object.entries(value).map(([k, v]) => [camelToSnake(k), snakeizeKeys(v)]),
+      Object.entries(value).map(([k, v]) =>
+        OPAQUE_VALUE_KEYS.has(k)
+          ? [camelToSnake(k), v]
+          : [camelToSnake(k), snakeizeKeys(v)],
+      ),
     );
   return value;
 }

--- a/apps/cli/test/unit/config.test.ts
+++ b/apps/cli/test/unit/config.test.ts
@@ -321,6 +321,42 @@ test("saveConfig round-trips provider_options verbatim in both directions", () =
   }
 });
 
+test("saveConfig round-trips webrtc provider_options verbatim", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
+  try {
+    const configPath = path.join(dir, "psilink.yaml");
+    // providerOptions is opaque on webrtc as well as sftp; the writer/reader
+    // key-normalization is channel-agnostic, so a literal camelCase key and a
+    // snake_case key must both survive the round-trip byte-for-byte.
+    const spec: ExchangeSpec = {
+      connection: {
+        channel: "webrtc",
+        server: { host: "api.peerjs.com" },
+        providerOptions: { readyTimeout: 5000, keepalive_interval: 1000 },
+      },
+      linkageTerms: getDefaultLinkageTerms("Agency A"),
+    };
+
+    saveConfig(configPath, spec);
+    const raw = fs.readFileSync(configPath, "utf8");
+    expect(raw).toContain("readyTimeout:");
+    expect(raw).toContain("keepalive_interval:");
+    expect(raw).not.toContain("ready_timeout:");
+    expect(raw).not.toContain("keepaliveInterval:");
+
+    const parsed = parseExchangeSpec(YAML.parse(raw));
+    expect(parsed).toEqual(spec);
+    if (parsed.connection.channel !== "webrtc")
+      throw new Error("expected webrtc channel");
+    expect(parsed.connection.providerOptions).toEqual({
+      readyTimeout: 5000,
+      keepalive_interval: 1000,
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("saveConfig keeps authentication when role remains after stripping (WebRTC)", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
   try {

--- a/apps/cli/test/unit/config.test.ts
+++ b/apps/cli/test/unit/config.test.ts
@@ -272,6 +272,54 @@ test("saveConfig strips pakeToken/expires and does not mutate the caller's spec"
   }
 });
 
+test("saveConfig round-trips provider_options verbatim in both directions", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
+  try {
+    const configPath = path.join(dir, "psilink.yaml");
+    // provider_options is opaque: a literal camelCase key (ssh2's readyTimeout)
+    // and a snake_case key must both survive the writer + reader unchanged. The
+    // writer must not snakeize readyTimeout, and the reader must not camelize
+    // keepalive_interval.
+    const spec: ExchangeSpec = {
+      connection: {
+        channel: "sftp",
+        server: { host: "h" },
+        providerOptions: { readyTimeout: 5000, keepalive_interval: 1000 },
+      },
+      linkageTerms: getDefaultLinkageTerms("Agency A"),
+    };
+
+    // write: keys land on disk byte-for-byte (camelCase stays camelCase, snake
+    // stays snake) -- not transformed by snakeizeKeys.
+    saveConfig(configPath, spec);
+    const raw1 = fs.readFileSync(configPath, "utf8");
+    expect(raw1).toContain("readyTimeout:");
+    expect(raw1).toContain("keepalive_interval:");
+    expect(raw1).not.toContain("ready_timeout:");
+    expect(raw1).not.toContain("keepaliveInterval:");
+
+    // read: parsing reproduces the spec exactly, opaque map included.
+    const parsed = parseExchangeSpec(YAML.parse(raw1));
+    expect(parsed).toEqual(spec);
+    if (parsed.connection.channel !== "sftp")
+      throw new Error("expected sftp channel");
+    expect(parsed.connection.providerOptions).toEqual({
+      readyTimeout: 5000,
+      keepalive_interval: 1000,
+    });
+
+    // read -> write: writing the re-read spec produces an identical opaque map,
+    // confirming the round-trip is stable in both directions.
+    saveConfig(configPath, parsed);
+    const raw2 = fs.readFileSync(configPath, "utf8");
+    expect(YAML.parse(raw2).connection.provider_options).toEqual(
+      YAML.parse(raw1).connection.provider_options,
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("saveConfig keeps authentication when role remains after stripping (WebRTC)", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
   try {

--- a/apps/cli/test/unit/config.test.ts
+++ b/apps/cli/test/unit/config.test.ts
@@ -279,7 +279,8 @@ test("saveConfig round-trips provider_options verbatim in both directions", () =
     // provider_options is opaque: a literal camelCase key (ssh2's readyTimeout)
     // and a snake_case key must both survive the writer + reader unchanged. The
     // writer must not snakeize readyTimeout, and the reader must not camelize
-    // keepalive_interval.
+    // keepalive_interval. The field name itself (`providerOptions`) is camelCase,
+    // which is what snakeizeKeys' raw-key opaque check relies on to skip it.
     const spec: ExchangeSpec = {
       connection: {
         channel: "sftp",

--- a/docs/EXCHANGE_SPEC.md
+++ b/docs/EXCHANGE_SPEC.md
@@ -628,7 +628,7 @@ The receiver only reads files whose on-disk size matches the declared byte count
 
 An opaque key-value map passed verbatim to the underlying transport library. Keys and values are defined by the package providing the connection implementation. `@`-file pathing is supported here as well.
 
-Unlike every other map in this spec, the keys here are **not** case-normalized: they are passed exactly as written. The SFTP channel forwards them to `ssh2-sftp-client`, whose options are camelCase (e.g. `readyTimeout`, `algorithms`, `keepaliveInterval`), so write those keys in the casing the library expects rather than snake_case.
+Unlike every other map in this spec, the keys here are **not** case-normalized on any channel: they are passed exactly as written, so author them in the casing the underlying transport library expects rather than snake_case. For the SFTP channel they are forwarded to `ssh2-sftp-client`, whose options are camelCase (e.g. `readyTimeout`, `algorithms`, `keepaliveInterval`).
 
 ---
 

--- a/docs/EXCHANGE_SPEC.md
+++ b/docs/EXCHANGE_SPEC.md
@@ -628,6 +628,8 @@ The receiver only reads files whose on-disk size matches the declared byte count
 
 An opaque key-value map passed verbatim to the underlying transport library. Keys and values are defined by the package providing the connection implementation. `@`-file pathing is supported here as well.
 
+Unlike every other map in this spec, the keys here are **not** case-normalized: they are passed exactly as written. The SFTP channel forwards them to `ssh2-sftp-client`, whose options are camelCase (e.g. `readyTimeout`, `algorithms`, `keepaliveInterval`), so write those keys in the casing the library expects rather than snake_case.
+
 ---
 
 ## Input metadata
@@ -746,6 +748,8 @@ When exactly one fan-out entry matches, the original row is accepted and all its
 **Distinction from `generate_fuzzy_comparisons`**: fan-out at the standardization stage and `generate_fuzzy_comparisons` on a key element both generate multiple PSI entries per row, but they serve different purposes. Standardization fan-out reflects that a field legitimately has multiple canonical values (e.g. a hyphenated name and its parts). `generate_fuzzy_comparisons` generates approximate variants of a single canonical value to tolerate data entry errors (e.g. digit transpositions in an SSN). Only one match is expected from a `generate_fuzzy_comparisons` expansion; multiple matches from the same row in a standardization fan-out may all be meaningful.
 
 ### Available functions
+
+Parameter names below are written in snake_case in YAML (e.g. `input_format`, `include_original`), following the same convention as the rest of the spec; they are normalized for the function library internally. Unlike `connection.provider_options`, a `params` block is not opaque and its keys are not passed verbatim.
 
 #### String transformation
 

--- a/docs/EXCHANGE_SPEC.md
+++ b/docs/EXCHANGE_SPEC.md
@@ -624,11 +624,12 @@ The receiver only reads files whose on-disk size matches the declared byte count
 ### `connection.provider_options`
 
 *Type:* object  
-*Required:* no
+*Required:* no  
+*Applies to:* `webrtc`, `sftp`
 
 An opaque key-value map passed verbatim to the underlying transport library. Keys and values are defined by the package providing the connection implementation. `@`-file pathing is supported here as well.
 
-Unlike every other map in this spec, the keys here are **not** case-normalized on any channel: they are passed exactly as written, so author them in the casing the underlying transport library expects rather than snake_case. For the SFTP channel they are forwarded to `ssh2-sftp-client`, whose options are camelCase (e.g. `readyTimeout`, `algorithms`, `keepaliveInterval`).
+Unlike every other map in this spec, the keys here are **not** case-normalized: they are passed exactly as written, so author them in the casing the underlying transport library expects rather than snake_case. For the SFTP channel they are forwarded to `ssh2-sftp-client`, whose options are camelCase (e.g. `readyTimeout`, `algorithms`, `keepaliveInterval`).
 
 ---
 

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -8,6 +8,8 @@ export type { HelloEnvelope } from "./connection/controlEnvelope";
 export * from "./connection/messageConnection";
 export { getLogger, setLogPrefixer } from "./utils/logger";
 export { retryPromise, withTimeout } from "./utils/promise";
+// @internal: shared with the CLI config writer so read/write skip identical
+// subtrees; not a stable public API (see the declaration's JSDoc).
 export { OPAQUE_VALUE_KEYS } from "./utils/camelizeKeys";
 
 export * from "./config/standardization";

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -8,6 +8,7 @@ export type { HelloEnvelope } from "./connection/controlEnvelope";
 export * from "./connection/messageConnection";
 export { getLogger, setLogPrefixer } from "./utils/logger";
 export { retryPromise, withTimeout } from "./utils/promise";
+export { OPAQUE_VALUE_KEYS } from "./utils/camelizeKeys";
 
 export * from "./config/standardization";
 export * from "./config/connection";

--- a/packages/core/src/utils/camelizeKeys.ts
+++ b/packages/core/src/utils/camelizeKeys.ts
@@ -1,3 +1,28 @@
+/**
+ * Field names whose value is an opaque map passed verbatim to an external
+ * library, and whose keys must therefore NOT be case-transformed. Currently
+ * only `connection.provider_options` / `providerOptions`, which is spread
+ * directly into the `ssh2-sftp-client` connect options -- a namespace defined by
+ * that library, whose keys are camelCase (e.g. `readyTimeout`, `algorithms`) and
+ * are not psilink's to normalize. Every other map in the exchange schema is
+ * psilink's own vocabulary and follows the snake_case-in-YAML <-> camelCase-in-TS
+ * convention (this includes the function-specific `params` blocks, which feed
+ * psilink's own standardizing-function library and are read as camelCase keys).
+ *
+ * The set is keyed by canonical camelCase name and is the single source of truth
+ * shared with the CLI config writer's inverse `snakeizeKeys`, so the read and
+ * write paths skip exactly the same subtrees and the write -> read round-trip
+ * stays byte-stable.
+ *
+ * This is a key-NAME match, not a path match: a key named `provider_options`
+ * (snake) / `providerOptions` (camel) at any depth is treated as opaque. No
+ * other schema field uses that name, and the contents of an opaque map are
+ * themselves opaque, so a nested occurrence is correctly left verbatim too.
+ */
+export const OPAQUE_VALUE_KEYS: ReadonlySet<string> = new Set([
+  "providerOptions",
+]);
+
 function snakeToCamel(s: string): string {
   return s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
 }
@@ -6,7 +31,15 @@ export function camelizeKeys(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(camelizeKeys);
   if (value !== null && typeof value === "object")
     return Object.fromEntries(
-      Object.entries(value).map(([k, v]) => [snakeToCamel(k), camelizeKeys(v)]),
+      Object.entries(value).map(([k, v]) => {
+        const camelKey = snakeToCamel(k);
+        // An opaque map's own key is still normalized, but its value is left
+        // verbatim: do not recurse, so user-authored keys (snake or camel)
+        // survive byte-for-byte. Symmetric with snakeizeKeys (CLI config writer).
+        return OPAQUE_VALUE_KEYS.has(camelKey)
+          ? [camelKey, v]
+          : [camelKey, camelizeKeys(v)];
+      }),
     );
   return value;
 }

--- a/packages/core/src/utils/camelizeKeys.ts
+++ b/packages/core/src/utils/camelizeKeys.ts
@@ -18,6 +18,13 @@
  * (snake) / `providerOptions` (camel) at any depth is treated as opaque. No
  * other schema field uses that name, and the contents of an opaque map are
  * themselves opaque, so a nested occurrence is correctly left verbatim too.
+ *
+ * Exported only so the CLI config writer's `snakeizeKeys` can share this exact
+ * set -- one source of truth keeps the read and write paths skipping identical
+ * subtrees. It is not a stable public API; consumers outside the workspace
+ * should not depend on its contents.
+ *
+ * @internal
  */
 export const OPAQUE_VALUE_KEYS: ReadonlySet<string> = new Set([
   "providerOptions",

--- a/packages/core/test/connection.test.ts
+++ b/packages/core/test/connection.test.ts
@@ -172,6 +172,7 @@ test("provider_options preserves a literal camelCase key unchanged", () => {
     // them survive byte-for-byte rather than being normalized to snake_case.
     provider_options: { readyTimeout: 5000, algorithms: { kex: ["a"] } },
   });
+  expect(result.channel).toBe("sftp");
   if (result.channel !== "sftp") return;
   expect(result.providerOptions).toEqual({
     readyTimeout: 5000,
@@ -184,6 +185,7 @@ test("provider_options is opaque all the way down (nested keys not camelized)", 
     ...sftpBase,
     provider_options: { nested_outer: { nested_inner: 1 } },
   });
+  expect(result.channel).toBe("sftp");
   if (result.channel !== "sftp") return;
   expect(result.providerOptions).toEqual({ nested_outer: { nested_inner: 1 } });
 });

--- a/packages/core/test/connection.test.ts
+++ b/packages/core/test/connection.test.ts
@@ -144,6 +144,50 @@ test("parses shared options including maxReconnectAttempts on an SFTP config", (
   expect(result.data.options?.maxReconnectAttempts).toBe(5);
 });
 
+// --- provider_options (opaque, verbatim) -------------------------------------
+
+test("provider_options keys pass through verbatim (snake_case preserved)", () => {
+  const result = parseConnectionConfig({
+    ...sftpBase,
+    // An opaque map is forwarded verbatim to the transport library, which
+    // defines its own key names; its keys must NOT be camelized.
+    provider_options: { ready_timeout: 5000, debug_mode: true },
+    // A sibling schema field in the same parse is still normalized.
+    options: { peer_timeout_ms: 120000 },
+  });
+  expect(result.channel).toBe("sftp");
+  if (result.channel !== "sftp") return;
+  expect(result.providerOptions).toEqual({
+    ready_timeout: 5000,
+    debug_mode: true,
+  });
+  // The known schema field was camelized as usual.
+  expect(result.options?.peerTimeoutMs).toBe(120000);
+});
+
+test("provider_options preserves a literal camelCase key unchanged", () => {
+  const result = parseConnectionConfig({
+    ...sftpBase,
+    // ssh2's option keys are camelCase; a user writing them literally must have
+    // them survive byte-for-byte rather than being normalized to snake_case.
+    provider_options: { readyTimeout: 5000, algorithms: { kex: ["a"] } },
+  });
+  if (result.channel !== "sftp") return;
+  expect(result.providerOptions).toEqual({
+    readyTimeout: 5000,
+    algorithms: { kex: ["a"] },
+  });
+});
+
+test("provider_options is opaque all the way down (nested keys not camelized)", () => {
+  const result = parseConnectionConfig({
+    ...sftpBase,
+    provider_options: { nested_outer: { nested_inner: 1 } },
+  });
+  if (result.channel !== "sftp") return;
+  expect(result.providerOptions).toEqual({ nested_outer: { nested_inner: 1 } });
+});
+
 // --- Discriminated union -----------------------------------------------------
 
 test("unknown channel is rejected", () => {

--- a/packages/core/test/connection.test.ts
+++ b/packages/core/test/connection.test.ts
@@ -190,6 +190,22 @@ test("provider_options is opaque all the way down (nested keys not camelized)", 
   expect(result.providerOptions).toEqual({ nested_outer: { nested_inner: 1 } });
 });
 
+test("provider_options is opaque on the webrtc channel too", () => {
+  // The opaque skip is channel-agnostic (a key-name match in camelizeKeys), and
+  // WebRTCConnectionConfig also declares providerOptions. Guard the webrtc path
+  // so a future schema change cannot silently start normalizing its keys.
+  const result = parseConnectionConfig({
+    ...webrtcBase,
+    provider_options: { readyTimeout: 5000, nested_outer: { nested_inner: 1 } },
+  });
+  expect(result.channel).toBe("webrtc");
+  if (result.channel !== "webrtc") return;
+  expect(result.providerOptions).toEqual({
+    readyTimeout: 5000,
+    nested_outer: { nested_inner: 1 },
+  });
+});
+
 // --- Discriminated union -----------------------------------------------------
 
 test("unknown channel is rejected", () => {

--- a/packages/core/test/linkageTerms.test.ts
+++ b/packages/core/test/linkageTerms.test.ts
@@ -320,6 +320,44 @@ test("parses snake_case keys from disk", () => {
   expect(result.legalAgreement?.expirationDate).toBe("2027-01-01");
 });
 
+test("transform params keys are normalized (params are not opaque)", () => {
+  // Unlike connection.provider_options, a transform `params` block is psilink's
+  // own function vocabulary and follows the snake_case-YAML -> camelCase-TS
+  // convention: the standardizing-function library reads camelCase param keys.
+  const result = parseLinkageTerms({
+    version: "1.0.0",
+    identity: "Test Party",
+    date: "2025-01-01",
+    algorithm: "psi",
+    output: { expects_output: true, share_with_partner: false },
+    deduplicate: false,
+    linkage_fields: [{ name: "dob", type: "dateOfBirth" }],
+    linkage_keys: [
+      {
+        name: "DOB",
+        elements: [
+          {
+            field: "dob",
+            transform: [
+              {
+                function: "parse_date",
+                params: {
+                  input_format: "MM/DD/YYYY",
+                  output_format: "YYYYMMDD",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+  expect(result.linkageKeys[0].elements[0].transform?.[0].params).toEqual({
+    inputFormat: "MM/DD/YYYY",
+    outputFormat: "YYYYMMDD",
+  });
+});
+
 // ─── validateCompatibility ───────────────────────────────────────────────────
 
 const sharedFields: LinkageTerms["linkageFields"] = [


### PR DESCRIPTION
## Summary

psilink now writes and reads `connection.provider_options` keys exactly as authored, so a key in the casing the transport library expects (for example ssh2's `readyTimeout`) survives the config round-trip instead of being silently case-folded. Previously the CLI config writer snakeized the map's keys to disk and the core reader camelized them back, contradicting the spec's "verbatim" guarantee. Both paths now skip the map symmetrically through a single shared `OPAQUE_VALUE_KEYS` set, so the write-then-read round-trip is byte-stable.

Implements Product item [196557243](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=196557243).

## Changes

- `packages/core/src/utils/camelizeKeys.ts`: add the internal `OPAQUE_VALUE_KEYS` set and stop recursing into a matching map on read, so its keys are not camelized.
- `packages/core/src/main.ts`: re-export `OPAQUE_VALUE_KEYS` (marked `@internal`) so the CLI writer shares one source of truth with the reader.
- `apps/cli/src/config.ts`: `snakeizeKeys` skips the same set on write; the JSDoc documents why the writer consults the raw key and does not normalize (its only caller passes a typed camelCase `ExchangeSpec`).
- `docs/EXCHANGE_SPEC.md`: document that `provider_options` keys are not case-normalized, and scope the section to `webrtc`/`sftp` with an `Applies to` line (filedrop has no `providerOptions`).
- `CHANGELOG.md`: add the Fixed entry under `[Unreleased]`.
- `packages/core/test/connection.test.ts`: parse tests for verbatim keys on `sftp` and `webrtc` (snake_case, literal camelCase, nested).
- `apps/cli/test/unit/config.test.ts`: `saveConfig` write-then-read round-trip tests for `sftp` and `webrtc`.
- `packages/core/test/linkageTerms.test.ts`: guard test that transform `params` keys are still normalized (params are not opaque).

## Background

The write-then-read round-trip must be byte-stable, which requires the reader (`camelizeKeys`) and writer (`snakeizeKeys`) to skip exactly the same subtrees. A single set keyed by canonical camelCase name enforces that by construction. `connection.provider_options` is the only genuinely opaque map: it is spread verbatim into the `ssh2-sftp-client` connect options, whose keys are camelCase and are not psilink's to normalize. Function `params` blocks look similar but are psilink's own vocabulary, read as camelCase by the standardizing-function library, so they stay normalized. The opaque skip is a key-name match, not a path match; this is intentional and documented, and no other schema field uses the name. The feature is entirely unreleased (absent at v0.1.0), so this corrects behavior before any release rather than changing a shipped contract.

## Out of scope / follow-on

- Follow-on: [196639172](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=196639172) - co-locate the opaque-key traversal in core so the read and write paths share one walker and cannot diverge, replacing the prose-and-test guarantee with a structural one.

## Test plan

- [x] `npm run typecheck && npm run lint` clean
- [x] `npm test -w packages/core` (683/683)
- [x] `npm run test:unit -w apps/cli` (159/159) and `npm run test:unit -w apps/web` (72/72)
- [x] CLI integration tests: `npm run test:integration -w apps/cli` (9/9)

New tests cover: verbatim `provider_options` keys on read for `sftp` and `webrtc` (snake_case preserved, literal camelCase preserved, nested keys untouched), `saveConfig` write-then-read round-trip stability for `sftp` and `webrtc`, and a guard that transform `params` keys remain normalized.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact; only `EXCHANGE_SPEC.md` references `provider_options`, and it is updated
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Cryptographic code changed? n/a - no cryptographic code touched
