### PR TITLE
Add a checked-in CLAUDE.md for contained sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+psilink does Privacy Preserving Record Linkage (PPRL) via Private Set Intersection (PSI) between two parties over SFTP, file-drop, or WebRTC.
+
+It is a npm workspaces monorepo (`packages/core`, `apps/cli`, `apps/web`); apps consume packages, not the reverse.
+
+**Read `CONTRIBUTING.md` before your first edit or commit.** It holds the build/test/dev reference and every coding and commit convention (enforced by CI and review), none of it repeated here. This file is only the complement: project operations and agent-specific rules.
+
+## Commands
+
+Non-obvious ones (full reference in `CONTRIBUTING.md`):
+
+```sh
+npm run build -w packages/core # required after any core change
+npm run test # unit tests only (root fans out to each workspace; cli/web run their unit project)
+npx vitest run path/to/file.test.ts # single test file, from workspace root
+```
+
+## GitHub project items
+
+Read and edit drafts by numeric ID (the `?itemId=N` URL value) or a `PVTI_` node id (the `id` from list-issues) via the scripts -- never hand-write the gh/GraphQL. Run any with no args for usage.
+
+- `node .claude/scripts/fetch-issues.mjs <project> <itemId> ...` -- read; shows custom fields
+- `node .claude/scripts/edit-issue.mjs <project> <itemId> ...` -- edit status/title/body/fields
+- `node .claude/scripts/list-epic.mjs <project> "<Epic>"` -- list an epic's items by Implementation Order
+- `node .claude/scripts/list-issues.mjs <project>` -- list every item on a board, fully paginated; `--status NAME` filters, `--json` for a machine array
+
+Create a draft (the one board op still on `gh`): `gh project item-create <project> --owner georgetown-mdi --title "..." --body "..."`.
+
+## Project manager
+
+The PM ruleset lives once at `.claude/pm/ruleset.md`; two front doors load it:
+
+- **`/pm` skill** -- interactive persona for board hygiene, epic scoping, and drafting/revising tasks in conversation. Confirms before board writes.
+- **`project-manager` consult agent** -- one-shot, spawned from a working session to advise on a finding or capture a deferred task. Returns one terminal result (FEEDBACK / FILED / NEEDS INPUT) and **cannot be continued** (no `SendMessage`).
+
+Driving the consult: the main thread owns the loop. Spawn it with a self-contained prompt; on a NEEDS INPUT result, relay its questions via AskUserQuestion and re-spawn with the answers folded in (the only form of "continuation"). Coding subagents bubble PM requests up rather than spawning the consult themselves -- AskUserQuestion and the human live only at the top level.
+
+## Agent conventions
+
+Beyond the conventions in `CONTRIBUTING.md`:
+
+- Prefer ASCII: `-` not an en-dash or em-dash, `->` not an arrow character.
+- Never commit to staging or main by yourself; don't attribute yourself on commits or pull requests.
+- Commit messages use no markdown and no top-level lists (other format rules in `CONTRIBUTING.md`, Commit Messages).
+- After a chain of edits, run `npm run typecheck && npm run lint`; the LSP server often has a stale cache.
+- Typecheck, lint, and format are CI checks.
+- Project state belongs in the GitHub project and docs/, not agent memory.
+- Prettier ignores markdown.
+- Branch names shouldn't use '/'.
+- Don't use chip to raise issues -- ask directly.
+- When you document a change, route the detail by tier: if you are writing a constant value, a byte/wire layout, an HKDF info string or other algorithm step, or a "would only need revisiting if..." design rationale, it belongs in `docs/spec/` -- regardless of which doc you currently have open. Overview docs (`docs/`) stay conceptual and operational.


### PR DESCRIPTION
## Summary

Add a tracked CLAUDE.md so contained and automated agent sessions load the
project's conventions and operational tooling. A dev container bind-mounts only
the workspace, so the gitignored CLAUDE.local.md -- a symlink to the host
checkout outside the mount -- dangles and never loads. Promoting the essentials
into a committed file gives a fresh clone the same context a host session has.

Implements [199809371](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=199809371).

## Changes

- CLAUDE.md (new): the non-obvious commands (build core, what `npm run test`
  runs, single-file vitest), the GitHub Projects board scripts, the
  project-manager workflow, and the agent conventions, with a pointer to
  CONTRIBUTING.md for the full reference.

## Background

Worktree and cwd-navigation specifics are omitted on purpose: a container is a
single clone of the repository, not the host's one-worktree-per-issue layout, so
that material is meaningless inside it and stays in the host-only CLAUDE.local.md.
The CLI integration-test note reflects the current self-managing in-process
server. The acceptance criteria are met structurally: a fresh container loads the
conventions from a tracked file, and nothing an autonomous agent must obey
depends on the private CLAUDE.local.md any longer.

## Out of scope / follow-on

- Trimming CLAUDE.local.md to drop the rules now duplicated here (keeping only
  its worktree section) is a separate host-side change; CLAUDE.local.md is
  gitignored, so it is not part of this PR.

## Test plan

- [x] `npm run typecheck && npm run lint` clean
- [x] `npm run formatcheck` and `npm run linkcheck` clean
- n/a -- documentation-only change (a new tracked markdown file); no core, unit,
  or integration tests apply, and it adds no new tests.

## Checklist

- [x] Ran `ls docs/` and `ls docs/spec/`: no impact -- this adds an agent-facing
  file at the repo root, not a docs page.
- [x] No detail added to a `docs/` overview (n/a -- no docs change).
- [x] `CHANGELOG.md` `[Unreleased]`: n/a -- agent and contributor tooling,
  consistent with the .devcontainer/ and .claude/ commits, which are not logged
  there.
- [x] Cryptographic code: n/a.
