### PR TITLE
Harden authenticatedExchange test path and SFTP isolation

### DIFF
--- a/apps/cli/test/integration/authenticatedExchange.test.ts
+++ b/apps/cli/test/integration/authenticatedExchange.test.ts
@@ -2,12 +2,14 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   afterAll,
   afterEach,
   beforeAll,
   beforeEach,
+  describe,
   expect,
   test,
 } from "vitest";
@@ -236,76 +238,84 @@ test("filedrop: authenticated recurring exchange matches the unauthenticated PSI
 
 // --- SFTP ---------------------------------------------------------------------
 
-// compose.yaml mounts apps/cli/test/container/sftp/srv/ as /home/{user}/psi, so
-// srv/authexchange is served at /psi/authexchange over SFTP. Both parties are
-// SFTP clients of the same path -- the realistic recurring-exchange topology.
-//
-// Each phase (baseline -> run1 -> run2) runs in its own subdir under this root,
-// derived from its run tag, so the hello/lock rendezvous namespace is never
-// shared across phases: both parties within a phase share a subdir (so they
-// rendezvous), and distinct phases get distinct subdirs (so they cannot
-// cross-contaminate). Isolation is therefore structural and does not depend on
-// deleting files between phases. The root is resolved to an absolute path so the
-// test does not depend on vitest's cwd being apps/cli (mirrors
-// mixedConnection.test.ts), and stays distinct from the sibling integration
-// files' server subdirs (sftpConnection -> sftp, mixedConnection -> mixed).
-const SFTP_LOCAL_ROOT = path.resolve("test/container/sftp/srv/authexchange");
-const SFTP_PATH_ROOT = "/psi/authexchange";
+// Grouped so the rendezvous-root lifecycle hooks below scope to the SFTP test
+// alone; file-scoped beforeAll/afterAll would otherwise also bracket the
+// filedrop test above, which has no business with the SFTP root.
+describe("sftp", () => {
+  // compose.yaml mounts apps/cli/test/container/sftp/srv/ as /home/{user}/psi,
+  // so srv/authexchange is served at /psi/authexchange over SFTP. Both parties
+  // are SFTP clients of the same path -- the realistic recurring-exchange
+  // topology.
+  //
+  // Each phase (baseline -> run1 -> run2) runs in its own subdir under this
+  // root, derived from its run tag, so the hello/lock rendezvous namespace is
+  // never shared across phases: both parties within a phase share a subdir (so
+  // they rendezvous), and distinct phases get distinct subdirs (so they cannot
+  // cross-contaminate). Isolation is therefore structural and does not depend on
+  // deleting files between phases. The root is resolved relative to this test
+  // file (via import.meta.url) so it is independent of vitest's cwd, and stays
+  // distinct from the sibling integration files' server subdirs (sftpConnection
+  // -> sftp, mixedConnection -> mixed).
+  const SFTP_LOCAL_ROOT = fileURLToPath(
+    new URL("../container/sftp/srv/authexchange", import.meta.url),
+  );
+  const SFTP_PATH_ROOT = "/psi/authexchange";
 
-// A config factory bound to a per-phase server subdir. Creates the host
-// directory the container serves so the SFTP path exists before either party
-// connects (the connection does not create remote directories).
-async function sftpForPhase(tag: string): Promise<ConfigFactory> {
-  await fsp.mkdir(path.join(SFTP_LOCAL_ROOT, tag), { recursive: true });
-  const serverPath = `${SFTP_PATH_ROOT}/${tag}`;
-  return (auth) => ({
-    channel: "sftp",
-    server: {
-      host: "localhost",
-      port: SFTP_PORT,
-      username: "usera",
-      password: "usera",
-      path: serverPath,
-    },
-    options: { pollIntervalMs: 50 },
-    authentication: auth,
+  // A config factory bound to a per-phase server subdir. Creates the host
+  // directory the container serves so the SFTP path exists before either party
+  // connects (the connection does not create remote directories).
+  async function sftpForPhase(tag: string): Promise<ConfigFactory> {
+    await fsp.mkdir(path.join(SFTP_LOCAL_ROOT, tag), { recursive: true });
+    const serverPath = `${SFTP_PATH_ROOT}/${tag}`;
+    return (auth) => ({
+      channel: "sftp",
+      server: {
+        host: "localhost",
+        port: SFTP_PORT,
+        username: "usera",
+        password: "usera",
+        path: serverPath,
+      },
+      options: { pollIntervalMs: 50 },
+      authentication: auth,
+    });
+  }
+
+  // Start each run from a clean root so stale files from a previously crashed
+  // run cannot leak into a phase subdir; within a run, isolation is the
+  // per-phase subdir, not this wipe. afterAll leaves the mounted dir tidy.
+  beforeAll(async () => {
+    await fsp.rm(SFTP_LOCAL_ROOT, { recursive: true, force: true });
+    await fsp.mkdir(SFTP_LOCAL_ROOT, { recursive: true });
   });
-}
 
-// Start each run from a clean root so stale files from a previously crashed run
-// cannot leak into a phase subdir; within a run, isolation is the per-phase
-// subdir, not this wipe. afterAll leaves the mounted dir tidy.
-beforeAll(async () => {
-  await fsp.rm(SFTP_LOCAL_ROOT, { recursive: true, force: true });
-  await fsp.mkdir(SFTP_LOCAL_ROOT, { recursive: true });
+  afterAll(async () => {
+    await fsp.rm(SFTP_LOCAL_ROOT, { recursive: true, force: true });
+  });
+
+  test("sftp: authenticated recurring exchange over the real server matches the unauthenticated PSI result and rotates the secret", async () => {
+    const baseline = await runBaseline(work, await sftpForPhase("baseline"));
+    expect(baseline.trim().split("\n").length).toBe(1 + RECEIVER_ROWS.length);
+
+    const run1 = await runAuthenticatedPair(
+      work,
+      "sftp1",
+      await sftpForPhase("sftp1"),
+      INITIAL_SECRET,
+    );
+    expect(run1.receiverOut).toBe(baseline);
+
+    // Recurring: the rotated secret from run 1 drives a second authenticated
+    // exchange over the real server in its own subdir, which must still
+    // authenticate and yield the same PSI result while rotating again to a fresh
+    // value.
+    const run2 = await runAuthenticatedPair(
+      work,
+      "sftp2",
+      await sftpForPhase("sftp2"),
+      run1.rotated,
+    );
+    expect(run2.receiverOut).toBe(baseline);
+    expect(run2.rotated).not.toBe(run1.rotated);
+  }, 90_000);
 });
-
-afterAll(async () => {
-  await fsp.rm(SFTP_LOCAL_ROOT, { recursive: true, force: true });
-});
-
-test("sftp: authenticated recurring exchange over the real server matches the unauthenticated PSI result and rotates the secret", async () => {
-  const baseline = await runBaseline(work, await sftpForPhase("baseline"));
-  expect(baseline.trim().split("\n").length).toBe(1 + RECEIVER_ROWS.length);
-
-  const run1 = await runAuthenticatedPair(
-    work,
-    "sftp1",
-    await sftpForPhase("sftp1"),
-    INITIAL_SECRET,
-  );
-  expect(run1.receiverOut).toBe(baseline);
-
-  // Recurring: the rotated secret from run 1 drives a second authenticated
-  // exchange over the real server in its own subdir, which must still
-  // authenticate and yield the same PSI result while rotating again to a fresh
-  // value.
-  const run2 = await runAuthenticatedPair(
-    work,
-    "sftp2",
-    await sftpForPhase("sftp2"),
-    run1.rotated,
-  );
-  expect(run2.receiverOut).toBe(baseline);
-  expect(run2.rotated).not.toBe(run1.rotated);
-}, 90_000);

--- a/apps/cli/test/integration/authenticatedExchange.test.ts
+++ b/apps/cli/test/integration/authenticatedExchange.test.ts
@@ -3,7 +3,14 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, beforeAll, beforeEach, expect, test } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+} from "vitest";
 import { prepareForExchange, SHARED_SECRET_REGEX } from "@psilink/core";
 import type { ExchangeDataSpec, LinkageTerms } from "@psilink/core";
 
@@ -232,52 +239,73 @@ test("filedrop: authenticated recurring exchange matches the unauthenticated PSI
 // compose.yaml mounts apps/cli/test/container/sftp/srv/ as /home/{user}/psi, so
 // srv/authexchange is served at /psi/authexchange over SFTP. Both parties are
 // SFTP clients of the same path -- the realistic recurring-exchange topology.
-const SFTP_LOCAL_DIRECTORY = "test/container/sftp/srv/authexchange";
-const SFTP_PATH = "/psi/authexchange";
+//
+// Each phase (baseline -> run1 -> run2) runs in its own subdir under this root,
+// derived from its run tag, so the hello/lock rendezvous namespace is never
+// shared across phases: both parties within a phase share a subdir (so they
+// rendezvous), and distinct phases get distinct subdirs (so they cannot
+// cross-contaminate). Isolation is therefore structural and does not depend on
+// deleting files between phases. The root is resolved to an absolute path so the
+// test does not depend on vitest's cwd being apps/cli (mirrors
+// mixedConnection.test.ts), and stays distinct from the sibling integration
+// files' server subdirs (sftpConnection -> sftp, mixedConnection -> mixed).
+const SFTP_LOCAL_ROOT = path.resolve("test/container/sftp/srv/authexchange");
+const SFTP_PATH_ROOT = "/psi/authexchange";
 
-async function cleanSftpDir() {
-  await fsp.mkdir(SFTP_LOCAL_DIRECTORY, { recursive: true });
-  for (const file of await fsp.readdir(SFTP_LOCAL_DIRECTORY)) {
-    try {
-      await fsp.unlink(path.join(SFTP_LOCAL_DIRECTORY, file));
-    } catch {
-      // ignore
-    }
-  }
+// A config factory bound to a per-phase server subdir. Creates the host
+// directory the container serves so the SFTP path exists before either party
+// connects (the connection does not create remote directories).
+async function sftpForPhase(tag: string): Promise<ConfigFactory> {
+  await fsp.mkdir(path.join(SFTP_LOCAL_ROOT, tag), { recursive: true });
+  const serverPath = `${SFTP_PATH_ROOT}/${tag}`;
+  return (auth) => ({
+    channel: "sftp",
+    server: {
+      host: "localhost",
+      port: SFTP_PORT,
+      username: "usera",
+      password: "usera",
+      path: serverPath,
+    },
+    options: { pollIntervalMs: 50 },
+    authentication: auth,
+  });
 }
 
-const sftp: ConfigFactory = (auth) => ({
-  channel: "sftp",
-  server: {
-    host: "localhost",
-    port: SFTP_PORT,
-    username: "usera",
-    password: "usera",
-    path: SFTP_PATH,
-  },
-  options: { pollIntervalMs: 50 },
-  authentication: auth,
+// Start each run from a clean root so stale files from a previously crashed run
+// cannot leak into a phase subdir; within a run, isolation is the per-phase
+// subdir, not this wipe. afterAll leaves the mounted dir tidy.
+beforeAll(async () => {
+  await fsp.rm(SFTP_LOCAL_ROOT, { recursive: true, force: true });
+  await fsp.mkdir(SFTP_LOCAL_ROOT, { recursive: true });
 });
 
-beforeAll(cleanSftpDir);
+afterAll(async () => {
+  await fsp.rm(SFTP_LOCAL_ROOT, { recursive: true, force: true });
+});
 
 test("sftp: authenticated recurring exchange over the real server matches the unauthenticated PSI result and rotates the secret", async () => {
-  const baseline = await runBaseline(work, sftp);
+  const baseline = await runBaseline(work, await sftpForPhase("baseline"));
   expect(baseline.trim().split("\n").length).toBe(1 + RECEIVER_ROWS.length);
 
-  await cleanSftpDir();
-
-  const run1 = await runAuthenticatedPair(work, "sftp1", sftp, INITIAL_SECRET);
+  const run1 = await runAuthenticatedPair(
+    work,
+    "sftp1",
+    await sftpForPhase("sftp1"),
+    INITIAL_SECRET,
+  );
   expect(run1.receiverOut).toBe(baseline);
 
-  await cleanSftpDir();
-
   // Recurring: the rotated secret from run 1 drives a second authenticated
-  // exchange over the real server, which must still authenticate and yield the
-  // same PSI result while rotating again to a fresh value.
-  const run2 = await runAuthenticatedPair(work, "sftp2", sftp, run1.rotated);
+  // exchange over the real server in its own subdir, which must still
+  // authenticate and yield the same PSI result while rotating again to a fresh
+  // value.
+  const run2 = await runAuthenticatedPair(
+    work,
+    "sftp2",
+    await sftpForPhase("sftp2"),
+    run1.rotated,
+  );
   expect(run2.receiverOut).toBe(baseline);
   expect(run2.rotated).not.toBe(run1.rotated);
-
-  await cleanSftpDir();
 }, 90_000);


### PR DESCRIPTION
## Summary

Harden the within-file SFTP isolation of the CLI integration test
`apps/cli/test/integration/authenticatedExchange.test.ts`. The test was correct
but fragile: it resolved its local SFTP directory as a cwd-relative path and ran
its three phases (baseline -> run1 -> run2) through one shared server subdir and
one rendezvous namespace, relying on strict sequencing plus best-effort cleanup
for isolation. Each phase now rendezvouses in its own server subdir and the root
is resolved relative to the test file, so isolation is structural rather than
cleanup-ordering dependent. No production, protocol, or cryptographic code
changes; assertions are unchanged.

Implements 9 item [197892579](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=197892579).

## Changes

- `apps/cli/test/integration/authenticatedExchange.test.ts` -- resolve the local
  rendezvous root from `import.meta.url` (via `fileURLToPath`) so it is
  independent of vitest's cwd; give each phase (`baseline`/`sftp1`/`sftp2`) its
  own server subdir derived from its run tag so the hello/lock rendezvous
  namespace is never shared across phases; replace the shared per-file
  `cleanSftpDir` with a `describe("sftp")`-scoped `beforeAll` clean-root wipe and
  `afterAll` tidy, so the lifecycle hooks bracket only the SFTP test and not the
  filedrop test above it.

## Background

Two bounded, within-file fragilities motivated the change. The cwd-relative
`SFTP_LOCAL_DIRECTORY` was correct only when vitest's cwd was `apps/cli`;
resolving from `import.meta.url` removes that assumption entirely (and is the
`fileURLToPath` pattern the code conventions already endorse for `file://`
URLs). Separately, the three phases shared one rendezvous namespace separated
only by sequential best-effort cleanup, so any future non-awaited or overlapping
phase could cross-contaminate the next phase's rendezvous state; per-phase
subdirs remove that dependency. Cross-file isolation is unchanged: the file
still uses an `authexchange` server subdir distinct from `sftpConnection.test.ts`
(`sftp`) and `mixedConnection.test.ts` (`mixed`).

## Out of scope

- Standardizing `sftpConnection.test.ts` onto the same absolute-path pattern was
  explicitly out of scope for this task (it still uses the bare relative form);
  left for a separate sweep.

## Test plan

- [x] `npm run typecheck && npm run lint` clean
- [x] `npm test -w packages/core` (957/957)
- [x] `npm run test:unit -w apps/cli` (318/318)
- [x] CLI integration tests: `npm run test:integration -w apps/cli` (13/13, atmoz/sftp container)

No new tests; this restructures an existing integration test. Its
security-bearing assertions are unchanged: matching PSI output across
baseline/run1/run2, and a rotated shared secret that differs between run1 and
run2. The per-phase-subdir isolation is what the green integration run now
proves more robustly.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact; none needed (test-only,
  no behavior change)
- [x] `CHANGELOG.md` `[Unreleased]` updated, or n/a -- n/a (test-only, no
  user-facing change)
- [x] Cryptographic code changed? Security review requested, or n/a -- n/a (no
  cryptographic code changed). An independent security review of the diff was
  conducted anyway given the test exercises the X25519/AEAD path, and it returned
  PASS with no findings (recursive-rm target confirmed bounded to the test
  scratch dir; no assertion weakened; no secrets introduced).
