### PR TITLE
Make interactive Claude prompt-free in container

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -51,7 +51,12 @@ Three layers, so prompt-free operation inside is safe:
 
 `post-create.sh` sets `permissions.defaultMode: bypassPermissions` in the
 container's *user* settings only, so sessions inside start prompt-free without
-changing how Claude behaves on the host.
+changing how Claude behaves on the host. It also pre-seeds Claude Code's
+interactive first-run state -- the onboarding and per-workspace trust prompts --
+and sets the VS Code extension's own bypass mode in `devcontainer.json` (the
+extension does not honor the CLI's `defaultMode`), so interactive sessions,
+terminal or extension, start prompt-free as well. Headless `claude -p` skips
+these gates either way.
 
 ### What it does not protect against
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -99,7 +99,11 @@ scope here.
   GitHub PAT. The container loads `.env` via docker `--env-file` (`devcontainer.json`
   `runArgs`) and `post-create.sh` runs `gh auth setup-git`, so both `git push`
   (HTTPS) and `gh pr create` authenticate with no prompt. Use a fine-grained PAT
-  scoped to this repo (contents + pull-requests write). `.env` is gitignored.
+  scoped to this repo (contents + pull-requests write); add the organization
+  Projects (read and write) permission as well if the session uses the
+  `.claude/scripts` board tooling, since those hit the org's GitHub Projects
+  v2 API, which the repository contents/pull-requests scopes do not cover.
+  `.env` is gitignored.
   `--env-file` is **literal**: write `GH_TOKEN=<value>` unquoted, with no `export`,
   and with no inline `# comment` -- quotes, an `export` prefix, and a trailing
   comment all become part of the token value (a corrupted token then fails only

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,9 @@
         "editor.codeActionsOnSave": {
           "source.fixAll.eslint": "explicit"
         },
-        "terminal.integrated.defaultProfile.linux": "zsh"
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "claudeCode.allowDangerouslySkipPermissions": true,
+        "claudeCode.initialPermissionMode": "bypassPermissions"
       }
     }
   },

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -46,6 +46,36 @@ SETTINGS="$CONFIG_DIR/settings.json" node -e '
   fs.writeFileSync(path, JSON.stringify(settings, null, 2) + "\n");
 '
 
+# Pre-seed Claude Code's interactive first-run state so sessions in this container
+# open at the prompt instead of the theme/welcome onboarding and the per-workspace
+# "Do you trust the files in this folder?" dialog. Auth (CLAUDE_CODE_OAUTH_TOKEN or
+# a per-container login) is separate and unaffected, and headless `claude -p` skips
+# these gates already -- this is for the interactive CLI and the VS Code extension,
+# which share this config dir. These keys live in .claude.json and are internal to
+# Claude Code (undocumented), captured against 2.1.177 -- re-verify on an upgrade.
+# Idempotent: fills only missing keys and refuses to overwrite an unreadable file,
+# matching the settings.json seeding above.
+CLAUDE_JSON="$CONFIG_DIR/.claude.json" WORKSPACE="/workspace" node -e '
+  const fs = require("fs");
+  const path = process.env.CLAUDE_JSON;
+  let state = {};
+  try {
+    state = JSON.parse(fs.readFileSync(path, "utf8"));
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      console.error("refusing to overwrite existing " + path + ": " + err.message);
+      process.exit(1);
+    }
+  }
+  if (!state.hasCompletedOnboarding) state.hasCompletedOnboarding = true;
+  state.projects = state.projects || {};
+  const ws = (state.projects[process.env.WORKSPACE] =
+    state.projects[process.env.WORKSPACE] || {});
+  if (!ws.hasTrustDialogAccepted) ws.hasTrustDialogAccepted = true;
+  if (!ws.hasCompletedProjectOnboarding) ws.hasCompletedProjectOnboarding = true;
+  fs.writeFileSync(path, JSON.stringify(state, null, 2) + "\n");
+'
+
 # Wire git push (over HTTPS) and the gh CLI to a GitHub token when one is present.
 # devcontainer.json loads a repo-root .env into the container via docker
 # --env-file; `gh auth setup-git` then registers gh as git's credential helper, so


### PR DESCRIPTION
## Summary

Make a dev container's interactive Claude Code sessions -- both the integrated
terminal and the VS Code extension -- start prompt-free, matching the headless
posture the container already had. The container previously defaulted only the
CLI to bypassPermissions, so the first interactive session still stopped at
Claude Code's onboarding and per-workspace trust gates, and the extension
prompted for every tool. No dedicated board item: a dev-container ergonomics fix
surfaced while bringing the container up for the autonomous issue-to-PR
initiative.

## Changes

- `.devcontainer/post-create.sh`: pre-seed Claude Code's interactive first-run
  state in the container's `.claude.json` (onboarding-complete at the top level,
  plus the trust and project-onboarding flags under the `/workspace` project) so
  terminal sessions open at the prompt. Idempotent, and refuses to overwrite an
  unreadable config -- the same guard as the adjacent settings.json seeding.
- `.devcontainer/devcontainer.json`: set the extension's
  `claudeCode.allowDangerouslySkipPermissions` and
  `claudeCode.initialPermissionMode`, because the VS Code extension has its own
  permission-mode mechanism and ignores the CLI's settings.json `defaultMode`.
- `.devcontainer/README.md`: note the interactive prompt-free behavior in the
  security model, and record that the `GH_TOKEN` PAT needs the org Projects (read
  and write) permission for the `.claude/scripts` board tooling.

## Background

Auth and the headless path are unaffected: `CLAUDE_CODE_OAUTH_TOKEN` still
authenticates, and `claude -p` skips the onboarding, trust, and permission gates
regardless -- this change only addresses the interactive surfaces. The
`.claude.json` keys are internal to Claude Code and undocumented; they were
captured against Claude Code 2.1.177 and the post-create.sh comment flags them
for re-verification on an upgrade. The README note is kept conceptual (it names
only the documented extension settings, not the internal keys), per the
docs-tier convention.

## Test plan

Dev-container config (a bash script, JSON, and markdown); no CI gate exercises
it. Verified instead:

- [x] `devcontainer.json` parses as valid JSON; `bash -n` clean on `post-create.sh`
- [x] pre-seed block tested against a fresh and an existing `.claude.json`: idempotent across runs, preserves existing keys, handles the missing-file path
- [x] confirmed in a live container that these keys clear the onboarding, trust, and permission prompts -- interactive `claude` opens straight at the prompt
- `npm run typecheck && npm run lint`, `npm test` -- n/a, no application code changed

## Checklist

- [x] Ran `ls docs/` and `ls docs/spec/`; this is dev-container config under `.devcontainer/`, no `docs/` page is affected
- n/a -- nothing added to a `docs/` overview (the `.devcontainer/README.md` note names only a documented extension setting; the internal `.claude.json` keys live in the post-create.sh comment, not the README)
- n/a -- dev-container tooling, not product behavior; no CHANGELOG entry, consistent with prior `.devcontainer`/`.claude` changes
- n/a -- no cryptographic code changed
