### PR TITLE
Extract key-file pre-flight validation into helper

### DIFF
--- a/apps/cli/src/keyFilePreflight.ts
+++ b/apps/cli/src/keyFilePreflight.ts
@@ -1,0 +1,206 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { getLogger } from "@psilink/core";
+
+/**
+ * Pre-flight validation for an authenticated exchange's key-file path, run
+ * before any connection is opened so a misconfiguration fails deterministically
+ * -- with no rendezvous I/O and before the partner can be left holding a rotated
+ * token this side cannot persist. It mirrors what {@link saveKeyFile} will do
+ * post-handshake (a recursive parent `mkdir`, then a write) and rejects up front
+ * the cases where that write would fail after a successful key exchange, when
+ * recovery would otherwise require a re-invitation.
+ *
+ * Returns the trimmed key-file path: leading and trailing whitespace is removed
+ * (a value like `"  ./key  "` is almost certainly a user typo) without mutating
+ * the caller's value, and the trimmed result is what the caller must hand to
+ * {@link saveKeyFile}. Throws -- with the user-facing error strings -- when:
+ *
+ * - `keyFilePath` is missing or whitespace-only;
+ * - the path already exists but is a directory or other non-regular node;
+ * - the parent exists but is not a directory, or cannot be created or written.
+ *
+ * Side effect: creates the parent directory (recursively) when it does not yet
+ * exist, mirroring {@link saveKeyFile}; the creation is logged and left in place
+ * even if a subsequent handshake or exchange fails.
+ *
+ * `log` receives the parent-directory-created notice; pass the same logger
+ * `runProtocol` uses so the message carries the run's context.
+ */
+export function preflightKeyFilePath(
+  keyFilePath: string,
+  log: ReturnType<typeof getLogger>,
+): string {
+  // Guards against a missing or whitespace-only keyFilePath before any
+  // connection is opened (a whitespace-only path would create a file named
+  // " " in the current directory rather than failing clearly). Trim leading
+  // and trailing whitespace from the supplied value before using it: a
+  // value like "  ./key  " is almost certainly user typo and would
+  // otherwise become "  ." for dirname and " ./key  " for the file name,
+  // producing a confusing on-disk artifact rather than the intended file.
+  if (typeof keyFilePath !== "string" || keyFilePath.trim().length === 0)
+    throw new Error(
+      "connection.authentication must include a non-empty keyFilePath",
+    );
+  const kfp = keyFilePath.trim();
+  // Pre-validate that the key file path itself, if it already exists, is
+  // a regular file rather than a directory or other special node. If it
+  // is a directory, saveKeyFile's renameSync would fail post-handshake
+  // (when the partner may already hold the rotated token) and force a
+  // re-invitation that is preventable here. Use lstatSync so a symlink at
+  // the key file path is inspected as-is rather than followed: a symlink
+  // pointing at a directory should still be rejected.
+  try {
+    const targetStat = fs.lstatSync(kfp);
+    if (!targetStat.isFile() && !targetStat.isSymbolicLink())
+      throw new Error(
+        `keyFilePath ${kfp} exists but is not a regular file (` +
+          `${
+            targetStat.isDirectory()
+              ? "directory"
+              : "non-regular filesystem entry"
+          }); saveKeyFile would fail after a successful key exchange. ` +
+          "Remove or rename it before running the exchange.",
+      );
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // ENOENT: keyFilePath does not yet exist (first run after invite/
+    // accept) and saveKeyFile will create it — fine.
+    // ENOTDIR: a component of the path prefix is a regular file, so kfp
+    // cannot exist; fall through and let the parent-directory check below
+    // raise the more specific "parent exists but is not a directory"
+    // error.
+    if (code !== "ENOENT" && code !== "ENOTDIR") throw err;
+  }
+  // Pre-validate that the parent directory exists (creating it if missing,
+  // mirroring saveKeyFile's `mkdirSync({ recursive: true })`) and that it
+  // is a directory, so saveKeyFile failure cannot occur after a successful
+  // key exchange, where the partner may already hold the rotated token
+  // and recovery requires re-invitation.
+  const parent = path.dirname(kfp);
+  let parentStat: fs.Stats | undefined;
+  try {
+    parentStat = fs.statSync(parent);
+  } catch (err) {
+    // ENOENT means the parent does not yet exist. saveKeyFile would create
+    // it via `mkdirSync({ recursive: true })`, so do the same here. Any
+    // failure that prevents creation (EACCES on a read-only ancestor, a
+    // dangling symlink whose target cannot be created) is the real
+    // misconfiguration and is surfaced with a clearer message.
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT")
+      throw new Error(
+        `keyFilePath parent directory ${parent} is not accessible: ` +
+          (err instanceof Error ? err.message : String(err)),
+      );
+    try {
+      fs.mkdirSync(parent, { recursive: true });
+      // Surface the side effect so users can see why a directory appeared
+      // even if the subsequent handshake or exchange fails and saveKeyFile
+      // never writes the key file into it.
+      log.info(
+        `created keyFilePath parent directory ${parent} (mirrors ` +
+          "saveKeyFile's recursive mkdir; left in place on failure)",
+      );
+      parentStat = fs.statSync(parent);
+    } catch (createErr) {
+      // lstat can distinguish a dangling symlink (target missing) from a
+      // truly absent path so the hint points at the actual cause.
+      let hint = "";
+      try {
+        if (fs.lstatSync(parent).isSymbolicLink())
+          hint = " (path is a symbolic link, possibly dangling)";
+      } catch {
+        /* lstat failure: parent truly absent; default message applies. */
+      }
+      throw new Error(
+        `keyFilePath parent directory ${parent} cannot be created${hint}: ` +
+          (createErr instanceof Error ? createErr.message : String(createErr)),
+      );
+    }
+  }
+  if (!parentStat.isDirectory())
+    throw new Error(
+      `keyFilePath parent ${parent} exists but is not a directory; ` +
+        "saveKeyFile would fail after a successful key exchange",
+    );
+  // Best-effort writability check: catches the common case of a read-only
+  // parent before the key exchange rotates the secret. fs.accessSync(W_OK) is
+  // unreliable on Windows (it consults only the read-only attribute, not
+  // the ACL) and can be inconsistent on Linux with capabilities such as
+  // CAP_DAC_OVERRIDE. A create-and-unlink probe on a sentinel file
+  // exercises the actual permission path that saveKeyFile will use, and
+  // works identically on every platform. PID + crypto-random nonce in the
+  // name prevents collisions with concurrent runs, and the unlink in
+  // `finally` cleans up even if open fails partway. The real rename in
+  // saveKeyFile may still fail (e.g. quota exceeded between probe and
+  // write), but the common misconfiguration is caught here before the
+  // partner can be left holding a rotated token this side cannot persist.
+  //
+  // Sweep any stale probe files from previous SIGKILL'd / OOM'd runs first
+  // so the directory does not accumulate empty zero-byte litter. Names
+  // include a unique nonce, so unlinking other entries that match the
+  // pattern is safe on POSIX: a concurrent run that has already opened its
+  // probe does not care if the path is unlinked underneath it (the fd
+  // remains valid). On Windows the open file is held without
+  // FILE_SHARE_DELETE, so unlinkSync on a peer's probe fails with EPERM;
+  // the inner catch swallows the failure and the peer's probe remains.
+  // The leftover is cosmetic (zero-byte file) and is swept on the next
+  // non-concurrent invocation. This is documented rather than worked
+  // around because no Node API exposes FILE_SHARE_DELETE without addons.
+  // Match the exact probe-file name format produced below
+  // (`.psilink-write-probe-<pid>-<8 hex chars>`) so that an unrelated
+  // file the user happens to have placed with this prefix is not
+  // silently unlinked.
+  const PROBE_NAME_RE = /^\.psilink-write-probe-\d+-[0-9a-f]{8}$/;
+  try {
+    for (const entry of fs.readdirSync(parent)) {
+      if (PROBE_NAME_RE.test(entry)) {
+        try {
+          fs.unlinkSync(path.join(parent, entry));
+        } catch {
+          /* best-effort cleanup; ignore failures (e.g. ENOENT from a
+           * concurrent run that just unlinked its own probe). */
+        }
+      }
+    }
+  } catch {
+    /* readdir failure (permission, transient) is non-fatal: the probe
+     * itself will surface the underlying access problem with a clearer
+     * message. */
+  }
+  const probeName =
+    `.psilink-write-probe-${process.pid}-` + crypto.randomUUID().slice(0, 8);
+  const probePath = path.join(parent, probeName);
+  let probeFd: number | undefined;
+  try {
+    probeFd = fs.openSync(
+      probePath,
+      fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY,
+    );
+  } catch (err) {
+    throw new Error(
+      `keyFilePath parent directory ${parent} is not writable: ` +
+        (err instanceof Error ? err.message : String(err)) +
+        ". Restore write permission before running the exchange, " +
+        "otherwise saveKeyFile would fail after a successful key " +
+        "exchange and both parties would need to re-invite.",
+    );
+  } finally {
+    if (probeFd !== undefined) {
+      try {
+        fs.closeSync(probeFd);
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+    try {
+      fs.unlinkSync(probePath);
+    } catch {
+      /* best-effort cleanup; open() may have failed before the file was
+       * created, in which case unlink ENOENT is expected. */
+    }
+  }
+  return kfp;
+}

--- a/apps/cli/src/keyFilePreflight.ts
+++ b/apps/cli/src/keyFilePreflight.ts
@@ -45,13 +45,17 @@ export function preflightKeyFilePath(
       "connection.authentication must include a non-empty keyFilePath",
     );
   const kfp = keyFilePath.trim();
-  // Pre-validate that the key file path itself, if it already exists, is
-  // a regular file rather than a directory or other special node. If it
-  // is a directory, saveKeyFile's renameSync would fail post-handshake
-  // (when the partner may already hold the rotated token) and force a
-  // re-invitation that is preventable here. Use lstatSync so a symlink at
-  // the key file path is inspected as-is rather than followed: a symlink
-  // pointing at a directory should still be rejected.
+  // Pre-validate the key path itself: it is fine as a regular file or a
+  // symlink, and rejected only if it already exists as a directory or other
+  // special node. saveKeyFile writes a temp file and renameSync()s it onto
+  // this path, and rename replaces the final component in place -- acting on a
+  // symlink as the link itself rather than following it -- so a regular file or
+  // a symlink (to anything, including a directory) is overwritten cleanly. Only
+  // a real directory or special node, which rename cannot overwrite, would make
+  // that write fail post-handshake, when the partner may already hold the
+  // rotated token and recovery needs a preventable re-invitation. Use lstatSync
+  // (not statSync) so a symlink is classified as a symlink and accepted as-is
+  // rather than resolved to its target's type.
   try {
     const targetStat = fs.lstatSync(kfp);
     if (!targetStat.isFile() && !targetStat.isSymbolicLink())

--- a/apps/cli/src/protocol.ts
+++ b/apps/cli/src/protocol.ts
@@ -1,7 +1,3 @@
-import crypto from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
-
 import PSI from "@openmined/psi.js";
 
 import {
@@ -28,6 +24,7 @@ import type {
 import { LocalFSClient } from "./connection/localFSClient";
 import { SSH2SFTPClientAdapter } from "./connection/ssh2SftpAdapter";
 import { saveKeyFile } from "./keyFile";
+import { preflightKeyFilePath } from "./keyFilePreflight";
 import { writeExchangeRecord, type RecordOutput } from "./recordFile";
 import { writeOutput } from "./util/cli";
 
@@ -245,179 +242,12 @@ export async function runProtocol(
     // runProtocol. The shared check carries psilinkRecoveryHintEmitted, so the
     // catch block below suppresses its generic advisory.
     assertSharedSecretReadyForHandshake(auth);
-    // Guards against a missing or whitespace-only keyFilePath before any
-    // connection is opened (a whitespace-only path would create a file named
-    // " " in the current directory rather than failing clearly). Trim leading
-    // and trailing whitespace from the supplied value before using it: a
-    // value like "  ./key  " is almost certainly user typo and would
-    // otherwise become "  ." for dirname and " ./key  " for the file name,
-    // producing a confusing on-disk artifact rather than the intended file.
-    const rawKfp = auth.keyFilePath;
-    if (typeof rawKfp !== "string" || rawKfp.trim().length === 0)
-      throw new Error(
-        "connection.authentication must include a non-empty keyFilePath",
-      );
-    const kfp = rawKfp.trim();
-    trimmedKeyFilePath = kfp;
-    // Pre-validate that the key file path itself, if it already exists, is
-    // a regular file rather than a directory or other special node. If it
-    // is a directory, saveKeyFile's renameSync would fail post-handshake
-    // (when the partner may already hold the rotated token) and force a
-    // re-invitation that is preventable here. Use lstatSync so a symlink at
-    // the key file path is inspected as-is rather than followed: a symlink
-    // pointing at a directory should still be rejected.
-    try {
-      const targetStat = fs.lstatSync(kfp);
-      if (!targetStat.isFile() && !targetStat.isSymbolicLink())
-        throw new Error(
-          `keyFilePath ${kfp} exists but is not a regular file (` +
-            `${
-              targetStat.isDirectory()
-                ? "directory"
-                : "non-regular filesystem entry"
-            }); saveKeyFile would fail after a successful key exchange. ` +
-            "Remove or rename it before running the exchange.",
-        );
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      // ENOENT: keyFilePath does not yet exist (first run after invite/
-      // accept) and saveKeyFile will create it — fine.
-      // ENOTDIR: a component of the path prefix is a regular file, so kfp
-      // cannot exist; fall through and let the parent-directory check below
-      // raise the more specific "parent exists but is not a directory"
-      // error.
-      if (code !== "ENOENT" && code !== "ENOTDIR") throw err;
-    }
-    // Pre-validate that the parent directory exists (creating it if missing,
-    // mirroring saveKeyFile's `mkdirSync({ recursive: true })`) and that it
-    // is a directory, so saveKeyFile failure cannot occur after a successful
-    // key exchange, where the partner may already hold the rotated token
-    // and recovery requires re-invitation.
-    const parent = path.dirname(kfp);
-    let parentStat: fs.Stats | undefined;
-    try {
-      parentStat = fs.statSync(parent);
-    } catch (err) {
-      // ENOENT means the parent does not yet exist. saveKeyFile would create
-      // it via `mkdirSync({ recursive: true })`, so do the same here. Any
-      // failure that prevents creation (EACCES on a read-only ancestor, a
-      // dangling symlink whose target cannot be created) is the real
-      // misconfiguration and is surfaced with a clearer message.
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT")
-        throw new Error(
-          `keyFilePath parent directory ${parent} is not accessible: ` +
-            (err instanceof Error ? err.message : String(err)),
-        );
-      try {
-        fs.mkdirSync(parent, { recursive: true });
-        // Surface the side effect so users can see why a directory appeared
-        // even if the subsequent handshake or exchange fails and saveKeyFile
-        // never writes the key file into it.
-        log.info(
-          `created keyFilePath parent directory ${parent} (mirrors ` +
-            "saveKeyFile's recursive mkdir; left in place on failure)",
-        );
-        parentStat = fs.statSync(parent);
-      } catch (createErr) {
-        // lstat can distinguish a dangling symlink (target missing) from a
-        // truly absent path so the hint points at the actual cause.
-        let hint = "";
-        try {
-          if (fs.lstatSync(parent).isSymbolicLink())
-            hint = " (path is a symbolic link, possibly dangling)";
-        } catch {
-          /* lstat failure: parent truly absent; default message applies. */
-        }
-        throw new Error(
-          `keyFilePath parent directory ${parent} cannot be created${hint}: ` +
-            (createErr instanceof Error
-              ? createErr.message
-              : String(createErr)),
-        );
-      }
-    }
-    if (!parentStat.isDirectory())
-      throw new Error(
-        `keyFilePath parent ${parent} exists but is not a directory; ` +
-          "saveKeyFile would fail after a successful key exchange",
-      );
-    // Best-effort writability check: catches the common case of a read-only
-    // parent before the key exchange rotates the secret. fs.accessSync(W_OK) is
-    // unreliable on Windows (it consults only the read-only attribute, not
-    // the ACL) and can be inconsistent on Linux with capabilities such as
-    // CAP_DAC_OVERRIDE. A create-and-unlink probe on a sentinel file
-    // exercises the actual permission path that saveKeyFile will use, and
-    // works identically on every platform. PID + crypto-random nonce in the
-    // name prevents collisions with concurrent runs, and the unlink in
-    // `finally` cleans up even if open fails partway. The real rename in
-    // saveKeyFile may still fail (e.g. quota exceeded between probe and
-    // write), but the common misconfiguration is caught here before the
-    // partner can be left holding a rotated token this side cannot persist.
-    //
-    // Sweep any stale probe files from previous SIGKILL'd / OOM'd runs first
-    // so the directory does not accumulate empty zero-byte litter. Names
-    // include a unique nonce, so unlinking other entries that match the
-    // pattern is safe on POSIX: a concurrent run that has already opened its
-    // probe does not care if the path is unlinked underneath it (the fd
-    // remains valid). On Windows the open file is held without
-    // FILE_SHARE_DELETE, so unlinkSync on a peer's probe fails with EPERM;
-    // the inner catch swallows the failure and the peer's probe remains.
-    // The leftover is cosmetic (zero-byte file) and is swept on the next
-    // non-concurrent invocation. This is documented rather than worked
-    // around because no Node API exposes FILE_SHARE_DELETE without addons.
-    // Match the exact probe-file name format produced below
-    // (`.psilink-write-probe-<pid>-<8 hex chars>`) so that an unrelated
-    // file the user happens to have placed with this prefix is not
-    // silently unlinked.
-    const PROBE_NAME_RE = /^\.psilink-write-probe-\d+-[0-9a-f]{8}$/;
-    try {
-      for (const entry of fs.readdirSync(parent)) {
-        if (PROBE_NAME_RE.test(entry)) {
-          try {
-            fs.unlinkSync(path.join(parent, entry));
-          } catch {
-            /* best-effort cleanup; ignore failures (e.g. ENOENT from a
-             * concurrent run that just unlinked its own probe). */
-          }
-        }
-      }
-    } catch {
-      /* readdir failure (permission, transient) is non-fatal: the probe
-       * itself will surface the underlying access problem with a clearer
-       * message. */
-    }
-    const probeName =
-      `.psilink-write-probe-${process.pid}-` + crypto.randomUUID().slice(0, 8);
-    const probePath = path.join(parent, probeName);
-    let probeFd: number | undefined;
-    try {
-      probeFd = fs.openSync(
-        probePath,
-        fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY,
-      );
-    } catch (err) {
-      throw new Error(
-        `keyFilePath parent directory ${parent} is not writable: ` +
-          (err instanceof Error ? err.message : String(err)) +
-          ". Restore write permission before running the exchange, " +
-          "otherwise saveKeyFile would fail after a successful key " +
-          "exchange and both parties would need to re-invite.",
-      );
-    } finally {
-      if (probeFd !== undefined) {
-        try {
-          fs.closeSync(probeFd);
-        } catch {
-          /* best-effort cleanup */
-        }
-      }
-      try {
-        fs.unlinkSync(probePath);
-      } catch {
-        /* best-effort cleanup; open() may have failed before the file was
-         * created, in which case unlink ENOENT is expected. */
-      }
-    }
+    // Validate and trim the key-file path before any connection is opened, so a
+    // misconfiguration fails here -- with no rendezvous I/O and before the
+    // partner can be left holding a rotated token this side cannot persist --
+    // rather than at saveKeyFile post-handshake. Returns the trimmed path, which
+    // the saveKeyFile call below reuses without re-reading the caller's auth.
+    trimmedKeyFilePath = preflightKeyFilePath(auth.keyFilePath, log);
   }
   const client =
     connection.channel === "filedrop"

--- a/apps/cli/test/unit/keyFilePreflight.test.ts
+++ b/apps/cli/test/unit/keyFilePreflight.test.ts
@@ -1,0 +1,175 @@
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import type { getLogger } from "@psilink/core";
+
+import { preflightKeyFilePath } from "../../src/keyFilePreflight";
+
+// Minimal logger stub: the helper only calls log.info (the parent-created
+// notice). Capture those messages so the mkdir-side-effect branch can be
+// asserted; cast through unknown because the helper's parameter is the full
+// loglevel logger type but only `info` is exercised.
+function makeLogger(): { log: ReturnType<typeof getLogger>; infos: string[] } {
+  const infos: string[] = [];
+  const log = {
+    info: (...args: unknown[]) => {
+      infos.push(args.map(String).join(" "));
+    },
+  } as unknown as ReturnType<typeof getLogger>;
+  return { log, infos };
+}
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-preflight-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// --- missing / whitespace-only path ------------------------------------------
+
+test("rejects a missing (non-string) keyFilePath", () => {
+  const { log } = makeLogger();
+  expect(() =>
+    preflightKeyFilePath(undefined as unknown as string, log),
+  ).toThrow("non-empty keyFilePath");
+});
+
+test("rejects an empty keyFilePath", () => {
+  const { log } = makeLogger();
+  expect(() => preflightKeyFilePath("", log)).toThrow("non-empty keyFilePath");
+});
+
+test("rejects a whitespace-only keyFilePath", () => {
+  const { log } = makeLogger();
+  expect(() => preflightKeyFilePath("   ", log)).toThrow(
+    "non-empty keyFilePath",
+  );
+});
+
+// --- trimming ----------------------------------------------------------------
+
+test("trims leading and trailing whitespace and returns the trimmed path", () => {
+  const { log } = makeLogger();
+  const realKey = path.join(dir, "key.json");
+  const result = preflightKeyFilePath(`  ${realKey}  `, log);
+  expect(result).toBe(realKey);
+  // The whitespace-padded name must never have produced an on-disk artifact.
+  expect(fs.readdirSync(dir)).toEqual([]);
+});
+
+// --- existing target is not a regular file -----------------------------------
+
+test("rejects when keyFilePath itself is an existing directory", () => {
+  const { log } = makeLogger();
+  const keyAsDir = path.join(dir, "key-as-directory");
+  fs.mkdirSync(keyAsDir);
+  expect(() => preflightKeyFilePath(keyAsDir, log)).toThrow(
+    "not a regular file",
+  );
+});
+
+test.skipIf(process.platform === "win32")(
+  "rejects when keyFilePath is an existing non-regular node (socket)",
+  async () => {
+    // A unix-domain socket is a non-regular, non-directory, non-symlink node,
+    // so it exercises the guard's "non-regular filesystem entry" arm (distinct
+    // from the directory sub-case). Created with net rather than mkfifo so the
+    // test needs no external command.
+    const { log } = makeLogger();
+    const sockPath = path.join(dir, "key.sock");
+    const server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(sockPath, resolve));
+    try {
+      expect(() => preflightKeyFilePath(sockPath, log)).toThrow(
+        "non-regular filesystem entry",
+      );
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  },
+);
+
+// --- parent directory checks -------------------------------------------------
+
+test("rejects when the parent exists but is a regular file", () => {
+  const { log } = makeLogger();
+  const fileParent = path.join(dir, "not-a-dir");
+  fs.writeFileSync(fileParent, "");
+  expect(() =>
+    preflightKeyFilePath(path.join(fileParent, "key.json"), log),
+  ).toThrow("exists but is not a directory");
+});
+
+test("creates the parent directory when it does not yet exist", () => {
+  const { log, infos } = makeLogger();
+  const createdParent = path.join(dir, "newly-created", "nested");
+  expect(fs.existsSync(createdParent)).toBe(false);
+  const keyFilePath = path.join(createdParent, "key.json");
+  const result = preflightKeyFilePath(keyFilePath, log);
+  expect(result).toBe(keyFilePath);
+  expect(fs.existsSync(createdParent)).toBe(true);
+  // The mkdir side effect is surfaced to the user.
+  expect(
+    infos.some((m) => m.includes("created keyFilePath parent directory")),
+  ).toBe(true);
+});
+
+test.skipIf(process.platform === "win32")(
+  "rejects when the parent is a dangling symlink",
+  () => {
+    const { log } = makeLogger();
+    const target = path.join(dir, "missing-target");
+    const link = path.join(dir, "dangling-link");
+    fs.symlinkSync(target, link);
+    expect(() =>
+      preflightKeyFilePath(path.join(link, "key.json"), log),
+    ).toThrow("dangling");
+  },
+);
+
+test.skipIf(process.platform === "win32")(
+  "rejects when the parent directory is not writable",
+  () => {
+    // root bypasses mode bits, so the probe would succeed; skip there.
+    if (process.getuid?.() === 0) return;
+    const { log } = makeLogger();
+    const readOnlyDir = path.join(dir, "readonly");
+    fs.mkdirSync(readOnlyDir);
+    fs.chmodSync(readOnlyDir, 0o555);
+    try {
+      expect(() =>
+        preflightKeyFilePath(path.join(readOnlyDir, "key.json"), log),
+      ).toThrow("not writable");
+    } finally {
+      // Restore mode so afterEach can remove the tmp dir.
+      fs.chmodSync(readOnlyDir, 0o755);
+    }
+  },
+);
+
+// --- valid cases -------------------------------------------------------------
+
+test("accepts a non-existent path under an existing writable directory", () => {
+  const { log } = makeLogger();
+  const keyFilePath = path.join(dir, "key.json");
+  const result = preflightKeyFilePath(keyFilePath, log);
+  expect(result).toBe(keyFilePath);
+  // The write probe must clean up after itself, leaving no litter.
+  expect(fs.readdirSync(dir)).toEqual([]);
+});
+
+test("accepts an existing regular file at the key path", () => {
+  const { log } = makeLogger();
+  const keyFilePath = path.join(dir, "existing.key");
+  fs.writeFileSync(keyFilePath, "{}");
+  const result = preflightKeyFilePath(keyFilePath, log);
+  expect(result).toBe(keyFilePath);
+  // Only the pre-existing file remains; the probe left nothing behind.
+  expect(fs.readdirSync(dir)).toEqual(["existing.key"]);
+});

--- a/apps/cli/test/unit/keyFilePreflight.test.ts
+++ b/apps/cli/test/unit/keyFilePreflight.test.ts
@@ -170,6 +170,68 @@ test.skipIf(process.platform === "win32")(
   },
 );
 
+test.skipIf(process.platform === "win32")(
+  "reports an inaccessible parent when an ancestor of the parent is a file",
+  () => {
+    // kfp's grandparent is a regular file, so statSync(parent) throws ENOTDIR
+    // and hits the "is not accessible" arm -- distinct from the direct
+    // parent-is-a-file case, which yields "exists but is not a directory".
+    const { log } = makeLogger();
+    const fileAncestor = path.join(dir, "file-ancestor");
+    fs.writeFileSync(fileAncestor, "");
+    expect(() =>
+      preflightKeyFilePath(path.join(fileAncestor, "sub", "key.json"), log),
+    ).toThrow("is not accessible");
+  },
+);
+
+test.skipIf(process.platform === "win32")(
+  "reports a parent that cannot be created under a read-only ancestor",
+  () => {
+    // root bypasses mode bits, so the mkdir would succeed; skip there.
+    if (process.getuid?.() === 0) return;
+    // A missing parent under a non-writable ancestor: statSync(parent) is
+    // ENOENT, then mkdirSync fails with EACCES for a non-symlink reason, so
+    // this exercises the "cannot be created" arm with an empty dangling hint
+    // (distinct from the dangling-symlink case, which carries the hint).
+    const { log } = makeLogger();
+    const readOnlyDir = path.join(dir, "readonly");
+    fs.mkdirSync(readOnlyDir);
+    fs.chmodSync(readOnlyDir, 0o555);
+    try {
+      expect(() =>
+        preflightKeyFilePath(path.join(readOnlyDir, "newsub", "key.json"), log),
+      ).toThrow("cannot be created");
+    } finally {
+      // Restore mode so afterEach can remove the tmp dir.
+      fs.chmodSync(readOnlyDir, 0o755);
+    }
+  },
+);
+
+// --- stale write-probe sweep -------------------------------------------------
+
+test("sweeps stale probe files but spares look-alike names", () => {
+  // The pre-flight unlinks leftover probe files from prior crashed runs,
+  // matching the exact `.psilink-write-probe-<pid>-<8 hex>` grammar. The
+  // anchored regex must not delete a user's file that merely shares the
+  // prefix -- a broadened pattern would silently remove unrelated files.
+  const { log } = makeLogger();
+  const stale = ".psilink-write-probe-99999-deadbeef"; // matches: swept
+  const lookAlikeBadSuffix = ".psilink-write-probe-12-zzzzzzzz"; // non-hex
+  const lookAlikeNoSuffix = ".psilink-write-probe-keep"; // no -<digits>-<hex>
+  const unrelated = "important.txt";
+  for (const name of [stale, lookAlikeBadSuffix, lookAlikeNoSuffix, unrelated])
+    fs.writeFileSync(path.join(dir, name), "");
+
+  preflightKeyFilePath(path.join(dir, "key.json"), log);
+
+  expect(fs.existsSync(path.join(dir, stale))).toBe(false);
+  expect(fs.existsSync(path.join(dir, lookAlikeBadSuffix))).toBe(true);
+  expect(fs.existsSync(path.join(dir, lookAlikeNoSuffix))).toBe(true);
+  expect(fs.existsSync(path.join(dir, unrelated))).toBe(true);
+});
+
 // --- valid cases -------------------------------------------------------------
 
 test("accepts a non-existent path under an existing writable directory", () => {

--- a/apps/cli/test/unit/keyFilePreflight.test.ts
+++ b/apps/cli/test/unit/keyFilePreflight.test.ts
@@ -75,6 +75,23 @@ test("rejects when keyFilePath itself is an existing directory", () => {
 });
 
 test.skipIf(process.platform === "win32")(
+  "accepts a symlink at the key path, even one resolving to a directory",
+  () => {
+    // saveKeyFile renames a temp file onto the key path, which replaces the
+    // symlink itself rather than following it, so a symlink here -- including
+    // one resolving to a directory -- is overwritten cleanly and must NOT be
+    // rejected. Locks the guard against a future false-positive "reject
+    // symlinks" change.
+    const { log } = makeLogger();
+    const realDir = path.join(dir, "some-dir");
+    fs.mkdirSync(realDir);
+    const linkAtKeyPath = path.join(dir, "key-symlink");
+    fs.symlinkSync(realDir, linkAtKeyPath);
+    expect(preflightKeyFilePath(linkAtKeyPath, log)).toBe(linkAtKeyPath);
+  },
+);
+
+test.skipIf(process.platform === "win32")(
   "rejects when keyFilePath is an existing non-regular node (socket)",
   async () => {
     // A unix-domain socket is a non-regular, non-directory, non-symlink node,


### PR DESCRIPTION
## Summary

Extract `runProtocol`'s ~175-line key-file path pre-flight validation into a
dedicated, exported `preflightKeyFilePath` helper with direct unit tests,
shrinking `runProtocol` and making the validation rules testable in isolation.
Pure maintainability refactor with no observable behavior change: the same
inputs succeed or throw with the same user-facing messages.

Implements 9 item [196895655](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=196895655).

## Changes

- `apps/cli/src/keyFilePreflight.ts` (new) -- exported
  `preflightKeyFilePath(keyFilePath, log)`: trims the path, rejects a missing or
  whitespace-only value, rejects a target that exists but is not a regular file,
  and pre-validates (creating if missing) and write-probes the parent directory;
  returns the trimmed path. Logic lifted verbatim from `protocol.ts`.
- `apps/cli/src/protocol.ts` -- `runProtocol` calls the helper and assigns its
  return value to `trimmedKeyFilePath`; the inline block and the now-unused
  `crypto`, `fs`, and `path` imports are removed.
- `apps/cli/test/unit/keyFilePreflight.test.ts` (new) -- direct unit tests for
  each branch of the helper.

## Background

The extraction is behavior-preserving by construction: the block is moved
verbatim, with only the closure read of `auth.keyFilePath` becoming a parameter
and the outer `trimmedKeyFilePath` assignment becoming the helper's return value.
A second commit corrects a pre-existing comment that misdescribed the symlink
case: the guard accepts a symlink at the key path, which is correct, because
`saveKeyFile`'s temp-file plus rename replaces the link rather than following it,
so rejecting it would be a false positive. This is the maintainability-only half
of a deferred `runProtocol` factoring; the functional half (the post-handshake
`onAuthenticated` hook) already landed separately.

## Out of scope / follow-on

- Pre-existing error-path hardening in the same block (a raw `EACCES`/`ELOOP`
  rethrow that preempts the friendly "not writable" message, and the write probe
  passing on a write-only-no-read parent that `fsyncParentDir` later rejects for
  read) is tracked separately: [198614174](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=198614174).

## Test plan

- [x] `npm run typecheck && npm run lint` clean (root and `apps/cli` project refs)
- [x] `npm test -w packages/core` (1018/1018)
- [x] `npm run test:unit -w apps/cli` (478/478)
- [x] CLI integration tests: `npm run test:integration -w apps/cli` (16/16)

New tests cover: a missing, empty, or whitespace-only path rejected; leading and
trailing whitespace trimmed; an existing directory or other non-regular node
rejected; a symlink at the key path accepted; the parent created when missing; a
parent that is a file, inaccessible, cannot be created, or is a dangling symlink
rejected; a non-writable parent rejected; the stale write-probe sweep removing
matching probes while sparing look-alike names; and the valid cases accepted.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact; none needed (internal
  refactor, no behavior or interface change)
- [x] `CHANGELOG.md` `[Unreleased]` updated, or n/a -- n/a (internal refactor, no
  user-facing or library-API change)
- [x] Cryptographic code changed? -- n/a (no cryptographic code changed;
  filesystem pre-flight only). Security-relevant nonetheless: an independent
  security review was completed with a clean verdict.
