### PR TITLE
Harden CLI post-handshake expiry test timing

### DIFF
--- a/apps/cli/test/unit/authentication.test.ts
+++ b/apps/cli/test/unit/authentication.test.ts
@@ -316,10 +316,22 @@ test("a legacy SPAKE2-shaped reply fails a new initiator with a clean error", as
 // drive the post-handshake branch (auth.ts) by faking only Date: start the
 // clock just before `expires`, kick off both sides over an in-memory pipe (no
 // real-timer coupling, so the handshake still completes), then advance the
-// clock past `expires` in a microtask while the round-trip is in flight. The
-// post-handshake checks -- which run only after both runKex calls resolve --
-// then see the secret as expired. (Ported from the deleted pake.test.ts, which
-// covered the equivalent SPAKE2 branch before the X25519 cutover.)
+// clock past `expires` while the round-trip is in flight, so the post-handshake
+// checks -- which run only after both runKex calls resolve -- see the secret as
+// expired. (Ported from the deleted pake.test.ts, which covered the equivalent
+// SPAKE2 branch before the X25519 cutover.)
+//
+// The advance is synchronous, between starting the two authenticateConnection
+// promises and awaiting them, not scheduled on a microtask tick. The
+// pre-handshake expiry check runs in authenticateConnection's synchronous
+// prologue (before its first await, and before any frame is delivered -- pipe
+// deliveries are queued microtasks that only run during the await), so by the
+// time both calls have returned their promises both pre-checks have already
+// passed at the pre-advance clock. Advancing here is therefore strictly after
+// both pre-checks and strictly before both post-checks, independent of how many
+// microtasks the kex spans -- whereas a single Promise.resolve() tick is not a
+// reliable barrier and could land the advance after the post-check, silently
+// resolving fulfilled on the wrong branch.
 
 test("authentication throws when the shared secret expires during the key-exchange round-trip", async () => {
   const expires = "2030-01-01T00:00:00.000Z";
@@ -328,25 +340,23 @@ test("authentication throws when the shared secret expires during the key-exchan
     now: new Date("2029-12-31T23:59:59.000Z"),
   });
   const [a, b] = createMessagePipe();
-  const authPromise = Promise.allSettled([
-    authenticateConnection(
-      a,
-      { sharedSecret: TOKEN_A, expires },
-      "initiator",
-      true,
-    ),
-    authenticateConnection(
-      b,
-      { sharedSecret: TOKEN_A, expires },
-      "responder",
-      true,
-    ),
-  ]);
-  // Advance past expires while the round-trip is still in flight.
-  await Promise.resolve().then(() =>
-    vi.setSystemTime(new Date("2030-01-01T00:00:01.000Z")),
+  const pA = authenticateConnection(
+    a,
+    { sharedSecret: TOKEN_A, expires },
+    "initiator",
+    true,
   );
-  const [resultA, resultB] = await authPromise;
+  const pB = authenticateConnection(
+    b,
+    { sharedSecret: TOKEN_A, expires },
+    "responder",
+    true,
+  );
+  // Advance past expires while the round-trip is in flight: strictly after both
+  // synchronous pre-handshake checks (already run, above) and before both
+  // post-handshake checks. See the block comment above for why this is reliable.
+  vi.setSystemTime(new Date("2030-01-01T00:00:01.000Z"));
+  const [resultA, resultB] = await Promise.allSettled([pA, pB]);
   expect(resultA.status).toBe("rejected");
   expect(resultB.status).toBe("rejected");
   expect((resultA as PromiseRejectedResult).reason.message).toContain(
@@ -364,24 +374,22 @@ test("authentication tags post-handshake-expiry errors with psilinkRecoveryHintE
     now: new Date("2029-12-31T23:59:59.000Z"),
   });
   const [a, b] = createMessagePipe();
-  const authPromise = Promise.allSettled([
-    authenticateConnection(
-      a,
-      { sharedSecret: TOKEN_A, expires },
-      "initiator",
-      true,
-    ),
-    authenticateConnection(
-      b,
-      { sharedSecret: TOKEN_A, expires },
-      "responder",
-      true,
-    ),
-  ]);
-  await Promise.resolve().then(() =>
-    vi.setSystemTime(new Date("2030-01-01T00:00:01.000Z")),
+  const pA = authenticateConnection(
+    a,
+    { sharedSecret: TOKEN_A, expires },
+    "initiator",
+    true,
   );
-  const [resultA, resultB] = await authPromise;
+  const pB = authenticateConnection(
+    b,
+    { sharedSecret: TOKEN_A, expires },
+    "responder",
+    true,
+  );
+  // Advance past expires while the round-trip is in flight (see the block
+  // comment above for why a synchronous advance here is a reliable barrier).
+  vi.setSystemTime(new Date("2030-01-01T00:00:01.000Z"));
+  const [resultA, resultB] = await Promise.allSettled([pA, pB]);
   expect(resultA.status).toBe("rejected");
   expect(resultB.status).toBe("rejected");
   // Tagged so the CLI surfaces a re-invite hint instead of the generic


### PR DESCRIPTION
## Summary

Make the CLI's two post-handshake round-trip expiry tests deterministic. They
advanced the fake clock on a single `Promise.resolve().then` microtask tick,
which is not a reliable barrier across the multi-microtask NNpsk0 handshake;
this replaces it with a synchronous advance between starting and awaiting both
`authenticateConnection` calls. Test-only, no production change -- it follows up
the identical fix made to the web copy in
[apps#113](https://github.com/georgetown-mdi/jspsi/pull/113).

## Changes

- `apps/cli/test/unit/authentication.test.ts` -- advance the fake clock
  synchronously between starting the two `authenticateConnection` promises and
  awaiting them, instead of on a `Promise.resolve().then` tick; expand the block
  comment to explain why the synchronous advance is a reliable barrier.

## Background

`authenticateConnection` runs its pre-handshake expiry check in its synchronous
prologue, before its first await and before any frame is delivered (the in-memory
pipe delivers frames via `queueMicrotask`, which only run during the await). So
by the time both calls have returned their promises, both pre-checks have already
passed at the old clock, and a synchronous `setSystemTime` after them is strictly
after both pre-checks and strictly before both post-checks, independent of how
many microtasks the kex spans. The old single-tick advance passed on Node's FIFO
microtask ordering but was latent-fragile: a scheduling change or a
synchronous-delivery refactor of the pipe could land the advance after the
post-check, leaving the secret still valid and resolving both ends fulfilled -- a
silent pass on the wrong branch, the worst failure mode for a test guarding a
fail-closed security property.

## Test plan

- [x] `npm run typecheck && npm run lint` clean
- [x] `npx vitest run apps/cli/test/unit/authentication.test.ts` (14/14), run 3x for determinism
- [x] `npm run test:unit -w apps/cli` (614/614)
- CLI integration tests -- n/a (unit test-only change)

## Checklist

- [x] Ran `ls docs/` and checked for impact; none (test-only)
- [x] `CHANGELOG.md` `[Unreleased]` -- n/a (test robustness, no behavior change)
- [x] Cryptographic code changed? n/a (test-only; no production or crypto change)
