### PR TITLE
Make web browser tests self-manage the dev server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,18 @@ npm run test:integration -w apps/web    # reuses the running server
 # stop the dev server in the terminal when done (Ctrl-C)
 ```
 
+The browser suite -- cross-implementation byte-vector checks plus a live PSI
+exchange, run in real Chromium via Playwright -- self-manages the dev server the
+same way: it stands up the PeerJS coordination server the exchange needs, reuses
+a running `npm run dev`, and otherwise starts and stops its own.
+
+```sh
+npm run test:browser -w apps/web    # auto-starts, waits for, and stops the dev server
+```
+
+It is not part of CI; run it locally when changing the web PSI exchange or the
+cross-implementation vectors.
+
 ## Code Conventions
 
 - **TypeScript** with strict mode throughout. Avoid `any`; if you must use it, add a comment explaining why.

--- a/apps/web/test/browser/invitedPSI.test.ts
+++ b/apps/web/test/browser/invitedPSI.test.ts
@@ -144,16 +144,18 @@ beforeAll(async () => {
           // enclosing promise unsettled and hang beforeAll until its timeout.
           .catch(reject);
       });
+      peer.on("error", (err) => reject(err));
     });
   })();
 
   const clientConnPromise: Promise<DataConnection> = (() => {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       clientPeer.on("connection", (conn) => {
         conn.on("open", () => {
           resolve(conn);
         });
       });
+      clientPeer.on("error", (err) => reject(err));
     });
   })();
 

--- a/apps/web/test/browser/invitedPSI.test.ts
+++ b/apps/web/test/browser/invitedPSI.test.ts
@@ -24,10 +24,11 @@ interface AddressInfo {
 const addressInfo: AddressInfo = {
   address: "127.0.0.1",
   family: "IpV4",
-  // The `browser` project's globalSetup publishes the port it launched the dev
-  // server on (browser tests run in Chromium and cannot read `process.env`), so
-  // the probe and exchange below cannot drift from the running server. Falls
-  // back to the Vite default when this file is run without that setup.
+  // The `browser` project's globalSetup publishes the port it probed/launched
+  // the dev server on (browser tests run in Chromium and cannot read
+  // `process.env`), so the probe and exchange below target that exact port
+  // rather than a hardcoded guess. Falls back to the Vite default when this
+  // file is run without that setup, where an unreachable server skips the suite.
   port: inject("webDevServerPort") ?? 3000,
 };
 const protocol = "http:";

--- a/apps/web/test/browser/invitedPSI.test.ts
+++ b/apps/web/test/browser/invitedPSI.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="@vitest/browser-playwright/context" />
 
-import { beforeAll, expect, test } from "vitest";
+import { beforeAll, expect, inject, test } from "vitest";
 
 import Peer from "peerjs";
 
@@ -24,7 +24,11 @@ interface AddressInfo {
 const addressInfo: AddressInfo = {
   address: "127.0.0.1",
   family: "IpV4",
-  port: 3000,
+  // The `browser` project's globalSetup publishes the port it launched the dev
+  // server on (browser tests run in Chromium and cannot read `process.env`), so
+  // the probe and exchange below cannot drift from the running server. Falls
+  // back to the Vite default when this file is run without that setup.
+  port: inject("webDevServerPort") ?? 3000,
 };
 const protocol = "http:";
 
@@ -32,8 +36,7 @@ const hostString =
   `${protocol}//${addressInfo.address}` +
   `${addressInfo.port ? ":" + addressInfo.port.toString() : ""}`;
 
-const serverUnreachableNote =
-  "PeerJS coordination server on 127.0.0.1:3000 unreachable";
+const serverUnreachableNote = `PeerJS coordination server at ${hostString} unreachable`;
 
 // Probe the PeerJS coordination server with a short timeout. The `browser`
 // vitest project stands this server up via the dev-server globalSetup, so a
@@ -84,15 +87,17 @@ const firstNameOnlyTerms = {
   linkageKeys: [{ name: "firstName", elements: [{ field: "firstName" }] }],
 };
 
-let reachable = false;
-let serverResult: ReturnType<typeof sortAssociationTable>;
-let clientResult: ReturnType<typeof sortAssociationTable>;
+// Undefined until a reachable server lets beforeAll run the exchange; the tests
+// gate on this, so an unreachable server skips rather than reading a stale or
+// absent result.
+let serverResult: ReturnType<typeof sortAssociationTable> | undefined;
+let clientResult: ReturnType<typeof sortAssociationTable> | undefined;
 
 // Generous timeout: peer coordination, the WASM load, and the round-trip
 // exchange all happen here. Previously this ran at module scope with no bound;
 // the hook timeout now turns a stuck server into a clear failure, not a hang.
 beforeAll(async () => {
-  reachable = await canReachServer();
+  const reachable = await canReachServer();
   if (!reachable) return;
 
   const session = await (async () => {
@@ -249,13 +254,13 @@ beforeAll(async () => {
 }, 60_000);
 
 test("server and client yield identical results", (ctx) => {
-  ctx.skip(!reachable, serverUnreachableNote);
+  if (!serverResult || !clientResult) return ctx.skip(serverUnreachableNote);
   expect(serverResult[0]).toStrictEqual(clientResult[1]);
   expect(serverResult[1]).toStrictEqual(clientResult[0]);
 });
 
 test("psi yields correct results", (ctx) => {
-  ctx.skip(!reachable, serverUnreachableNote);
+  if (!serverResult) return ctx.skip(serverUnreachableNote);
   expect(serverResult[0]).toStrictEqual([2, 4]);
   expect(serverResult[1]).toStrictEqual([0, 1]);
 });

--- a/apps/web/test/browser/invitedPSI.test.ts
+++ b/apps/web/test/browser/invitedPSI.test.ts
@@ -182,9 +182,17 @@ beforeAll(async () => {
         }
       });
 
-      eventSource.addEventListener("error", (ev: Event) => {
+      eventSource.addEventListener("error", () => {
+        // An EventSource "error" Event carries no enumerable detail
+        // (JSON.stringify yields "{}"), so name the endpoint that failed
+        // instead -- otherwise this surfaces as an opaque message.
         eventSource.close();
-        reject(new Error("EventSource connection error:" + JSON.stringify(ev)));
+        reject(
+          new Error(
+            "EventSource error while waiting for the invited peer id at " +
+              `${hostString}/api/psi/${session.uuid}/wait`,
+          ),
+        );
       });
     });
   })();

--- a/apps/web/test/browser/invitedPSI.test.ts
+++ b/apps/web/test/browser/invitedPSI.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="@vitest/browser-playwright/context" />
 
-import { expect, test } from "vitest";
+import { beforeAll, expect, test } from "vitest";
 
 import Peer from "peerjs";
 
@@ -32,108 +32,29 @@ const hostString =
   `${protocol}//${addressInfo.address}` +
   `${addressInfo.port ? ":" + addressInfo.port.toString() : ""}`;
 
-const session = await (async () => {
-  const response = await fetch(`${hostString}/api/psi/create`, {
-    method: "POST",
-    body: JSON.stringify({
-      initiatedName: "Test Server",
-      invitedName: "Test Code",
-      description: "Testing invited",
-    }),
-  });
-  return await response.json();
-})();
+const serverUnreachableNote =
+  "PeerJS coordination server on 127.0.0.1:3000 unreachable";
 
-const clientPeer: Peer = await (() => {
-  return new Promise((resolve, reject) => {
-    const peer = new Peer({
-      host: addressInfo.address,
-      path: "/api/",
-      port: addressInfo.port,
-    });
-    peer.on("open", (id: string) => {
-      fetch(`${hostString}/api/psi/${session["uuid"]}`, {
-        headers: {
-          "Content-Type": "application/json",
-        },
-        method: "POST",
-        body: JSON.stringify({
-          invitedPeerId: id,
-        }),
-      }).then((response) => {
-        if (!response.ok) {
-          reject(
-            new Error(
-              `error posting peer id: ${response.status}, text: ${response.statusText}`,
-            ),
-          );
-        } else {
-          resolve(peer);
-        }
-      });
-    });
-  });
-})();
-
-const clientConnPromise: Promise<DataConnection> = (() => {
-  return new Promise((resolve) => {
-    clientPeer.on("connection", (conn) => {
-      conn.on("open", () => {
-        resolve(conn);
-      });
-    });
-  });
-})();
-
-const clientPeerId: string = await (() => {
-  return new Promise((resolve, reject) => {
-    const eventSource = new EventSource(
-      `${hostString}/api/psi/${session.uuid}/wait`,
-      { withCredentials: false },
-    );
-
-    eventSource.addEventListener("message", (ev: MessageEvent<any>) => {
-      try {
-        const messageData = ev.data && JSON.parse(ev.data);
-        if (!("invitedPeerId" in messageData)) {
-          throw new Error("unexpected message from server: " + ev.data);
-        } else {
-          const invitedPeerId = messageData["invitedPeerId"];
-          eventSource.close();
-          resolve(invitedPeerId);
-        }
-      } catch (err) {
-        eventSource.close();
-        reject(err);
-      }
-    });
-
-    eventSource.addEventListener("error", (ev: Event) => {
-      eventSource.close();
-      reject(new Error("EventSource connection error:" + JSON.stringify(ev)));
-    });
-  });
-})();
-
-const [serverPeer, serverConn]: [Peer, DataConnection] = await (async () => {
-  return new Promise((resolve, reject) => {
-    const peer = new Peer({
-      host: addressInfo.address,
-      path: "/api/",
-      port: addressInfo.port,
-    });
-    peer.on("open", () => {
-      const conn = peer.connect(clientPeerId, { reliable: true });
-      resolve([peer, conn]);
-    });
-
-    peer.on("error", (err) => reject(err));
-  });
-})();
-
-const psiLibrary = await (PSI() as Promise<PSILibrary>);
-
-const clientConn = await clientConnPromise;
+// Probe the PeerJS coordination server with a short timeout. The `browser`
+// vitest project stands this server up via the dev-server globalSetup, so a
+// normal `test:browser` run finds it. Running this file directly without that
+// setup leaves it down -- in which case this suite skips rather than failing.
+// Reachability is decided here, inside a hook, never at module scope: the
+// networked exchange below used to run during import, where a "Failed to fetch"
+// took down the entire browser project (0 tests collected), hiding the
+// server-less vector suites (canonical, exchangeRecord) that share it.
+async function canReachServer(): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1_000);
+  try {
+    await fetch(`${hostString}/`, { signal: controller.signal });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 const serverRows = [
   { first_name: "Alice" },
@@ -163,61 +84,178 @@ const firstNameOnlyTerms = {
   linkageKeys: [{ name: "firstName", elements: [{ field: "firstName" }] }],
 };
 
-const serverPrepared = prepareForExchange(
-  { linkageTerms: { ...firstNameOnlyTerms, identity: "server" } },
-  "server",
-  serverRows,
-  ["first_name"],
-);
-const clientPrepared = prepareForExchange(
-  { linkageTerms: { ...firstNameOnlyTerms, identity: "client" } },
-  "client",
-  clientRows,
-  ["first_name"],
-);
+let reachable = false;
+let serverResult: ReturnType<typeof sortAssociationTable>;
+let clientResult: ReturnType<typeof sortAssociationTable>;
 
-const serverMc = await openPeerMessageConnection(serverConn);
-const clientMc = await openPeerMessageConnection(clientConn);
+// Generous timeout: peer coordination, the WASM load, and the round-trip
+// exchange all happen here. Previously this ran at module scope with no bound;
+// the hook timeout now turns a stuck server into a clear failure, not a hang.
+beforeAll(async () => {
+  reachable = await canReachServer();
+  if (!reachable) return;
 
-const runServerPSI = async () => {
-  const { associationTable } = await runExchange(
-    serverMc,
-    "responder",
-    serverPrepared,
-    { psiLibrary },
+  const session = await (async () => {
+    const response = await fetch(`${hostString}/api/psi/create`, {
+      method: "POST",
+      body: JSON.stringify({
+        initiatedName: "Test Server",
+        invitedName: "Test Code",
+        description: "Testing invited",
+      }),
+    });
+    return await response.json();
+  })();
+
+  const clientPeer: Peer = await (() => {
+    return new Promise((resolve, reject) => {
+      const peer = new Peer({
+        host: addressInfo.address,
+        path: "/api/",
+        port: addressInfo.port,
+      });
+      peer.on("open", (id: string) => {
+        fetch(`${hostString}/api/psi/${session["uuid"]}`, {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          method: "POST",
+          body: JSON.stringify({
+            invitedPeerId: id,
+          }),
+        }).then((response) => {
+          if (!response.ok) {
+            reject(
+              new Error(
+                `error posting peer id: ${response.status}, text: ${response.statusText}`,
+              ),
+            );
+          } else {
+            resolve(peer);
+          }
+        });
+      });
+    });
+  })();
+
+  const clientConnPromise: Promise<DataConnection> = (() => {
+    return new Promise((resolve) => {
+      clientPeer.on("connection", (conn) => {
+        conn.on("open", () => {
+          resolve(conn);
+        });
+      });
+    });
+  })();
+
+  const clientPeerId: string = await (() => {
+    return new Promise((resolve, reject) => {
+      const eventSource = new EventSource(
+        `${hostString}/api/psi/${session.uuid}/wait`,
+        { withCredentials: false },
+      );
+
+      eventSource.addEventListener("message", (ev: MessageEvent<any>) => {
+        try {
+          const messageData = ev.data && JSON.parse(ev.data);
+          if (!("invitedPeerId" in messageData)) {
+            throw new Error("unexpected message from server: " + ev.data);
+          } else {
+            const invitedPeerId = messageData["invitedPeerId"];
+            eventSource.close();
+            resolve(invitedPeerId);
+          }
+        } catch (err) {
+          eventSource.close();
+          reject(err);
+        }
+      });
+
+      eventSource.addEventListener("error", (ev: Event) => {
+        eventSource.close();
+        reject(new Error("EventSource connection error:" + JSON.stringify(ev)));
+      });
+    });
+  })();
+
+  const [serverPeer, serverConn]: [Peer, DataConnection] = await (async () => {
+    return new Promise((resolve, reject) => {
+      const peer = new Peer({
+        host: addressInfo.address,
+        path: "/api/",
+        port: addressInfo.port,
+      });
+      peer.on("open", () => {
+        const conn = peer.connect(clientPeerId, { reliable: true });
+        resolve([peer, conn]);
+      });
+
+      peer.on("error", (err) => reject(err));
+    });
+  })();
+
+  const psiLibrary = await (PSI() as Promise<PSILibrary>);
+
+  const clientConn = await clientConnPromise;
+
+  const serverPrepared = prepareForExchange(
+    { linkageTerms: { ...firstNameOnlyTerms, identity: "server" } },
+    "server",
+    serverRows,
+    ["first_name"],
   );
-  return associationTable;
-};
-
-const runClientPSI = async () => {
-  const { associationTable } = await runExchange(
-    clientMc,
-    "initiator",
-    clientPrepared,
-    { psiLibrary },
+  const clientPrepared = prepareForExchange(
+    { linkageTerms: { ...firstNameOnlyTerms, identity: "client" } },
+    "client",
+    clientRows,
+    ["first_name"],
   );
-  return associationTable;
-};
 
-let [serverResult, clientResult] = await Promise.all([
-  runServerPSI(),
-  runClientPSI(),
-]);
+  const serverMc = await openPeerMessageConnection(serverConn);
+  const clientMc = await openPeerMessageConnection(clientConn);
 
-await serverMc.close();
-await clientMc.close();
-serverPeer.disconnect();
-clientPeer.disconnect();
+  const runServerPSI = async () => {
+    const { associationTable } = await runExchange(
+      serverMc,
+      "responder",
+      serverPrepared,
+      { psiLibrary },
+    );
+    return associationTable;
+  };
 
-serverResult = sortAssociationTable(serverResult);
-clientResult = sortAssociationTable(clientResult, true);
+  const runClientPSI = async () => {
+    const { associationTable } = await runExchange(
+      clientMc,
+      "initiator",
+      clientPrepared,
+      { psiLibrary },
+    );
+    return associationTable;
+  };
 
-test("server and client yield identical results", () => {
+  const [rawServerResult, rawClientResult] = await Promise.all([
+    runServerPSI(),
+    runClientPSI(),
+  ]);
+
+  await serverMc.close();
+  await clientMc.close();
+  serverPeer.disconnect();
+  clientPeer.disconnect();
+
+  serverResult = sortAssociationTable(rawServerResult);
+  clientResult = sortAssociationTable(rawClientResult, true);
+}, 60_000);
+
+test("server and client yield identical results", (ctx) => {
+  ctx.skip(!reachable, serverUnreachableNote);
   expect(serverResult[0]).toStrictEqual(clientResult[1]);
   expect(serverResult[1]).toStrictEqual(clientResult[0]);
 });
 
-test("psi yields correct results", () => {
+test("psi yields correct results", (ctx) => {
+  ctx.skip(!reachable, serverUnreachableNote);
   expect(serverResult[0]).toStrictEqual([2, 4]);
   expect(serverResult[1]).toStrictEqual([0, 1]);
 });

--- a/apps/web/test/browser/invitedPSI.test.ts
+++ b/apps/web/test/browser/invitedPSI.test.ts
@@ -128,17 +128,21 @@ beforeAll(async () => {
           body: JSON.stringify({
             invitedPeerId: id,
           }),
-        }).then((response) => {
-          if (!response.ok) {
-            reject(
-              new Error(
-                `error posting peer id: ${response.status}, text: ${response.statusText}`,
-              ),
-            );
-          } else {
-            resolve(peer);
-          }
-        });
+        })
+          .then((response) => {
+            if (!response.ok) {
+              reject(
+                new Error(
+                  `error posting peer id: ${response.status}, text: ${response.statusText}`,
+                ),
+              );
+            } else {
+              resolve(peer);
+            }
+          })
+          // Without this, a rejected fetch (refused/aborted) would leave the
+          // enclosing promise unsettled and hang beforeAll until its timeout.
+          .catch(reject);
       });
     });
   })();

--- a/apps/web/test/devServer/globalSetup.ts
+++ b/apps/web/test/devServer/globalSetup.ts
@@ -12,12 +12,16 @@ import type { TestProject } from "vitest/node";
 // touches the dev server.
 //
 // The dev server runs on 127.0.0.1 (the Vite bind host -- not `localhost`,
-// which may resolve to ::1 and miss the IPv4 bind). The port comes from the
-// PORT env var (default 3000), matching vite.config.ts. The integration tests
-// (Node) derive their target from the same `process.env.PORT ?? "3000"`. The
-// browser tests run in Chromium and cannot read `process.env`, so the resolved
-// port is published via `provide()` for them to `inject()` -- so neither
-// consumer's tested port can drift from the launched/probed one.
+// which may resolve to ::1 and miss the IPv4 bind). This setup resolves the
+// port as `process.env.PORT ?? "3000"` and probes/launches there, matching
+// vite.config.ts. The integration tests (Node) read their target from the same
+// expression. The browser tests run in Chromium and cannot read `process.env`,
+// so the resolved port is published via `provide()` for them to `inject()`,
+// pinning each browser test to the exact port this setup probed rather than a
+// hardcoded guess. All three derive from `process.env.PORT ?? "3000"`, so they
+// agree whenever PORT is set in the environment or unset (the repo's `.env`
+// pins 3000); a non-3000 PORT set only in `.env` would not reach this read and
+// is unsupported.
 //
 // If a server is already listening on 127.0.0.1:PORT when the suite starts,
 // it is reused and left running on teardown, so a developer's long-lived

--- a/apps/web/test/devServer/globalSetup.ts
+++ b/apps/web/test/devServer/globalSetup.ts
@@ -2,22 +2,33 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
 
-// Vitest globalSetup for the `integration` project: brings the Vite/TanStack
-// dev server up before the suite and tears it down after, so `npm run
-// test:integration` is self-contained rather than requiring the operator to
-// start `npm run dev` first. Only the integration project references this file,
-// so the unit project (and `npm run test`) never touches the dev server.
+import type { TestProject } from "vitest/node";
+
+// Vitest globalSetup shared by the `integration` and `browser` projects: it
+// brings the Vite/TanStack dev server up before the suite and tears it down
+// after, so `npm run test:integration` and `npm run test:browser` are each
+// self-contained rather than requiring the operator to start `npm run dev`
+// first. The unit project does not reference this file, so `npm run test` never
+// touches the dev server.
 //
 // The dev server runs on 127.0.0.1 (the Vite bind host -- not `localhost`,
 // which may resolve to ::1 and miss the IPv4 bind). The port comes from the
 // PORT env var (default 3000), matching vite.config.ts. The integration tests
-// derive their target from the same `process.env.PORT ?? "3000"`, so the
-// launched/probed port and the tested port cannot drift.
+// (Node) derive their target from the same `process.env.PORT ?? "3000"`. The
+// browser tests run in Chromium and cannot read `process.env`, so the resolved
+// port is published via `provide()` for them to `inject()` -- so neither
+// consumer's tested port can drift from the launched/probed one.
 //
 // If a server is already listening on 127.0.0.1:PORT when the suite starts,
 // it is reused and left running on teardown, so a developer's long-lived
 // `npm run dev` is not killed mid-session -- matching the CLI integration
 // suite's warm-container reuse behavior.
+
+declare module "vitest" {
+  interface ProvidedContext {
+    webDevServerPort?: number;
+  }
+}
 
 const here = dirname(fileURLToPath(import.meta.url));
 // apps/web/test/devServer -> apps/web is two levels up.
@@ -72,9 +83,15 @@ async function waitForServer(url: string): Promise<void> {
   }
 }
 
-export default async function setup(): Promise<() => Promise<void>> {
+export default async function setup({
+  provide,
+}: TestProject): Promise<() => Promise<void>> {
   const port = getPort();
   const url = `http://127.0.0.1:${port}/`;
+
+  // Publish the port for browser tests, which cannot read `process.env`. Done
+  // before the reuse early-return so it is set on every path.
+  provide("webDevServerPort", port);
 
   // Reuse a server already listening on the port (manual `npm run dev`, or a
   // warm one from a prior run): skip launch and leave it running on teardown.

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -74,6 +74,12 @@ export default defineConfig((_configEnv) => {
               "test/**/*.browser.{test,spec}.ts",
             ],
             name: "browser",
+            // Stand up the dev server (PeerJS coordination + /api) the same way
+            // the integration project does, so a cold `test:browser` is green:
+            // the server-dependent suite (invitedPSI) needs :3000, and the setup
+            // reuses a developer's running `npm run dev` rather than starting a
+            // second one. The server-less vector suites pay a reuse-aware probe.
+            globalSetup: ["./test/devServer/globalSetup.ts"],
             browser: {
               provider: playwright(),
               headless: true,


### PR DESCRIPTION
## Summary

`npm run test:browser -w apps/web` now passes from a cold start: the `browser`
vitest project stands up and tears down the dev server it needs, reuse-aware,
the same way the `integration` project already does. A server-dependent test
that cannot reach the :3000 coordination server now skips cleanly instead of
throwing at import time, so the server-less cross-implementation vector suites
(canonical, exchangeRecord) are no longer masked behind another file's
connection failure.

Implements board 10 item [197914649](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=197914649).

## Changes

- `apps/web/vite.config.ts` -- attach the dev-server `globalSetup` to the
  `browser` project, so a cold `test:browser` self-manages (and reuses) the
  server.
- `apps/web/test/devServer/globalSetup.ts` -- publish the resolved port via
  vitest `provide()` for browser tests, which run in Chromium and cannot read
  `process.env`, so they target the exact port this setup probed; update the
  header for its now-dual (integration + browser) consumers.
- `apps/web/test/browser/invitedPSI.test.ts` -- move the networked PSI exchange
  out of module scope into `beforeAll` behind a reachability probe, so an
  unreachable server skips the suite rather than failing the whole project at
  import; `inject()` the port; reject the peer/fetch/EventSource wait-promises
  on error instead of hanging to the hook timeout.
- `CONTRIBUTING.md` -- document the self-managing browser suite.

## Background

The networked `await` ran at module scope (predates this work; introduced in
04ce31a), so with no server on :3000 the import threw "Failed to fetch" and the
browser project collected 0 tests -- taking the server-less vector suites down
with it. CI does not run `test:browser`, so the gap only surfaced for a
developer running the suite directly. The port channel exists because the dev
server's port (`process.env.PORT ?? 3000`) is resolved in Node by `globalSetup`
but consumed in Chromium by the test, which cannot read `process.env`;
`provide`/`inject` keeps the two from drifting.

## Out of scope / follow-on

- Adding a `test:browser` step to CI once the suite is self-managing -- raised
  in the task, deliberately not included here.

## Test plan

- [x] `npm run typecheck && npm run lint` clean (plus `tsc` for `apps/web`,
  which covers the test files, and `prettier --check`)
- [x] `npm test -w packages/core` (1018/1018; core unchanged, run as a baseline)
- [x] `npm run test:unit -w apps/web` (72/72)
- [x] `npm run test:integration -w apps/web` (11/11; shares the `globalSetup`
  changed here)
- [x] `npm run test:browser -w apps/web` (24/24, cold) -- the suite this PR fixes
- [x] CLI integration -- n/a, no `apps/cli` code changed

Verified behaviors (the acceptance criteria):

- Cold `test:browser` is green: the server is started, used, and stopped.
- The server-less vector suites run and report regardless of server state; with
  the server down they pass (22) while the server-dependent suite skips (2),
  with no import crash.
- An already-running `npm run dev` is reused and left running (no double-start,
  no teardown out from under it).
- The browser test follows the launched port: a `PORT=3100` cold run is green
  (server and test both on 3100), not a silent skip.
- A genuine mid-exchange failure fails the run loudly (red, non-zero exit), not
  a silent skip -- confirmed by injecting a throw.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact; none of the product /
  protocol / ops pages cover the test harness, so none needed updating. The
  dev-workflow note went to `CONTRIBUTING.md`.
- [x] `CHANGELOG.md` `[Unreleased]` -- n/a. Dev-only test infrastructure; no
  user-facing, library, protocol, or security behavior change.
- [x] Cryptographic code changed? n/a. No `src/`, crypto, protocol, transport,
  or dependency changes; the diff is test infrastructure and one doc.
