### PR TITLE
Refresh contribution docs and devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,6 +48,18 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
   && apt-get install -y --no-install-recommends gh \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Shared-library dependencies for the headless Chromium that the web app's
+# `test:browser` suite drives through Playwright. Playwright's own installer
+# resolves the exact apt set for this Debian release; only the libraries are baked
+# here (stable across Chromium builds), while the matching browser BINARY is
+# fetched in post-create.sh -- after `npm ci`, so it tracks the locked playwright
+# version, and before the egress firewall, so the download succeeds. Pinned to the
+# lockfile's playwright; a small lag behind a version bump is harmless here because
+# the dep list rarely shifts (the binary, which must match exactly, is not pinned
+# here -- post-create derives it from the lockfile).
+RUN npx --yes playwright@1.59.1 install-deps chromium \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # The native sshd test backend spawns an unprivileged sshd, which still fatally
 # checks for the privilege-separation directory at startup even when run as a
 # normal user; create it at build time so the backend needs no root at test time
@@ -83,8 +95,8 @@ ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
 ENV PATH=$PATH:/usr/local/share/npm-global/bin
 
 ENV SHELL=/bin/zsh
-ENV EDITOR=nano
-ENV VISUAL=nano
+ENV EDITOR=vim
+ENV VISUAL=vim
 
 # Claude Code itself, so an agent session runs inside the container.
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "psilink",
+  "name": "${localWorkspaceFolderBasename}",
   "build": {
     "dockerfile": "Dockerfile",
     "args": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -15,6 +15,15 @@ npm ci
 # node_modules volume), so a fresh container would otherwise see it unbuilt.
 npm run build -w packages/core
 
+# Fetch the Chromium build the web app's browser test suite drives via Playwright.
+# Here -- after `npm ci`, so the browser tracks the locked playwright version, and
+# before the egress firewall (a postStartCommand), so the one-time CDN download
+# reaches the network. The shared libraries Chromium links against are baked into
+# the image (.devcontainer/Dockerfile); this pulls only the browser binary, so it
+# needs no root. The test:browser run itself is loopback-only (dev server on
+# 127.0.0.1), so the firewall does not affect it.
+npx playwright install chromium
+
 # Default this container's Claude sessions to prompt-free. The container's egress
 # firewall plus the checked-in deny-list and protected-branch push hook in
 # .claude/ are the safety floor (both deny rules and PreToolUse hooks apply even in

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,59 +1,65 @@
 <!--
-PR description guidance. A PR is a task closed out, so this skeleton mirrors the PM task template (Summary / Acceptance criteria / Affected areas / notes). Drop any optional section that has nothing non-obvious to say -- keep small PRs small. Conventions: ASCII only, `-` (not `*`) for bullets, no en-dash, em-dash, or arrow characters, imperative mood, terse and technical, single space after periods, wrap and don't break lines. Start headings at `##`; do not repeat the PR title as a heading.
+PR description. Drop any optional section that has nothing non-obvious to say -- keep small PRs small. Delete every HTML comment (guidance, not content) before submitting.
+Conventions:
+- ASCII only: `-` (not `*`) for bullets; no en-dash, em-dash, or arrow characters.
+- Imperative mood, terse and technical. Single space after periods. Soft-wrap; do not hard-wrap lines.
+- Headings start at `##`. Do not repeat the PR title as a heading.
 -->
 
 ## Summary
 
-One short paragraph, outcome first: what this PR delivers and why it matters, not how.
+One short paragraph, outcome first: what this PR delivers and why it matters. The "how" goes in Changes.
 
-Implements <board> item [<id>](https://github.com/orgs/georgetown-mdi/projects/<board>/views/1?pane=issue&itemId=<id>).
+Implements [<id>](https://github.com/orgs/georgetown-mdi/projects/<board>/views/1?pane=issue&itemId=<id>).
 <!--
-Board items are GitHub Project draft IDs, not issue numbers -- `Closes #<id>` does not work and renders as a broken link. Always use the full itemId URL. Use project 9 (Product) or 10 (Release & Operations). Pick the verb:
-  Implements [<id>](url) -- this PR closes out the task
-  Part of     [<id>](url) -- partial delivery
-  Depends on  [<id>](url) -- needs another item merged first
-  Follow-on:  [<id>](url) -- spun off, tracked separately
+Board items are GitHub Project draft itemIds, not issue numbers -- `Closes #<id>` renders as a broken link. Use the full itemId URL; board is 9 (Product) or 10 (Release & Operations). Pick one verb for the line above, or delete the line for a bug fix or doc tweak with no board item:
+  Implements -- closes the task
+  Part of -- partial delivery
+  Depends on -- needs another item merged first
+  Follow-on -- spun off, tracked separately
 -->
 
 ## Changes
 
-<!--
-Focused PR (<= ~5 files): one bullet or table row per file, with the why. Broad PR (rename, refactor, cross-cutting): group by area or pattern and call out only what is non-obvious.
--->
+<!-- The map of the diff (the "how"); the "why" is in Summary. Focused PR (<= ~5 files): one bullet per file. Broad PR (rename, refactor, cross-cutting): group by area and call out only what is non-obvious. -->
 
--
+- <file or area>: <what changed>
+
+## Test plan
+
+<!-- CI runs typecheck, lint, format, and the test suites and is the authority on pass/fail. Here, record what you exercised locally and the coverage this change adds, and point a reviewer at the evidence. -->
+
+Ran: <suites or files exercised locally, e.g. `npx vitest run packages/core/test/foo.test.ts`>
+New tests cover: <the specific behaviors verified, or n/a -- reason>
 
 ## Background
 
-<!-- Optional. Root cause, the invariant being preserved, a non-obvious constraint honored. Omit if the Summary already says everything. -->
-
-## Breaking change
-
-<!-- Only if applicable. What breaks and what a consumer must do. Delete if not. -->
+<!-- Optional. Context that predates this PR: root cause, the invariant preserved, a non-obvious constraint. Omit if the Summary covers it. -->
 
 ## Out of scope / follow-on
 
 <!-- Optional. Deferred work, each with its board link. Delete if none. -->
 
--
-
-## Test plan
-
-<!-- How the change was verified. The evidence it works -- maps back to the task's acceptance criteria. Verification only; housekeeping goes below. -->
-
-- [ ] `npm run typecheck && npm run lint` clean
-- [ ] `npm test -w packages/core` (N/N)
-- [ ] `npm run test:unit -w apps/cli` and/or `apps/web` as relevant
-- [ ] CLI integration tests: `npm run test:integration -w apps/cli`
-
-New tests cover: <name the specific behaviors, as the acceptance criteria do>
+- <deferred item and its board link>
 
 ## Checklist
 
-<!-- Pre-merge hygiene that keeps the rest of the repo consistent. Not testing. Check or mark n/a -- do not delete; a deliberate "n/a" is the signal you looked. -->
+<!--
+Pre-merge obligations CI does not verify. Resolve every line: check it when done OR when genuinely not applicable -- a checked box means "resolved", and the trailing clause says which. Checking n/a items too keeps the PR-list progress badge honest (it counts only checked boxes); never leave a box unchecked to mean n/a. Every n/a MUST carry a reason tied to this diff; a bare "n/a" does not count. Do not delete lines here.
+  done:  - [x] CHANGELOG.md [Unreleased] updated -- added under Fixed
+  n/a:   - [x] CHANGELOG.md [Unreleased] updated -- n/a: internal refactor, no user-facing change
+-->
 
-- [ ] Ran `ls docs/` and `ls docs/spec/`, checked each file for impact, and updated affected pages or confirmed none needed (enumerate both directories -- do not rely on a static list)
-- [ ] Any detail I added to a `docs/` overview is conceptual -- no constants, byte/wire layouts, algorithm steps, or deferred-decision rationale (those go in `docs/spec/`), or n/a
-  <!-- Tier litmus, kept in sync across this template, CONTRIBUTING.md, and docs/spec/README.md: If you are writing a constant value, a byte/wire layout, an HKDF info string or other algorithm step, or a "would only need revisiting if..." design rationale, it belongs in `docs/spec/` - regardless of which doc you currently have open. Overview docs (`docs/`) stay conceptual and operational. -->
-- [ ] `CHANGELOG.md` `[Unreleased]` updated, or n/a
-- [ ] Cryptographic code changed? Security review requested (see Dependency Policy), or n/a
+- [ ] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- <which pages, or n/a: no documented behavior changed>
+- [ ] `CHANGELOG.md` `[Unreleased]` updated -- <the entry, or n/a: reason>
+<!--
+Security review applies if this PR touches any of -- do it and record the type, else n/a:
+- cryptographic code or its inputs: the PSI / key-exchange protocol, key derivation, or canonical encoding
+- the application-layer AEAD, or the frame-size / directory-listing / liveness / connect bounds
+- credential or secret handling: the key file, signing identity, result CSV, or config @path resolution
+- authentication, fingerprint / certificate pinning, or token expiry / token_max_age_days
+- what is disclosed: data sent, logged, displayed, or written to disk, or what the result reveals (cardinality, linkage terms, consent-surfaced fields)
+- a security-relevant dependency: @openmined/psi.js, @noble/curves, any AEAD / key-agreement / KDF library, or the SFTP stack (ssh2 / ssh2-sftp-client)
+Modifying an existing control counts, not only adding one. Full list: CONTRIBUTING Dependency Policy.
+-->
+- [ ] Security review -- <type of review done, or n/a: none of the above touched>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Beyond the conventions in `CONTRIBUTING.md`:
 - Prefer ASCII: `-` not an en-dash or em-dash, `->` not an arrow character.
 - Never commit to staging or main by yourself; don't attribute yourself on commits or pull requests.
 - Commit messages use no markdown and no top-level lists (other format rules in `CONTRIBUTING.md`, Commit Messages).
-- After a chain of edits, run `npm run typecheck && npm run lint`; the LSP server often has a stale cache.
+- After a chain of edits, run `npm run typecheck && npm run lint && npm run format`; the LSP server often has a stale cache.
 - Typecheck, lint, and format are CI checks.
 - Project state belongs in the GitHub project and docs/, not agent memory.
 - Prettier ignores markdown.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,8 +182,8 @@ Documentation-tier placement is in scope for code review: a reviewer flags spec-
 
 1. For significant changes, open a draft issue on the Github project first to align on approach. Bug fixes and documentation improvements do not require a prior issue.
 2. Keep pull requests focused - one logical change per PR.
-3. Ensure all tests pass and lint is clean before marking the PR ready for review. Include this as a checklist in the PR.
-4. Changes to cryptographic code require explicit security review before merging (see Dependency Policy).
+3. Ensure typecheck, lint, format, and the relevant tests pass before marking the PR ready for review (CI enforces all four). Record what you ran and the coverage you added in the PR's Test plan, and resolve every line of the template Checklist.
+4. Changes within the security-review scope -- cryptographic code, the channel-security controls, credential or disclosure surfaces, or a security-relevant dependency -- require explicit security review before merging (see [Dependency Policy](#dependency-policy) for the full enumeration).
 5. Update documentation when behavior changes - see [Documentation](#documentation) for which tier. Update `CHANGELOG.md` with a line in the `[Unreleased]` section.
 6. A maintainer will review and merge. Force-pushes to `main` are not permitted.
 
@@ -192,6 +192,18 @@ Documentation-tier placement is in scope for code review: a reviewer flags spec-
 Opening a PR populates [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md), whose inline comments explain each section and the writing conventions (ASCII, imperative mood, `##` headings, board-reference verbs). Fill in what applies; delete any optional section with nothing non-obvious to say -- keep small PRs small.
 
 ## Dependency Policy
+
+A change requires explicit security review and maintainer approval before merging if it touches any of the following. This list is the trigger; [docs/SECURITY_DESIGN.md](docs/SECURITY_DESIGN.md) is the model behind it, consulted only to decide a case the list does not settle.
+
+- Cryptographic code or its inputs: the PSI protocol, the X25519 key exchange / handshake / key schedule, token generation / rotation / derivation, or canonical encoding.
+- The application-layer AEAD: encryption, the nonce / sequence scheme, or the integrity / replay / reordering / gap checks.
+- The channel-hardening controls: the frame-size, directory-listing, liveness / timeout, connect-probe, and whole-exchange bounds, plus the SFTP crash-safety and authenticated abort-marker controls.
+- Credential and secret handling: how the key file, signing identity, or result CSV is written or permissioned; how secrets are stored, transmitted, logged, or referenced (the configuration `@path` resolution).
+- Authentication and identity: the auth gate's fail-closed behavior, fingerprint / certificate pinning and verification, or token expiry and `token_max_age_days` enforcement.
+- What is disclosed: any change to what is sent on the wire, logged, displayed, or written to disk, or to what the result reveals (cardinality, linkage terms, consent-surfaced fields).
+- A security-relevant dependency (see Cryptographic dependencies and the SFTP stack below).
+
+Modifying an existing control in these areas is in scope exactly as adding one is: a change that weakens or removes a guarantee triggers review no less than a new control does.
 
 PSI-Link is licensed under [Apache 2.0](LICENSE.md); add third-party dependencies conservatively. For every new dependency:
 


### PR DESCRIPTION
## Summary

Improve how contributions are made and verified, with no change to product behavior. Restructure the pull-request template's action items so the checklist is small and reads honestly from the PR list, define an enumerated scope for when a change needs security review, and run the web app's browser-test suite inside the development container.

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md`: restructure action items. The checklist uses "checked means resolved" semantics (done, or not applicable with a reason) so the GitHub progress count is trustworthy at a glance; test verification moves to an evidence-based Test plan, since CI is the authority on pass/fail; the prerelease breaking-change section is dropped and the sections reordered so verification leads.
- `CONTRIBUTING.md`: add an enumerated security-review scope under Dependency Policy -- the trigger list a change is checked against -- with `docs/SECURITY_DESIGN.md` as the model behind it rather than required reading. Reconcile the pull-request-process steps with the template.
- `CLAUDE.md`: include `format` in the local pre-push command set alongside typecheck and lint.
- `.devcontainer/`: bake Chromium's shared libraries into the image and fetch the matching Playwright browser binary in `post-create.sh` (after `npm ci`, so it tracks the locked Playwright version, and before the egress firewall, so the download succeeds), so `npm run test:browser -w apps/web` runs in-container. Default the editor to `vim` and derive the container name from the workspace folder.

## Test plan

Ran: n/a -- the source changes are prettier-ignored markdown and devcontainer configuration, with no code paths touched; CI runs typecheck, lint, and format. The devcontainer browser-test setup is exercised by rebuilding the image and running `npm run test:browser -w apps/web`.

New tests cover: n/a -- no behavior code changed.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented product behavior changed; the security-review scope mirrors the existing `SECURITY_DESIGN.md` model.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: contributor tooling and process only, no user-facing change.
- [x] Security review -- n/a: none of the triggers touched; the changes are documentation and dev-image tooling (Playwright is a dev/test dependency, not a product runtime or crypto/SFTP dependency).
