### PR TITLE
Extract shared CI setup into a composite action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,29 @@
+# Shared CI setup prologue: pin Node, install from the lockfile, and build
+# @psilink/core. The four build/test workflows (static_checks, cli_build_and_test,
+# release, eb_build_and_test) each run this before their app-specific build and
+# test steps, so the Node version and install/cache strategy live in one place.
+#
+# Checkout is deliberately NOT part of this action: a local action referenced as
+# ./.github/actions/setup only exists on the runner after actions/checkout has
+# run, so each workflow keeps its own checkout step before calling this.
+#
+# Core is built here because the apps consume @psilink/core from its built dist/
+# (the same way they do locally), so typecheck/build/test in every workflow needs
+# it present first.
+name: "Setup"
+description: "Set up Node, install dependencies, and build @psilink/core"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: "24"
+        cache: "npm"
+    - name: Install dependencies
+      run: npm ci
+      shell: bash
+    - name: Build core
+      run: npm run build -w packages/core
+      shell: bash

--- a/.github/workflows/cli_build_and_test.yaml
+++ b/.github/workflows/cli_build_and_test.yaml
@@ -20,6 +20,7 @@ on:
       - "lib/**"
       - "package-lock.json"
       - "tsconfig.base.json"
+      - ".github/actions/setup/**"
       - ".github/workflows/cli_build_and_test.yaml"
 
 # Cancel a superseded run when a newer commit lands on the same PR/branch.

--- a/.github/workflows/cli_build_and_test.yaml
+++ b/.github/workflows/cli_build_and_test.yaml
@@ -37,14 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: "npm"
-      - name: Install dependencies
-        run: npm ci
-      - name: Build
-        run: npm run build -w packages/core -w apps/cli
+      # Pins Node, installs from the lockfile, and builds @psilink/core.
+      - uses: ./.github/actions/setup
+      - name: Build CLI
+        run: npm run build -w apps/cli
       - name: Unit tests (CLI)
         run: npm run test:unit -w apps/cli
       # Integration tests exercise the real ssh2 SFTPWrapper contract end to end

--- a/.github/workflows/eb_build_and_test.yaml
+++ b/.github/workflows/eb_build_and_test.yaml
@@ -48,15 +48,11 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v6
-      - name: Setup NodeJS
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: "npm"
-      - name: Install dependencies
-        run: npm ci
+      # Pins Node, installs from the lockfile, and builds @psilink/core.
+      - name: Set up and build core
+        uses: ./.github/actions/setup
       - name: Build server
-        run: npm run -w packages/core -w apps/web build
+        run: npm run -w apps/web build
       - name: Run tests
         run: |
           npm run -w packages/core test

--- a/.github/workflows/eb_build_and_test.yaml
+++ b/.github/workflows/eb_build_and_test.yaml
@@ -29,6 +29,7 @@ on:
       - "packages/core/package.json"
       - "packages/core/rollup.config.ts"
       - "packages/core/tsconfig.json"
+      - ".github/actions/setup/**"
       - ".github/workflows/eb_build_and_test.yaml"
 
   workflow_call:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,14 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: "npm"
-      - name: Install dependencies
-        run: npm ci
-      - name: Build
-        run: npm run build -w packages/core -w apps/cli
+      # Pins Node, installs from the lockfile, and builds @psilink/core.
+      - uses: ./.github/actions/setup
+      - name: Build CLI
+        run: npm run build -w apps/cli
       - name: Unit tests (core)
         run: npm test -w packages/core
       - name: Unit tests (CLI)

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -31,16 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: "npm"
-      - name: Install dependencies
-        run: npm ci
-      # Built first so the CLI and web typechecks can resolve @psilink/core's
-      # declarations from its dist (the same way the apps consume it).
-      - name: Build core
-        run: npm run build -w packages/core
+      # Pins Node, installs from the lockfile, and builds @psilink/core (built
+      # first so the CLI and web typechecks resolve its declarations from dist,
+      # the same way the apps consume it).
+      - uses: ./.github/actions/setup
       - name: Typecheck
         run: npm run typecheck
       - name: Lint


### PR DESCRIPTION
## Summary

Extract the setup prologue repeated across the four CI build/test workflows --
`actions/setup-node` (Node 24, npm cache), `npm ci`, and a build of
`@psilink/core` -- into a single composite action, so the Node version and the
install/cache strategy live in one place with one edit point. No change to what
the workflows test.

Implements Release & Operations item [198960887](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=198960887).

## Changes

- `.github/actions/setup/action.yml` (new) -- composite action: `actions/setup-node@v6`
  (Node 24, `cache: "npm"`) + `npm ci` + `npm run build -w packages/core`. The
  Node version is now pinned here and nowhere else.
- `static_checks.yaml` -- inlined prologue replaced by the composite; the
  typecheck/lint/format steps are unchanged.
- `cli_build_and_test.yaml` -- prologue replaced; the combined
  `build -w packages/core -w apps/cli` is split so the composite builds core and
  a `Build CLI` step builds `apps/cli`. Adds `.github/actions/setup/**` to the
  path filter.
- `release.yaml` -- same prologue and build split in the `test` job; the
  `publish` job is untouched.
- `eb_build_and_test.yaml` -- prologue replaced; `Build server` reduced to
  `apps/web` (core now built by the composite). Adds `.github/actions/setup/**`
  to the path filter.

## Background

Checkout stays inline in each workflow rather than moving into the action: a
local action referenced as `./.github/actions/setup` only exists on the runner
after `actions/checkout` has run, so the prologue cannot check the repo out
itself. The two path-scoped workflows gain `.github/actions/setup/**` so a PR
that changes only the composite still re-runs them; `static_checks` has no path
filter and `release` triggers on tags, so both already cover the composite.

The refactor dedupes the workflow definitions only, not the build execution:
core is still built per job rather than shared across runners via artifacts, and
the workflows stay separate (distinct triggers, path scopes, and a web-only
deploy). Both are deliberate non-goals carried over from the task.

## Out of scope / follow-on

- Node version value (24 vs 26): pinned to 24 here to match current CI. The
  decision and the `engines.node` source-of-truth are owned by
  [198492208](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=198492208);
  this PR only centralizes where the version is pinned, giving that item one
  place to change.
- Two pre-existing shellcheck nits (`actionlint` SC2086 at
  `eb_build_and_test.yaml:80`, SC2140 in `eb_deploy_reusable_action.yaml`) are
  outside this branch's diff and harmless in practice; left for a separate tidy.

## Test plan

Workflow-definition-only change (no TypeScript or runtime code), so the
unit/integration suites do not exercise it -- the real validation is the four
workflows running on this PR. Local evidence:

- [x] `npm run typecheck && npm run lint` clean
- [x] `npm run build -w packages/core` succeeds
- [x] `prettier --list-different` clean on all changed and new YAML
- [x] All five YAML files parse; the composite resolves to `using: composite`
      with steps setup-node / `npm ci` / build core
- [x] `actionlint` reports no issues on changed lines and resolves the
      `./.github/actions/setup` references
- [x] CI: `static_checks`, `cli_build_and_test`, `eb_build_and_test`, and
      `release` each run to completion with the same gates (this PR's checks)

Unit and integration suites (`npm test -w packages/core`, `test:unit`,
`test:integration`) are n/a -- no source or test code changed.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact; none affected (CI tooling only)
- [x] `CHANGELOG.md` `[Unreleased]` -- n/a; internal CI tooling, no product or operator behavior change
- Cryptographic code changed? n/a -- no cryptographic surface
