### PR TITLE
Enable gated autonomous push from dev containers

### DIFF
--- a/.claude/hooks/block-protected-push.mjs
+++ b/.claude/hooks/block-protected-push.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+// PreToolUse hook: refuse `git push` whose destination is a protected branch
+// (staging/main).
+//
+// Why this exists: the gated-autonomous-push work removes the blanket `git push`
+// deny from .claude/settings.json so a contained, unattended agent can push
+// feature branches and open PRs without an interactive prompt. This hook is the
+// client-side half of the replacement gate; GitHub branch protection on
+// staging/main is the authoritative server-side half. The hook gives an
+// unattended agent instant local feedback instead of a wasted network round-trip
+// the server would reject anyway -- it is defense-in-depth, not the wall.
+//
+// Why a hook and not an `ask` rule: the container runs in bypassPermissions mode,
+// which skips `ask` prompts (and an `ask` would stall an unattended agent anyway).
+// PreToolUse hooks run in every permission mode, including bypass, so the gate
+// holds there. Exit 0 allows the call; exit 2 blocks it and feeds stderr back to
+// Claude. Any unexpected failure here falls through to exit 0 (fail open) so a bug
+// in this hook can never wedge every Bash command -- branch protection backstops a
+// push this hook misses.
+
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const PROTECTED = new Set(["staging", "main"]);
+
+function block(reason) {
+  process.stderr.write(
+    `Blocked by block-protected-push hook: ${reason}.\n` +
+      "staging and main are protected; open a PR from a feature branch instead.\n",
+  );
+  process.exit(2);
+}
+
+// Split a command line into shell segments so a push hidden in a compound command
+// (`a && git push ...`, `b; git push ...`, `c | git push ...`) is still inspected.
+// Pragmatic, not a full shell parser; branch protection backstops exotic quoting.
+function splitSegments(command) {
+  return command.split(/\s*(?:&&|\|\||[;|\n])\s*/);
+}
+
+// Whitespace tokenizer that keeps quoted spans intact, then strips quotes. Good
+// enough to read remote/refspec arguments; not POSIX-complete.
+function tokenize(segment) {
+  const tokens = segment.match(/(?:[^\s'"]+|'[^']*'|"[^"]*")+/g) || [];
+  // Strip ALL quote characters, not just the outermost pair: a quoted ref like
+  // HEAD:'staging' must normalize to HEAD:staging (branch/remote names never
+  // contain quotes). A first/last-char-only strip left an inner quote, so the
+  // destination read back as 'staging and slipped past the protected-branch check.
+  return tokens.map((t) => t.replace(/['"]/g, ""));
+}
+
+// git global options that consume a following token as their value, so the
+// subcommand scan does not mistake that value for the subcommand.
+const VALUE_GLOBALS = new Set([
+  "-C",
+  "-c",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+]);
+
+// If this segment invokes `git push`, return the argument list after `push`;
+// otherwise null. Requires git to be the command word (after leading env
+// assignments and simple wrappers) so `echo git push ...` is not mistaken for one.
+function gitPushArgs(tokens) {
+  let i = 0;
+  while (i < tokens.length) {
+    const t = tokens[i];
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(t)) {
+      i++; // leading env assignment: FOO=bar git ...
+      continue;
+    }
+    if (t === "sudo" || t === "command" || t === "env" || t === "nice") {
+      i++;
+      continue;
+    }
+    break;
+  }
+  const cmd = tokens[i];
+  if (!cmd) return null;
+  if (cmd.replace(/^.*\//, "") !== "git") return null;
+  i++;
+  while (i < tokens.length && tokens[i].startsWith("-")) {
+    i += VALUE_GLOBALS.has(tokens[i]) ? 2 : 1;
+  }
+  if (tokens[i] !== "push") return null;
+  return tokens.slice(i + 1);
+}
+
+// Destination branch names targeted by an explicit refspec, or null when the push
+// gives no refspec (a bare `git push` / `git push <remote>`), which must be
+// resolved against the branch's configured push target instead.
+function explicitDestinations(args) {
+  const positionals = [];
+  let skipNext = false;
+  for (const a of args) {
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
+    if (a.startsWith("-")) {
+      // push options that take a separate value, so the value is not read as a
+      // refspec (e.g. `--push-option staging`).
+      if (/^(-o|--push-option|--repo|--exec|--receive-pack)$/.test(a)) {
+        skipNext = true;
+      }
+      continue;
+    }
+    positionals.push(a);
+  }
+  // 0 positionals: bare `git push`. 1 positional: `git push <remote>` -- still no
+  // refspec, so the destination follows push.default. Both resolve via @{push}.
+  if (positionals.length < 2) return null;
+  const [, ...refspecs] = positionals;
+  return refspecs.map((r) => {
+    // `src:dst` and `+src:dst` (force) target dst; `:dst` (delete) targets dst; a
+    // bare ref targets itself. Normalize a refs/heads/ prefix to the branch name.
+    const spec = r.replace(/^\+/, "");
+    const colon = spec.indexOf(":");
+    const dst = colon >= 0 ? spec.slice(colon + 1) : spec;
+    return dst.replace(/^refs\/heads\//, "");
+  });
+}
+
+function gitRef(cwd, gitArgs) {
+  try {
+    return execFileSync("git", gitArgs, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// Decide whether a bare `git push` (no refspec) would land on a protected branch.
+function barePushVerdict(cwd) {
+  const current = gitRef(cwd, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
+  if (current && PROTECTED.has(current)) {
+    return `bare 'git push' while on protected branch '${current}'`;
+  }
+  const pushRef = gitRef(cwd, [
+    "rev-parse",
+    "--abbrev-ref",
+    "--symbolic-full-name",
+    "@{push}",
+  ]);
+  if (pushRef) {
+    const dst = pushRef.replace(/^[^/]+\//, ""); // strip the "origin/" remote
+    if (PROTECTED.has(dst)) {
+      return `bare 'git push' resolves to protected branch '${dst}' via @{push}`;
+    }
+    return null; // resolves to a non-protected branch -- allow
+  }
+  // No resolvable push target. A bare push here either errors (git will ask for
+  // -u) or relies on push.default landing somewhere unverifiable; refuse and make
+  // the agent name an explicit, non-protected destination.
+  return "bare 'git push' has no resolvable upstream; specify an explicit destination, e.g. 'git push -u origin <branch>'";
+}
+
+function main() {
+  let event;
+  try {
+    event = JSON.parse(readFileSync(0, "utf8"));
+  } catch {
+    process.exit(0); // unreadable event -- do not interfere
+  }
+  if (event.tool_name !== "Bash") process.exit(0);
+  const command = event?.tool_input?.command;
+  if (typeof command !== "string" || !command.includes("push")) process.exit(0);
+  const cwd = typeof event.cwd === "string" ? event.cwd : process.cwd();
+
+  for (const segment of splitSegments(command)) {
+    const args = gitPushArgs(tokenize(segment));
+    if (!args) continue;
+    // --all / --mirror push (or mirror) every ref, including staging and main, and
+    // carry no refspec to inspect -- so they would otherwise fall through to
+    // barePushVerdict and be allowed from a feature branch. Refuse them outright; a
+    // legitimate feature-branch push names an explicit refspec, never --all/--mirror.
+    if (args.some((a) => a === "--all" || a === "--mirror")) {
+      block(
+        "'git push --all'/'--mirror' pushes every ref, including staging and main",
+      );
+    }
+    const dests = explicitDestinations(args);
+    if (dests === null) {
+      const verdict = barePushVerdict(cwd);
+      if (verdict) block(verdict);
+      continue;
+    }
+    for (const dst of dests) {
+      if (PROTECTED.has(dst)) block(`push targets protected branch '${dst}'`);
+    }
+  }
+  process.exit(0);
+}
+
+try {
+  main();
+} catch {
+  process.exit(0); // fail open: never wedge Bash on an unexpected hook error
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,6 @@
 {
   "permissions": {
     "deny": [
-      "Bash(git push:*)",
-      "Bash(git -C * push:*)",
       "Read(~/.ssh/**)",
       "Edit(~/.ssh/**)",
       "Write(~/.ssh/**)",
@@ -20,6 +18,19 @@
       "Write(**/.env.*)",
       "Edit(/etc/**)",
       "Write(/etc/**)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-protected-push.mjs\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -32,15 +32,22 @@ Three layers, so prompt-free operation inside is safe:
    API and login, and the VS Code extension CDN. Telemetry and updater hosts are
    absent: the container sets `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` and
    `DISABLE_AUTOUPDATER`, so Claude makes no such calls.
-3. **Command deny-list** (`.claude/settings.json`, checked in): a guardrail that
-   holds even with prompts disabled -- it denies `git push`, and through Claude's
-   Read/Edit/Write tools it blocks reads and writes of SSH private keys and `.env`
-   files and writes to `/etc`. Deny rules are enforced in every permission mode,
-   including bypass. It is a floor against the common paths, not an airtight wall:
-   an arbitrary shell command (`cp`, `tar`, a script) can still touch those files,
-   which is why layer 1 -- the container boundary -- is the real protection. Note
-   this file is checked in, so the same deny rules also apply to Claude sessions
-   run against this repo *on the host*, where there is no container wall behind them.
+3. **Command deny-list and a protected-branch push hook** (`.claude/settings.json`,
+   checked in): guardrails that hold even with prompts disabled. Through Claude's
+   Read/Edit/Write tools the deny-list blocks reads and writes of SSH private keys
+   and `.env` files and writes to `/etc`; a checked-in `PreToolUse` hook
+   (`.claude/hooks/block-protected-push.mjs`) blocks a direct `git push` to
+   `staging` or `main`. Both deny rules and PreToolUse hooks are enforced in every
+   permission mode, including bypass. These are a floor against the common paths,
+   not an airtight wall: an arbitrary shell command (`cp`, `tar`, a script) can
+   still touch the denied files, and the push hook is best-effort -- it catches a
+   direct or accidental push but is bypassable by shell indirection (`sh -c`,
+   `eval`, a subshell, `git -c`), so it is fast local feedback, not a security
+   boundary. The authoritative wall for `staging`/`main` is GitHub branch
+   protection (server-side, no bypass actors); layer 1 -- the container boundary --
+   is the real protection for the filesystem. Note this file is checked in, so the
+   same rules also apply to Claude sessions run against this repo *on the host*,
+   where there is no container wall behind them.
 
 `post-create.sh` sets `permissions.defaultMode: bypassPermissions` in the
 container's *user* settings only, so sessions inside start prompt-free without
@@ -58,10 +65,20 @@ the host filesystem, not an airtight seal:
   Pages/`raw`/the API are allowlisted wholesale) can be reached by sending a
   different SNI/Host to that IP. GitHub in particular is a usable exfiltration
   channel via `git`/`gh` whenever a token is present.
-- **"Pushing is blocked" means literal `git push` plus the absence of
-  credentials.** The deny-list blocks `git push`, not every `gh` write path
-  (`gh pr create`, `gh api -X POST`, ...). In practice push fails because no push
-  credential is mounted, not because every path is denied.
+- **A provided token grants real GitHub write access.** When `GH_TOKEN` is set in
+  `.env` (see Prerequisites), the container can push feature branches and open
+  PRs. The push hook refuses `staging`/`main` and branch protection rejects them
+  server-side, but any other branch is writable, and -- as the bullet above notes --
+  `git`/`gh` over an allowlisted GitHub IP is then a usable exfiltration channel.
+  Scope the token narrowly (a fine-grained PAT limited to this repo, contents +
+  pull-requests write) so a leak cannot reach other repos. With no token, push/PR
+  are unauthenticated and fail.
+- **The push hook is not a security boundary.** It blocks direct or accidental
+  pushes to `staging`/`main`, but a wrapped command (`sh -c`, `eval`, a subshell,
+  `git -c remote.origin.push=...`) bypasses it, and it does not gate `gh` API
+  writes (`gh pr merge`, `gh api`) at all. GitHub branch protection enforces
+  `staging`/`main` server-side across every path -- that is the wall; the hook is
+  fast local feedback for an unattended agent, nothing more.
 - **DNS egress is permitted** to the container's resolver -- a low-bandwidth
   exfiltration channel an IP allowlist cannot close.
 - **A write into the workspace is a write to the host repo.** The workspace bind is
@@ -76,8 +93,19 @@ scope here.
 - Docker on the host (Docker Desktop on macOS).
 - Git identity: VS Code's Dev Containers feature shares the host `~/.gitconfig`
   into the container automatically. With the bare `devcontainer` CLI, set it once
-  inside (`git config --global user.name/.email`) if you need to commit; pushing
-  is blocked from inside regardless.
+  inside (`git config --global user.name/.email`) if you need to commit.
+- Push/PR credentials (optional): to let a session push and open PRs from inside,
+  copy `.env.example` to `.env` at the repository root and set `GH_TOKEN` to a
+  GitHub PAT. The container loads `.env` via docker `--env-file` (`devcontainer.json`
+  `runArgs`) and `post-create.sh` runs `gh auth setup-git`, so both `git push`
+  (HTTPS) and `gh pr create` authenticate with no prompt. Use a fine-grained PAT
+  scoped to this repo (contents + pull-requests write). `.env` is gitignored.
+  `--env-file` is **literal**: write `GH_TOKEN=<value>` unquoted, with no `export`,
+  and with no inline `# comment` -- quotes, an `export` prefix, and a trailing
+  comment all become part of the token value (a corrupted token then fails only
+  later, at push time). `GITHUB_TOKEN` is accepted as an alternative name. With no
+  `.env` (an empty one is created automatically so the container always starts),
+  push/PR stay unauthenticated.
 
 ## Using it
 
@@ -101,4 +129,7 @@ PSILINK_SFTP_BACKEND=native npm run test:integration -w apps/cli   # native sshd
 npm run dev -w apps/web            # web dev server on localhost:3000
 ```
 
-Pushing is intentionally blocked inside the container; push from the host.
+With a `GH_TOKEN` set in `.env` (see Prerequisites) a session can push feature
+branches and open PRs from inside; pushes to `staging`/`main` are refused by the
+push hook and by GitHub branch protection. With no token, push/PR are
+unauthenticated and fail.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,13 @@
       "CLAUDE_CODE_VERSION": "latest"
     }
   },
-  "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
+  "runArgs": [
+    "--cap-add=NET_ADMIN",
+    "--cap-add=NET_RAW",
+    "--env-file",
+    "${localWorkspaceFolder}/.env"
+  ],
+  "initializeCommand": "test -f \"${localWorkspaceFolder}/.env\" || touch \"${localWorkspaceFolder}/.env\"",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -16,10 +16,11 @@ npm ci
 npm run build -w packages/core
 
 # Default this container's Claude sessions to prompt-free. The container's egress
-# firewall plus the checked-in command deny-list in .claude/settings.json are the
-# safety floor (deny rules are enforced even in bypassPermissions mode), so
-# prompts add nothing here. This sets only the CONTAINER's user settings (a
-# mounted volume), never the project or host config, so it does not change how
+# firewall plus the checked-in deny-list and protected-branch push hook in
+# .claude/ are the safety floor (both deny rules and PreToolUse hooks apply even in
+# bypassPermissions mode), so prompts add nothing here. This sets only the
+# CONTAINER's user settings (a mounted volume), never the project or host config,
+# so it does not change how
 # Claude behaves on the host that shares this repo's .claude/settings.json. It is
 # idempotent: it leaves an existing defaultMode untouched.
 CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
@@ -44,5 +45,18 @@ SETTINGS="$CONFIG_DIR/settings.json" node -e '
   }
   fs.writeFileSync(path, JSON.stringify(settings, null, 2) + "\n");
 '
+
+# Wire git push (over HTTPS) and the gh CLI to a GitHub token when one is present.
+# devcontainer.json loads a repo-root .env into the container via docker
+# --env-file; `gh auth setup-git` then registers gh as git's credential helper, so
+# both `git push` and `gh pr create` authenticate with no interactive prompt.
+# Pushes to staging/main are still refused by the protected-branch hook and,
+# server-side, by GitHub branch protection. With no token forwarded, push/PR stay
+# unauthenticated -- the prior posture -- so skip rather than failing creation.
+if [ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]; then
+  gh auth setup-git || echo "post-create: warning -- 'gh auth setup-git' failed; 'git push' over HTTPS may prompt."
+else
+  echo "post-create: no GH_TOKEN/GITHUB_TOKEN in env; skipping git credential setup (push/PR unauthenticated)."
+fi
 
 echo "post-create complete: dependencies installed; container Claude sessions default to prompt-free."

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GH_TOKEN=

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 *.local*
+.env*
 .nitro
 .tanstack
 .output


### PR DESCRIPTION
## Summary

Let a contained dev-container agent push feature branches and open PRs without an interactive prompt, while keeping `staging` and `main` changeable only through a pull request. This unblocks the unattended issue-to-PR pipeline: the container can authenticate and push, and direct writes to the protected branches are refused both locally and server-side.

Implements board 10 item [199809359](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=199809359).

## Changes

- `.claude/settings.json`: remove the blanket `Bash(git push:*)` deny rules and register a `PreToolUse` hook on `Bash`; the deny is replaced by branch protection plus the hook.
- `.claude/hooks/block-protected-push.mjs`: new hook that blocks (exit 2) a `git push` whose destination resolves to `staging` or `main` -- explicit refspecs, bare push via `@{push}`, and `--all`/`--mirror`; fails open so a hook error can never wedge Bash.
- `.devcontainer/devcontainer.json`: load `GH_TOKEN` from a gitignored repo-root `.env` via docker `--env-file`; an `initializeCommand` ensures `.env` exists so a tokenless container still starts.
- `.devcontainer/post-create.sh`: run `gh auth setup-git` when a token is present so `git push` (HTTPS) and `gh pr create` authenticate non-interactively.
- `.devcontainer/README.md`: document the credential setup and the security model.
- `.env.example`, `.prettierignore`: add a tracked token template; keep prettier off `.env*`.

## Background

The server-side GitHub branch-protection ruleset on `staging`/`main` (PR required, no bypass actors) is the authoritative wall and is what makes relaxing the client-side push deny safe -- even if the hook regresses, the protected branches stay protected. Because `.claude/settings.json` is checked in, lifting the deny also relaxes host Claude sessions in this repo; this is intended. The hook is fast local feedback for an unattended agent, not a security boundary: it is bypassable by shell indirection and does not gate `gh` API writes, both of which the ruleset covers server-side.

## Test plan

- [x] `npm run typecheck && npm run lint` clean
- [x] `npm run formatcheck` clean
- Unit and integration suites -- n/a: this change adds no `packages/core` or `apps/*` runtime code (config, a standalone hook script, and docs only). CI runs the full suites on the PR.

Verified end to end in a dev container: the forwarded token authenticated (`gh auth status`), a feature-branch push succeeded with no prompt, and a direct push to `staging` was rejected. The hook was checked across direct, bare, refspec, `--all`/`--mirror`, and quoted-refspec cases. GitHub branch protection was confirmed active server-side (ruleset, no bypass actors).

## Checklist

- [x] Ran `ls docs/` and `ls docs/spec/`, checked each for impact -- none affected (the dev container is documented in `.devcontainer/README.md`, updated here)
- [x] Any detail added to a `docs/` overview is conceptual -- n/a (no `docs/` change; operational detail lives in `.devcontainer/README.md`)
- [x] `CHANGELOG.md` `[Unreleased]` -- n/a (dev-workflow tooling; consistent with dev-container PR #125, which added no CHANGELOG entry)
- [x] Cryptographic code changed? -- n/a (no cryptographic code; an independent security review of the change was performed regardless)
