### PR TITLE
Fix shellcheck quoting in EB CI workflows

### DIFF
--- a/.github/workflows/eb_build_and_test.yaml
+++ b/.github/workflows/eb_build_and_test.yaml
@@ -77,4 +77,4 @@ jobs:
           compression-level: 0
       - name: Output artifact name
         id: artifact-name
-        run: echo "artifactName=${{env.ARTIFACT_NAME}}" >> $GITHUB_OUTPUT
+        run: echo "artifactName=${{env.ARTIFACT_NAME}}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/eb_deploy_reusable_action.yaml
+++ b/.github/workflows/eb_deploy_reusable_action.yaml
@@ -51,7 +51,7 @@ jobs:
                 --application-name ${{vars.EB_APPLICATION_NAME}} \
                 --version-label ${{github.sha}} \
                 --description "${{env.ENVIRONMENT_NAME}}-${{github.sha}}" \
-                --source-bundle S3Bucket="elasticbeanstalk-${{vars.AWS_REGION_NAME}}-${{secrets.AWS_ACCOUNT_ID}}",S3Key="${{github.sha}}.zip"
+                --source-bundle "S3Bucket=elasticbeanstalk-${{vars.AWS_REGION_NAME}}-${{secrets.AWS_ACCOUNT_ID}},S3Key=${{github.sha}}.zip"
           fi
           aws elasticbeanstalk update-environment \
               --application-name ${{vars.EB_APPLICATION_NAME}} \


### PR DESCRIPTION
## Summary

Quote two shell expansions that `actionlint` (via shellcheck) flagged in the
Elastic Beanstalk workflows. Both fixes are behavior-preserving CI hygiene --
no board item, surfaced while reviewing the CI composite action work in #94.

Follow-on from [#94](https://github.com/georgetown-mdi/jspsi/pull/94).

## Changes

- `eb_build_and_test.yaml` -- quote `$GITHUB_OUTPUT` in the artifact-name output
  step (SC2086). It is a runner-set path with no spaces, so this is hygiene, not
  a live bug.
- `eb_deploy_reusable_action.yaml` -- the `aws create-application-version`
  `--source-bundle` argument was written `S3Bucket="...",S3Key="..."`, which
  shellcheck reads as adjacent quoted strings (SC2140). Wrap the whole value in a
  single pair of quotes instead.

## Background

The `--source-bundle` change is behavior-preserving: the bucket name, region,
account id, and object key contain no spaces or shell-special characters, so the
shell builds the identical single argument either way -- only the quote
boundaries move. Confirmed with `actionlint`, which now reports no issues on
either file (both SC2086 and SC2140 cleared, nothing new).

## Test plan

- [x] `actionlint` clean on the whole `.github/` tree (both findings gone, no new)
- [x] `prettier --list-different` clean on the changed YAML
- [x] Both files re-parse as valid YAML

No source or runtime code changed, so the unit/integration suites are n/a.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact; none affected (CI tooling only)
- [x] `CHANGELOG.md` `[Unreleased]` -- n/a; CI hygiene, no product or operator behavior change
- [x] Cryptographic code changed? n/a -- no cryptographic surface
