### PR TITLE
Resolve SFTP test .env file-relative for cwd-independent port

### DIFF
--- a/apps/cli/test/container/env.ts
+++ b/apps/cli/test/container/env.ts
@@ -1,14 +1,16 @@
 import fs from "node:fs";
 import fsp from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 
 // The SFTP container's host port can be overridden per checkout via
 // test/container/.env (COMPOSE_PROJECT_NAME, SFTP_PORT) so multiple worktrees
 // can run the container concurrently without colliding on the default 2222. The
 // make-worktree command writes that file with a free port; the SFTP_PORT env
-// var takes precedence when set (e.g. CI). Resolved relative to cwd, which is
-// the cli package root when the integration tests run, matching the other
-// relative paths in those tests.
-const ENV_FILE = "test/container/.env";
+// var takes precedence when set (e.g. CI). Resolved relative to this module
+// (import.meta.url) rather than the process cwd, so a single integration file
+// run from any directory still finds it -- matching the file-relative SFTP root
+// resolution in the sibling integration tests.
+const ENV_FILE = fileURLToPath(new URL("./.env", import.meta.url));
 
 export function sftpPort(): number {
   if (process.env.SFTP_PORT) return Number(process.env.SFTP_PORT);

--- a/apps/cli/test/container/env.ts
+++ b/apps/cli/test/container/env.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 // resolution in the sibling integration tests.
 const ENV_FILE = fileURLToPath(new URL("./.env", import.meta.url));
 
+/** @internal exported for testing */
 export function sftpPort(): number {
   if (process.env.SFTP_PORT) return Number(process.env.SFTP_PORT);
   try {
@@ -36,6 +37,7 @@ export function sftpPort(): number {
 // CI runner enforces it. 0777 lets any uid operate; the protocol only creates,
 // reads, renames, and deletes whole files (never modifies another uid's file in
 // place), so directory-level write permission is sufficient.
+/** @internal exported for testing */
 export async function ensureServerDir(dir: string): Promise<void> {
   await fsp.mkdir(dir, { recursive: true });
   await fsp.chmod(dir, 0o777);


### PR DESCRIPTION
## Summary

Make the CLI SFTP integration tests' port lookup cwd-independent. `sftpPort()` now resolves the per-checkout `test/container/.env` relative to its own module via `import.meta.url` instead of the process cwd, so running a single integration file from any directory picks up that checkout's `SFTP_PORT` rather than silently falling back to the default 2222. This completes the "run any CLI integration file from any cwd with zero env" story: #59 made the sibling SFTP local-directory resolution file-relative but deliberately left this port lookup, the last cwd-dependent read.

Implements Release & Operations item [198005015](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=198005015).

## Changes

- `apps/cli/test/container/env.ts` -- resolve `ENV_FILE` via `fileURLToPath(new URL("./.env", import.meta.url))` instead of the cwd-relative string `"test/container/.env"`, and refresh the stale "relative to cwd" comment. Also add `/** @internal exported for testing */` to the two test-only exports (`sftpPort`, `ensureServerDir`) so they satisfy the export-JSDoc convention.

## Background

`env.ts` is read by both the integration tests and the `globalSetup` that brings the SFTP container up. `globalSetup` already computes the repo root from `import.meta.url` and runs `docker compose --env-file` from there, so it brought the container up on the per-checkout port; only this reader still resolved the file from the cwd, so a run from a non-cli cwd read 2222 and missed the running container. `process.env.SFTP_PORT` keeps precedence over the file (the path CI uses), and the 2222 fallback when no `.env` exists is unchanged.

## Test plan

- [x] `npm run typecheck && npm run lint` clean (also `npm run formatcheck`)
- [x] `npm test -w packages/core` -- n/a, core unchanged
- [x] `npm run test:unit -w apps/cli` (614/614)
- [x] CLI integration tests: `npm run test:integration -w apps/cli` (17/17; the supported cli-root path is unaffected)
- [x] Acceptance criteria: from the repo root with no env, `npx vitest run apps/cli/test/integration/sftpConnection.test.ts` reaches the per-checkout container (9/9); the same run with no container up fails on connect, confirming the pass comes from the file-relative resolution rather than a default. Direct checks from a non-cli cwd: with no `SFTP_PORT` it resolves the checkout port, with `SFTP_PORT` set the env var still wins, and a copy with no sibling `.env` falls back to 2222.

No new tests: the change is to the test harness itself, exercised by the existing CLI integration suite plus the from-any-cwd run above.

## Checklist

- [x] Ran `ls docs/` and checked each for impact; none affected (the supported test flow is documented in CONTRIBUTING.md and is unchanged)
- [x] `CHANGELOG.md` `[Unreleased]` -- n/a, test-infrastructure only with no user-facing change (parent #59 added none)
- [x] Cryptographic code changed? n/a
