### PR TITLE
Enforce referential integrity of linkage element fields and swap targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ This changelog records, per release, the changes that affect how PSI-Link is run
 - A malformed message from a peer is reported as a protocol error instead of crashing, and a failed exchange surfaces its original cause instead of a generic connection error.
 - The acceptor is warned, or the exchange blocked (exit 64), when its CSV cannot satisfy the inviter's linkage terms, instead of silently producing an empty result. See `docs/CLI.md`.
 - Linkage terms that pair `output.expects_output: false` with `payload.receive` columns are rejected as incoherent at parse time. See `docs/EXCHANGE_REFERENCE.md`.
+- Linkage terms that reference an undeclared linkage field, or whose `swap` names no element in its key, are rejected as incoherent at decode, instead of silently collapsing the affected key to an empty result. See `docs/EXCHANGE_REFERENCE.md`.
 
 ### Security
 

--- a/docs/EXCHANGE_REFERENCE.md
+++ b/docs/EXCHANGE_REFERENCE.md
@@ -255,7 +255,7 @@ Each step in a `transform` array applies one function from the cleaning and stan
 
 #### Swapped keys
 
-When a `swap` array is present, the receiver transmits a linkage key generated with the two named elements swapped, while the sender generates a linkage key with un-swapped elements. Element names are matched first against element `name` values, then against `field` names. For example, a key might match first name swapped with last name to catch data entry errors where the names are reversed at one agency. Each `swap` target must resolve to an element of the same key by this rule; a target matching no element in its key is rejected when the terms are decoded, rather than silently doing nothing at exchange time.
+When a `swap` array is present, the receiver transmits a linkage key generated with the two named elements swapped, while the sender generates a linkage key with un-swapped elements. A `swap` target names an element by that element's effective identifier: its `name` if it declares one, otherwise its `field`. An element that declares a `name` is referenced by that `name`, not by its `field`. For example, a key might match first name swapped with last name to catch data entry errors where the names are reversed at one agency. Each `swap` target must resolve to an element of the same key by this rule; a target matching no element in its key is rejected when the terms are decoded, rather than silently doing nothing at exchange time.
 
 ### `linkage_terms.legal_agreement`
 

--- a/docs/EXCHANGE_REFERENCE.md
+++ b/docs/EXCHANGE_REFERENCE.md
@@ -195,7 +195,7 @@ The table above is the complete set of constraints. Constraints not listed for a
 
 An ordered list of linkage keys applied in sequence from most to least precise. Each round of the PSI protocol matches only records not yet resolved in a prior round. Each element references a linkage field by name and may optionally specify transformations applied to that field's canonical value before it is concatenated into the key.
 
-The name of each linkage key must be unique. The elements within any linkage must either reference a unique linkage field or have an alias that is unique.
+The name of each linkage key must be unique. The elements within any linkage must either reference a unique linkage field or have an alias that is unique. Each element's `field` must name a declared linkage field (a `name` from `linkage_terms.linkage_fields`); a key that references an undeclared field is rejected when the terms are decoded, rather than silently collapsing to an empty key at exchange time.
 
 ```yaml
 linkage_terms:
@@ -255,7 +255,7 @@ Each step in a `transform` array applies one function from the cleaning and stan
 
 #### Swapped keys
 
-When a `swap` array is present, the receiver transmits a linkage key generated with the two named elements swapped, while the sender generates a linkage key with un-swapped elements. Element names are matched first against element `name` values, then against `field` names. For example, a key might match first name swapped with last name to catch data entry errors where the names are reversed at one agency.
+When a `swap` array is present, the receiver transmits a linkage key generated with the two named elements swapped, while the sender generates a linkage key with un-swapped elements. Element names are matched first against element `name` values, then against `field` names. For example, a key might match first name swapped with last name to catch data entry errors where the names are reversed at one agency. Each `swap` target must resolve to an element of the same key by this rule; a target matching no element in its key is rejected when the terms are decoded, rather than silently doing nothing at exchange time.
 
 ### `linkage_terms.legal_agreement`
 

--- a/packages/core/src/config/linkageTerms.ts
+++ b/packages/core/src/config/linkageTerms.ts
@@ -469,6 +469,10 @@ const LegalAgreementSchema: z.ZodType<LegalAgreement> = z.object({
  * - Within each linkage key, the effective element identifier (`element.name`
  *   if present, otherwise `element.field`) must be unique so that `swap`
  *   references are unambiguous.
+ * - Every linkage-key element `field` must name a declared linkage field (a
+ *   member of `linkageFields[].name`); a dangling reference is rejected.
+ * - Every `swap` target must match an element identifier (`element.name` if
+ *   present, otherwise `element.field`) present within that same linkage key.
  *
  * TODO: versioning compatibility rules (migration paths between semver
  * versions).
@@ -582,6 +586,52 @@ export const LinkageTermsSchema: z.ZodType<LinkageTerms> =
         message:
           "element identifiers (name if present, otherwise field) must be " +
           "unique within each linkage key",
+        path: ["linkageKeys"],
+      },
+    )
+    // Referential integrity, element field -> declared linkage field. Every
+    // key element's `field` must name a member of linkageFields[].name. A
+    // dangling field reference parses cleanly but resolves to no values at
+    // exchange time (buildStandardizedDataset builds only declared fields, so
+    // getField returns undefined and the key collapses to null), producing a
+    // silent empty/missed-match result byte-indistinguishable from a
+    // legitimately empty intersection. Enforce it once here so no consumer ever
+    // sees a dangling reference. The message names no partner-controlled value:
+    // the parse-error path is left unsanitized (see protocolSetup and the test
+    // pinning it), so the offending element is located by its issue `path`, not
+    // by echoing its raw field string.
+    .refine(
+      (a) => {
+        const declared = new Set(a.linkageFields.map((f) => f.name));
+        return a.linkageKeys.every((key) =>
+          key.elements.every((el) => declared.has(el.field)),
+        );
+      },
+      {
+        message:
+          "each linkage key element must reference a declared linkage field " +
+          "(a name in linkageFields)",
+        path: ["linkageKeys"],
+      },
+    )
+    // Referential integrity, swap target -> element within the same key. Each
+    // `swap` entry must match an element identifier (name if present, otherwise
+    // field) present in that same key, matching the within-key resolution the
+    // LinkageKey doc comment describes. A dangling swap target silently no-ops
+    // at exchange time. Element identity uses `el.name ?? el.field`, the same
+    // expression as the element-identifier-uniqueness refine above, so the two
+    // checks agree. As above, the message echoes no partner-controlled value.
+    .refine(
+      (a) =>
+        a.linkageKeys.every((key) => {
+          if (key.swap === undefined) return true;
+          const ids = new Set(key.elements.map((el) => el.name ?? el.field));
+          return key.swap.every((target) => ids.has(target));
+        }),
+      {
+        message:
+          "each linkage key swap target must match an element identifier " +
+          "(name if present, otherwise field) within the same key",
         path: ["linkageKeys"],
       },
     );

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -950,12 +950,15 @@ export function assessLinkageSatisfiability(
   // The set of field names that are BOTH declared and producible. A key element
   // referencing a name absent from this set is unsatisfiable -- whether the field
   // is declared-but-unproducible (in `unsatisfied`) or not declared at all. The
-  // latter matters: the schema does not require a key element's `field` to name a
-  // declared linkage field, and at exchange time an undeclared reference resolves
-  // to no values (buildStandardizedDataset only builds declared fields, so
-  // getField returns undefined and the key collapses to null). Counting such a
-  // key satisfiable would let an incoherent or hostile terms set defeat the block
-  // and run to the silent-empty result this pre-flight exists to prevent.
+  // latter is now rejected upstream by LinkageTermsSchema's referential-integrity
+  // refine (a key element `field` must name a declared linkage field), so a
+  // schema-validated terms set cannot reach here with an undeclared reference;
+  // this filter is kept as defense-in-depth for any terms not built through that
+  // schema, since at exchange time an undeclared reference resolves to no values
+  // (buildStandardizedDataset only builds declared fields, so getField returns
+  // undefined and the key collapses to null) and counting such a key satisfiable
+  // would let an incoherent terms set defeat the block and run to the
+  // silent-empty result this pre-flight exists to prevent.
   const producibleNames = new Set(
     terms.linkageFields
       .map((f) => f.name)

--- a/packages/core/test/linkageTerms.test.ts
+++ b/packages/core/test/linkageTerms.test.ts
@@ -1080,7 +1080,16 @@ test("rejects more linkageFields than the maximum count", () => {
     { length: MAX_LINKAGE_ENTRIES + 1 },
     (_, i) => ({ name: `f${i}`, type: "ssn" }),
   );
-  expect(() => parseLinkageTerms({ ...base, linkageFields })).toThrow(ZodError);
+  // Point the key at a declared field so the rejection is the count bound alone,
+  // not base's "ssn" reference (undeclared under this override) tripping the
+  // referential-integrity refine.
+  expect(() =>
+    parseLinkageTerms({
+      ...base,
+      linkageFields,
+      linkageKeys: [{ name: "K", elements: [{ field: "f0" }] }],
+    }),
+  ).toThrow(ZodError);
 });
 
 test("rejects an over-long constraint exclude value", () => {
@@ -1099,9 +1108,18 @@ test("rejects an over-long constraint exclude value", () => {
 });
 
 test("rejects an over-long linkage key swap reference", () => {
+  // Declare both element fields so the rest of the fixture is coherent; the
+  // rejection is then about the swap entry alone. An over-long swap value trips
+  // the swap-entry length bound and, being un-matchable to any element, the
+  // swap-target referential check too -- both are intrinsic to the over-long
+  // value under test.
   expect(() =>
     parseLinkageTerms({
       ...base,
+      linkageFields: [
+        { name: "ssn", type: "ssn" },
+        { name: "ssn4", type: "ssn4" },
+      ],
       linkageKeys: [
         {
           name: "SSN",
@@ -1116,6 +1134,8 @@ test("rejects an over-long linkage key swap reference", () => {
 test("rejects an over-long allowedCharacters constraint", () => {
   // A run of one character is a valid (if redundant) regex character class, so it
   // passes the class-validity refine and the rejection is the length bound alone.
+  // The key references firstName so base's "ssn" reference does not dangle under
+  // this override and trip the referential-integrity refine.
   expect(() =>
     parseLinkageTerms({
       ...base,
@@ -1126,6 +1146,7 @@ test("rejects an over-long allowedCharacters constraint", () => {
           constraints: { allowedCharacters: "a".repeat(MAX_NAME_LENGTH + 1) },
         },
       ],
+      linkageKeys: [{ name: "FN", elements: [{ field: "firstName" }] }],
     }),
   ).toThrow(ZodError);
 });
@@ -1177,10 +1198,17 @@ test("rejects an over-long linkage key name", () => {
 });
 
 test("rejects an over-long linkage field name", () => {
+  // Declare a short field for base's key to reference so the rejection is the
+  // field-name length bound alone; the over-long-named field is unreferenced, so
+  // it does not also trip the element-field length bound or the referential
+  // refine.
   expect(() =>
     parseLinkageTerms({
       ...base,
-      linkageFields: [{ name: "x".repeat(MAX_NAME_LENGTH + 1), type: "ssn" }],
+      linkageFields: [
+        { name: "ssn", type: "ssn" },
+        { name: "x".repeat(MAX_NAME_LENGTH + 1), type: "ssn" },
+      ],
     }),
   ).toThrow(ZodError);
 });

--- a/packages/core/test/linkageTerms.test.ts
+++ b/packages/core/test/linkageTerms.test.ts
@@ -50,13 +50,15 @@ test("parses a complete valid set of terms", () => {
       },
       { name: "dateOfBirth", type: "dateOfBirth" },
       { name: "ssn", type: "ssn" },
+      { name: "firstName", type: "firstName" },
     ],
     linkageKeys: [
       {
-        name: "SSN4 + Last Name + DOB",
+        name: "SSN4 + Last Name + First Name + DOB",
         elements: [
           { field: "ssn4" },
           { field: "lastName" },
+          { field: "firstName" },
           { field: "dateOfBirth" },
         ],
         swap: ["firstName", "lastName"],
@@ -80,7 +82,7 @@ test("parses a complete valid set of terms", () => {
   });
 
   expect(result.algorithm).toBe("psi-c");
-  expect(result.linkageFields).toHaveLength(4);
+  expect(result.linkageFields).toHaveLength(5);
   expect(result.linkageKeys).toHaveLength(2);
   expect(result.legalAgreement?.reference).toBe("MOU-2025-0042");
   expect(result.legalAgreement?.purpose).toBe(
@@ -310,6 +312,109 @@ test("same field used twice with distinct names is valid", () => {
           { field: "dateOfBirth" },
         ],
         swap: ["name1", "name2"],
+      },
+    ],
+  });
+  expect(result.success).toBe(true);
+});
+
+// ─── referential integrity: element fields and swap targets ──────────────────
+// Linkage terms are partner-controlled, so an incoherent set (a key element
+// naming an undeclared field, or a swap target matching no element in its key)
+// must be rejected at decode rather than collapsing the affected key to a
+// silent, undiagnosable empty result at exchange time.
+
+test("an element field not declared in linkageFields is rejected", () => {
+  const result = safeParseLinkageTerms({
+    ...base,
+    linkageFields: [{ name: "ssn", type: "ssn" }],
+    linkageKeys: [{ name: "Dangling", elements: [{ field: "lastName" }] }],
+  });
+  expect(result.success).toBe(false);
+  if (result.success) return;
+  expect(result.error.issues[0].path).toContain("linkageKeys");
+  expect(result.error.issues[0].message).toMatch(/declared linkage field/);
+});
+
+test("a swap target matching no element in its key is rejected", () => {
+  const result = safeParseLinkageTerms({
+    ...base,
+    linkageFields: [
+      { name: "ssn", type: "ssn" },
+      { name: "lastName", type: "lastName" },
+    ],
+    linkageKeys: [
+      {
+        name: "Bad swap",
+        elements: [{ field: "ssn" }, { field: "lastName" }],
+        // "firstName" is a declared-elsewhere idea but no element of this key,
+        // so the swap target resolves to nothing.
+        swap: ["ssn", "firstName"],
+      },
+    ],
+  });
+  expect(result.success).toBe(false);
+  if (result.success) return;
+  expect(result.error.issues[0].path).toContain("linkageKeys");
+  expect(result.error.issues[0].message).toMatch(/swap target/);
+});
+
+test("a swap resolving via element field names validates", () => {
+  const result = safeParseLinkageTerms({
+    ...base,
+    linkageFields: [
+      { name: "firstName", type: "firstName" },
+      { name: "lastName", type: "lastName" },
+    ],
+    linkageKeys: [
+      {
+        name: "Swap by field",
+        elements: [{ field: "firstName" }, { field: "lastName" }],
+        swap: ["firstName", "lastName"],
+      },
+    ],
+  });
+  expect(result.success).toBe(true);
+});
+
+test("a swap resolving via an element name alias and a field both validate", () => {
+  // One target resolves via an element `name` alias, the other via `field`;
+  // both resolution forms must be accepted within the same swap.
+  const result = safeParseLinkageTerms({
+    ...base,
+    linkageFields: [
+      { name: "firstName", type: "firstName" },
+      { name: "lastName", type: "lastName" },
+    ],
+    linkageKeys: [
+      {
+        name: "Swap by alias and field",
+        elements: [
+          { field: "firstName", name: "given" },
+          { field: "lastName" },
+        ],
+        swap: ["given", "lastName"],
+      },
+    ],
+  });
+  expect(result.success).toBe(true);
+});
+
+test("a duplicate element field with distinct name aliases still validates", () => {
+  // The same field may appear twice when each occurrence carries a distinct
+  // `name`; the new referential-integrity checks must not regress the existing
+  // element-identifier-uniqueness rule, and a swap may target the aliases.
+  const result = safeParseLinkageTerms({
+    ...base,
+    linkageFields: [{ name: "phone", type: "phoneNumber" }],
+    linkageKeys: [
+      {
+        name: "Two phones",
+        elements: [
+          { field: "phone", name: "home" },
+          { field: "phone", name: "work" },
+        ],
+        swap: ["home", "work"],
       },
     ],
   });
@@ -959,7 +1064,15 @@ test("accepts linkageFields at exactly the maximum count", () => {
     name: `f${i}`,
     type: "ssn",
   }));
-  expect(() => parseLinkageTerms({ ...base, linkageFields })).not.toThrow();
+  // The key must reference a declared field, so point it at one of the f* names
+  // rather than base's "ssn", which this override does not declare.
+  expect(() =>
+    parseLinkageTerms({
+      ...base,
+      linkageFields,
+      linkageKeys: [{ name: "K", elements: [{ field: "f0" }] }],
+    }),
+  ).not.toThrow();
 });
 
 test("rejects more linkageFields than the maximum count", () => {


### PR DESCRIPTION
## Summary

`LinkageTermsSchema` now rejects, at decode, linkage terms that reference a field no linkage field declares, or whose `swap` names no element in its key, so an incoherent partner-controlled terms set can no longer parse and then silently collapse a linkage key to an empty result mid-exchange. Linkage terms arrive in a partner-controlled invitation token and are re-parsed off the wire, so enforcing the invariant once at schema-validation time protects every consumer, including the invite path that the prior accept-path CSV-satisfiability detector did not cover.

Implements [201033682](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=201033682).

## Changes

- packages/core/src/config/linkageTerms.ts: add two `.refine()` checks to `LinkageTermsSchema` (every element `field` names a declared linkage field; every `swap` target resolves to an element identifier `name ?? field` within the same key) and record both invariants in the `LinkageTerms` doc comment. Messages are static and locate the offender by issue `path`, never echoing a partner value -- the parse-error path is deliberately unsanitized.
- packages/core/src/standardization.ts: comment-only update to `assessLinkageSatisfiability`, noting its undeclared-field handling is now defense-in-depth behind the schema; the stopgap behavior is unchanged and retained.
- packages/core/test/linkageTerms.test.ts: new cases for the four acceptance criteria; make the existing bound-test and happy-path fixtures coherent so each rejects only on the constraint it names.
- docs/EXCHANGE_REFERENCE.md: document the referential-integrity rules alongside the sibling uniqueness and swap rules, and correct the swap-target resolution wording to the actual `name ?? field` rule.
- CHANGELOG.md: Fixed entry for the new decode rejection.

## Test plan

Ran: `npx vitest run packages/core/test/linkageTerms.test.ts` (76 pass), the full `npm test -w packages/core` (1275 pass), and `npm run test:unit -w apps/cli` (688) and `-w apps/web` (160) to confirm no fixture reaching decode carries incoherent terms. `npm run typecheck && npm run lint && npm run format` clean; `node scripts/check-doc-links.mjs` passes.
New tests cover: (a) an element `field` absent from `linkageFields` is rejected; (b) a `swap` target naming no element in its key is rejected; (c) a swap resolving via element `name` and one via `field` both pass; (d) a duplicate element `field` with distinct `name` aliases still validates.

## Background

At exchange time a dangling element `field` resolves to no values (`buildStandardizedDataset` builds only declared fields, so `getField` returns undefined and `buildKeyStrings` collapses the key to null) and a dangling `swap` target silently no-ops -- both produce a silent, undiagnosable empty result byte-indistinguishable from a legitimately empty intersection. The current blast radius is safe but fragile: about a dozen consumers happen to fail safe, so the invariant rested on scattered resolves-to-undefined conventions that a single future edit could turn into a mid-exchange throw. Enforcing it at schema validation makes the invariant hold once for every consumer. The cross-implementation byte vectors and existing fixtures were checked for incoherent terms that would newly fail decode; only two test fixtures qualified, both corrected here.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages -- docs/EXCHANGE_REFERENCE.md (the linkage_keys constraints and swapped-keys sections). Placed in the overview tier with the sibling linkage-terms validation rules: no `docs/spec/` doc covers terms-decode validation, and EXCHANGE_REFERENCE.md owns these normative config invariants per the spec/README tier-inversion precedent. Open to moving it to `docs/spec/` if a reviewer prefers.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- added under Fixed: terms referencing an undeclared field, or whose `swap` names no element in its key, are rejected as incoherent at decode.
- [x] Security review -- security-relevant (validation tightening on partner-controlled linkage terms; changes what terms are accepted at decode and improves the disclosure posture). Conducted three independent adversarial reviews -- parser attack surface, protocol/threat-model, and guarantee-weakening -- all clean: fail-closed pre-channel rejection, no DoS/bypass/info-leak, the `assessLinkageSatisfiability` stopgap intact, and the agreed-terms hash byte-identical for coherent terms. Flagged for maintainer security review per the Dependency Policy.
