### PR TITLE
Add a contained Node development container

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(git push:*)",
+      "Bash(git -C * push:*)",
+      "Read(~/.ssh/**)",
+      "Edit(~/.ssh/**)",
+      "Write(~/.ssh/**)",
+      "Read(.env)",
+      "Read(**/.env)",
+      "Read(.env.*)",
+      "Read(**/.env.*)",
+      "Edit(.env)",
+      "Edit(**/.env)",
+      "Edit(.env.*)",
+      "Edit(**/.env.*)",
+      "Write(.env)",
+      "Write(**/.env)",
+      "Write(.env.*)",
+      "Write(**/.env.*)",
+      "Edit(/etc/**)",
+      "Write(/etc/**)"
+    ]
+  }
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,99 @@
+# Development container for psilink. Node 26 (the shipped runtime and the version
+# .nvmrc, CI, and the product image pin), running as the non-root `node` user.
+# It carries the OpenSSH server the native SFTP test backend spawns and the
+# iptables/ipset stack the egress firewall installs at startup, so the full suite
+# -- build, unit, lint, typecheck, web dev server, and both SFTP integration
+# backends -- runs inside with no Docker present.
+FROM node:26-bookworm
+
+ARG TZ
+ENV TZ="$TZ"
+
+ARG CLAUDE_CODE_VERSION=latest
+
+# Base development tools, the OpenSSH server/client the native SFTP test backend
+# spawns and keygens against, and the iptables/ipset/dns toolchain the egress
+# firewall uses (aggregate collapses the GitHub CIDR list, jq parses the meta
+# feed, dnsutils provides dig, iproute2 provides ip).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  less \
+  git \
+  procps \
+  sudo \
+  fzf \
+  zsh \
+  man-db \
+  unzip \
+  gnupg2 \
+  openssh-server \
+  openssh-client \
+  iptables \
+  ipset \
+  iproute2 \
+  dnsutils \
+  aggregate \
+  jq \
+  nano \
+  vim \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# The GitHub CLI is not in Debian's repositories; add its official signed apt
+# source, then install it. (The reference devcontainer's bare `apt-get install
+# gh` only works where this source is already configured.)
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends gh \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# The native sshd test backend spawns an unprivileged sshd, which still fatally
+# checks for the privilege-separation directory at startup even when run as a
+# normal user; create it at build time so the backend needs no root at test time
+# (CI creates the same directory before its native leg).
+RUN mkdir -p /run/sshd
+
+# Give the non-root node user a writable global npm prefix (so claude-code can be
+# installed -- and self-update -- without root), and put its bin on PATH for login
+# shells too: a Dockerfile ENV PATH is rebuilt from scratch by Debian's
+# /etc/profile, which both bash and zsh login shells re-source, so the npm-global
+# bin (where the `claude` launcher lives) would otherwise drop off an interactive
+# terminal's PATH.
+RUN mkdir -p /usr/local/share/npm-global && \
+  chown -R node:node /usr/local/share/npm-global && \
+  echo 'export PATH="$PATH:/usr/local/share/npm-global/bin"' > /etc/profile.d/npm-global-path.sh
+
+# Marks the environment as a dev container for orientation/tooling.
+ENV DEVCONTAINER=true
+
+# Create the workspace and Claude config mount points owned by the node user.
+# /workspace/node_modules is pre-created and owned by node so the named volume
+# mounted there in devcontainer.json (which isolates Linux-built dependencies,
+# including the native cpu-features, from the bind-mounted host tree) is writable
+# by the non-root user on first creation.
+RUN mkdir -p /workspace/node_modules /home/node/.claude && \
+  chown -R node:node /workspace /home/node/.claude
+
+WORKDIR /workspace
+
+USER node
+
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=$PATH:/usr/local/share/npm-global/bin
+
+ENV SHELL=/bin/zsh
+ENV EDITOR=nano
+ENV VISUAL=nano
+
+# Claude Code itself, so an agent session runs inside the container.
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+
+# Install the egress firewall script and grant the node user passwordless sudo
+# for that one command only, so devcontainer.json can apply it on start.
+COPY init-firewall.sh /usr/local/bin/
+USER root
+RUN chmod +x /usr/local/bin/init-firewall.sh && \
+  echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-firewall && \
+  chmod 0440 /etc/sudoers.d/node-firewall
+USER node

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,104 @@
+# Development container
+
+A plain Node 26 container in which an agent (or a developer) can run the whole
+psilink workflow -- build, unit tests, lint, typecheck, the web dev server, and
+both SFTP integration backends -- with no Docker inside it. It runs as the
+non-root `node` user behind an egress firewall, so Claude can run prompt-free
+with its writes confined to the container.
+
+## What is inside
+
+- **Node 26** (`node:26-bookworm`), matching the shipped runtime and CI.
+- **OpenSSH server and client** plus the baked-in `/run/sshd` directory, so the
+  native `sshd` SFTP test backend (`PSILINK_SFTP_BACKEND=native`) spawns without
+  root. The in-process backend (the default) needs nothing extra.
+- **git**, the **GitHub CLI**, and the build toolchain for native npm modules.
+- An **egress firewall** (`init-firewall.sh`) applied on start.
+
+## Security model
+
+Three layers, so prompt-free operation inside is safe:
+
+1. **The container is the wall.** The only host filesystem a session can reach is
+   the bind-mounted workspace (read-write), plus the named `node_modules` and
+   Claude-config volumes; everything else it writes lives in the ephemeral
+   container layer and is discarded on rebuild (the named volumes persist). This
+   boundary -- not the deny-list below -- is what actually confines writes and
+   secret reads.
+2. **Egress firewall** (`init-firewall.sh`, run via passwordless sudo on start):
+   default-deny outbound (IPv4 and IPv6, failing closed if it cannot build the
+   full ruleset), allowing only the hosts a real `npm ci` trace showed (the npm
+   registry and `nodejs.org`), GitHub (its published IP ranges), the Anthropic
+   API and login, and the VS Code extension CDN. Telemetry and updater hosts are
+   absent: the container sets `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` and
+   `DISABLE_AUTOUPDATER`, so Claude makes no such calls.
+3. **Command deny-list** (`.claude/settings.json`, checked in): a guardrail that
+   holds even with prompts disabled -- it denies `git push`, and through Claude's
+   Read/Edit/Write tools it blocks reads and writes of SSH private keys and `.env`
+   files and writes to `/etc`. Deny rules are enforced in every permission mode,
+   including bypass. It is a floor against the common paths, not an airtight wall:
+   an arbitrary shell command (`cp`, `tar`, a script) can still touch those files,
+   which is why layer 1 -- the container boundary -- is the real protection. Note
+   this file is checked in, so the same deny rules also apply to Claude sessions
+   run against this repo *on the host*, where there is no container wall behind them.
+
+`post-create.sh` sets `permissions.defaultMode: bypassPermissions` in the
+container's *user* settings only, so sessions inside start prompt-free without
+changing how Claude behaves on the host.
+
+### What it does not protect against
+
+Accepted residuals -- the same posture as the reference Claude Code container. The
+firewall and container boundary are guardrails against reaching arbitrary hosts or
+the host filesystem, not an airtight seal:
+
+- **Allowlisted hosts are reachable by name on shared infrastructure.** The
+  firewall matches destination IPs, so a host sharing a CDN edge with an
+  allowlisted name (the npm registry and `nodejs.org` sit on Cloudflare; GitHub
+  Pages/`raw`/the API are allowlisted wholesale) can be reached by sending a
+  different SNI/Host to that IP. GitHub in particular is a usable exfiltration
+  channel via `git`/`gh` whenever a token is present.
+- **"Pushing is blocked" means literal `git push` plus the absence of
+  credentials.** The deny-list blocks `git push`, not every `gh` write path
+  (`gh pr create`, `gh api -X POST`, ...). In practice push fails because no push
+  credential is mounted, not because every path is denied.
+- **DNS egress is permitted** to the container's resolver -- a low-bandwidth
+  exfiltration channel an IP allowlist cannot close.
+- **A write into the workspace is a write to the host repo.** The workspace bind is
+  read-write, so a planted `.git/hooks/*` or edited file persists on the host and
+  can run there later. Treat what runs inside as you would any code in the repo.
+
+Closing the first three would need a name-aware egress proxy, which is out of
+scope here.
+
+## Prerequisites
+
+- Docker on the host (Docker Desktop on macOS).
+- Git identity: VS Code's Dev Containers feature shares the host `~/.gitconfig`
+  into the container automatically. With the bare `devcontainer` CLI, set it once
+  inside (`git config --global user.name/.email`) if you need to commit; pushing
+  is blocked from inside regardless.
+
+## Using it
+
+Open the repository in an editor with dev-container support and reopen in the
+container, or use the `devcontainer` CLI. On first creation `post-create.sh` runs
+`npm ci` into an isolated `node_modules` volume (kept separate from the
+bind-mounted host tree so Linux-built native modules do not collide with the
+host's macOS build) and builds `@psilink/core` so the apps resolve it. This runs
+*before* the egress firewall (a start step), so the initial install has full
+network access; the firewall constrains subsequent sessions.
+
+Inside the container:
+
+```sh
+npm run build -w packages/core
+npm run test                       # unit tests (core, cli, web)
+npm run lint
+npm run typecheck
+npm run test:integration -w apps/cli                          # in-process SFTP
+PSILINK_SFTP_BACKEND=native npm run test:integration -w apps/cli   # native sshd
+npm run dev -w apps/web            # web dev server on localhost:3000
+```
+
+Pushing is intentionally blocked inside the container; push from the host.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+{
+  "name": "psilink",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "TZ": "${localEnv:TZ:America/Los_Angeles}",
+      "CLAUDE_CODE_VERSION": "latest"
+    }
+  },
+  "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "anthropic.claude-code",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.codeActionsOnSave": {
+          "source.fixAll.eslint": "explicit"
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh"
+      }
+    }
+  },
+  "remoteUser": "node",
+  "mounts": [
+    "source=psilink-claude-config-${devcontainerId},target=/home/node/.claude,type=volume",
+    "source=psilink-node-modules-${devcontainerId},target=/workspace/node_modules,type=volume"
+  ],
+  "containerEnv": {
+    "NODE_OPTIONS": "--max-old-space-size=4096",
+    "CLAUDE_CONFIG_DIR": "/home/node/.claude",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    "DISABLE_AUTOUPDATER": "1"
+  },
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
+  "workspaceFolder": "/workspace",
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
+  "waitFor": "postStartCommand"
+}

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+set -Eeuo pipefail # Exit on error (inherited by functions/subshells), undefined
+IFS=$'\n\t'        # vars, and pipeline failures; stricter word splitting.
+
+# Egress firewall for the psilink dev container. Default-deny outbound, with an
+# allowlist holding only what the workflow needs:
+#
+#   - registry.npmjs.org, nodejs.org -- the only two hosts a real `npm ci` trace
+#     in this image (cold cache) contacted that are not GitHub; node-gyp fetches
+#     Node headers from nodejs.org to build the ssh2 optional dep cpu-features.
+#   - GitHub's published IP ranges -- the trace's other two hosts (github.com and
+#     release-assets.githubusercontent.com, which resolves into 185.199.108.0/22)
+#     both fall in these, and they also cover gh, the API, and raw.
+#   - api.anthropic.com -- the Claude model API.
+#   - claude.ai / console.anthropic.com -- interactive Claude login (API-key auth
+#     via ANTHROPIC_API_KEY needs neither; these are best-effort).
+#   - the VS Code extension CDN -- only used when opened through the VS Code UI.
+#
+# Telemetry and error-reporting hosts are deliberately absent: the container sets
+# CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC and DISABLE_AUTOUPDATER, so Claude makes
+# no telemetry/Sentry/updater calls. Applied on container start via passwordless
+# sudo. The SFTP backends and the web dev server bind loopback, covered by the lo
+# allow below; they need no outbound rule.
+
+# Fail closed: if anything below errors before the full ruleset is in place, slam
+# the OUTPUT/FORWARD policy to DROP so a half-built firewall never leaves egress
+# open. On the normal path the explicit DROP later makes this a no-op.
+trap 'rc=$?; echo "init-firewall: error (rc=$rc) -- forcing INPUT/OUTPUT/FORWARD DROP (fail closed)"; iptables -P INPUT DROP 2>/dev/null || true; iptables -P OUTPUT DROP 2>/dev/null || true; iptables -P FORWARD DROP 2>/dev/null || true; exit $rc' ERR
+
+# 1. Extract Docker DNS info BEFORE any flushing.
+DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
+
+# Flush existing rules and delete existing ipsets.
+iptables -F
+iptables -X
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
+ipset destroy allowed-domains 2>/dev/null || true
+
+# 2. Selectively restore ONLY internal Docker DNS resolution.
+if [ -n "$DOCKER_DNS_RULES" ]; then
+  echo "Restoring Docker DNS rules..."
+  iptables -t nat -N DOCKER_OUTPUT 2>/dev/null || true
+  iptables -t nat -N DOCKER_POSTROUTING 2>/dev/null || true
+  echo "$DOCKER_DNS_RULES" | xargs -L 1 iptables -t nat
+else
+  echo "No Docker DNS rules to restore"
+fi
+
+# Allow DNS and localhost before any restrictions.
+# Outbound DNS (UDP, plus TCP for responses that exceed 512 bytes).
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+# Inbound DNS responses, restricted to established lookups rather than any packet
+# that merely claims source port 53.
+iptables -A INPUT -p udp --sport 53 -m state --state ESTABLISHED -j ACCEPT
+iptables -A INPUT -p tcp --sport 53 -m state --state ESTABLISHED -j ACCEPT
+# Localhost (the SFTP test backends and the web dev server bind here).
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# Create ipset with CIDR support.
+ipset create allowed-domains hash:net
+
+# Fetch GitHub meta information and aggregate + add their IP ranges. This single
+# set covers git over HTTPS, the gh CLI, the API, raw.githubusercontent.com, and
+# codeload.github.com -- everything reachable under github.com.
+echo "Fetching GitHub IP ranges..."
+gh_ranges=$(curl -s --connect-timeout 5 --max-time 20 https://api.github.com/meta)
+if [ -z "$gh_ranges" ]; then
+  echo "ERROR: Failed to fetch GitHub IP ranges"
+  exit 1
+fi
+
+if ! echo "$gh_ranges" | jq -e '.web and .api and .git' >/dev/null; then
+  echo "ERROR: GitHub API response missing required fields"
+  exit 1
+fi
+
+echo "Processing GitHub IPs..."
+# Materialize the IPv4 CIDR list in a command substitution rather than a process
+# substitution: a failure anywhere in the jq | grep | aggregate pipeline then
+# propagates under `set -o pipefail` and trips the fail-closed trap, instead of
+# being swallowed by `< <(...)` (whose exit status is not checked) and leaving the
+# loop to build an empty or partial allowlist. The meta feed's IPv6 CIDRs are
+# filtered out here because the ipset is IPv4 (hash:net), `aggregate` is IPv4-only,
+# and IPv6 egress is dropped wholesale below.
+# grep is wrapped so its zero-match exit (1) is not fatal -- otherwise, under
+# pipefail, an IPv4-less feed would trip the trap with a generic message before
+# the explicit, clearer check below runs. A jq or aggregate failure still
+# propagates and fails closed.
+gh_cidrs=$(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | { grep -E '^[0-9]+\.' || true; } | aggregate -q)
+if [ -z "$gh_cidrs" ]; then
+  echo "ERROR: GitHub meta feed yielded no IPv4 ranges"
+  exit 1
+fi
+while read -r cidr; do
+  if [[ ! "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
+    echo "ERROR: Invalid CIDR range from GitHub meta: $cidr"
+    exit 1
+  fi
+  echo "Adding GitHub range $cidr"
+  ipset add -exist allowed-domains "$cidr"
+done <<<"$gh_cidrs"
+
+# Resolve a domain's A records and add them. `-exist` keeps the add idempotent --
+# several of these hosts share an IP (api.anthropic.com, claude.ai, and
+# console.anthropic.com currently all resolve to the same address), which would
+# otherwise make the second add fail under `set -e`.
+add_domain() { # $1 = domain, $2 = "required" | "optional"
+  echo "Resolving $1..."
+  local ips
+  ips=$(dig +short A "$1" | grep -E '^[0-9]{1,3}(\.[0-9]{1,3}){3}$' || true)
+  if [ -z "$ips" ]; then
+    if [ "$2" = required ]; then
+      echo "ERROR: failed to resolve required domain $1"
+      return 1
+    fi
+    echo "WARN: skipping optional domain $1 (no A record)"
+    return 0
+  fi
+  while read -r ip; do
+    echo "Adding $ip for $1"
+    ipset add -exist allowed-domains "$ip"
+  done < <(echo "$ips")
+}
+
+# Required hosts: a resolution failure here is fatal (the ERR trap then leaves
+# egress closed). Best-effort hosts must never take the whole firewall down.
+for domain in "registry.npmjs.org" "nodejs.org" "api.anthropic.com"; do
+  add_domain "$domain" required
+done
+for domain in \
+  "claude.ai" \
+  "console.anthropic.com" \
+  "marketplace.visualstudio.com" \
+  "vscode.blob.core.windows.net" \
+  "update.code.visualstudio.com"; do
+  add_domain "$domain" optional || true
+done
+
+# Allow the container to reach the host gateway so host-forwarded ports work.
+# Restricted to the gateway address itself rather than the whole bridge /24, so
+# the container cannot reach other containers on the same Docker network.
+HOST_IP=$(ip -4 route show default | awk '{print $3; exit}')
+if [ -z "$HOST_IP" ]; then
+  echo "ERROR: Failed to detect host IP"
+  exit 1
+fi
+echo "Host gateway detected as: $HOST_IP"
+iptables -A INPUT -s "$HOST_IP" -j ACCEPT
+iptables -A OUTPUT -d "$HOST_IP" -j ACCEPT
+
+# Add the accept rules (established connections, then the allowlist) BEFORE
+# flipping the default policy to DROP, so the change is closing a gap rather than
+# briefly orphaning an in-flight connection.
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+
+# Default policies to DROP.
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP
+
+# Explicitly REJECT other outbound traffic (appended last, so it is the catch-all
+# after the allowlist accept) for immediate feedback instead of a silent drop.
+iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
+
+# Block IPv6 entirely: the allowlist above is IPv4-only, so without this an agent
+# could bypass it over IPv6 wherever the container has IPv6 connectivity. Loopback
+# stays open. The flush is best-effort, but the policy DROPs are applied without
+# masking -- a genuine failure must trip the fail-closed trap rather than print a
+# false "blocked". A host whose ip6tables is unusable (no IPv6 stack) has nothing
+# to block and is skipped.
+if command -v ip6tables >/dev/null 2>&1 && ip6tables -L >/dev/null 2>&1; then
+  ip6tables -F || true
+  ip6tables -X || true
+  ip6tables -P INPUT DROP
+  ip6tables -P FORWARD DROP
+  ip6tables -P OUTPUT DROP
+  ip6tables -A INPUT -i lo -j ACCEPT
+  ip6tables -A OUTPUT -o lo -j ACCEPT
+  echo "IPv6 egress blocked (loopback allowed)"
+else
+  echo "ip6tables unusable or no IPv6 stack; nothing to block"
+fi
+
+# The full ruleset is in place; drop the fail-closed trap so a benign error in the
+# verification below does not get reported as a firewall build failure.
+trap - ERR
+
+echo "Firewall configuration complete"
+echo "Verifying firewall rules..."
+if curl --connect-timeout 5 -s https://example.com >/dev/null 2>&1; then
+  echo "ERROR: Firewall verification failed - was able to reach https://example.com"
+  exit 1
+else
+  echo "Firewall verification passed - unable to reach https://example.com as expected"
+fi
+
+# Verify the allowlist actually permits GitHub and the npm registry.
+if ! curl --connect-timeout 5 -s https://api.github.com/zen >/dev/null 2>&1; then
+  echo "ERROR: Firewall verification failed - unable to reach https://api.github.com"
+  exit 1
+else
+  echo "Firewall verification passed - able to reach https://api.github.com as expected"
+fi
+
+if ! curl --connect-timeout 5 -sSf https://registry.npmjs.org/ >/dev/null 2>&1; then
+  echo "ERROR: Firewall verification failed - unable to reach https://registry.npmjs.org"
+  exit 1
+else
+  echo "Firewall verification passed - able to reach https://registry.npmjs.org as expected"
+fi

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+# Runs once on container creation, before the egress firewall is applied (the
+# firewall is a postStartCommand), so this install reaches the full network.
+
+# Install workspace dependencies into the node_modules volume (isolated from the
+# bind-mounted host tree by devcontainer.json), building any native pieces for
+# this Linux container rather than reusing the host's macOS build. `npm ci` is the
+# reproducible, lockfile-faithful install for the from-scratch volume.
+npm ci
+
+# Build @psilink/core so the apps resolve it immediately: they import it from its
+# built dist/, which is gitignored and lives on the bind-mounted tree (not the
+# node_modules volume), so a fresh container would otherwise see it unbuilt.
+npm run build -w packages/core
+
+# Default this container's Claude sessions to prompt-free. The container's egress
+# firewall plus the checked-in command deny-list in .claude/settings.json are the
+# safety floor (deny rules are enforced even in bypassPermissions mode), so
+# prompts add nothing here. This sets only the CONTAINER's user settings (a
+# mounted volume), never the project or host config, so it does not change how
+# Claude behaves on the host that shares this repo's .claude/settings.json. It is
+# idempotent: it leaves an existing defaultMode untouched.
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+mkdir -p "$CONFIG_DIR"
+SETTINGS="$CONFIG_DIR/settings.json" node -e '
+  const fs = require("fs");
+  const path = process.env.SETTINGS;
+  let settings = {};
+  try {
+    settings = JSON.parse(fs.readFileSync(path, "utf8"));
+  } catch (err) {
+    // A missing file is fine (start fresh); an existing but unreadable or invalid
+    // one must not be silently overwritten -- abort and leave it for inspection.
+    if (err.code !== "ENOENT") {
+      console.error("refusing to overwrite existing " + path + ": " + err.message);
+      process.exit(1);
+    }
+  }
+  settings.permissions = settings.permissions || {};
+  if (!settings.permissions.defaultMode) {
+    settings.permissions.defaultMode = "bypassPermissions";
+  }
+  fs.writeFileSync(path, JSON.stringify(settings, null, 2) + "\n");
+'
+
+echo "post-create complete: dependencies installed; container Claude sessions default to prompt-free."

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -27,15 +27,26 @@ npm run dev -w apps/cli --server-private-key=@PEM_FILE sftp://USER@HOST/PATH INP
 
 ## To build for Docker Hub
 
-Do once:
+Multi-platform images require a `docker-container`-driver buildx builder. Create
+it once, but do NOT make it your default (no `--use`): a global default
+`docker-container` builder breaks tools that build and then load a single image
+into the local engine -- notably `devcontainer up`, which then hangs after the
+build with no container created. Select the builder explicitly with `--builder`
+on each deployment build instead, leaving your everyday default on the
+engine-native `docker` driver.
+
+Run these from the repository root (the Dockerfile lives there).
+
+Do once (skip if `multiarch-builder` already exists; run `docker buildx rm
+multiarch-builder` first to recreate):
 ```sh
-docker buildx create --use --name multiarch-builder
-docker buildx inspect --bootstrap
+docker buildx create --name multiarch-builder
+docker buildx inspect --bootstrap multiarch-builder
 ```
 
 Do every time:
 ```sh
-docker buildx build \
+docker buildx build --builder multiarch-builder \
   --platform linux/amd64,linux/arm64 \
   -t vdorie/psi-link:latest \
   --push .
@@ -45,7 +56,7 @@ docker buildx stop multiarch-builder
 
 ## To build for testing
 
-Before pushing to Docker hub:
+Before pushing to Docker hub, from the repository root:
 
 ```sh
 docker image rm -f vdorie/psi-link:latest


### PR DESCRIPTION
## Summary

Add a plain Node 26 development container in which an agent or developer runs the
whole psilink workflow -- build, unit tests, lint, typecheck, the web dev server,
and both SFTP integration backends -- with no Docker inside it. It runs as the
non-root `node` user behind a default-deny egress firewall, so Claude can run
prompt-free with writes confined to the container. With the integration suite no
longer needing a Docker SFTP server (#119), the container needs no nested daemon
and no CPU emulation.

Part of [199536728](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=199536728).

## Changes

- `.devcontainer/Dockerfile` -- Node 26 (the shipped runtime and CI version),
  non-root `node`, the OpenSSH server the native SFTP backend spawns (`/run/sshd`
  baked in), the GitHub CLI, and the iptables/ipset toolchain the firewall uses.
- `.devcontainer/init-firewall.sh` -- default-deny egress, fails closed, blocks
  IPv6. The allowlist is derived from a real `npm ci` network trace (the npm
  registry, nodejs.org, and GitHub's published ranges) plus the Anthropic API and
  login hosts and the VS Code extension CDN. Telemetry and the updater are
  disabled by container env, so no telemetry hosts are allowlisted.
- `.devcontainer/devcontainer.json`, `.devcontainer/post-create.sh` -- install
  dependencies and build `@psilink/core` on create, isolate the Linux
  `node_modules` from the bind-mounted host tree via a named volume, apply the
  firewall on start, and set prompt-free mode only in the container's user
  settings so the host is unaffected.
- `.claude/settings.json` -- new checked-in command deny-list, enforced in every
  permission mode: denies `git push`, and via the Read/Edit/Write tools the SSH
  private keys, `.env` files, and writes to `/etc`.
- `.devcontainer/README.md` -- usage and the security model, including the
  accepted residuals.
- `apps/cli/README.md` -- the Docker Hub build selects the multi-arch buildx
  builder per build (`--builder`) instead of `docker buildx create --use`, which
  made a `docker-container` builder the global default and stalled `devcontainer
  up`.

## Background

The egress firewall is an IP allowlist; the real containment is the container
boundary, and the deny-list is a floor an arbitrary shell command can still step
around. Because the deny-list is checked in, the same rules also apply to host
Claude sessions in this repo.

## Out of scope / follow-on

- Phase 3 (hardened native-`sshd` configurations) remains, tracked in the same
  item.

## Test plan

- [x] `npm run typecheck && npm run lint` clean
- [x] `npm test -w packages/core` (1187/1187)
- [x] `npm run test:unit -w apps/cli` (615/615), `apps/web` (103/103)
- [x] CLI integration tests: `npm run test:integration -w apps/cli` (24/24
  in-process; 21/24 native, with the 3 documented in-process-only skips)

All ran inside the built container with no Docker present; `npm ci` succeeds under
the active firewall; the full `devcontainer up` lifecycle was exercised end to end
(create, `npm ci`, core build, firewall, ready). No new tests -- this is an
infrastructure change validated by running the existing suite in the container.

## Checklist

- [x] Ran `ls docs/`; no page needs changes for this change. RELEASES.md step 8's
  multi-arch image build is CI-automated and does not use the global-default
  `--use` pattern, so the builder fix does not affect it.
- [x] `CHANGELOG.md` `[Unreleased]`: n/a -- developer tooling, not a product or
  user-facing change.
- [x] Cryptographic code changed? n/a -- none touched.
