### PR TITLE
Make sibling SFTP test dirs cwd-independent

### DIFF
--- a/apps/cli/test/integration/mixedConnection.test.ts
+++ b/apps/cli/test/integration/mixedConnection.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterAll, beforeAll, expect, test } from "vitest";
 import { FileSyncConnection } from "@psilink/core";
@@ -16,11 +17,14 @@ log.setLevel(log.levels.DEBUG);
 // inside the container, so subdirectories of srv/ are served as subdirectories
 // of /psi via SFTP. beforeAll creates SFTP_LOCAL_DIRECTORY with { recursive:
 // true } before opening connections, so the host directory exists when the
-// server needs it. Relative path used for cleanup; LocalFSClient requires
-// absolute.
-const SFTP_LOCAL_DIRECTORY = "test/container/sftp/srv/mixed";
+// server needs it. The directory is resolved relative to this test file (via
+// import.meta.url) so it is independent of vitest's cwd, matching the pattern in
+// authenticatedExchange.test.ts; the resulting absolute path serves both the
+// cleanup helpers and LocalFSClient, which requires an absolute path.
+const SFTP_LOCAL_DIRECTORY = fileURLToPath(
+  new URL("../container/sftp/srv/mixed", import.meta.url),
+);
 const SFTP_PATH = "/psi/mixed";
-const LOCAL_DIRECTORY = path.resolve(SFTP_LOCAL_DIRECTORY);
 const SFTP_PORT = sftpPort();
 
 async function cleanServer() {
@@ -64,7 +68,7 @@ beforeAll(async () => {
         path: SFTP_PATH,
       },
     }),
-    localConn.open({ channel: "filedrop", path: LOCAL_DIRECTORY }),
+    localConn.open({ channel: "filedrop", path: SFTP_LOCAL_DIRECTORY }),
   ]);
 });
 

--- a/apps/cli/test/integration/sftpConnection.test.ts
+++ b/apps/cli/test/integration/sftpConnection.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterAll, beforeAll, expect, test } from "vitest";
 import {
@@ -19,8 +20,12 @@ log.setLevel(log.levels.DEBUG);
 // inside the container, so subdirectories of srv/ are served as subdirectories
 // of /psi via SFTP. beforeAll creates SFTP_LOCAL_DIRECTORY with { recursive:
 // true } before opening connections, so the host directory exists when the
-// server needs it.
-const SFTP_LOCAL_DIRECTORY = "test/container/sftp/srv/sftp";
+// server needs it. The directory is resolved relative to this test file (via
+// import.meta.url) so it is independent of vitest's cwd, matching the pattern in
+// authenticatedExchange.test.ts.
+const SFTP_LOCAL_DIRECTORY = fileURLToPath(
+  new URL("../container/sftp/srv/sftp", import.meta.url),
+);
 const SFTP_PATH = "/psi/sftp";
 const SFTP_PORT = sftpPort();
 


### PR DESCRIPTION
## Summary

The two remaining CLI integration tests now resolve their local SFTP
rendezvous directory relative to the test file rather than to vitest's
working directory, so a single file runs correctly from any cwd. Before
this, `sftpConnection.test.ts` and `mixedConnection.test.ts` passed only
because the integration runner sets cwd to `apps/cli`; running one file
from a different cwd (for example `npx vitest run <file>` from the repo
root) broke them. This is test-infrastructure hardening only -- no
production, protocol, or cryptographic code, and no behavior change.

Implements 9 item [197987086](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=197987086).

## Changes

- `apps/cli/test/integration/sftpConnection.test.ts` -- resolve
  `SFTP_LOCAL_DIRECTORY` via `fileURLToPath(new URL("../container/sftp/srv/sftp", import.meta.url))`
  instead of a cwd-relative string literal; the cleanup `readdir`/`unlink`,
  the `beforeAll` `mkdir`, and the `path.join` helpers all operate on that
  file-relative absolute path.
- `apps/cli/test/integration/mixedConnection.test.ts` -- same file-relative
  resolution; drop the now-redundant `LOCAL_DIRECTORY = path.resolve(...)`
  and hand the file-relative absolute path straight to `LocalFSClient`,
  which requires an absolute path.

This adopts the pattern PR #58 established in
`authenticatedExchange.test.ts`. Per-phase subdir isolation (the other
half of PR #58) is out of scope: neither sibling is a phased test. Each
file keeps its existing subdir (`sftp`, `mixed`).

## Out of scope / follow-on

- `sftpPort()` in `apps/cli/test/container/env.ts` still reads
  `test/container/.env` relative to cwd, so a from-repo-root single-file
  run picks up the port only via the documented `SFTP_PORT` env-var
  override (or the default 2222). That cwd-dependence is a separate
  concern this issue explicitly excluded; not filed.

## Test plan

- [x] `npm run typecheck && npm run lint` clean
- `npm test -w packages/core` -- n/a (no core change)
- [x] `npm run test:unit -w apps/cli` (318/318)
- [x] CLI integration tests: `npm run test:integration -w apps/cli` (3 files, 13/13)
- [x] Both files pass run individually from the repo root:
      `npx vitest run apps/cli/test/integration/sftpConnection.test.ts` (7/7)
      and `mixedConnection.test.ts` (4/4)

No new tests -- this is test-infrastructure path resolution. The
acceptance criterion is that the existing integration tests now pass when
a single file is run from a cwd other than `apps/cli`.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact; none affected
      (internal test infrastructure, no behavior/CLI/protocol/config change)
- [x] `CHANGELOG.md` `[Unreleased]` updated, or n/a -- n/a (test-infra only,
      matching PR #58 which added no entry)
- Cryptographic code changed? Security review requested, or n/a -- n/a
