### PR TITLE
Add field-rich board listing and run board scripts in-sandbox

### DIFF
--- a/.claude/agents/project-manager.md
+++ b/.claude/agents/project-manager.md
@@ -31,7 +31,7 @@ spawned you owns the loop and will re-spawn you with the answers folded in.
    or `apps/web/src/` only when the task's affected areas genuinely require it.
    Keep reads targeted -- you are a consult, not an explorer.
 3. **Classify and check for duplicates** per the ruleset (board 9 vs 10; the
-   `--jq`-projected `item-list` skim).
+   `list-issues.mjs` whole-board skim).
 4. **Decide your terminal result** -- one of the three below -- and return it.
 
 ## Output contract: return exactly one of these

--- a/.claude/pm/ruleset.md
+++ b/.claude/pm/ruleset.md
@@ -130,16 +130,20 @@ Two GitHub Projects under the `georgetown-mdi` org; pick one per task:
 
 ## Checking for duplicates
 
-Before filing, list titles on the chosen project and skim for an existing task
-that already covers the work:
+Before filing, list every item on the chosen project and skim for an existing
+task that already covers the work:
 
 ```sh
-gh project item-list <PROJECT_NUMBER> --owner georgetown-mdi --format json --limit 100 \
-  --jq '[.items[] | {id, title, status}]'
+node .claude/scripts/list-issues.mjs <PROJECT_NUMBER>
 ```
 
-Always project the fields with `--jq`. If the request straddles both boards,
-check both.
+This pages through the whole board with no silent truncation -- one line per
+item with its numeric id, node id, status, Implementation Order, Epic, and
+title. A raw `gh project item-list --limit N` would instead cap at N and drop
+the rest without warning (board 9 already exceeds one 100-item page), and its
+JSON omits the numeric id and the custom fields. Add `--json` for a
+machine-readable array, or `--status Todo --status "In Progress"` to skip Done
+items. If the request straddles both boards, check both.
 When a specific item is referenced by its numeric ID (the `?itemId=N` value from
 the URL), fetch just that item with `node .claude/scripts/fetch-issues.mjs
 <PROJECT_NUMBER> <itemId>` instead of pulling the whole list.
@@ -189,13 +193,12 @@ Board 9 carries two custom fields board 10 does not: `Epic` (free text) and
 into an existing epic if one clearly fits. Do not invent a new epic, and do not
 do any of this on board 10.
 
-Discover the candidate epics from the same `item-list` call you already run for
-the duplicate check -- just project `epic` and take the distinct non-null
-values, no extra round-trip:
+Discover the candidate epics from the same `list-issues.mjs` call you already run
+for the duplicate check -- its Epic column already carries them, so take the
+distinct non-empty values, no extra round-trip:
 
 ```sh
-gh project item-list 9 --owner georgetown-mdi --format json --limit 100 \
-  --jq '[.items[] | {id, title, status, epic}]'
+node .claude/scripts/list-issues.mjs --json 9   # the `epic` field on each item
 ```
 
 If one fits, create the draft with `--format json` to capture the new item's id

--- a/.claude/scripts/edit-issue.mjs
+++ b/.claude/scripts/edit-issue.mjs
@@ -11,9 +11,10 @@
 // node IDs or look up option IDs by hand.
 //
 // The <itemId> may be EITHER a numeric ID (the `?itemId=N` value) OR a
-// `PVTI_...` global node ID as printed by `gh project item-list`; the node ID is
+// `PVTI_...` global node ID as printed by `list-issues.mjs`; the node ID is
 // decoded back to its numeric ID, so a listed item can be edited without
-// hand-decoding it.
+// hand-decoding it. A node ID from a different board than <project-number> is
+// rejected rather than silently remapped.
 //
 // Usage:
 //   node edit-issue.mjs <project-number> <itemId|PVTI_...> [edits...]
@@ -42,21 +43,21 @@
 import { readFileSync } from "node:fs";
 import {
   fetchItems,
+  fieldValueInput,
   graphql,
-  numericIdFromNodeId,
   OWNER,
   pvtiNodeId,
+  toNumericId,
 } from "./lib/projectItems.mjs";
 
 /** Parse argv into { projectNumber, numericId, title?, body?, fields: [{name, value}] }. */
 function parseArgs(argv) {
   const projectNumber = Number(argv[0]);
   // The item argument is a numeric ID or a PVTI_ node ID; resolve both to
-  // numeric. A malformed PVTI_ id throws (a clearer signal than the NaN below).
+  // numeric, passing the project so a node ID from another board is rejected.
+  // A malformed/mismatched PVTI_ id throws (a clearer signal than the NaN below).
   const itemArg = argv[1] ?? "";
-  const numericId = itemArg.startsWith("PVTI_")
-    ? numericIdFromNodeId(itemArg)
-    : Number(itemArg);
+  const numericId = toNumericId(itemArg, projectNumber);
   if (!Number.isInteger(projectNumber) || !Number.isInteger(numericId)) {
     usage();
   }
@@ -230,47 +231,6 @@ function findField(fields, name) {
     throw new Error(`field "${name}" not found; available: ${names}`);
   }
   return field;
-}
-
-/**
- * Build the `ProjectV2FieldValue` input for updateProjectV2ItemFieldValue,
- * picking the typed key from the field's dataType: a single-select resolves the
- * option ID by name; text/number/date map straight through (number as a JS
- * number, since the GraphQL field is a Float). Knowing dataType up front removes
- * the old value-shape inference and its misrouting caveat.
- */
-function fieldValueInput(field, value) {
-  switch (field.dataType) {
-    case "SINGLE_SELECT": {
-      const option = (field.options ?? []).find(
-        (o) => o.name.toLowerCase() === value.toLowerCase(),
-      );
-      if (!option) {
-        const names = (field.options ?? []).map((o) => o.name).join(", ");
-        throw new Error(
-          `option "${value}" not valid for "${field.name}"; choices: ${names}`,
-        );
-      }
-      return { singleSelectOptionId: option.id };
-    }
-    case "TEXT":
-      return { text: value };
-    case "NUMBER": {
-      const number = Number(value);
-      if (!Number.isFinite(number)) {
-        throw new Error(
-          `field "${field.name}" is a number field but value "${value}" is not numeric`,
-        );
-      }
-      return { number };
-    }
-    case "DATE":
-      return { date: value };
-    default:
-      throw new Error(
-        `field "${field.name}" has unsupported type ${field.dataType}; extend edit-issue.mjs to handle it`,
-      );
-  }
 }
 
 /** Set one project-item field value via a GraphQL mutation. */

--- a/.claude/scripts/edit-issue.mjs
+++ b/.claude/scripts/edit-issue.mjs
@@ -42,7 +42,7 @@
 import { readFileSync } from "node:fs";
 import {
   fetchItems,
-  gh,
+  graphql,
   numericIdFromNodeId,
   OWNER,
   pvtiNodeId,
@@ -128,10 +128,9 @@ function usage(msg) {
  * Resolve a draft item's DI_ content node ID from its PVTI_ item ID. Title/body
  * edits target the DraftIssue content object, not the project item.
  */
-function draftContentId(pvti) {
+async function draftContentId(pvti) {
   const query = `{ node(id: "${pvti}") { ... on ProjectV2Item { content { __typename ... on DraftIssue { id } } } } }`;
-  const content = JSON.parse(gh(["api", "graphql", "-f", `query=${query}`]))
-    .data.node?.content;
+  const content = (await graphql(query)).data.node?.content;
   if (!content || content.__typename !== "DraftIssue") {
     throw new Error(
       `item is not a draft issue (content type ${content?.__typename ?? "unknown"}); title/body editing is only supported for drafts`,
@@ -206,69 +205,110 @@ function printBodyDiff(label, oldText, newText) {
     process.stdout.write(`  ${oldLines[i]}\n`);
 }
 
-/** Find a field (case-insensitive) in the project's field list. */
-function findField(projectNumber, name) {
-  const fields = JSON.parse(
-    gh([
-      "project",
-      "field-list",
-      String(projectNumber),
-      "--owner",
-      OWNER,
-      "--format",
-      "json",
-    ]),
-  ).fields;
+/**
+ * Fetch a project's node ID and its field list in one GraphQL call, returning
+ * { projectId, fields } where each field carries { id, name, dataType,
+ * options? }. `dataType` (TEXT / NUMBER / DATE / SINGLE_SELECT / ...) is the
+ * precise field kind; the old `gh project field-list` porcelain collapsed text,
+ * number, and date all to one type, forcing a value-shape guess at write time.
+ * Replaces both `gh project view` (project id) and `gh project field-list`.
+ */
+async function projectMeta(projectNumber) {
+  const query = `{ organization(login: "${OWNER}") { projectV2(number: ${projectNumber}) { id fields(first: 50) { nodes { __typename ... on ProjectV2FieldCommon { id name dataType } ... on ProjectV2SingleSelectField { options { id name } } } } } } }`;
+  const project = (await graphql(query)).data?.organization?.projectV2;
+  if (!project) {
+    throw new Error(`project ${projectNumber} not found under owner ${OWNER}`);
+  }
+  return { projectId: project.id, fields: project.fields.nodes };
+}
+
+/** Find a field (case-insensitive) in a fetched field list. */
+function findField(fields, name) {
   const field = fields.find((f) => f.name.toLowerCase() === name.toLowerCase());
   if (!field) {
     const names = fields.map((f) => f.name).join(", ");
-    throw new Error(
-      `field "${name}" not found on project ${projectNumber}; available: ${names}`,
-    );
+    throw new Error(`field "${name}" not found; available: ${names}`);
   }
   return field;
 }
 
-/** Build the gh item-edit args that set one field value, resolving option IDs as needed. */
-function fieldEditArgs(field, value, itemId, projectId) {
-  const base = [
-    "--id",
-    itemId,
-    "--project-id",
-    projectId,
-    "--field-id",
-    field.id,
-  ];
-  switch (field.type) {
-    case "ProjectV2SingleSelectField": {
-      const option = field.options.find(
+/**
+ * Build the `ProjectV2FieldValue` input for updateProjectV2ItemFieldValue,
+ * picking the typed key from the field's dataType: a single-select resolves the
+ * option ID by name; text/number/date map straight through (number as a JS
+ * number, since the GraphQL field is a Float). Knowing dataType up front removes
+ * the old value-shape inference and its misrouting caveat.
+ */
+function fieldValueInput(field, value) {
+  switch (field.dataType) {
+    case "SINGLE_SELECT": {
+      const option = (field.options ?? []).find(
         (o) => o.name.toLowerCase() === value.toLowerCase(),
       );
       if (!option) {
-        const names = field.options.map((o) => o.name).join(", ");
+        const names = (field.options ?? []).map((o) => o.name).join(", ");
         throw new Error(
           `option "${value}" not valid for "${field.name}"; choices: ${names}`,
         );
       }
-      return [...base, "--single-select-option-id", option.id];
+      return { singleSelectOptionId: option.id };
     }
-    case "ProjectV2Field":
-      // Plain field: text, number, or date. gh picks the column by which flag
-      // is set, but the API does not tell us which of the three this field is,
-      // so we infer from the value's shape. Caveat: an all-digit or YYYY-MM-DD
-      // value bound for a *text* field is misrouted to --number / --date. No
-      // board field in use hits this; revisit if a text field needs such a value.
-      if (/^\d+$/.test(value)) return [...base, "--number", value];
-      if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return [...base, "--date", value];
-      return [...base, "--text", value];
+    case "TEXT":
+      return { text: value };
+    case "NUMBER": {
+      const number = Number(value);
+      if (!Number.isFinite(number)) {
+        throw new Error(
+          `field "${field.name}" is a number field but value "${value}" is not numeric`,
+        );
+      }
+      return { number };
+    }
+    case "DATE":
+      return { date: value };
     default:
       throw new Error(
-        `field "${field.name}" has unsupported type ${field.type}; extend edit-issue.mjs to handle it`,
+        `field "${field.name}" has unsupported type ${field.dataType}; extend edit-issue.mjs to handle it`,
       );
   }
 }
 
-function main() {
+/** Set one project-item field value via a GraphQL mutation. */
+async function setItemFieldValue(projectId, itemId, fieldId, value) {
+  const mutation = `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: ProjectV2FieldValue!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: $value }) { projectV2Item { id } } }`;
+  const res = await graphql(mutation, { projectId, itemId, fieldId, value });
+  if (res.errors) {
+    throw new Error(`failed to set field: ${JSON.stringify(res.errors)}`);
+  }
+}
+
+/**
+ * Set a draft issue's title and/or body via a GraphQL mutation. Only the keys
+ * present in `edits` are sent: an omitted field is left untouched, whereas an
+ * explicit null would clear it.
+ */
+async function setDraftFields(draftId, edits) {
+  const varDecls = ["$draftId: ID!"];
+  const inputParts = ["draftIssueId: $draftId"];
+  const variables = { draftId };
+  if (edits.title !== undefined) {
+    varDecls.push("$title: String!");
+    inputParts.push("title: $title");
+    variables.title = edits.title;
+  }
+  if (edits.body !== undefined) {
+    varDecls.push("$body: String!");
+    inputParts.push("body: $body");
+    variables.body = edits.body;
+  }
+  const mutation = `mutation(${varDecls.join(", ")}) { updateProjectV2DraftIssue(input: { ${inputParts.join(", ")} }) { draftIssue { id } } }`;
+  const res = await graphql(mutation, variables);
+  if (res.errors) {
+    throw new Error(`failed to update draft: ${JSON.stringify(res.errors)}`);
+  }
+}
+
+async function main() {
   // A long diff is often piped to head/less; exit quietly when the reader closes
   // the pipe rather than crashing with an EPIPE stack trace.
   process.stdout.on("error", (err) => {
@@ -292,7 +332,7 @@ function main() {
   if (args.title !== undefined || args.body !== undefined) {
     // Fetch current values once: needed for no-op detection, --diff, and the
     // post-push verification re-fetch below.
-    const before = fetchItems(args.projectNumber, [args.numericId])[0];
+    const before = (await fetchItems(args.projectNumber, [args.numericId]))[0];
     if (before.type === "missing") {
       throw new Error(
         `item ${args.numericId} not found on project ${args.projectNumber}`,
@@ -325,16 +365,18 @@ function main() {
       if (args.dryRun) {
         process.stdout.write(`dry-run: would set ${changed.join(", ")}\n`);
       } else {
-        const edit = ["project", "item-edit", "--id", draftContentId(itemId)];
-        if (wantTitle) edit.push("--title", args.title);
-        if (wantBody) edit.push("--body", args.body);
-        gh(edit);
+        await setDraftFields(await draftContentId(itemId), {
+          ...(wantTitle ? { title: args.title } : {}),
+          ...(wantBody ? { body: args.body } : {}),
+        });
         process.stdout.write(`set ${changed.join(", ")}\n`);
 
         // Verify: re-fetch and assert the store matches what we sent. Tolerates
         // trailing-newline-only differences GitHub may introduce (see
         // equalsStored); anything else is a real failure.
-        const after = fetchItems(args.projectNumber, [args.numericId])[0];
+        const after = (
+          await fetchItems(args.projectNumber, [args.numericId])
+        )[0];
         if (wantTitle && !equalsStored(args.title, after.title ?? "")) {
           throw new Error(
             "post-push verify failed: stored title differs from sent title",
@@ -350,32 +392,26 @@ function main() {
     }
   }
 
-  // Field edits each need the project node ID; resolve it once if any are requested.
+  // Field edits each need the project node ID and the field list; fetch both
+  // once if any are requested.
   if (args.fields.length > 0) {
-    const projectId = JSON.parse(
-      gh([
-        "project",
-        "view",
-        String(args.projectNumber),
-        "--owner",
-        OWNER,
-        "--format",
-        "json",
-      ]),
-    ).id;
+    const { projectId, fields } = await projectMeta(args.projectNumber);
     for (const { name, value } of args.fields) {
-      const field = findField(args.projectNumber, name);
-      // Resolve (and validate) the field/option names even in a dry run, so a
+      const field = findField(fields, name);
+      // Resolve (and validate) the field/option name even in a dry run, so a
       // bad field or option name is reported without making any edit.
-      const editArgs = fieldEditArgs(field, value, itemId, projectId);
+      const valueInput = fieldValueInput(field, value);
       if (args.dryRun) {
         process.stdout.write(`dry-run: would set ${field.name} = ${value}\n`);
       } else {
-        gh(["project", "item-edit", ...editArgs]);
+        await setItemFieldValue(projectId, itemId, field.id, valueInput);
         process.stdout.write(`set ${field.name} = ${value}\n`);
       }
     }
   }
 }
 
-main();
+main().catch((err) => {
+  process.stderr.write(`${err.message ?? err}\n`);
+  process.exit(1);
+});

--- a/.claude/scripts/fetch-issues.mjs
+++ b/.claude/scripts/fetch-issues.mjs
@@ -43,7 +43,7 @@ import { fetchItems, toNumericId } from "./lib/projectItems.mjs";
 // board's primary triage axes, so they lead.
 const LEAD_FIELDS = ["Status", "Epic", "Implementation Order"];
 
-function main() {
+async function main() {
   const argv = process.argv.slice(2);
   // Leading option flags, in any order: --json, --out-dir DIR.
   let asJson = false;
@@ -80,7 +80,7 @@ function main() {
     process.exit(2);
   }
 
-  const items = fetchItems(projectNumber, numericIds);
+  const items = await fetchItems(projectNumber, numericIds);
 
   if (asJson) {
     // Compact, not pretty-printed: --json feeds programmatic/agent consumers,
@@ -132,4 +132,7 @@ function main() {
   }
 }
 
-main();
+main().catch((err) => {
+  process.stderr.write(`${err.message ?? err}\n`);
+  process.exit(1);
+});

--- a/.claude/scripts/fetch-issues.mjs
+++ b/.claude/scripts/fetch-issues.mjs
@@ -33,24 +33,15 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 // fetchItems lives in lib/projectItems.mjs so lint-issues.mjs can reuse the same
-// aliased multi-fetch for resolving cross-references. numericIdFromNodeId lets a
-// PVTI_ node ID argument be accepted alongside the numeric form.
-import { fetchItems, numericIdFromNodeId } from "./lib/projectItems.mjs";
+// aliased multi-fetch for resolving cross-references. toNumericId (which decodes
+// a PVTI_ node ID via numericIdFromNodeId) lets a PVTI_ argument be accepted
+// alongside the numeric form, and is shared so the sibling scripts agree on it.
+import { fetchItems, toNumericId } from "./lib/projectItems.mjs";
 
 // Fields surfaced first, in this order, in human-readable output; any other
 // populated field is printed afterward in encounter order. These three are the
 // board's primary triage axes, so they lead.
 const LEAD_FIELDS = ["Status", "Epic", "Implementation Order"];
-
-/**
- * Resolve one item argument to its numeric ID. A `PVTI_...` value is decoded via
- * numericIdFromNodeId; anything else is parsed as a base-10 integer. Returns NaN
- * for an unparseable numeric argument so the caller's Number.isInteger check
- * still rejects it. A malformed PVTI_ id throws (a clearer signal than NaN).
- */
-function toNumericId(arg) {
-  return arg.startsWith("PVTI_") ? numericIdFromNodeId(arg) : Number(arg);
-}
 
 function main() {
   const argv = process.argv.slice(2);

--- a/.claude/scripts/fetch-issues.mjs
+++ b/.claude/scripts/fetch-issues.mjs
@@ -15,8 +15,8 @@
 // number of IDs, returning only those items, with no scan-and-filter.
 //
 // Each item argument may be EITHER a numeric ID (the `?itemId=N` value) OR a
-// `PVTI_...` global node ID as printed by `gh project item-list` -- the latter
-// is decoded back to its numeric ID, so a listed item can be looked up without
+// `PVTI_...` global node ID as printed by `list-issues.mjs` -- the latter is
+// decoded back to its numeric ID, so a listed item can be looked up without
 // hand-decoding the node ID. The two forms mix freely in one invocation.
 //
 // Usage:
@@ -67,8 +67,11 @@ async function main() {
   const rest = argv.slice(i);
 
   const projectNumber = Number(rest[0]);
-  // Each argument is a numeric ID or a PVTI_ node ID; resolve both to numeric.
-  const numericIds = rest.slice(1).map(toNumericId);
+  // Each argument is a numeric ID or a PVTI_ node ID; resolve both to numeric,
+  // rejecting a node ID that belongs to a different project than requested.
+  const numericIds = rest
+    .slice(1)
+    .map((arg) => toNumericId(arg, projectNumber));
   if (
     !Number.isInteger(projectNumber) ||
     numericIds.length === 0 ||

--- a/.claude/scripts/lib/projectItems.mjs
+++ b/.claude/scripts/lib/projectItems.mjs
@@ -53,8 +53,10 @@ export function githubToken({
   env = process.env,
   readStoredToken = () => gh(["auth", "token"]),
 } = {}) {
-  const fromEnv = env.GH_TOKEN || env.GITHUB_TOKEN;
-  if (fromEnv) return fromEnv.trim();
+  // Trim before the truthiness test so a whitespace-only env var falls through
+  // to the stored credential instead of yielding an empty bearer token.
+  const fromEnv = (env.GH_TOKEN || env.GITHUB_TOKEN || "").trim();
+  if (fromEnv) return fromEnv;
   let stored;
   try {
     stored = readStoredToken().trim();
@@ -136,8 +138,13 @@ export function pvtiNodeId(projectNumber, numericId) {
  * bytes) must match a known PROJECT_PREFIXES entry, which both validates the ID
  * shape and guards against a node ID from some other project sneaking through.
  * numericIdFromNodeId(pvtiNodeId(p, n)) === n holds for every known p.
+ *
+ * A node ID encodes its own project. When `expectedProject` is given (and is a
+ * known project), the decoded project must equal it -- otherwise the numeric ID
+ * would be re-encoded under a different project's prefix and silently address
+ * the wrong item; reject the mismatch instead.
  */
-export function numericIdFromNodeId(nodeId) {
+export function numericIdFromNodeId(nodeId, expectedProject) {
   if (typeof nodeId !== "string" || !nodeId.startsWith("PVTI_")) {
     throw new Error(`not a PVTI_ node id: ${nodeId}`);
   }
@@ -146,10 +153,21 @@ export function numericIdFromNodeId(nodeId) {
     throw new Error(`PVTI_ node id too short to decode: ${nodeId}`);
   }
   const prefixHex = buf.subarray(0, -4).toString("hex");
-  const known = Object.values(PROJECT_PREFIXES).includes(prefixHex);
-  if (!known) {
+  const ownerProject = Object.keys(PROJECT_PREFIXES).find(
+    (p) => PROJECT_PREFIXES[p] === prefixHex,
+  );
+  if (ownerProject === undefined) {
     throw new Error(
       `PVTI_ node id "${nodeId}" has prefix ${prefixHex}, not a known project; known: ${Object.values(PROJECT_PREFIXES).join(", ")}`,
+    );
+  }
+  if (
+    expectedProject !== undefined &&
+    PROJECT_PREFIXES[expectedProject] !== undefined &&
+    Number(ownerProject) !== Number(expectedProject)
+  ) {
+    throw new Error(
+      `node id ${nodeId} is on project ${ownerProject}, not the requested project ${expectedProject}`,
     );
   }
   return buf.readUInt32BE(buf.length - 4);
@@ -160,10 +178,14 @@ export function numericIdFromNodeId(nodeId) {
  * numericIdFromNodeId; anything else is parsed as a base-10 integer. Returns NaN
  * for an unparseable numeric argument so a caller's Number.isInteger check still
  * rejects it. A malformed PVTI_ id throws (a clearer signal than NaN). Shared so
- * fetch-issues.mjs and lint-issues.mjs accept the two id forms identically.
+ * fetch-issues.mjs, lint-issues.mjs, and edit-issue.mjs accept the two id forms
+ * identically. Pass `expectedProject` (the project number the caller was given)
+ * so a node ID from a different board is rejected rather than silently remapped.
  */
-export function toNumericId(arg) {
-  return arg.startsWith("PVTI_") ? numericIdFromNodeId(arg) : Number(arg);
+export function toNumericId(arg, expectedProject) {
+  return arg.startsWith("PVTI_")
+    ? numericIdFromNodeId(arg, expectedProject)
+    : Number(arg);
 }
 
 /**
@@ -197,6 +219,49 @@ export function extractFields(fieldValues) {
     else if (typeof node.name === "string") out[name] = node.name;
   }
   return out;
+}
+
+/**
+ * Build the `ProjectV2FieldValue` input for updateProjectV2ItemFieldValue (the
+ * write-side counterpart to extractFields), picking the typed key from the
+ * field's `dataType`: a single-select resolves the option ID by name;
+ * text/number/date map straight through (number as a JS number, since the
+ * GraphQL field is a Float). `field` is { name, dataType, options? } as returned
+ * by the project field introspection in edit-issue.mjs. Throws on an unknown
+ * option, a non-numeric value for a NUMBER field, or an unsupported dataType.
+ */
+export function fieldValueInput(field, value) {
+  switch (field.dataType) {
+    case "SINGLE_SELECT": {
+      const option = (field.options ?? []).find(
+        (o) => o.name.toLowerCase() === value.toLowerCase(),
+      );
+      if (!option) {
+        const names = (field.options ?? []).map((o) => o.name).join(", ");
+        throw new Error(
+          `option "${value}" not valid for "${field.name}"; choices: ${names}`,
+        );
+      }
+      return { singleSelectOptionId: option.id };
+    }
+    case "TEXT":
+      return { text: value };
+    case "NUMBER": {
+      const number = Number(value);
+      if (!Number.isFinite(number)) {
+        throw new Error(
+          `field "${field.name}" is a number field but value "${value}" is not numeric`,
+        );
+      }
+      return { number };
+    }
+    case "DATE":
+      return { date: value };
+    default:
+      throw new Error(
+        `field "${field.name}" has unsupported type ${field.dataType}; extend the field-value handling to support it`,
+      );
+  }
 }
 
 /**

--- a/.claude/scripts/lib/projectItems.mjs
+++ b/.claude/scripts/lib/projectItems.mjs
@@ -73,6 +73,17 @@ export function numericIdFromNodeId(nodeId) {
 }
 
 /**
+ * Resolve one item argument to its numeric ID. A `PVTI_...` value is decoded via
+ * numericIdFromNodeId; anything else is parsed as a base-10 integer. Returns NaN
+ * for an unparseable numeric argument so a caller's Number.isInteger check still
+ * rejects it. A malformed PVTI_ id throws (a clearer signal than NaN). Shared so
+ * fetch-issues.mjs and lint-issues.mjs accept the two id forms identically.
+ */
+export function toNumericId(arg) {
+  return arg.startsWith("PVTI_") ? numericIdFromNodeId(arg) : Number(arg);
+}
+
+/**
  * GraphQL selection for an item's project-field values. Covers the value types
  * the boards use -- text, number, and single-select -- each carrying its field
  * name via the ProjectV2FieldCommon interface. Shared so fetchItems (read by
@@ -164,4 +175,60 @@ export function fetchItems(projectNumber, numericIds) {
       fields: extractFields(node.fieldValues),
     };
   });
+}
+
+// GitHub's projectV2 items connection caps `first` at 100, so this is also the
+// per-page size: fetchAllItems pages through the connection 100 at a time rather
+// than relying on a single page covering the whole board.
+export const PAGE_SIZE = 100;
+
+/**
+ * Default GraphQL runner for fetchAllItems: run the query through gh and return
+ * its `data`. Split out as the injection point so tests can drive fetchAllItems
+ * with synthetic pages instead of a live board.
+ */
+function runQueryViaGh(query) {
+  return JSON.parse(gh(["api", "graphql", "-f", `query=${query}`])).data;
+}
+
+/**
+ * Fetch every item of a project with its field values and node IDs, returning
+ * [{ id, nodeId, title, fields }] where id is the numeric item ID, nodeId is the
+ * `PVTI_` global node ID, and fields is the { name -> value } map (see
+ * extractFields, which surfaces Status / Epic / Implementation Order among
+ * others). Pages through the items connection with a cursor until hasNextPage is
+ * false, so no item is dropped however large the board grows -- the silent
+ * truncation a single `gh project item-list --limit N` would cause is impossible
+ * here. Shared by list-epic.mjs (filter to one Epic) and list-issues.mjs (whole
+ * board). `runQuery(query) -> data` is injectable for tests; it defaults to gh.
+ */
+export function fetchAllItems(
+  projectNumber,
+  { runQuery = runQueryViaGh } = {},
+) {
+  const nodes = [];
+  let cursor = null;
+  do {
+    // Inline the cursor into the query the same way the other args are inlined;
+    // GitHub's endCursor is an opaque base64 token with no quote/backslash chars
+    // to escape. Omit `after` entirely on the first page.
+    const after = cursor === null ? "" : `, after: "${cursor}"`;
+    const query = `{ organization(login: "${OWNER}") { projectV2(number: ${projectNumber}) { items(first: ${PAGE_SIZE}${after}) { pageInfo { hasNextPage endCursor } nodes { id ${FIELD_VALUES_FRAGMENT} content { __typename ... on DraftIssue { title } ... on Issue { title } } } } } } }`;
+    const data = runQuery(query);
+    const project = data?.organization?.projectV2;
+    if (!project) {
+      throw new Error(
+        `project ${projectNumber} not found under owner ${OWNER}`,
+      );
+    }
+    const conn = project.items;
+    nodes.push(...conn.nodes);
+    cursor = conn.pageInfo.hasNextPage ? conn.pageInfo.endCursor : null;
+  } while (cursor !== null);
+  return nodes.map((node) => ({
+    id: numericIdFromNodeId(node.id),
+    nodeId: node.id,
+    title: node.content?.title ?? null,
+    fields: extractFields(node.fieldValues),
+  }));
 }

--- a/.claude/scripts/lib/projectItems.mjs
+++ b/.claude/scripts/lib/projectItems.mjs
@@ -22,12 +22,95 @@ export const PROJECT_PREFIXES = {
 /** Owner login for both psilink project boards. */
 export const OWNER = "georgetown-mdi";
 
-/** Run gh with the given argv and return stdout as a string. */
+const GRAPHQL_ENDPOINT = "https://api.github.com/graphql";
+// GitHub rejects API requests without a User-Agent; identify these scripts.
+const USER_AGENT = "psilink-board-scripts";
+
+/**
+ * Run gh with the given argv and return stdout as a string. Network calls go
+ * through `graphql` (Node fetch) now, not gh -- gh (a Go binary) verifies TLS
+ * via the macOS `trustd` Mach service, which the command sandbox blocks, so its
+ * network subcommands fail in-sandbox. gh is kept only for `gh auth token`,
+ * which is network-free (it just reads stored credentials) and so works in-sandbox.
+ */
 export function gh(args) {
   return execFileSync("gh", args, {
     encoding: "utf8",
     maxBuffer: 16 * 1024 * 1024,
   });
+}
+
+/**
+ * Resolve a GitHub token without a network round-trip, in precedence order:
+ * `GH_TOKEN`, then `GITHUB_TOKEN`, then `gh auth token` (which reads the stored
+ * credential). Env-first matches gh's own precedence and is friendlier to CI /
+ * headless. The token is returned for use only as a bearer header -- never log
+ * it. Exported with injectable `env` / `readStoredToken` for tests; production
+ * callers pass no argument.
+ * @internal
+ */
+export function githubToken({
+  env = process.env,
+  readStoredToken = () => gh(["auth", "token"]),
+} = {}) {
+  const fromEnv = env.GH_TOKEN || env.GITHUB_TOKEN;
+  if (fromEnv) return fromEnv.trim();
+  let stored;
+  try {
+    stored = readStoredToken().trim();
+  } catch {
+    stored = "";
+  }
+  if (!stored) {
+    throw new Error(
+      "no GitHub token: set GH_TOKEN or GITHUB_TOKEN, or run `gh auth login`",
+    );
+  }
+  return stored;
+}
+
+/**
+ * POST a GraphQL query or mutation to the GitHub API over Node `fetch`, returning
+ * the parsed `{ data, errors }` body. Using Node rather than `gh api graphql`
+ * lets these scripts run inside the command sandbox: Node verifies TLS against
+ * its own bundled CA store instead of the sandbox-blocked `trustd`. (The sandbox
+ * also forces egress through an injected HTTPS proxy that Node's fetch ignores by
+ * default; running with NODE_USE_ENV_PROXY=1 in the environment -- e.g. via
+ * Claude Code's local settings -- makes fetch honor it.)
+ *
+ * A response is returned whenever it carries `data` -- even an HTTP 200 that also
+ * has `errors`, which is how GraphQL reports a partial result (e.g. one NOT_FOUND
+ * node in a batch). This preserves the "one bad ID does not sink the whole fetch"
+ * behavior that `fetchItems` relies on. A response with no usable `data` (auth
+ * failure, rate limit, malformed body) throws. `variables` is omitted from the
+ * request body when not given.
+ */
+export async function graphql(query, variables) {
+  const res = await fetch(GRAPHQL_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${githubToken()}`,
+      "Content-Type": "application/json",
+      "User-Agent": USER_AGENT,
+    },
+    body: JSON.stringify(variables ? { query, variables } : { query }),
+  });
+  const text = await res.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw new Error(
+      `GitHub GraphQL returned non-JSON (HTTP ${res.status}): ${text.slice(0, 300)}`,
+    );
+  }
+  if (body.data == null) {
+    const detail = body.errors
+      ? JSON.stringify(body.errors)
+      : text.slice(0, 300);
+    throw new Error(`GitHub GraphQL error (HTTP ${res.status}): ${detail}`);
+  }
+  return body;
 }
 
 /** Derive an item's PVTI_ global node ID from its project number and numeric ID. */
@@ -126,7 +209,7 @@ export function extractFields(fieldValues) {
  * the aliased multi-fetch has one implementation. The id/type/title/body/url
  * properties are stable; fields was added later and is purely additive.
  */
-export function fetchItems(projectNumber, numericIds) {
+export async function fetchItems(projectNumber, numericIds) {
   const fields =
     "... on ProjectV2Item { databaseId " +
     FIELD_VALUES_FRAGMENT +
@@ -141,17 +224,10 @@ export function fetchItems(projectNumber, numericIds) {
     .join("\n");
   const query = `{ ${aliases} }`;
 
-  // gh exits non-zero if any aliased node is NOT_FOUND, but still prints the
-  // JSON body (data for the found nodes, errors for the missing ones). Recover
-  // it so one bad ID in a batch does not sink the whole fetch.
-  let raw;
-  try {
-    raw = gh(["api", "graphql", "-f", `query=${query}`]);
-  } catch (e) {
-    if (!e.stdout) throw e;
-    raw = e.stdout;
-  }
-  const data = JSON.parse(raw).data;
+  // GraphQL returns HTTP 200 with both `data` (the found nodes) and `errors`
+  // (NOT_FOUND for the missing ones), so one bad ID in a batch does not sink the
+  // whole fetch -- the missing aliases simply come back as null nodes below.
+  const data = (await graphql(query)).data;
 
   return numericIds.map((id, i) => {
     const node = data[`i${i}`];
@@ -183,12 +259,12 @@ export function fetchItems(projectNumber, numericIds) {
 export const PAGE_SIZE = 100;
 
 /**
- * Default GraphQL runner for fetchAllItems: run the query through gh and return
+ * Default GraphQL runner for fetchAllItems: run the query via fetch and return
  * its `data`. Split out as the injection point so tests can drive fetchAllItems
  * with synthetic pages instead of a live board.
  */
-function runQueryViaGh(query) {
-  return JSON.parse(gh(["api", "graphql", "-f", `query=${query}`])).data;
+async function runQueryViaFetch(query) {
+  return (await graphql(query)).data;
 }
 
 /**
@@ -200,11 +276,11 @@ function runQueryViaGh(query) {
  * false, so no item is dropped however large the board grows -- the silent
  * truncation a single `gh project item-list --limit N` would cause is impossible
  * here. Shared by list-epic.mjs (filter to one Epic) and list-issues.mjs (whole
- * board). `runQuery(query) -> data` is injectable for tests; it defaults to gh.
+ * board). `runQuery(query) -> data` is injectable for tests; it defaults to fetch.
  */
-export function fetchAllItems(
+export async function fetchAllItems(
   projectNumber,
-  { runQuery = runQueryViaGh } = {},
+  { runQuery = runQueryViaFetch } = {},
 ) {
   const nodes = [];
   let cursor = null;
@@ -214,7 +290,7 @@ export function fetchAllItems(
     // to escape. Omit `after` entirely on the first page.
     const after = cursor === null ? "" : `, after: "${cursor}"`;
     const query = `{ organization(login: "${OWNER}") { projectV2(number: ${projectNumber}) { items(first: ${PAGE_SIZE}${after}) { pageInfo { hasNextPage endCursor } nodes { id ${FIELD_VALUES_FRAGMENT} content { __typename ... on DraftIssue { title } ... on Issue { title } } } } } } }`;
-    const data = runQuery(query);
+    const data = await runQuery(query);
     const project = data?.organization?.projectV2;
     if (!project) {
       throw new Error(

--- a/.claude/scripts/lib/projectItems.test.mjs
+++ b/.claude/scripts/lib/projectItems.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   fetchAllItems,
+  fieldValueInput,
   githubToken,
   numericIdFromNodeId,
   PAGE_SIZE,
@@ -129,6 +130,18 @@ describe("toNumericId", () => {
   it("returns NaN for an unparseable numeric argument (so Number.isInteger rejects it)", () => {
     expect(toNumericId("not-a-number")).toBeNaN();
   });
+
+  it("rejects a node id whose project disagrees with the requested project", () => {
+    // A board-10 node id passed with project 9 would otherwise decode and be
+    // re-encoded under board 9's prefix, silently addressing a different item.
+    const board10NodeId = pvtiNodeId(10, 199240250);
+    expect(() => toNumericId(board10NodeId, 9)).toThrow(
+      /not the requested project/,
+    );
+    expect(toNumericId(board10NodeId, 10)).toBe(199240250);
+    // With no expected project given, the cross-check is skipped (back-compat).
+    expect(toNumericId(board10NodeId)).toBe(199240250);
+  });
 });
 
 describe("githubToken", () => {
@@ -164,5 +177,61 @@ describe("githubToken", () => {
     expect(() => githubToken({ env: {}, readStoredToken: () => "" })).toThrow(
       /no GitHub token/,
     );
+  });
+
+  it("falls through a whitespace-only env var to the stored credential", () => {
+    expect(
+      githubToken({
+        env: { GH_TOKEN: "   " },
+        readStoredToken: () => "stored",
+      }),
+    ).toBe("stored");
+  });
+});
+
+describe("fieldValueInput", () => {
+  const status = {
+    name: "Status",
+    dataType: "SINGLE_SELECT",
+    options: [
+      { id: "opt_todo", name: "Todo" },
+      { id: "opt_done", name: "Done" },
+    ],
+  };
+
+  it("resolves a single-select option id by name, case-insensitively", () => {
+    expect(fieldValueInput(status, "todo")).toEqual({
+      singleSelectOptionId: "opt_todo",
+    });
+  });
+
+  it("throws on an unknown single-select option, listing the choices", () => {
+    expect(() => fieldValueInput(status, "Nope")).toThrow(/Todo, Done/);
+  });
+
+  it("maps text straight through and number to a JS number", () => {
+    expect(fieldValueInput({ name: "Epic", dataType: "TEXT" }, "Sync")).toEqual(
+      {
+        text: "Sync",
+      },
+    );
+    expect(fieldValueInput({ name: "Order", dataType: "NUMBER" }, "7")).toEqual(
+      { number: 7 },
+    );
+    expect(
+      fieldValueInput({ name: "Due", dataType: "DATE" }, "2026-01-02"),
+    ).toEqual({ date: "2026-01-02" });
+  });
+
+  it("throws on a non-numeric value for a number field", () => {
+    expect(() =>
+      fieldValueInput({ name: "Order", dataType: "NUMBER" }, "soon"),
+    ).toThrow(/not numeric/);
+  });
+
+  it("throws on an unsupported field type", () => {
+    expect(() =>
+      fieldValueInput({ name: "Sprint", dataType: "ITERATION" }, "x"),
+    ).toThrow(/unsupported type/);
   });
 });

--- a/.claude/scripts/lib/projectItems.test.mjs
+++ b/.claude/scripts/lib/projectItems.test.mjs
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  fetchAllItems,
+  numericIdFromNodeId,
+  PAGE_SIZE,
+  pvtiNodeId,
+  toNumericId,
+} from "./projectItems.mjs";
+
+// Build a synthetic project item as the GraphQL listing query selects it: a
+// PVTI_ node id (so numericIdFromNodeId can decode it), a fieldValues node list
+// covering the three triage fields, and a draft-issue title.
+function fakeNode(projectNumber, numericId, { status, epic, order, title }) {
+  return {
+    id: pvtiNodeId(projectNumber, numericId),
+    fieldValues: {
+      nodes: [
+        {
+          __typename: "ProjectV2ItemFieldSingleSelectValue",
+          name: status,
+          field: { name: "Status" },
+        },
+        {
+          __typename: "ProjectV2ItemFieldTextValue",
+          text: epic,
+          field: { name: "Epic" },
+        },
+        {
+          __typename: "ProjectV2ItemFieldNumberValue",
+          number: order,
+          field: { name: "Implementation Order" },
+        },
+      ],
+    },
+    content: { __typename: "DraftIssue", title },
+  };
+}
+
+// A runQuery that serves `nodes` in pages of `pageSize`, honoring the cursor the
+// way GitHub's items connection does: each call returns the next page and an
+// endCursor, with hasNextPage false on the last. fetchAllItems only feeds the
+// returned endCursor back as an opaque token, so a served-count closure is a
+// faithful stand-in for real cursor pagination.
+function pagedRunQuery(nodes, pageSize) {
+  let served = 0;
+  return () => {
+    const page = nodes.slice(served, served + pageSize);
+    served += page.length;
+    const hasNextPage = served < nodes.length;
+    return {
+      organization: {
+        projectV2: {
+          items: {
+            pageInfo: {
+              hasNextPage,
+              endCursor: hasNextPage ? `cursor-${served}` : null,
+            },
+            nodes: page,
+          },
+        },
+      },
+    };
+  };
+}
+
+describe("fetchAllItems pagination", () => {
+  it("returns every item across more than one page (past the default page size)", () => {
+    const total = PAGE_SIZE + 50; // 150: forces a second page beyond the 100 cap
+    const nodes = Array.from({ length: total }, (_, idx) =>
+      fakeNode(9, 100000000 + idx, {
+        status: "Todo",
+        epic: "Epic A",
+        order: idx,
+        title: `Item ${idx}`,
+      }),
+    );
+
+    const result = fetchAllItems(9, {
+      runQuery: pagedRunQuery(nodes, PAGE_SIZE),
+    });
+
+    // No silent truncation: all 150 come back, not just the first 100-item page.
+    expect(result).toHaveLength(total);
+    expect(total).toBeGreaterThan(PAGE_SIZE);
+
+    // Each item carries numeric id, node id, title, and the extracted fields
+    // (status / Epic / Implementation Order) the listing promises.
+    const last = result[total - 1];
+    expect(last.id).toBe(numericIdFromNodeId(nodes[total - 1].id));
+    expect(last.nodeId).toBe(nodes[total - 1].id);
+    expect(last.title).toBe(`Item ${total - 1}`);
+    expect(last.fields).toEqual({
+      Status: "Todo",
+      Epic: "Epic A",
+      "Implementation Order": total - 1,
+    });
+  });
+
+  it("stops after a single page when the board fits in one", () => {
+    const nodes = [
+      fakeNode(10, 199240250, {
+        status: "Todo",
+        epic: undefined,
+        order: undefined,
+        title: "Only item",
+      }),
+    ];
+    const result = fetchAllItems(10, {
+      runQuery: pagedRunQuery(nodes, PAGE_SIZE),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(199240250);
+  });
+});
+
+describe("toNumericId", () => {
+  it("resolves a PVTI_ node id to the same numeric item id as its numeric form", () => {
+    // lint-issues.mjs routes its arguments through toNumericId, so a node id and
+    // the numeric id it was derived from must address the same item.
+    const numeric = 199240250;
+    const nodeId = pvtiNodeId(10, numeric);
+
+    expect(toNumericId(nodeId)).toBe(numeric);
+    expect(toNumericId(String(numeric))).toBe(numeric);
+    expect(toNumericId(nodeId)).toBe(toNumericId(String(numeric)));
+  });
+
+  it("returns NaN for an unparseable numeric argument (so Number.isInteger rejects it)", () => {
+    expect(toNumericId("not-a-number")).toBeNaN();
+  });
+});

--- a/.claude/scripts/lib/projectItems.test.mjs
+++ b/.claude/scripts/lib/projectItems.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   fetchAllItems,
+  githubToken,
   numericIdFromNodeId,
   PAGE_SIZE,
   pvtiNodeId,
@@ -64,7 +65,7 @@ function pagedRunQuery(nodes, pageSize) {
 }
 
 describe("fetchAllItems pagination", () => {
-  it("returns every item across more than one page (past the default page size)", () => {
+  it("returns every item across more than one page (past the default page size)", async () => {
     const total = PAGE_SIZE + 50; // 150: forces a second page beyond the 100 cap
     const nodes = Array.from({ length: total }, (_, idx) =>
       fakeNode(9, 100000000 + idx, {
@@ -75,7 +76,7 @@ describe("fetchAllItems pagination", () => {
       }),
     );
 
-    const result = fetchAllItems(9, {
+    const result = await fetchAllItems(9, {
       runQuery: pagedRunQuery(nodes, PAGE_SIZE),
     });
 
@@ -96,7 +97,7 @@ describe("fetchAllItems pagination", () => {
     });
   });
 
-  it("stops after a single page when the board fits in one", () => {
+  it("stops after a single page when the board fits in one", async () => {
     const nodes = [
       fakeNode(10, 199240250, {
         status: "Todo",
@@ -105,7 +106,7 @@ describe("fetchAllItems pagination", () => {
         title: "Only item",
       }),
     ];
-    const result = fetchAllItems(10, {
+    const result = await fetchAllItems(10, {
       runQuery: pagedRunQuery(nodes, PAGE_SIZE),
     });
     expect(result).toHaveLength(1);
@@ -127,5 +128,41 @@ describe("toNumericId", () => {
 
   it("returns NaN for an unparseable numeric argument (so Number.isInteger rejects it)", () => {
     expect(toNumericId("not-a-number")).toBeNaN();
+  });
+});
+
+describe("githubToken", () => {
+  it("prefers GH_TOKEN, then GITHUB_TOKEN, then the stored credential", () => {
+    const stored = () => "stored-token";
+    expect(
+      githubToken({
+        env: { GH_TOKEN: "gh-token", GITHUB_TOKEN: "github-token" },
+        readStoredToken: stored,
+      }),
+    ).toBe("gh-token");
+    expect(
+      githubToken({
+        env: { GITHUB_TOKEN: "github-token" },
+        readStoredToken: stored,
+      }),
+    ).toBe("github-token");
+    // gh auth token prints a trailing newline; it must be trimmed off.
+    expect(
+      githubToken({ env: {}, readStoredToken: () => "stored-token\n" }),
+    ).toBe("stored-token");
+  });
+
+  it("throws (rather than returning empty) when no token is available", () => {
+    expect(() =>
+      githubToken({
+        env: {},
+        readStoredToken: () => {
+          throw new Error("gh: not logged in");
+        },
+      }),
+    ).toThrow(/no GitHub token/);
+    expect(() => githubToken({ env: {}, readStoredToken: () => "" })).toThrow(
+      /no GitHub token/,
+    );
   });
 });

--- a/.claude/scripts/lint-issues.mjs
+++ b/.claude/scripts/lint-issues.mjs
@@ -190,8 +190,11 @@ async function main() {
 
   const projectNumber = Number(positional[0]);
   // Each item argument is a numeric ID or a PVTI_ node ID; resolve both to
-  // numeric so a node ID lints the same item as its numeric form.
-  const numericIds = positional.slice(1).map(toNumericId);
+  // numeric (rejecting a node ID from another project) so a node ID lints the
+  // same item as its numeric form.
+  const numericIds = positional
+    .slice(1)
+    .map((arg) => toNumericId(arg, projectNumber));
   if (
     !Number.isInteger(projectNumber) ||
     numericIds.length === 0 ||

--- a/.claude/scripts/lint-issues.mjs
+++ b/.claude/scripts/lint-issues.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 //
-// Lint GitHub Projects v2 draft-issue bodies by their numeric item IDs (the
-// `?itemId=N` value from the project web UI URL). Companion to fetch-issues.mjs
-// and edit-issue.mjs.
+// Lint GitHub Projects v2 draft-issue bodies, addressed by their numeric item ID
+// (the `?itemId=N` value from the project web UI URL) or, equivalently, their
+// `PVTI_...` global node ID -- the two forms mix freely, matching fetch-issues.mjs
+// and edit-issue.mjs. Companion to fetch-issues.mjs and edit-issue.mjs.
 //
 // Draft bodies are written and revised by humans and language models that do not
 // share a stable address space: an LLM may cite an opaque GraphQL node ID it
@@ -13,7 +14,7 @@
 // trusts them.
 //
 // Usage:
-//   node lint-issues.mjs <project-number> <itemId> [itemId...] [--strict]
+//   node lint-issues.mjs <project-number> <itemId|PVTI_...> [more...] [--strict]
 //
 // Default exit is 0. With --strict, exit non-zero if any error-severity finding
 // exists, so the linter can gate a workflow.
@@ -21,7 +22,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { fetchItems } from "./lib/projectItems.mjs";
+import { fetchItems, toNumericId } from "./lib/projectItems.mjs";
 
 // Repo root: line-anchor staleness is checked against files here. This file
 // lives at <root>/.claude/scripts/lint-issues.mjs, so the working tree root is
@@ -188,14 +189,16 @@ function main() {
   const positional = argv.filter((a) => a !== "--strict");
 
   const projectNumber = Number(positional[0]);
-  const numericIds = positional.slice(1).map(Number);
+  // Each item argument is a numeric ID or a PVTI_ node ID; resolve both to
+  // numeric so a node ID lints the same item as its numeric form.
+  const numericIds = positional.slice(1).map(toNumericId);
   if (
     !Number.isInteger(projectNumber) ||
     numericIds.length === 0 ||
     numericIds.some((n) => !Number.isInteger(n))
   ) {
     process.stderr.write(
-      "Usage: node lint-issues.mjs <project-number> <itemId> [itemId...] [--strict]\n",
+      "Usage: node lint-issues.mjs <project-number> <itemId|PVTI_...> [more...] [--strict]\n",
     );
     process.exit(2);
   }

--- a/.claude/scripts/lint-issues.mjs
+++ b/.claude/scripts/lint-issues.mjs
@@ -183,7 +183,7 @@ function checkOpenQuestions(body) {
 
 const SEVERITY_RANK = { error: 0, warning: 1, info: 2 };
 
-function main() {
+async function main() {
   const argv = process.argv.slice(2);
   const strict = argv.includes("--strict");
   const positional = argv.filter((a) => a !== "--strict");
@@ -203,7 +203,7 @@ function main() {
     process.exit(2);
   }
 
-  const items = fetchItems(projectNumber, numericIds);
+  const items = await fetchItems(projectNumber, numericIds);
   const inSet = new Set(numericIds.map(String));
 
   // First pass: collect every distinct referenced 9-digit ID across all bodies
@@ -221,7 +221,10 @@ function main() {
   // ones in the set are known-good by construction.
   const resolved = new Map(); // string id -> { type, title } | null (unresolved)
   if (outsideSetIds.length > 0) {
-    for (const r of fetchItems(projectNumber, outsideSetIds.map(Number))) {
+    for (const r of await fetchItems(
+      projectNumber,
+      outsideSetIds.map(Number),
+    )) {
       resolved.set(
         String(r.id),
         r.type === "missing" ? null : { type: r.type, title: r.title },
@@ -324,4 +327,7 @@ function main() {
   if (strict && totalErrors > 0) process.exit(1);
 }
 
-main();
+main().catch((err) => {
+  process.stderr.write(`${err.message ?? err}\n`);
+  process.exit(1);
+});

--- a/.claude/scripts/list-epic.mjs
+++ b/.claude/scripts/list-epic.mjs
@@ -23,54 +23,10 @@
 // { id, order, status, title } for programmatic consumers, consistent with
 // fetch-issues.mjs.
 
-import {
-  extractFields,
-  FIELD_VALUES_FRAGMENT,
-  gh,
-  numericIdFromNodeId,
-  OWNER,
-} from "./lib/projectItems.mjs";
-
-// GitHub's projectV2 items connection caps `first` at 100, so this is also the
-// per-page size: fetchAllItems pages through the connection 100 at a time rather
-// than relying on a single page covering the whole board.
-const PAGE_SIZE = 100;
-
-/**
- * Fetch all items of a project with their field values and node IDs, returning
- * [{ id, title, fields }] where id is the numeric item ID and fields is the
- * { name -> value } map (see extractFields). Pages through the items connection
- * with a cursor until hasNextPage is false, so no item is dropped however large
- * the board grows.
- */
-function fetchAllItems(projectNumber) {
-  const nodes = [];
-  let cursor = null;
-  do {
-    // Inline the cursor into the query the same way the other args are inlined;
-    // GitHub's endCursor is an opaque base64 token with no quote/backslash chars
-    // to escape. Omit `after` entirely on the first page.
-    const after = cursor === null ? "" : `, after: "${cursor}"`;
-    const query = `{ organization(login: "${OWNER}") { projectV2(number: ${projectNumber}) { items(first: ${PAGE_SIZE}${after}) { pageInfo { hasNextPage endCursor } nodes { id ${FIELD_VALUES_FRAGMENT} content { __typename ... on DraftIssue { title } ... on Issue { title } } } } } } }`;
-    const data = JSON.parse(
-      gh(["api", "graphql", "-f", `query=${query}`]),
-    ).data;
-    const project = data?.organization?.projectV2;
-    if (!project) {
-      throw new Error(
-        `project ${projectNumber} not found under owner ${OWNER}`,
-      );
-    }
-    const conn = project.items;
-    nodes.push(...conn.nodes);
-    cursor = conn.pageInfo.hasNextPage ? conn.pageInfo.endCursor : null;
-  } while (cursor !== null);
-  return nodes.map((node) => ({
-    id: numericIdFromNodeId(node.id),
-    title: node.content?.title ?? null,
-    fields: extractFields(node.fieldValues),
-  }));
-}
+// fetchAllItems (the paginated, field-rich whole-project fetch) lives in
+// lib/projectItems.mjs so list-issues.mjs shares the exact same pagination and
+// field extraction; this script is just that listing filtered to one Epic.
+import { fetchAllItems } from "./lib/projectItems.mjs";
 
 /**
  * Sort comparator: by Implementation Order ascending, with unset orders last.

--- a/.claude/scripts/list-epic.mjs
+++ b/.claude/scripts/list-epic.mjs
@@ -39,7 +39,7 @@ function byOrder(a, b) {
   return oa - ob;
 }
 
-function main() {
+async function main() {
   const argv = process.argv.slice(2);
   let asJson = false;
   let i = 0;
@@ -59,7 +59,7 @@ function main() {
   }
 
   const wanted = epicName.toLowerCase();
-  const matches = fetchAllItems(projectNumber)
+  const matches = (await fetchAllItems(projectNumber))
     .filter((item) => (item.fields.Epic ?? "").toLowerCase() === wanted)
     .map((item) => ({
       id: item.id,
@@ -91,4 +91,7 @@ function main() {
   }
 }
 
-main();
+main().catch((err) => {
+  process.stderr.write(`${err.message ?? err}\n`);
+  process.exit(1);
+});

--- a/.claude/scripts/list-issues.mjs
+++ b/.claude/scripts/list-issues.mjs
@@ -27,7 +27,7 @@
 
 import { fetchAllItems } from "./lib/projectItems.mjs";
 
-function main() {
+async function main() {
   // A whole-board dump is routinely piped to `head`/`grep`, which closes the
   // read end early; exit quietly on the resulting EPIPE instead of crashing.
   process.stdout.on("error", (err) => {
@@ -67,7 +67,7 @@ function main() {
   }
 
   const wanted = new Set(statuses);
-  const items = fetchAllItems(projectNumber)
+  const items = (await fetchAllItems(projectNumber))
     .map((item) => ({
       id: item.id,
       nodeId: item.nodeId,
@@ -104,4 +104,7 @@ function main() {
   }
 }
 
-main();
+main().catch((err) => {
+  process.stderr.write(`${err.message ?? err}\n`);
+  process.exit(1);
+});

--- a/.claude/scripts/list-issues.mjs
+++ b/.claude/scripts/list-issues.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+//
+// List every item on a GitHub Projects v2 board with its triage fields, fully
+// paginated. Companion to fetch-issues.mjs (read one item by ID), list-epic.mjs
+// (this listing filtered to one Epic), and edit-issue.mjs (write).
+//
+// A board-hygiene pass needs the whole inventory in one round-trip: every item
+// with its numeric `?itemId=N` id, its `PVTI_` node id, status, Epic, and
+// Implementation Order. `gh project item-list` cannot supply that -- its JSON
+// omits the numeric id and the custom fields, and it silently caps at `--limit`
+// (board 9 already holds more than one 100-item page), so a too-low limit drops
+// items with no warning. This script goes through the same paginated GraphQL
+// path as list-epic.mjs (shared fetchAllItems), which pages until the board is
+// exhausted, so no item is ever dropped.
+//
+// Usage:
+//   node list-issues.mjs [--json] [--status NAME]... <project-number>
+//
+// Default output is human-readable: one tab-separated line per item with numeric
+// id, node id, status, [Implementation Order], Epic, and title, in board order.
+// --json emits a compact array of { id, nodeId, status, epic, order, title } for
+// programmatic consumers, consistent with fetch-issues.mjs and list-epic.mjs.
+//
+// With no --status, every item is listed. Each --status NAME (repeatable) keeps
+// only items whose Status equals NAME (case-insensitive); e.g. `--status Todo
+// --status "In Progress"` is the common non-Done hygiene view.
+
+import { fetchAllItems } from "./lib/projectItems.mjs";
+
+function main() {
+  // A whole-board dump is routinely piped to `head`/`grep`, which closes the
+  // read end early; exit quietly on the resulting EPIPE instead of crashing.
+  process.stdout.on("error", (err) => {
+    if (err.code === "EPIPE") process.exit(0);
+    throw err;
+  });
+
+  const argv = process.argv.slice(2);
+  // Leading option flags, in any order: --json, --status NAME (repeatable).
+  let asJson = false;
+  const statuses = [];
+  let i = 0;
+  while (argv[i] !== undefined && argv[i].startsWith("--")) {
+    if (argv[i] === "--json") {
+      asJson = true;
+      i += 1;
+    } else if (argv[i] === "--status") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        process.stderr.write("error: --status requires a value\n");
+        process.exit(2);
+      }
+      statuses.push(value.toLowerCase());
+      i += 2;
+    } else {
+      break;
+    }
+  }
+  const rest = argv.slice(i);
+
+  const projectNumber = Number(rest[0]);
+  if (!Number.isInteger(projectNumber) || rest.length !== 1) {
+    process.stderr.write(
+      "Usage: node list-issues.mjs [--json] [--status NAME]... <project-number>\n",
+    );
+    process.exit(2);
+  }
+
+  const wanted = new Set(statuses);
+  const items = fetchAllItems(projectNumber)
+    .map((item) => ({
+      id: item.id,
+      nodeId: item.nodeId,
+      status: item.fields.Status ?? null,
+      epic: item.fields.Epic ?? null,
+      order: item.fields["Implementation Order"],
+      title: item.title,
+    }))
+    .filter(
+      (item) =>
+        wanted.size === 0 ||
+        (item.status !== null && wanted.has(item.status.toLowerCase())),
+    );
+
+  if (asJson) {
+    // Compact, not pretty-printed: --json feeds programmatic/agent consumers,
+    // where indentation is dead weight in the reader's context.
+    process.stdout.write(JSON.stringify(items) + "\n");
+    return;
+  }
+
+  if (items.length === 0) {
+    const filter =
+      wanted.size === 0 ? "" : ` matching status ${[...wanted].join(", ")}`;
+    process.stdout.write(`no items on project ${projectNumber}${filter}\n`);
+    return;
+  }
+
+  for (const m of items) {
+    const order = typeof m.order === "number" ? String(m.order) : "-";
+    process.stdout.write(
+      `${m.id}\t${m.nodeId}\t${m.status ?? "-"}\t[${order}]\t${m.epic ?? "-"}\t${m.title}\n`,
+    );
+  }
+}
+
+main();

--- a/.claude/scripts/vitest.config.mjs
+++ b/.claude/scripts/vitest.config.mjs
@@ -1,0 +1,17 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+// Vitest project for the .claude/scripts board tooling. These are plain .mjs dev
+// scripts outside the workspaces, so they are not covered by `npm test` (which
+// fans out to packages/* and apps/*); the root vitest config registers this as a
+// project so `npx vitest` (and `npm run test:scripts`) discovers them. The tests
+// are deterministic -- they drive the GraphQL layer with synthetic pages and
+// never touch a live board -- so they need no network or gh auth.
+export default defineConfig({
+  test: {
+    name: "scripts",
+    root: fileURLToPath(new URL(".", import.meta.url)),
+    include: ["**/*.test.mjs"],
+    environment: "node",
+  },
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format": "prettier --write .",
     "formatcheck": "prettier --list-different .",
     "typecheck": "tsc -p packages/core/tsconfig.json --noEmit && tsc -p apps/cli/tsconfig.test.json && tsc -p apps/web/tsconfig.json",
-    "test": "npm run test -w packages/core -w apps/cli -w apps/web"
+    "test": "npm run test -w packages/core -w apps/cli -w apps/web",
+    "test:scripts": "vitest run --project scripts"
   },
   "keywords": [
     "private set intersection",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    projects: ["packages/*", "apps/*"],
+    // .claude/scripts holds the board tooling -- plain .mjs scripts outside the
+    // workspaces, with their own vitest config. They are not in `npm test`
+    // (which fans out to the workspaces); registering the project here lets
+    // `npx vitest` and `npm run test:scripts` pick up their deterministic tests.
+    projects: ["packages/*", "apps/*", ".claude/scripts"],
   },
 });


### PR DESCRIPTION
## Summary

Make the `.claude/` GitHub-board tooling complete and runnable inside the command
sandbox. Adds a fully-paginated, field-rich board listing so a hygiene pass pulls
every item -- numeric id, node id, status, Epic, Implementation Order -- in one
untruncated call; lets `lint-issues.mjs` take `PVTI_` node ids like its sibling
scripts; and replaces the scripts' `gh` network shell-outs with Node `fetch`, so
reads and writes run with no `dangerouslyDisableSandbox`.

Implements release items [199240250](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=199240250) and
[199242091](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=199242091), landed together because both rework the shared `lib/projectItems.mjs`.

## Changes

- `lib/projectItems.mjs` -- shared core: a cursor-paginated `fetchAllItems`, a
  `fetch`-based `graphql` caller plus a network-free token resolver
  (`GH_TOKEN`/`GITHUB_TOKEN`/`gh auth token`, never logged), `toNumericId` with a
  cross-project guard, and `fieldValueInput` (the write-side counterpart to
  `extractFields`). The reads are now async.
- `list-issues.mjs` (new) -- whole-board listing with a repeatable `--status`
  filter and `--json`; pages through everything, no silent `--limit` truncation.
- `fetch-issues.mjs`, `lint-issues.mjs`, `list-epic.mjs` -- consume the shared
  helpers; `lint-issues` now accepts `PVTI_` node ids; all await the async reads.
- `edit-issue.mjs` -- writes ported from `gh project` porcelain to the
  `updateProjectV2DraftIssue` / `updateProjectV2ItemFieldValue` mutations, typing
  each field value by its GraphQL `dataType` (drops the old value-shape guess).
- `.claude/pm/ruleset.md`, `.claude/agents/project-manager.md` -- duplicate-check
  and epic-discovery use `list-issues.mjs` instead of the truncating
  `gh project item-list`.
- `lib/projectItems.test.mjs` (new), `vitest.config.mjs` (new), root
  `vitest.config.ts`, `package.json` -- register a `scripts` vitest project, run
  by `npm run test:scripts`.

## Background

`gh` (a Go binary) verifies TLS through the macOS `trustd` Mach service, which
the command sandbox blocks, so every `gh` board call failed in-sandbox. Node
verifies TLS against its own bundled CA store, so moving the calls into `fetch`
fixes that -- but the sandbox also forces egress through an injected `HTTPS_PROXY`
that Node's `fetch` ignores by default, so `NODE_USE_ENV_PROXY=1` is set in local
Claude Code settings (environmental, not committed) to make `fetch` honor it.

## Out of scope / follow-on

- `gh project item-create` (the PM create flow) stays on `gh`; it runs unsandboxed
  via the local sandbox `excludedCommands`, so it needs no port.
- Optional review polish not taken: parameterize the pagination cursor as a
  GraphQL variable, memoize the token across pages, un-export the now-internal
  `gh` helper.

## Test plan

- [x] `npm run typecheck && npm run lint` clean
- [x] `npm run formatcheck` clean
- [x] `npm run test:scripts` (13/13) -- the new board-tooling suite
- [x] `npm test -w packages/core` (1145/1145)
- [x] `npm run test:unit -w apps/cli` (594/594) and `apps/web` (91/91) -- no
  product code is touched; run only to confirm no regression. One cli socket test
  fails solely under the command sandbox's `listen` restriction and passes
  normally.
- [x] In-sandbox smoke test: a sandboxed Node `fetch` to the GraphQL API returns
  200 with no `dangerouslyDisableSandbox`; `fetch-issues` (read) and `edit-issue`
  (a field set and a real body edit) both succeed.
- CLI Docker integration tests -- n/a, no transport or product code changed.

New tests cover: pagination past the default 100-item page; `PVTI_`/numeric id
equivalence and cross-project-node-id rejection; token precedence and the
whitespace-only fall-through; `fieldValueInput` typing and validation.

## Checklist

- [x] Ran `ls docs/` and checked each file for impact: none affected -- this is
  `.claude/` developer tooling, with no product, protocol, CLI, or web behavior
  change.
- [x] `CHANGELOG.md` n/a -- `.claude/` agent tooling is not product behavior
  (consistent with prior `.claude/scripts` commits).
- [x] Cryptographic code changed? n/a -- no crypto/PSI code touched (confirmed by
  an independent security review of the branch).
