### PR TITLE
Test web exchange-record round-trip and cross-verification

### DIFF
--- a/apps/web/test/browser/exchangeRecord.test.ts
+++ b/apps/web/test/browser/exchangeRecord.test.ts
@@ -3,7 +3,14 @@
 
 import { describe, expect, test } from "vitest";
 
-import { buildExchangeRecord, verifyRecordCommitments } from "@psilink/core";
+import {
+  buildExchangeRecord,
+  parseExchangeRecord,
+  parseOpeningData,
+  serializeExchangeRecord,
+  serializeOpeningData,
+  verifyRecordCommitments,
+} from "@psilink/core";
 
 import vectorsRaw from "../../../../packages/core/test/vectors/exchange-record-vectors.json?raw";
 
@@ -67,6 +74,61 @@ describe("exchange record in the browser", () => {
       );
       expect(record).toEqual(vector.record);
       expect(opening).toEqual(vector.opening);
+
+      const { allValid } = await verifyRecordCommitments(record, opening);
+      expect(allValid).toBe(true);
+    },
+  );
+});
+
+// The acceptance-criteria coverage for "bring the exchange record to the web
+// app": the two facets the vector replay above does not exercise on its own --
+// the serialize -> parse round-trip of a record the web app produces, and an
+// explicit web <-> CLI cross-verification -- both run here in the real browser
+// runtime so they prove the WEB build's behavior, not Node's.
+describe("web-produced record: round-trip and cross-verification", () => {
+  // A record the web app produces survives the on-disk/download form. Built with
+  // real CSPRNG randomness (no injected `randomness`) so it is a genuine web
+  // record rather than a vector replay, then serialized, parsed back, and its
+  // commitments re-verified through that boundary -- the serialize -> parse
+  // round-trip the acceptance criteria call for. Iterating the vector inputs runs
+  // it across every governance/commitment shape (with and without an association
+  // table, legal agreement, or retention pointer).
+  test.each(vectors)(
+    "$name: a web-built record round-trips through serialize -> parse and re-verifies",
+    async (vector) => {
+      const { record, opening } = await buildExchangeRecord(vector.inputs);
+      const parsedRecord = parseExchangeRecord(
+        JSON.parse(serializeExchangeRecord(record)),
+      );
+      const parsedOpening = parseOpeningData(
+        JSON.parse(serializeOpeningData(opening)),
+      );
+      expect(parsedRecord).toEqual(record);
+      expect(parsedOpening).toEqual(opening);
+
+      const { allValid } = await verifyRecordCommitments(
+        parsedRecord,
+        parsedOpening,
+      );
+      expect(allValid).toBe(true);
+    },
+  );
+
+  // Cross-verification across runtimes. The checked-in vectors are the CLI/Node
+  // side of the contract -- the Node suite in
+  // packages/core/test/exchangeRecord.test.ts builds and verifies them -- so
+  // parsing a vector's record/opening here and verifying its commitments proves
+  // the web build verifies a CLI-produced record. The reverse direction (the CLI
+  // verifies a web-produced record) follows from byte-identity: the vector-replay
+  // suite above asserts the web build reproduces this exact record and opening,
+  // and the Node suite verifies that same pair, so the CLI verifies the
+  // byte-identical web record.
+  test.each(vectors)(
+    "$name: the web build verifies a CLI-produced record",
+    async (vector) => {
+      const record = parseExchangeRecord(vector.record);
+      const opening = parseOpeningData(vector.opening);
 
       const { allValid } = await verifyRecordCommitments(record, opening);
       expect(allValid).toBe(true);


### PR DESCRIPTION
## Summary

The web app already produces the self-attested exchange record at the end of an
exchange and offers the record and opening files as downloads; this PR adds the
cross-runtime reproducibility tests that close the item's remaining acceptance
criterion. They prove, in the real browser runtime, that a record the web app
builds round-trips through serialize -> parse intact and that a record produced
by one runtime verifies under the other, so a web record and a CLI record are
interchangeable for the same inputs.

Implements 9 item [196100773](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=196100773).

## Changes

- `apps/web/test/browser/exchangeRecord.test.ts` -- add two browser tests over
  the checked-in record vectors, run against the browser build of
  `@psilink/core`: a serialize -> parse round-trip of a web-built record (built
  with real CSPRNG randomness, then re-verified through the boundary) and a
  cross-verification that the web build verifies the CLI/Node-produced vector
  record and opening. Extends the existing vector-replay byte-identity test
  rather than replacing it.

## Background

The web production wiring -- consuming the record `runExchange` returns and
surfacing the record and opening as downloads -- shipped earlier, and the
record's governance field set was settled by the record-enrichment work and its
follow-ups. This item was sequenced last so the web app is tested against the
settled format once. Cross-runtime byte-identity was already covered by the
vector replay (the browser build reproduces the CLI's checked-in vectors); this
PR adds the two acceptance-criteria facets that replay does not exercise on its
own -- the serialize/parse round-trip and an executed cross-verification.

## Out of scope / follow-on

- A web UI for governance input (legal agreement, retention/disposition) is not
  included; the web app infers terms from an empty spec today, so a web record
  carries the algorithm, matching basis, and payload categories but not a legal
  agreement or retention pointer. Separate future work, not yet tracked on the
  board.
- The "CLI verifies a web-produced record" direction is proven transitively (the
  web build reproduces the vector byte-for-byte and the Node suite verifies that
  pair), not executed; documented in the test comment and the commit. Executing
  it literally would require piping a browser-built artifact into a Node test.

## Test plan

- [x] `npm run typecheck && npm run lint` clean
- [x] `npm test -w packages/core` (1052/1052)
- [x] `npm run test:unit -w apps/web` (72/72)
- [x] `npm run test:browser -w apps/web` (38/38) -- the cross-runtime suite that
      proves this PR; not part of CI, run locally
- CLI integration tests: n/a (no CLI or transport change)

New tests cover: a web-produced record round-trips through serialize -> parse and
re-verifies its commitments, and the web build verifies a CLI-produced record --
the cross-runtime reproducibility the acceptance criteria require.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact; no behavior change, and
      `docs/EXCHANGE_RECORD.md` already documents the web app offering the
      downloads
- [x] `CHANGELOG.md` `[Unreleased]` n/a -- test-only coverage of already-shipped,
      already-documented behavior (the record entry already notes the web
      downloads and the cross-impl vectors verified on Node and in the browser)
- Cryptographic code changed? n/a -- test-only, no change to crypto,
      protocol, or public API
