### PR TITLE
Guard canonicalString against throwing getters

### DIFF
--- a/packages/core/src/utils/canonical.ts
+++ b/packages/core/src/utils/canonical.ts
@@ -43,7 +43,11 @@ export type CanonicalValue =
  * Thrown when a value cannot be canonically encoded because it falls outside
  * the reproducible domain (see {@link assertCanonical}). The message names the
  * offending value's JSON path (e.g. `$.linkageKeys[0].elements[1]`) so the
- * caller can locate it.
+ * caller can locate it. One exception: an error the boundary guard in
+ * {@link canonicalString} converts -- a property getter that throws, or a
+ * circular reference that overflows the traversal -- is pathed at the root `$`,
+ * because the precise location is not recoverable there; the original error is
+ * preserved on `.cause`, whose stack still locates it.
  *
  * It extends {@link UsageError}: a value outside the canonical domain is a
  * configuration/data problem, so any call site that lets it propagate to the
@@ -52,15 +56,23 @@ export type CanonicalValue =
  * `canonicalString` in their own try/catch.
  */
 export class CanonicalEncodingError extends UsageError {
-  constructor(message: string) {
+  constructor(message: string, options?: { cause?: unknown }) {
     super(message);
     this.name = "CanonicalEncodingError";
+    // Preserve the underlying error (e.g. a throwing getter caught at the
+    // canonicalString boundary) as the cause, matching the error-conversion
+    // convention used elsewhere in the codebase. UsageError's constructor takes
+    // only a message, so set cause directly rather than forwarding super options.
+    if (options?.cause !== undefined) this.cause = options.cause;
   }
 }
 
-function fail(reason: string, path: string): never {
+function fail(reason: string, path: string, cause?: unknown): never {
   throw new CanonicalEncodingError(
     `canonical encoding failed at ${path}: ${reason}`,
+    // Only pass options when there is a cause, so the common origin rejections
+    // (which have none) do not allocate an options object per call.
+    cause === undefined ? undefined : { cause },
   );
 }
 
@@ -185,6 +197,12 @@ function assertCanonical(value: unknown, path: string): void {
         );
       // Object.entries includes a key explicitly set to `undefined`, so the
       // recursive call rejects it rather than letting canonicalize drop it.
+      // Hazard: Object.entries reads each enumerable property value, which
+      // invokes any getter -- a getter that throws escapes here as its own raw
+      // error, not a CanonicalEncodingError. That is tolerated rather than
+      // guarded per-property: the boundary try/catch in canonicalString converts
+      // any such error so the module's single-error-type contract holds even for
+      // non-schema-parsed input (the only kind that can carry a throwing getter).
       // Identifier-like keys extend the path with dot notation; any other key
       // (containing a dot, a digit-leading name, etc.) uses bracket notation so
       // the path stays unambiguous, e.g. `$["a.b"]` rather than `$.a.b`.
@@ -212,18 +230,54 @@ function assertCanonical(value: unknown, path: string): void {
  *   canonical domain.
  */
 export function canonicalString(value: unknown): string {
-  // assertCanonical MUST run first: the safety of the output rests entirely on
-  // it catching every value canonicalize would coerce. canonicalize 2.1.0 does
-  // not uniformly skip out-of-domain values -- e.g. a function-valued property
-  // is stringified to the literal `undefined`, producing invalid JSON -- so the
-  // pre-validator, not canonicalize, is what guarantees well-formed output.
-  assertCanonical(value, "$");
-  const encoded = canonicalize(value);
-  // canonicalize returns undefined for any top-level value that JSON.stringify
-  // drops entirely -- undefined, a function, or a symbol. assertCanonical has
-  // already rejected all of those, so this only guards the declared return type.
-  if (encoded === undefined) fail("value is not canonicalizable", "$");
-  return encoded;
+  try {
+    // assertCanonical MUST run first: the safety of the output rests entirely on
+    // it catching every value canonicalize would coerce. canonicalize 2.1.0 does
+    // not uniformly skip out-of-domain values -- e.g. a function-valued property
+    // is stringified to the literal `undefined`, producing invalid JSON -- so the
+    // pre-validator, not canonicalize, is what guarantees well-formed output.
+    assertCanonical(value, "$");
+    const encoded = canonicalize(value);
+    // canonicalize returns undefined for any top-level value that JSON.stringify
+    // drops entirely -- undefined, a function, or a symbol. assertCanonical has
+    // already rejected all of those, so this only guards the declared return type.
+    if (encoded === undefined) fail("value is not canonicalizable", "$");
+    return encoded;
+  } catch (err) {
+    // Boundary guard upholding the module's contract that every rejection is a
+    // CanonicalEncodingError. Both assertCanonical and canonicalize read property
+    // values as they traverse, invoking any enumerable getter on the input (see
+    // the Object.entries hazard note in assertCanonical). A getter that throws, a
+    // circular reference that overflows the recursion, or any other unexpected
+    // failure during traversal would otherwise escape as a raw error (a circular
+    // input is itself un-encodable, so converting it to a usage error is correct,
+    // not merely tolerated). The domain rejections fail() raises are CanonicalEncoding
+    // errors already, each carrying its precise JSON path; re-throw those
+    // unchanged so the path messages are preserved. Anything else is converted
+    // here. The converted error is still a CanonicalEncodingError (a UsageError,
+    // exit 64): a throwing getter on caller-supplied data is a data problem, not
+    // an internal failure. This blanket catch also reclassifies a genuine bug in
+    // assertCanonical/canonicalize as a CanonicalEncodingError; that is an
+    // accepted trade for the single-error-type contract, not accidental.
+    //
+    // Unlike the domain rejections, a converted error is pathed at the root `$`,
+    // not at the offending property (e.g. a getter at `$.outer.boom` still
+    // reports `$`). Pinpointing the property would require a per-property
+    // try/catch inside the traversal, reintroducing exactly the per-node overhead
+    // this single boundary wrap was chosen to avoid; a getter-bearing input is
+    // also exotic (only non-schema-parsed data can carry one). The original
+    // error is preserved as `.cause`, so its stack still locates the property
+    // even though the message says `$`. If a consumer ever feeds getter-bearing
+    // objects in routinely, revisit and thread the precise path.
+    if (err instanceof CanonicalEncodingError) throw err;
+    fail(
+      `unexpected error during traversal (${
+        err instanceof Error ? err.message : String(err)
+      })`,
+      "$",
+      err,
+    );
+  }
 }
 
 // Local TextEncoder so this module depends only on a platform API rather than

--- a/packages/core/test/canonical.test.ts
+++ b/packages/core/test/canonical.test.ts
@@ -270,6 +270,83 @@ describe("values outside the canonical domain are rejected", () => {
   });
 });
 
+// --- boundary guard: every rejection is a CanonicalEncodingError --------------
+
+describe("the boundary guard keeps the single-error-type contract", () => {
+  test("a throwing enumerable getter surfaces as a CanonicalEncodingError, not the raw error", () => {
+    // Only a non-schema-parsed object can carry this; the traversal in
+    // assertCanonical (and canonicalize) reads the getter, which throws. The
+    // boundary try/catch in canonicalString converts the raw error so callers
+    // still see the module's one error type.
+    const value = {
+      get boom(): never {
+        throw new RangeError("getter blew up");
+      },
+    };
+    expect(() => canonicalString(value)).toThrow(CanonicalEncodingError);
+    expect(() => canonicalString(value)).toThrow(
+      /unexpected error during traversal/,
+    );
+  });
+
+  test("the converted error preserves the original as its cause", () => {
+    // The boundary message is pathed at the root `$`, so the original error --
+    // attached as `.cause` -- is what still locates the offending property (via
+    // its stack). Guard that the link is not dropped.
+    const original = new RangeError("getter blew up");
+    const value = {
+      get boom(): never {
+        throw original;
+      },
+    };
+    let caught: unknown;
+    try {
+      canonicalString(value);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CanonicalEncodingError);
+    expect((caught as CanonicalEncodingError).cause).toBe(original);
+  });
+
+  test("a throwing getter nested below the root is still converted", () => {
+    const value = {
+      outer: {
+        get boom(): never {
+          throw new RangeError("deep getter blew up");
+        },
+      },
+    };
+    expect(() => canonicalString(value)).toThrow(CanonicalEncodingError);
+  });
+
+  test("a circular reference surfaces as a CanonicalEncodingError, not a raw stack overflow", () => {
+    // assertCanonical recurses into the cycle until the stack overflows; the
+    // boundary guard converts that RangeError. A cyclic object is itself
+    // un-encodable, so a CanonicalEncodingError (a usage error) is the correct
+    // type rather than a raw RangeError escaping. Only non-schema-parsed data can
+    // form a cycle, so this shares the throwing-getter reachability.
+    const value: Record<string, unknown> = {};
+    value.self = value;
+    expect(() => canonicalString(value)).toThrow(CanonicalEncodingError);
+  });
+
+  test("an ordinary domain rejection keeps its precise JSON-path message", () => {
+    // The guard re-throws a CanonicalEncodingError unchanged: it must not flatten
+    // the path messages fail() produces into the generic traversal message.
+    expect(() => canonicalString({ when: new Date(0) })).toThrow(
+      CanonicalEncodingError,
+    );
+    expect(() => canonicalString({ when: new Date(0) })).toThrow(/\$\.when/);
+    expect(() => canonicalString({ when: new Date(0) })).not.toThrow(
+      /unexpected error during traversal/,
+    );
+    expect(() => canonicalString({ items: [1, 10n] })).toThrow(
+      /\$\.items\[1\]/,
+    );
+  });
+});
+
 // --- safeIntegerSchema -------------------------------------------------------
 
 describe("safeIntegerSchema", () => {


### PR DESCRIPTION
## Summary

Make `canonicalString`'s "every rejection is a `CanonicalEncodingError`" contract hold for any input. The encoder walks objects with `Object.entries`, which invokes enumerable getters; a getter that throws -- or a circular reference that overflows the traversal -- previously escaped as its own raw error, breaking the single-error-type contract callers rely on for the CLI's exit-64 (EX_USAGE) classification. A single boundary guard now converts any such error into a `CanonicalEncodingError`, while leaving the precise JSON-path messages of ordinary domain rejections untouched. The gap was inert while inputs were JSON-/Zod-parsed but became reachable once the self-attested exchange record began feeding hand-built objects into the encoder.

Implements Product board item [196660514](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=196660514).

## Changes

- `packages/core/src/utils/canonical.ts` -- wrap the `canonicalString` body in a boundary `try`/`catch`: an existing `CanonicalEncodingError` is re-thrown unchanged (preserving its JSON-path message); any other error is converted into one (still a `UsageError`, exit 64) with the original attached as `.cause`. `CanonicalEncodingError` gains an optional `{ cause }`; `fail()` threads it. The class JSDoc and a boundary code note record the getter/circular-reference hazard and the root-path trade.
- `packages/core/test/canonical.test.ts` -- add tests for the conversions, the cause link, and the preserved path messages.

## Background

Resolves the issue's open question in favor of the defensive boundary wrap over a call-site "only schema-parsed data in" guarantee: the current consumer (`exchangeRecord.ts`) already passes hand-built objects into the encoder, so the guarantee was not assertable without spreading guards across call sites. The wrap sits once at the boundary (O(1)), not around each property read, so it adds no per-traversal overhead. The converted error is pathed at the root `$` rather than the offending property -- pinpointing it would reintroduce the per-property `try`/`catch` the boundary design exists to avoid, for inputs only non-schema-parsed data can form -- so the preserved `.cause` keeps the locator via its stack. A circular input is itself un-encodable, so converting its stack overflow to a usage error is correct, not merely tolerated.

## Test plan

- [x] `npm run typecheck && npm run lint` clean (and `npm run format`)
- [x] `npm test -w packages/core` (901/901)
- [x] `npm run test:unit -w apps/cli` (168/168) and `npm run test:unit -w apps/web` (72/72)
- CLI integration tests: not run locally -- the change is core-encoder-only with no transport surface, so it is unaffected; CI/maintainer to confirm against the pre-merge gate.

New tests cover: a throwing enumerable getter (top-level and nested) surfacing as a `CanonicalEncodingError` rather than the raw error; a circular reference surfacing as a `CanonicalEncodingError` rather than a raw stack overflow; the converted error preserving the original on `.cause`; and ordinary domain rejections (a `Date`, a `bigint`) keeping their precise JSON-path messages, i.e. the guard does not flatten them.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact; none needed. `CANONICAL_ENCODING.md` already requires a conforming implementation to reject an out-of-domain value with an error (this strengthens that, language-independently), and its non-normative implementation note stays accurate; no byte-format or value-domain change.
- [x] `CHANGELOG.md` `[Unreleased]`: n/a -- the canonical encoder is unreleased (added under `[Unreleased]` in #36); this is pre-release hardening of it, with no released-behavior change.
- [x] Cryptographic code changed? Security review: n/a -- `canonical.ts` produces the preimage for receipt commitments and hashes, but this change touches only error classification for malformed inputs; every cross-implementation vector still encodes byte-identically (901/901), so no encoded bytes change and the cryptographic guarantees are untouched.
