### PR TITLE
Fix flaky restricted-crypto SFTP test directory race

### DIFF
--- a/apps/cli/test/integration/sftpConnection.test.ts
+++ b/apps/cli/test/integration/sftpConnection.test.ts
@@ -75,13 +75,15 @@ async function waitFor(
 }
 
 // A freshly-created, exclusively-owned rendezvous directory under the served
-// root, for tests that stand up their own connections. The shared `sftp`
-// namespace is reused by the persistent serverConn/clientConn across the first
-// tests; a test that opens a new exchange on that same path can trip the
-// directory-exclusivity guard on a stray message or lock file a prior test's
-// still-settling poll/close left behind -- a window the restricted-crypto
-// native-sshd profile widens via its slower handshake (board item 200576628).
-// Giving each such test its own mkdtemp directory isolates it from that residue.
+// root, for tests that stand up their own connections. The persistent
+// serverConn/clientConn reuse the shared `sftp` namespace across the first
+// tests and stop() without close(): stop() halts only the next poll, so a
+// mid-flight list() can straddle the test boundary and read a later exchange's
+// files as foreign, and a lock a prior rendezvous left behind (swept only by
+// close()) outlives the test. On a shared path either residue trips a test's
+// directory-exclusivity guard -- a window the restricted-crypto native-sshd
+// profile widens via its slower handshake (board item 200576628). A dedicated
+// mkdtemp directory per such test removes the sharing in both directions.
 // Returns the remote path to connect to and records the host directory for
 // teardown in afterAll, so the per-test directories do not pile up under the
 // served root over the run.

--- a/apps/cli/test/integration/sftpConnection.test.ts
+++ b/apps/cli/test/integration/sftpConnection.test.ts
@@ -74,6 +74,19 @@ async function waitFor(
   throw new Error("waitFor: condition not met within timeout");
 }
 
+// A freshly-created, exclusively-owned rendezvous directory under the served
+// root, for tests that stand up their own connections. The shared `sftp`
+// namespace is reused by the persistent serverConn/clientConn across the first
+// tests; a test that opens a new exchange on that same path can trip the
+// directory-exclusivity guard on a stray message or lock file a prior test's
+// still-settling poll/close left behind -- a window the restricted-crypto
+// native-sshd profile widens via its slower handshake (board item 200576628).
+// Giving each such test its own mkdtemp directory isolates it from that residue.
+async function freshRendezvous(): Promise<{ remote: string; local: string }> {
+  const local = await fs.mkdtemp(path.join(srv.backingDir, "sftp-"));
+  return { remote: remotePath(srv, path.basename(local)), local };
+}
+
 const serverSFTP = new SSH2SFTPClientAdapter();
 const serverConn = new FileSyncConnection(serverSFTP, { verbose: -1 });
 const clientSFTP = new SSH2SFTPClientAdapter();
@@ -203,7 +216,7 @@ test("public-key authentication connects and runs a rendezvous", async () => {
     throw new Error(String(err));
   });
 
-  await cleanServer();
+  const { remote } = await freshRendezvous();
   try {
     await Promise.all([
       keyServerConn.open({
@@ -212,7 +225,7 @@ test("public-key authentication connects and runs a rendezvous", async () => {
           host: srv.host,
           port: srv.port,
           ...publicKeyAuth(srv.usera),
-          path: SFTP_PATH,
+          path: remote,
         },
       }),
       keyClientConn.open({
@@ -221,7 +234,7 @@ test("public-key authentication connects and runs a rendezvous", async () => {
           host: srv.host,
           port: srv.port,
           ...publicKeyAuth(srv.userb),
-          path: SFTP_PATH,
+          path: remote,
         },
       }),
     ]);
@@ -243,7 +256,6 @@ test("public-key authentication connects and runs a rendezvous", async () => {
     keyServerConn.stop();
   } finally {
     await Promise.all([keyServerConn.close(), keyClientConn.close()]);
-    await cleanServer();
   }
 });
 
@@ -260,9 +272,10 @@ test("terminal frame is received when sender closes before receiver polls", asyn
   const receiverSFTP = new SSH2SFTPClientAdapter();
   const receiverConn = new FileSyncConnection(receiverSFTP, { verbose: -1 });
 
+  const { remote } = await freshRendezvous();
   const base = {
     channel: "sftp" as const,
-    server: { host: srv.host, port: srv.port, path: SFTP_PATH },
+    server: { host: srv.host, port: srv.port, path: remote },
   };
 
   await Promise.all([

--- a/apps/cli/test/integration/sftpConnection.test.ts
+++ b/apps/cli/test/integration/sftpConnection.test.ts
@@ -82,10 +82,22 @@ async function waitFor(
 // still-settling poll/close left behind -- a window the restricted-crypto
 // native-sshd profile widens via its slower handshake (board item 200576628).
 // Giving each such test its own mkdtemp directory isolates it from that residue.
-async function freshRendezvous(): Promise<{ remote: string; local: string }> {
+// Returns the remote path to connect to and records the host directory for
+// teardown in afterAll, so the per-test directories do not pile up under the
+// served root over the run.
+const rendezvousDirs: string[] = [];
+
+async function freshRendezvous(): Promise<string> {
   const local = await fs.mkdtemp(path.join(srv.backingDir, "sftp-"));
-  return { remote: remotePath(srv, path.basename(local)), local };
+  rendezvousDirs.push(local);
+  return remotePath(srv, path.basename(local));
 }
+
+afterAll(async () => {
+  await Promise.all(
+    rendezvousDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
 
 const serverSFTP = new SSH2SFTPClientAdapter();
 const serverConn = new FileSyncConnection(serverSFTP, { verbose: -1 });
@@ -216,7 +228,7 @@ test("public-key authentication connects and runs a rendezvous", async () => {
     throw new Error(String(err));
   });
 
-  const { remote } = await freshRendezvous();
+  const remote = await freshRendezvous();
   try {
     await Promise.all([
       keyServerConn.open({
@@ -272,7 +284,7 @@ test("terminal frame is received when sender closes before receiver polls", asyn
   const receiverSFTP = new SSH2SFTPClientAdapter();
   const receiverConn = new FileSyncConnection(receiverSFTP, { verbose: -1 });
 
-  const { remote } = await freshRendezvous();
+  const remote = await freshRendezvous();
   const base = {
     channel: "sftp" as const,
     server: { host: srv.host, port: srv.port, path: remote },


### PR DESCRIPTION
## Summary

Stabilize the hardened native-sshd `restricted-crypto` CLI integration leg, which intermittently failed `sftpConnection.test.ts` on a test-isolation race rather than any product fault. Tests that stand up their own connections shared the persistent connections' `sftp` rendezvous directory, so a still-settling poll or a leftover lock from one test could trip the next exchange's directory-exclusivity guard. The slower `restricted-crypto` handshake widened the window. Give each such test its own dedicated directory so no residue crosses tests.

Implements [200576628](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=200576628).

## Changes

- `apps/cli/test/integration/sftpConnection.test.ts`: add a `freshRendezvous()` helper that creates a per-test `mkdtemp` directory under the served root and records it for `afterAll` teardown; move the public-key and terminal-frame tests onto their own directories, off the shared `sftp` namespace; drop the now-unneeded `cleanServer()` calls from the public-key test.

## Test plan

Ran: `npm run test:integration -w apps/cli` (in-process) and `PSILINK_SFTP_BACKEND=native PSILINK_SFTP_NATIVE_PROFILE=restricted-crypto npm run test:integration -w apps/cli`, plus the `restricted-crypto` leg 10x in a loop -- all green. Also typecheck, lint, format.
New tests cover: n/a -- test-only reliability fix, no new product behavior. The existing coverage (public-key rendezvous, terminal-frame drain-before-cleanup, the ssh2 lifecycle contract assertions) is preserved, now isolated per directory.

## Background

The leak has two directions, both removed by per-test directories: `stop()` halts only the next poll, so a persistent connection's mid-flight `list()` can read a later test's files as foreign; and a lock a prior rendezvous left behind (swept only by `close()`, which these `stop()`-without-`close()` tests skip) outlives the test. Independent lifecycle review confirmed this is test-infrastructure isolation, not a product defect; the directory-exclusivity guard itself is unchanged.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; this is a test-only reliability fix and the directory-exclusivity control is untouched.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-only change, not visible to an operator/deployer or a security reviewer.
- [x] Security review -- n/a: test-only; touches no cryptographic code, channel-hardening control, credential/disclosure surface, or security-relevant dependency (the guard logic and the SFTP stack are unchanged).
