### PR TITLE
Share Claude auth across agent dev containers

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -106,6 +106,27 @@ scope here.
   later, at push time). `GITHUB_TOKEN` is accepted as an alternative name. With no
   `.env` (an empty one is created automatically so the container always starts),
   push/PR stay unauthenticated.
+- Claude credentials (optional): each container's `~/.claude` is a separate
+  per-`${devcontainerId}` volume, so by default every container needs its own
+  one-time browser `/login` -- friction once several agents run in parallel. To
+  reuse one host-side login instead, run `claude setup-token` on the host and
+  export the resulting `CLAUDE_CODE_OAUTH_TOKEN` in the shell that launches the
+  container; `devcontainer.json` forwards it through `containerEnv` via
+  `${localEnv:...}`, so Claude authenticates with no per-container login. The
+  token is inference-scoped and draws on your Claude subscription
+  (Pro/Max/Team/Enterprise) rather than per-token API billing. Only this one
+  credential is forwarded, not `ANTHROPIC_API_KEY`: Claude Code's auth precedence
+  lets an API key silently override an OAuth token when both are set, so wiring
+  both invites a surprise-billing footgun. Unlike `GH_TOKEN`, the token comes from
+  the launching process's *shell environment*, not from `.env` -- so start VS Code
+  or the `devcontainer` CLI from a shell where the variable is exported (a
+  GUI-launched editor may not inherit it). With no token set the variable forwards
+  empty, the passthrough is inactive, and the container still starts with the
+  per-container `/login` available as the fallback. No firewall change is needed:
+  the token authenticates against `api.anthropic.com`, already on the egress
+  allowlist (`init-firewall.sh`). It is readable by anything running inside the
+  container -- the same posture as `GH_TOKEN` -- so use a dedicated token and
+  rotate or revoke it through your Claude account if it may be exposed.
 
 ## Using it
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,8 @@
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
-    "DISABLE_AUTOUPDATER": "1"
+    "DISABLE_AUTOUPDATER": "1",
+    "CLAUDE_CODE_OAUTH_TOKEN": "${localEnv:CLAUDE_CODE_OAUTH_TOKEN}"
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",


### PR DESCRIPTION
## Summary

Share a single host-side Claude login across the parallel agent dev containers,
removing the per-container browser login that becomes friction once several
agents run at once. The container reads a `CLAUDE_CODE_OAUTH_TOKEN` from the host
shell environment and authenticates with no interactive step; when the host sets
nothing, the container still starts and the per-container `/login` remains as the
fallback.

Implements board 10 (Release & Operations) item [199793480](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=199793480).

## Changes

- `.devcontainer/devcontainer.json` -- forward `CLAUDE_CODE_OAUTH_TOKEN` from the
  host shell into the container through `containerEnv` `${localEnv:...}`, so Claude
  authenticates without a per-container login.
- `.devcontainer/README.md` -- document the new credential path: `claude
  setup-token` on the host, the host-shell-env source (distinct from the
  `GH_TOKEN` `.env` mechanism, including the GUI-launch caveat), the subscription
  billing model, the empty-when-unset fallback, the no-firewall-change rationale,
  and the in-container exposure.

## Background

Each container's `~/.claude` is a separate per-`${devcontainerId}` volume, so a
login does not carry across the parallel containers -- the friction this removes.
Only `CLAUDE_CODE_OAUTH_TOKEN` is forwarded, not `ANTHROPIC_API_KEY` as well:
Claude Code's documented auth precedence has an API key silently override an OAuth
token when both are set, so forwarding both invites a surprise-billing/wrong-org
footgun. The OAuth token is the documented headless path for subscription auth and
is inference-scoped. No egress-firewall change is needed -- the token
authenticates against `api.anthropic.com`, already on the `init-firewall.sh`
allowlist.

## Out of scope / follow-on

- Egress-allowlist host names: Claude Code's current docs list `platform.claude.com`
  (Console auth) and `downloads.claude.ai` (updater) among its hosts, while
  `init-firewall.sh` allowlists the older `console.anthropic.com`. This affects
  only the interactive in-container `/login` fallback (pre-existing, not the token
  passthrough added here, which reaches only `api.anthropic.com`). Left unchanged;
  flagged for a separate look at the firewall's interactive-login coverage. No
  board item yet.

## Test plan

Config-and-docs change with no source touched, so the applicable gates plus a
behavior probe of the fallback:

- [x] `npm run typecheck && npm run lint` clean
- [x] `npm run formatcheck` clean (`devcontainer.json` is prettier-checked; the
      README is markdown, prettier-ignored)
- [x] `npm run build -w packages/core` (fresh worktree; the apps resolve
      `@psilink/core` from its built `dist/`)
- [x] Empty-token fallback verified in a `node:26-bookworm` container (claude-code
      2.1.177, matching `CLAUDE_CODE_VERSION=latest`): an empty
      `CLAUDE_CODE_OAUTH_TOKEN` yields `Not logged in -- Please run /login`,
      byte-identical to leaving it unset, while a bogus non-empty token yields a
      401 -- so the empty passthrough is inert and the per-container `/login`
      fallback stays intact.
- Core/CLI/web unit and integration suites -- n/a, no source changed.

No automated tests accompany the change: `devcontainer.json` is container config
with no test harness in the repo, so verification is the gates above plus the
empty-token probe.

## Checklist

- [x] Ran `ls docs/` and `ls docs/spec/` and checked each for impact: the only
      affected doc is `.devcontainer/README.md` (updated); no `docs/` or
      `docs/spec/` page references the dev container.
- [x] n/a -- no detail was added to a `docs/` overview (the doc change lives in
      `.devcontainer/README.md`).
- [x] n/a -- `CHANGELOG.md` records product changes; the dev container is internal
      developer/agent tooling (PRs #125 and #129 set this precedent and added no
      changelog entry).
- [x] n/a -- no cryptographic code changed.
