### PR TITLE
Tidy CI workflows: triggers, install, concurrency

### DIFF
--- a/.github/workflows/cli_build_and_test.yaml
+++ b/.github/workflows/cli_build_and_test.yaml
@@ -22,6 +22,11 @@ on:
       - "tsconfig.base.json"
       - ".github/workflows/cli_build_and_test.yaml"
 
+# Cancel a superseded run when a newer commit lands on the same PR/branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 # Least privilege: this build/test gate only needs to read the repo.
 permissions:
   contents: read

--- a/.github/workflows/eb_build_and_test.yaml
+++ b/.github/workflows/eb_build_and_test.yaml
@@ -4,12 +4,32 @@ name: Build and Test for Elastic Beanstalk
 # https://blog.danskingdom.com/Multiple-ways-to-setup-your-CI-CD-pipelines-in-GitHub-Actions/#approach-5-deploy-workflow-includes-build-workflow-and-uses-template-for-deployments-include-approach-with-reusable-workflows
 
 on:
-  # PR validation only. Deploys build through eb_deploy.yaml's workflow_call, so
-  # there is no standalone push trigger here: one would double-run on a feature
-  # branch that already has an open PR (push event + PR synchronize), and on dev,
-  # which eb_deploy also builds.
+  # PR validation only, scoped by path to web/core-affecting changes. Deploys
+  # build through eb_deploy.yaml's workflow_call, so there is no standalone push
+  # trigger here -- it would double-run with the pull_request event on a feature
+  # branch that already has an open PR. If this job becomes a required status
+  # check, configure branch protection so a path-skipped run does not block an
+  # unrelated PR -- a skipped required check otherwise stays pending.
   pull_request:
     branches: [main, staging]
+    paths:
+      - "lib/**"
+      - "package-lock.json"
+      - "tsconfig.base.json"
+      - "apps/web/deploy/aws_eb/**"
+      - "apps/web/public/**"
+      - "apps/web/server/**"
+      - "apps/web/src/**"
+      - "apps/web/nitro.config.ts"
+      - "apps/web/package.json"
+      - "apps/web/postcss.config.cjs"
+      - "apps/web/tsconfig.json"
+      - "apps/web/vite.config.ts"
+      - "packages/core/src/**"
+      - "packages/core/package.json"
+      - "packages/core/rollup.config.ts"
+      - "packages/core/tsconfig.json"
+      - ".github/workflows/eb_build_and_test.yaml"
 
   workflow_call:
     outputs:

--- a/.github/workflows/eb_build_and_test.yaml
+++ b/.github/workflows/eb_build_and_test.yaml
@@ -4,28 +4,12 @@ name: Build and Test for Elastic Beanstalk
 # https://blog.danskingdom.com/Multiple-ways-to-setup-your-CI-CD-pipelines-in-GitHub-Actions/#approach-5-deploy-workflow-includes-build-workflow-and-uses-template-for-deployments-include-approach-with-reusable-workflows
 
 on:
+  # PR validation only. Deploys build through eb_deploy.yaml's workflow_call, so
+  # there is no standalone push trigger here: one would double-run on a feature
+  # branch that already has an open PR (push event + PR synchronize), and on dev,
+  # which eb_deploy also builds.
   pull_request:
     branches: [main, staging]
-
-  push:
-    branches-ignore: [main, staging]
-    paths:
-      - "lib/**"
-      - "package-lock.json"
-      - "tsconfig.base.json"
-      - "apps/web/deploy/aws_eb/**"
-      - "apps/web/public/**"
-      - "apps/web/server/**"
-      - "apps/web/src/**"
-      - "apps/web/nitro.config.ts"
-      - "apps/web/package.json"
-      - "apps/web/postcss.config.cjs"
-      - "apps/web/tsconfig.json"
-      - "apps/web/vite.config.ts"
-      - "packages/core/src/**"
-      - "packages/core/package.json"
-      - "packages/core/rollup.config.ts"
-      - "packages/core/tsconfig.json"
 
   workflow_call:
     outputs:
@@ -48,21 +32,11 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24"
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        shell: bash
-        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-      - uses: actions/cache@v4
-        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{steps.npm-cache-dir.outputs.dir}}
-          key: ${{runner.os}}-node-${{hashFiles('**/package-lock.json')}}
-          restore-keys: |
-            ${{runner.os}}-node-
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
       - name: Build server
-        run: |
-          npm i . -w packages/core -w apps/web
-          npm run -w packages/core -w apps/web build
+        run: npm run -w packages/core -w apps/web build
       - name: Run tests
         run: |
           npm run -w packages/core test

--- a/.github/workflows/eb_deploy.yaml
+++ b/.github/workflows/eb_deploy.yaml
@@ -1,8 +1,10 @@
 name: Deploy to Elastic Beanstalk
 
 on:
+  # No dev entry: there is no Elastic Beanstalk environment for dev yet, so a
+  # dev push must not trigger a deploy.
   push:
-    branches: [main, staging, dev]
+    branches: [main, staging]
     paths:
       - "lib/**"
       - "package-lock.json"

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -16,6 +16,11 @@ on:
   pull_request:
     branches: [main, staging]
 
+# Cancel a superseded run when a newer commit lands on the same PR/branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 # Least privilege: these checks only need to read the repo.
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Tidy the GitHub Actions workflows for several issues surfaced while reviewing
the CI pipeline: `eb_build_and_test` double-ran on a single change, ran on PRs
that do not touch the web app, and its setup had drifted from the other
workflows; no workflow cancelled superseded runs; and `eb_deploy` was wired to
deploy a `dev` branch that has no environment. No board item -- direct CI tidy;
the composite-action refactor and Node-version reconciliation are tracked
separately on project 10.

## Changes

- `eb_build_and_test.yaml`: drop the standalone `push` trigger. It double-fired
  with `pull_request` on any feature branch that had an open PR, and with
  `eb_deploy.yaml`'s `workflow_call` on pushes to `dev`. Now `pull_request` +
  `workflow_call` only -- matching `cli_build_and_test`.
- `eb_build_and_test.yaml`: scope the `pull_request` trigger by path (web/core
  sources plus the workflow file itself), so the web build and tests no longer
  run on CLI-only or docs-only PRs.
- `eb_build_and_test.yaml`: install with `npm ci` instead of `npm i`, and use
  `setup-node`'s `cache: "npm"` shorthand instead of the hand-rolled
  `actions/cache` step.
- `eb_deploy.yaml`: drop `dev` from the deploy `push` branches -- there is no
  Elastic Beanstalk environment for `dev` yet, so a `dev` push must not deploy.
- `cli_build_and_test.yaml`, `static_checks.yaml`: add a `cancel-in-progress`
  concurrency group so a newer commit on the same PR cancels an in-flight run.

## Background

Deployment is owned by `eb_deploy.yaml` (unchanged except for dropping `dev`)
and stays gated by its own `paths` filter, so non-web changes still never
deploy. `eb_build_and_test` only builds, tests, and packages an artifact -- it
never deploys. Its new `pull_request` `paths` filter mirrors `eb_deploy`'s list;
if it becomes a required status check, branch protection must allow a
path-skipped run (the same caveat `cli_build_and_test` documents). Concurrency
is intentionally left off `eb_build_and_test`, `eb_deploy`, and `release`: those
are deploy-coupled, and cancelling a deploy build midway is riskier than the
compute it would save.

## Out of scope / follow-on

- Extract the shared setup prologue (setup-node + cache + install + build core)
  into a composite action -- tracked on Release & Operations (project 10).
- Reconcile the Node version: CONTRIBUTING says 26, the workflows pin 24 --
  tracked separately on project 10.

## Test plan

- [x] All changed workflows parse as valid YAML.
- This PR self-validates: it touches the `cli`, `eb`, and `static_checks`
  workflow files, which sit in their own path filters (or run unfiltered), so
  all three run on this `pull_request` and exercise the new triggers, path
  scoping, `npm ci`/cache, and concurrency live.

New tests cover: n/a -- CI configuration only.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact; none affected.
- [x] `CHANGELOG.md` `[Unreleased]`: n/a -- internal CI tooling, no user-facing
  change.
- [x] Cryptographic code changed? n/a.
