### PR TITLE
Correct AEAD context labels to directional pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ All notable changes to PSI-Link are documented here. The format follows [Keep a 
 - SPAKE2 blinding points M and N are derived via hash-to-curve (RFC 9380, SSWU for P-256) with `psilink`-specific domain separation strings, ensuring no known discrete-log relationship with the generator.
 - Password scalar derivation uses HKDF-SHA-256 expanded to 48 bytes before reduction modulo the P-256 order, keeping mod-reduction bias below 2^-128.
 - Invitation tokens carry a bounded lifetime (default 1 hour); rotation tokens carry no expiration, making them suitable for recurring scheduled exchanges.
-- `deriveAeadKey`'s `context` parameter is constrained to a fixed, ASCII-only set of channel labels (`AeadContext`/`AEAD_CONTEXTS`, currently `"sftp-aead"` and `"filedrop-aead"`) instead of an open `string`, with a runtime guard for untyped callers. This prevents a future AEAD caller from deriving the channel key from a variable, non-ASCII, or non-NFC label, which would make the two parties derive different AES-256-GCM keys and fail AEAD with an opaque auth-tag/decrypt error instead of a clear cause.
+- `deriveAeadKey`'s `context` parameter is constrained to a fixed, ASCII-only set of per-direction labels (`AeadContext`/`AEAD_CONTEXTS`, currently `"initiator-to-responder"` and `"responder-to-initiator"`) instead of an open `string`, with a runtime guard for untyped callers. This prevents a future AEAD caller from deriving the per-direction key from a variable, non-ASCII, or non-NFC label, which would make the two parties derive different AES-256-GCM keys and fail AEAD with an opaque auth-tag/decrypt error instead of a clear cause.
 
 ### Documentation
 

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -16,10 +16,11 @@ export interface AuthResult {
   /**
    * 32-byte SPAKE2 session key (`Ke`).  Both parties hold the same value after
    * a successful handshake.  Callers that need application-layer encryption
-   * (e.g. `sftp` and `filedrop` channels) should pass this to
-   * {@link deriveAeadKey} to obtain a full-strength AES-GCM key; callers
-   * that rely on transport-layer security (e.g. WebRTC with DTLS) may ignore
-   * it.
+   * (the `sftp` and `filedrop` channels) pass this to {@link deriveAeadKey} to
+   * derive the AES-256-GCM keys; those keys are per direction, not per channel,
+   * so the channels share one AEAD mechanism rather than each having its own
+   * key.  Callers that rely on transport-layer security (e.g. WebRTC with DTLS)
+   * may ignore it.
    */
   sessionKey: Uint8Array<ArrayBuffer>;
   /**

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -35,29 +35,35 @@ export interface AuthResult {
 }
 
 /**
- * The fixed set of AEAD channel-context labels accepted by
- * {@link deriveAeadKey}.  Each label is an ASCII-only domain-separation string
- * that binds a derived key to one encrypted channel; both endpoints of a
- * channel must pass the same label to derive the same AES-256-GCM key.
+ * The fixed set of AEAD direction-context labels accepted by
+ * {@link deriveAeadKey}.  The application-layer AEAD channel derives one
+ * AES-256-GCM key per direction, so each label is an ASCII-only
+ * domain-separation string for one direction of the encrypted stream; both
+ * endpoints must pass the same label for a direction to derive the same key.
  *
- * Adding a channel that needs application-layer encryption is a deliberate,
- * reviewed change (it already adds a `connection.channel` discriminant and its
- * config interface); append its label here so the new caller cannot introduce
- * a variable, non-ASCII, or non-NFC context that would make the two parties
- * derive different keys and fail AEAD with an opaque auth-tag/decrypt error.
- * `webrtc` is absent because it relies on DTLS transport security and ignores
- * the session key.
+ * The set is per-direction, not per-channel: the encrypted-connection decorator
+ * wraps any channel (`sftp`, `filedrop`, or `webrtc`) and keys only by
+ * direction, so there is no per-channel label.  The per-direction split is
+ * load-bearing: both directions number their messages from zero and build the
+ * AEAD nonce from that sequence, so a single shared key would reuse a key-nonce
+ * pair - catastrophic for AES-GCM - whereas one key per sender keeps every pair
+ * unique.
+ *
+ * Adding a label is a deliberate, reviewed change: append it here so a new
+ * caller cannot introduce a variable, non-ASCII, or non-NFC context that would
+ * make the two parties derive different keys and fail AEAD with an opaque
+ * auth-tag/decrypt error.
  *
  * Frozen so the readonly compile-time type also holds at runtime: a plain-JS
  * caller cannot `push` a label and widen the set the runtime guard checks.
  */
 export const AEAD_CONTEXTS = Object.freeze([
-  "sftp-aead",
-  "filedrop-aead",
+  "initiator-to-responder",
+  "responder-to-initiator",
 ] as const);
 
 /**
- * An AEAD channel-context label.  One of the fixed {@link AEAD_CONTEXTS}; the
+ * An AEAD direction-context label.  One of the fixed {@link AEAD_CONTEXTS}; the
  * open `string` is deliberately not accepted so a variable label cannot reach
  * {@link deriveAeadKey} without a reviewed change to that tuple.
  */
@@ -71,13 +77,14 @@ export type AeadContext = (typeof AEAD_CONTEXTS)[number];
  * channel's encryption layer.
  *
  * @param sessionKey  The `sessionKey` field from {@link AuthResult}.
- * @param context     A fixed AEAD channel-context label from
- *                    {@link AEAD_CONTEXTS} (e.g. `"sftp-aead"`) that binds the
- *                    derived key to its intended channel.  The {@link AeadContext}
- *                    type rejects a free-form label at compile time; the runtime
- *                    check below catches an untyped (plain-JS or `as`-cast)
- *                    caller, failing fast rather than silently deriving a key
- *                    the two parties may not agree on.
+ * @param context     A fixed AEAD direction-context label from
+ *                    {@link AEAD_CONTEXTS} (e.g. `"initiator-to-responder"`)
+ *                    that binds the derived key to one direction of the
+ *                    encrypted stream.  The {@link AeadContext} type rejects a
+ *                    free-form label at compile time; the runtime check below
+ *                    catches an untyped (plain-JS or `as`-cast) caller, failing
+ *                    fast rather than silently deriving a key the two parties
+ *                    may not agree on.
  * @throws {Error} if `context` is not one of {@link AEAD_CONTEXTS}.
  */
 export async function deriveAeadKey(

--- a/packages/core/test/pake.test.ts
+++ b/packages/core/test/pake.test.ts
@@ -587,7 +587,11 @@ test("both sides produce the same AEAD key after a successful handshake", async 
     authenticateConnection(connA, auth, "initiator"),
     authenticateConnection(connB, auth, "responder"),
   ]);
-  const keyA = await deriveAeadKey(a.sessionKey, "initiator-to-responder");
-  const keyB = await deriveAeadKey(b.sessionKey, "initiator-to-responder");
-  expect(keyA).toEqual(keyB);
+  // Each party derives both per-direction keys from its own session key; the
+  // two parties must agree on the key for every direction, not just one.
+  for (const context of AEAD_CONTEXTS) {
+    const keyA = await deriveAeadKey(a.sessionKey, context);
+    const keyB = await deriveAeadKey(b.sessionKey, context);
+    expect(keyA).toEqual(keyB);
+  }
 });

--- a/packages/core/test/pake.test.ts
+++ b/packages/core/test/pake.test.ts
@@ -484,7 +484,7 @@ test("authenticateConnection: newToken differs between successive handshake roun
 // --- deriveAeadKey -----------------------------------------------------------
 
 test("deriveAeadKey returns 32 bytes", async () => {
-  const key = await deriveAeadKey(new Uint8Array(32), "sftp-aead");
+  const key = await deriveAeadKey(new Uint8Array(32), "initiator-to-responder");
   expect(key).toHaveLength(32);
 });
 
@@ -498,16 +498,45 @@ test("deriveAeadKey derives a stable 32-byte key for each allowed label", async 
   }
 });
 
+test("deriveAeadKey matches an independent HKDF known-answer vector", async () => {
+  // Pin the `psilink-aead-v1:<context>` derivation so an accidental change to the
+  // info-string prefix, the delimiter, or a label changes the bytes and fails
+  // here. Vectors were computed independently with Node's OpenSSL HKDF-SHA-256
+  // (zero 32-byte salt, info "psilink-aead-v1:<context>", 32-byte output) over a
+  // sessionKey of 32 0x42 bytes -- a cross-implementation check on the WebCrypto
+  // hkdfDerive. Regenerate only if the labels or the info string change.
+  const sessionKey = new Uint8Array(32).fill(0x42);
+  const vectors: Record<AeadContext, string> = {
+    "initiator-to-responder":
+      "8930a442439a6f917cfcce8f4d12a950a936317e2e5cceaf583cf13708764fa6",
+    "responder-to-initiator":
+      "2a21a1c0e66391e03c9d24d618da04827278d6f1ae0f4bf77df8cd3d0b0d7bad",
+  };
+  for (const context of AEAD_CONTEXTS) {
+    const key = await deriveAeadKey(sessionKey, context);
+    const hex = Array.from(key, (b) => b.toString(16).padStart(2, "0")).join(
+      "",
+    );
+    expect(hex).toBe(vectors[context]);
+  }
+});
+
 test("deriveAeadKey differs for different context labels", async () => {
   const sessionKey = new Uint8Array(32).fill(0x01);
-  const k1 = await deriveAeadKey(sessionKey, "sftp-aead");
-  const k2 = await deriveAeadKey(sessionKey, "filedrop-aead");
+  const k1 = await deriveAeadKey(sessionKey, "initiator-to-responder");
+  const k2 = await deriveAeadKey(sessionKey, "responder-to-initiator");
   expect(k1).not.toEqual(k2);
 });
 
 test("deriveAeadKey differs for different session keys", async () => {
-  const k1 = await deriveAeadKey(new Uint8Array(32).fill(0x01), "sftp-aead");
-  const k2 = await deriveAeadKey(new Uint8Array(32).fill(0x02), "sftp-aead");
+  const k1 = await deriveAeadKey(
+    new Uint8Array(32).fill(0x01),
+    "initiator-to-responder",
+  );
+  const k2 = await deriveAeadKey(
+    new Uint8Array(32).fill(0x02),
+    "initiator-to-responder",
+  );
   expect(k1).not.toEqual(k2);
 });
 
@@ -539,7 +568,12 @@ test("deriveAeadKey rejects a context outside the fixed set", async () => {
   // AeadContext constraint with a free-form, empty, or non-ASCII label; the
   // runtime guard must fail fast rather than silently derive a key the two
   // parties may not agree on.
-  for (const bad of ["sftp", "", "cafe-aead́", "é-aead"]) {
+  for (const bad of [
+    "initiator",
+    "",
+    "responder-to-initiatoŕ",
+    "é-to-responder",
+  ]) {
     await expect(
       deriveAeadKey(sessionKey, bad as unknown as AeadContext),
     ).rejects.toThrow(/unknown AEAD context/);
@@ -553,7 +587,7 @@ test("both sides produce the same AEAD key after a successful handshake", async 
     authenticateConnection(connA, auth, "initiator"),
     authenticateConnection(connB, auth, "responder"),
   ]);
-  const keyA = await deriveAeadKey(a.sessionKey, "sftp-aead");
-  const keyB = await deriveAeadKey(b.sessionKey, "sftp-aead");
+  const keyA = await deriveAeadKey(a.sessionKey, "initiator-to-responder");
+  const keyB = await deriveAeadKey(b.sessionKey, "initiator-to-responder");
   expect(keyA).toEqual(keyB);
 });


### PR DESCRIPTION
## Summary

Correct the AEAD context label set merged in #39. That PR narrowed
`deriveAeadKey`'s `context` to a fixed union but froze the labels
`"sftp-aead"`/`"filedrop-aead"`, which came from an illustrative example in the
source task, not the real caller. The actual application-layer AEAD decorator
keys per direction, so this sets `AEAD_CONTEXTS` to
`["initiator-to-responder", "responder-to-initiator"]`, reframes the `auth.ts`
JSDoc from per-channel to per-direction, updates the tests, and adds a
known-answer vector. `deriveAeadKey` is still inert (no live caller), so there is
no behavioral change; this lands the correct contract before the decorator wires
the live caller.

Implements Product item [196771292](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=196771292).
Unblocks [192893869](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=192893869) (the decorator transcription, which is told not to touch `auth.ts`).

## Changes

- `packages/core/src/auth.ts` -- `AEAD_CONTEXTS` becomes the two directional
  labels; the `AEAD_CONTEXTS`/`AeadContext` JSDoc and the `deriveAeadKey`
  `@param` example are reframed from per-channel to per-direction.
- `packages/core/test/pake.test.ts` -- the `deriveAeadKey` tests use the
  directional labels; a new known-answer vector test pins the
  `psilink-aead-v1:<context>` derivation.
- `CHANGELOG.md` -- the `[Unreleased]` Security entry now names the directional
  labels (the Changed entry is label-agnostic and unchanged).

## Background

The labels were wrong because they were a placeholder. The real caller
(`feat/application-encryption:packages/core/src/connection/encryptedConnection.ts:104-105`,
and the acceptance criteria of item 192893869) derives one key per direction:
`deriveAeadKey(sessionKey, "initiator-to-responder")` and
`"responder-to-initiator"`. Neither was in the merged set, so the decorator would
fail to type-check and throw on the runtime guard. A review of the whole
Application Encryption epic (192893869, 195802623, 195802633) confirmed the AEAD
key is per-direction and channel-uniform -- even the webrtc path reuses the
decorator unchanged -- and that the channel labels have no caller anywhere in the
tree. The per-direction split is load-bearing: both directions number their
messages from zero and build the AEAD nonce from that sequence, so a single
shared key would reuse a key-nonce pair, which is catastrophic for AES-GCM. The
labels here, item 192893869's KAT criterion, and the decorator's `deriveAeadKey`
calls all pin `psilink-aead-v1:<context>` and must use the same two labels.

## Breaking change

Source-breaking only for a direct TypeScript caller of `@psilink/core` that
passed the literal `"sftp-aead"`/`"filedrop-aead"` to `deriveAeadKey`. There is
no such caller anywhere (verified by grep across `packages`, `apps`, and `docs`),
the package is pre-1.0, and `deriveAeadKey` is inert, so there is no runtime
fallout. The derived bytes for the new labels differ from the old ones, but no
key was ever derived on any live path.

## Test plan

- [x] `npm run typecheck && npm run lint` clean
- [x] `npm test -w packages/core` (764/764)
- [x] `npm run test:unit -w apps/cli` (159/159) and `apps/web` (72/72)
- CLI integration tests not run: core-only change, no transport or protocol
  path touched; deferred to CI.

New tests cover: a known-answer vector pinning `psilink-aead-v1:<context>` for
each directional label (cross-checked against an independent OpenSSL HKDF
computation); plus the existing per-label stable-key, distinct-key, ASCII-only,
freeze, and out-of-set-rejection tests, now on the directional labels.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact; the AEAD key derivation is
  documented per-direction in `docs/SECURITY_DESIGN.md` (Channel security) as of
  the preceding commit, and `docs/PROTOCOL.md` references only the
  `psilink-aead-v1:` prefix, which is unchanged. No doc update needed here.
- [x] `CHANGELOG.md` `[Unreleased]` updated (Security entry relabeled).
- [x] Cryptographic code changed (`auth.ts`): security review requested per
  Dependency Policy. The HKDF derivation is unchanged; this changes only the
  fixed set of context labels and the surrounding documentation.
