### PR TITLE
Capture intended logs in error-path unit tests

### DIFF
--- a/apps/cli/test/unit/protocolDisplaySanitization.test.ts
+++ b/apps/cli/test/unit/protocolDisplaySanitization.test.ts
@@ -77,12 +77,27 @@ vi.mock("../../src/connection/ssh2SftpAdapter", () => ({
 }));
 
 import { FileSyncConnection } from "@psilink/core";
+import { withCapturedLogs } from "@psilink/core/testing";
 
 import { runProtocol } from "../../src/protocol";
 
 // runExchange/buildOutputTable are never reached on these failure paths, so the
 // prepared value is unused.
 const minimalPrepared = {} as unknown as PreparedExchange;
+
+// runProtocol constructs a real FileSyncConnection, which logs through the
+// (un-mocked) getLoggerForVerbosity -- notably the unpinned-host-key WARN every
+// sftp open() emits. Run it under withCapturedLogs so that connection-level
+// chatter is captured rather than leaked to the suite output; runProtocol's own
+// logs still reach mockState through the mocked getLogger. The host-key
+// warning's content is covered by core's fileSyncConnection tests, and the
+// failure-path rejection propagates unchanged (withCapturedLogs rethrows), so
+// callers still assert `.rejects`.
+function runProtocolCapturingConnLogs(
+  ...args: Parameters<typeof runProtocol>
+): Promise<void> {
+  return withCapturedLogs(() => runProtocol(...args)).then(() => {});
+}
 
 function sftpConfig(host: string) {
   return {
@@ -116,7 +131,7 @@ test("routes a partner-controlled SFTP host through sanitizeForDisplay before lo
   const hostileHost = "\x1b[31mevil.example‮com";
 
   await expect(
-    runProtocol(
+    runProtocolCapturingConnLogs(
       sftpConfig(hostileHost),
       null,
       minimalPrepared,
@@ -142,7 +157,7 @@ test("leaves an ordinary printable SFTP host unchanged", async () => {
   };
 
   await expect(
-    runProtocol(
+    runProtocolCapturingConnLogs(
       sftpConfig("sftp.example.com"),
       null,
       minimalPrepared,
@@ -212,7 +227,7 @@ test("renders a hostile close error through sanitizeErrorForDisplay in the clean
 
   try {
     await expect(
-      runProtocol(
+      runProtocolCapturingConnLogs(
         sftpConfig("sftp.example.com"),
         null,
         minimalPrepared,
@@ -252,7 +267,7 @@ test("leaves an ordinary close error message intact (only control bytes are esca
 
   try {
     await expect(
-      runProtocol(
+      runProtocolCapturingConnLogs(
         sftpConfig("sftp.example.com"),
         null,
         minimalPrepared,
@@ -285,7 +300,7 @@ test("renders a hostile close error through sanitizeErrorForDisplay in the opene
 
   try {
     await expect(
-      runProtocol(
+      runProtocolCapturingConnLogs(
         sftpConfig("sftp.example.com"),
         null,
         minimalPrepared,

--- a/apps/cli/test/unit/recordFile.test.ts
+++ b/apps/cli/test/unit/recordFile.test.ts
@@ -2,7 +2,29 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, beforeEach, expect, test } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+// Capture writeExchangeRecord's logger so the non-fatal "audit record could not
+// be written" WARN is asserted (proving the failure is surfaced) rather than
+// leaked to the suite output. getLogger is the only @psilink/core export
+// replaced; everything else stays real.
+const logCapture = vi.hoisted(() => ({ warnings: [] as string[] }));
+
+vi.mock("@psilink/core", async (importActual) => {
+  const actual = await importActual<typeof import("@psilink/core")>();
+  return {
+    ...actual,
+    getLogger: () => ({
+      info: () => {},
+      warn: (msg: string, ...args: unknown[]) => {
+        logCapture.warnings.push([msg, ...args.map(String)].join(" "));
+      },
+      debug: () => {},
+      error: () => {},
+      trace: () => {},
+    }),
+  };
+});
 
 import {
   parseExchangeRecord,
@@ -23,6 +45,7 @@ let dir: string;
 
 beforeEach(() => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-record-test-"));
+  logCapture.warnings.length = 0;
 });
 
 afterEach(() => {
@@ -157,4 +180,11 @@ test("writeExchangeRecord is non-fatal when the destination is unwritable", () =
     ),
   ).not.toThrow();
   expect(fs.existsSync(recordFilePath)).toBe(false);
+  // The non-fatal failure is surfaced as a WARN (asserting it both proves the
+  // diagnostic fired and keeps it off the suite output).
+  expect(
+    logCapture.warnings.some((m) =>
+      m.includes("the audit record could not be written"),
+    ),
+  ).toBe(true);
 });

--- a/apps/cli/test/unit/ssh2SftpAdapter.test.ts
+++ b/apps/cli/test/unit/ssh2SftpAdapter.test.ts
@@ -21,6 +21,24 @@ import {
   SFTP_STALL_DEADLINE_MS,
 } from "../../src/connection/sftpLivenessGuard";
 
+// Models ssh2-sftp-client exposing the underlying ssh2 Client (which carries
+// setNoDelay) on `.client`. connect() calls setNoDelay(true) on it to disable
+// Nagle; a mock that omits it makes connect() warn that setNoDelay is
+// unavailable on every successful connect. Provide a no-op so the faithful mock
+// matches the real client and that warning does not fire.
+const noDelayClient = () => ({ setNoDelay: () => {} });
+
+// Replaces the adapter's logger with a warn-swallowing stub. The deadline /
+// idle-window tests advance past SFTP_SLOW_OPERATION_WARNING_MS (30 s) on the
+// way to the 60 s deadline, so the non-fatal slow-operation warning fires
+// incidentally; this keeps it off the console. That warning's content is
+// asserted by the "slow-operation warning" describe block, so suppressing it
+// here loses no coverage (this.log.warn is the adapter's only WARN sink).
+function stubAdapterLog(adapter: SSH2SFTPClientAdapter): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (adapter as any).log = { warn: vi.fn() };
+}
+
 // --- connect retry -----------------------------------------------------------
 
 describe("connect retry", () => {
@@ -43,6 +61,7 @@ describe("connect retry", () => {
       connect: vi.fn().mockImplementation(async () => {
         if (++calls < 3) throw new Error("connection refused");
       }),
+      client: noDelayClient(),
     };
 
     try {
@@ -104,6 +123,7 @@ describe("connect retry", () => {
         .mockImplementation(async (opts: Record<string, unknown>) => {
           capturedOptions = opts;
         }),
+      client: noDelayClient(),
     };
 
     // 0 retries = 1 total attempt.
@@ -127,6 +147,7 @@ describe("connect retry", () => {
       // session property itself is present, so the bare null check would pass.
       sftp: { open: vi.fn(), close: vi.fn(), opendir: vi.fn() },
       connect: vi.fn().mockResolvedValue(undefined),
+      client: noDelayClient(),
     };
     await expect(
       adapter.connect({ host: "sftp.example.org", maxReconnectAttempts: 0 }),
@@ -533,6 +554,7 @@ describe("createExclusive", () => {
     // forever. The whole-operation deadline must fail it with the typed error.
     vi.useFakeTimers();
     try {
+      stubAdapterLog(adapter);
       mockOpen.mockImplementation(() => {
         // Deliberately never invokes the callback.
       });
@@ -555,6 +577,7 @@ describe("createExclusive", () => {
     // was created.
     vi.useFakeTimers();
     try {
+      stubAdapterLog(adapter);
       mockClose.mockImplementation(() => {
         // Deliberately never invokes the callback.
       });
@@ -782,6 +805,7 @@ describe("capped get", () => {
     vi.useFakeTimers();
     try {
       const adapter = new SSH2SFTPClientAdapter();
+      stubAdapterLog(adapter);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (adapter as any).client = {
         get: vi.fn().mockImplementation(() => new Promise<Writable>(() => {})),
@@ -805,6 +829,7 @@ describe("capped get", () => {
     vi.useFakeTimers();
     try {
       const adapter = new SSH2SFTPClientAdapter();
+      stubAdapterLog(adapter);
       let resolveGet!: (s: Writable) => void;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (adapter as any).client = {
@@ -838,6 +863,7 @@ describe("capped get", () => {
     vi.useFakeTimers();
     try {
       const adapter = new SSH2SFTPClientAdapter();
+      stubAdapterLog(adapter);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (adapter as any).client = {
         get: vi.fn().mockImplementation(() => new Promise(() => {})),
@@ -1389,6 +1415,7 @@ describe("bounded list", () => {
     vi.useFakeTimers();
     try {
       const adapter = new SSH2SFTPClientAdapter();
+      stubAdapterLog(adapter);
       let readdirCalls = 0;
       let closeCalls = 0;
       const sftp = {
@@ -1434,6 +1461,7 @@ describe("bounded list", () => {
     vi.useFakeTimers();
     try {
       const adapter = new SSH2SFTPClientAdapter();
+      stubAdapterLog(adapter);
       let closeCalls = 0;
       const sftp = {
         opendir: (_path: string, cb: (err: Error | null, h: Buffer) => void) =>
@@ -1659,6 +1687,7 @@ describe("fatal wrapper-error guard", () => {
     (adapter as any).client = {
       sftp: wrapper,
       connect: vi.fn().mockResolvedValue(undefined),
+      client: noDelayClient(),
     };
     await adapter.connect({ host: "h", maxReconnectAttempts: 0 });
     expect(wrapper.listenerCount("error")).toBe(1);
@@ -1671,6 +1700,7 @@ describe("fatal wrapper-error guard", () => {
     (adapter as any).client = {
       sftp: wrapper,
       connect: vi.fn().mockResolvedValue(undefined),
+      client: noDelayClient(),
     };
     await adapter.connect({ host: "h", maxReconnectAttempts: 0 });
     // Node throws on an 'error' event only when there are zero listeners; the
@@ -1687,6 +1717,7 @@ describe("fatal wrapper-error guard", () => {
     (adapter as any).client = {
       sftp: wrapper,
       connect: vi.fn().mockResolvedValue(undefined),
+      client: noDelayClient(),
     };
     await adapter.connect({ host: "h", maxReconnectAttempts: 0 });
     await adapter.connect({ host: "h", maxReconnectAttempts: 0 });
@@ -1702,6 +1733,7 @@ describe("fatal wrapper-error guard", () => {
     const client = {
       sftp: first as EventEmitter,
       connect: vi.fn().mockResolvedValue(undefined),
+      client: noDelayClient(),
     };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (adapter as any).client = client;
@@ -1728,6 +1760,7 @@ describe("fatal wrapper-error guard", () => {
     (adapter as any).client = {
       sftp: wrapper,
       connect: vi.fn().mockResolvedValue(undefined),
+      client: noDelayClient(),
     };
     await adapter.connect({ host: "h", maxReconnectAttempts: 0 });
     wrapper.emit("error", new Error("Malformed NAME packet"));
@@ -1777,6 +1810,7 @@ describe("fatal wrapper-error guard", () => {
       rename,
       exists,
       get,
+      client: noDelayClient(),
     };
     await adapter.connect({ host: "h", maxReconnectAttempts: 0 });
     wrapper.emit("error", new Error("Malformed DATA packet"));

--- a/apps/web/test/unit/exchangeLifecycle.test.ts
+++ b/apps/web/test/unit/exchangeLifecycle.test.ts
@@ -35,9 +35,34 @@ vi.mock("../../src/psi/peerMessageConnection.js", () => ({
 vi.mock("../../src/psi/authenticateExchange.js", () => ({
   authenticateExchange: vi.fn(),
 }));
+// Captured log output from the mock getLogger handed to exchangeLifecycle.
+// Hoisted so the vi.mock factory (lifted above imports) can close over it.
+const logCapture = vi.hoisted(() => ({
+  errors: [] as Array<string>,
+  warnings: [] as Array<string>,
+}));
+
 vi.mock("@psilink/core", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, runExchange: vi.fn() };
+  return {
+    ...actual,
+    runExchange: vi.fn(),
+    // The module-level `log = getLogger("exchangeLifecycle")` is created at
+    // import time, so withCapturedLogs cannot reach it; replace getLogger
+    // instead. This routes the lifecycle's teardown / early-disconnect ERROR
+    // lines into logCapture (asserted by the negative-path tests below) rather
+    // than letting them leak to stderr. The logger is informational only --
+    // replacing it does not affect the lifecycle's control flow.
+    getLogger: () => ({
+      info: () => {},
+      warn: (msg: string, ...args: Array<unknown>) =>
+        logCapture.warnings.push([msg, ...args.map(String)].join(" ")),
+      error: (msg: string, ...args: Array<unknown>) =>
+        logCapture.errors.push([msg, ...args.map(String)].join(" ")),
+      debug: () => {},
+      trace: () => {},
+    }),
+  };
 });
 
 const mockedOpen = vi.mocked(openPeerMessageConnection);
@@ -136,6 +161,8 @@ const OUTPUTS = {
 
 afterEach(() => {
   vi.clearAllMocks();
+  logCapture.errors.length = 0;
+  logCapture.warnings.length = 0;
 });
 
 describe("runExchangeLifecycle", () => {
@@ -342,6 +369,13 @@ describe("runExchangeLifecycle", () => {
     // success state survives and neither alert is shown (F2).
     expect(s.onResult).toHaveBeenCalledWith(OUTPUTS);
     expect(s.onError).not.toHaveBeenCalled();
+    // The swallowed teardown failure is still logged (capturing it proves the
+    // diagnostic fired and keeps it off the test output).
+    expect(
+      logCapture.errors.some((e) =>
+        e.includes("teardown: closing the connection failed"),
+      ),
+    ).toBe(true);
   });
 
   test("drops the broker on the first inbound frame, armed before the open await", async () => {
@@ -393,6 +427,55 @@ describe("runExchangeLifecycle", () => {
 
     expect(s.onResult).toHaveBeenCalled();
     expect(s.onError).not.toHaveBeenCalled();
+    // The run (and its teardown) drains on microtasks during the tick above, so
+    // the one-shot throwing disconnect is consumed by teardown's peer.disconnect
+    // -- and the swallowed failure is logged rather than leaked to stderr.
+    expect(
+      logCapture.errors.some((e) =>
+        e.includes("teardown: disconnecting the peer failed"),
+      ),
+    ).toBe(true);
+  });
+
+  test("a throw in the early broker disconnect is swallowed and logged", async () => {
+    // Holding the open await pending keeps the run parked with the first-frame
+    // data listener attached (teardown has not run), so a throwing peer.disconnect
+    // on the first frame exercises the early-broker catch -- the distinct ERROR
+    // sink from the teardown-disconnect path above, and the only one no other
+    // test reaches. The throw must not fail the exchange, and it must be logged
+    // (captured here) rather than leaked.
+    const peer = new FakePeer();
+    peer.disconnect.mockImplementationOnce(() => {
+      throw new Error("disconnect boom");
+    });
+    const { acquired, conn } = makeResources({ peer });
+    const opened = deferred<MessageConnection>();
+    mockedOpen.mockReturnValue(opened.promise);
+    const acquire: Acquire = () => Promise.resolve(acquired);
+    const s = seams();
+
+    const run = runExchangeLifecycle({
+      acquire,
+      exchangeRole: "initiator",
+      signal: new AbortController().signal,
+      ...s,
+    });
+    // Park on the still-pending open await with the data listener attached, then
+    // deliver the first frame so dropBrokerOnFirstFrame runs and throws.
+    await tick();
+    conn.emit("data", "first frame");
+
+    // Finish opening so the run completes cleanly despite the early throw.
+    opened.resolve(makeFakeMc().mc);
+    await run;
+
+    expect(s.onResult).toHaveBeenCalled();
+    expect(s.onError).not.toHaveBeenCalled();
+    expect(
+      logCapture.errors.some((e) =>
+        e.includes("early broker disconnect failed"),
+      ),
+    ).toBe(true);
   });
 
   test("abort mid-run closes the connection, the run rejects, teardown runs once, no alert", async () => {

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -234,12 +234,20 @@ test("emit('error', ...) with an attached listener is delivered and not buffered
   expect(conn.takeBufferedError()).toBeUndefined();
 });
 
-test("only the most recent buffered error is retained", () => {
+test("only the most recent buffered error is retained", async () => {
   const { client } = makeMockClient();
-  const conn = new FileSyncConnection(client, { verbose: -1 });
-  conn.emit("error", new Error("first"));
-  conn.emit("error", new Error("second"));
-  expect((conn.takeBufferedError() as Error).message).toBe("second");
+  // The second unhandled error supersedes the buffered first and emits a WARN
+  // naming the superseded one; capture it (proving the supersede path fired) so
+  // it does not leak to the suite output, mirroring the sibling escaping test.
+  const [, logs] = await withCapturedLogs(async () => {
+    const conn = new FileSyncConnection(client, { verbose: -1 });
+    conn.emit("error", new Error("first"));
+    conn.emit("error", new Error("second"));
+    expect((conn.takeBufferedError() as Error).message).toBe("second");
+  });
+  expect(
+    logs.some((l) => l.message.includes("superseding earlier buffered error")),
+  ).toBe(true);
 });
 
 test("the superseding-buffered-error warn escapes control/ANSI bytes in the prior error", async () => {
@@ -262,40 +270,67 @@ test("the superseding-buffered-error warn escapes control/ANSI bytes in the prio
   expect(warn!.message).toContain("\\x1b");
 });
 
-test("re-emitting the same buffered error does not create a self-referential cause cycle", () => {
+test("re-emitting the same buffered error does not create a self-referential cause cycle", async () => {
   // Regression guard: when an unhandled error is buffered and then the same
   // Error reference is emitted again, the cause-chain branch must NOT assign
   // `err.cause = err`. A self-cycle would loop any downstream walker.
   const { client } = makeMockClient();
-  const conn = new FileSyncConnection(client, { verbose: -1 });
   const err = new Error("repeated");
-  conn.emit("error", err);
-  conn.emit("error", err);
-  expect(conn.takeBufferedError()).toBe(err);
-  expect(err.cause).toBeUndefined();
+  // The re-emit still supersedes the buffered error and emits the WARN naming
+  // it -- the cause-cycle guard only suppresses the cause mutation, not the log
+  // -- so capture the WARN here too rather than let it leak.
+  const [, logs] = await withCapturedLogs(async () => {
+    const conn = new FileSyncConnection(client, { verbose: -1 });
+    conn.emit("error", err);
+    conn.emit("error", err);
+    expect(conn.takeBufferedError()).toBe(err);
+    expect(err.cause).toBeUndefined();
+  });
+  expect(
+    logs.some((l) => l.message.includes("superseding earlier buffered error")),
+  ).toBe(true);
 });
 
 // --- open (sftp) -------------------------------------------------------------
 
 test("open connects and sets path from sftp config", async () => {
   const { client } = makeMockClient();
-  const conn = new FileSyncConnection(client, { verbose: -1 });
-  await conn.open({
-    channel: "sftp",
-    server: { host: "sftp.example.org", path: "/exchanges" },
+  let conn!: FileSyncConnection;
+  // Opening an sftp target with no host_key_fingerprint pinned warns that the
+  // server identity is unverified. This test owns the assertion that the warning
+  // fires (proving intent); the other unpinned-open tests below suppress the
+  // same incidental WARN through the same capture rather than re-asserting it.
+  const [, logs] = await withCapturedLogs(async () => {
+    conn = new FileSyncConnection(client, { verbose: -1 });
+    await conn.open({
+      channel: "sftp",
+      server: { host: "sftp.example.org", path: "/exchanges" },
+    });
   });
   expect(conn.connected).toBe(true);
   expect(conn.path).toBe("/exchanges");
+  expect(
+    logs.some((l) =>
+      l.message.includes(
+        "SFTP server identity is NOT verified: no host_key_fingerprint is pinned",
+      ),
+    ),
+  ).toBe(true);
 });
 
 test("open maps peerTimeoutMs to timeToLive for sftp config", async () => {
   const { client } = makeMockClient();
-  const conn = new FileSyncConnection(client, { verbose: -1 });
+  let conn!: FileSyncConnection;
   const before = Date.now();
-  await conn.open({
-    channel: "sftp",
-    server: { host: "sftp.example.org" },
-    options: { peerTimeoutMs: 60_000 },
+  // Capture suppresses the incidental unpinned-host-key WARN (asserted by the
+  // "open connects and sets path" test above); this test is about timeToLive.
+  await withCapturedLogs(async () => {
+    conn = new FileSyncConnection(client, { verbose: -1 });
+    await conn.open({
+      channel: "sftp",
+      server: { host: "sftp.example.org" },
+      options: { peerTimeoutMs: 60_000 },
+    });
   });
   const after = Date.now();
   const ttl = conn.options.timeToLive!.getTime();
@@ -305,11 +340,15 @@ test("open maps peerTimeoutMs to timeToLive for sftp config", async () => {
 
 test("open maps pollIntervalMs to pollingFrequency for sftp config", async () => {
   const { client } = makeMockClient();
-  const conn = new FileSyncConnection(client, { verbose: -1 });
-  await conn.open({
-    channel: "sftp",
-    server: { host: "sftp.example.org" },
-    options: { pollIntervalMs: 15_000 },
+  let conn!: FileSyncConnection;
+  // Capture suppresses the incidental unpinned-host-key WARN (see above).
+  await withCapturedLogs(async () => {
+    conn = new FileSyncConnection(client, { verbose: -1 });
+    await conn.open({
+      channel: "sftp",
+      server: { host: "sftp.example.org" },
+      options: { pollIntervalMs: 15_000 },
+    });
   });
   expect(conn.options.pollingFrequency).toBe(15_000);
 });
@@ -320,14 +359,18 @@ test("open preserves constructor timeToLive and stores config peerTimeoutMs when
   // close() can read peerTimeoutMs from it for a fresh drain deadline.
   const { client } = makeMockClient();
   const constructorTtl = new Date(Date.now() + 9_999_999);
-  const conn = new FileSyncConnection(client, {
-    verbose: -1,
-    timeToLive: constructorTtl,
-  });
-  await conn.open({
-    channel: "sftp",
-    server: { host: "sftp.example.org" },
-    options: { peerTimeoutMs: 30_000 },
+  let conn!: FileSyncConnection;
+  // Capture suppresses the incidental unpinned-host-key WARN (see above).
+  await withCapturedLogs(async () => {
+    conn = new FileSyncConnection(client, {
+      verbose: -1,
+      timeToLive: constructorTtl,
+    });
+    await conn.open({
+      channel: "sftp",
+      server: { host: "sftp.example.org" },
+      options: { peerTimeoutMs: 30_000 },
+    });
   });
   expect(conn.options.timeToLive).toBe(constructorTtl);
   expect(
@@ -345,13 +388,17 @@ test("open preserves constructor timeToLive and leaves peerTimeoutMs undefined w
   // to DEFAULT_PEER_TIMEOUT_MS for the drain deadline.
   const { client } = makeMockClient();
   const constructorTtl = new Date(Date.now() + 9_999_999);
-  const conn = new FileSyncConnection(client, {
-    verbose: -1,
-    timeToLive: constructorTtl,
-  });
-  await conn.open({
-    channel: "sftp",
-    server: { host: "sftp.example.org" },
+  let conn!: FileSyncConnection;
+  // Capture suppresses the incidental unpinned-host-key WARN (see above).
+  await withCapturedLogs(async () => {
+    conn = new FileSyncConnection(client, {
+      verbose: -1,
+      timeToLive: constructorTtl,
+    });
+    await conn.open({
+      channel: "sftp",
+      server: { host: "sftp.example.org" },
+    });
   });
   expect(conn.options.timeToLive).toBe(constructorTtl);
   expect(
@@ -368,12 +415,16 @@ test("open derives timeToLive from config peerTimeoutMs when no constructor time
   // -> timeToLive is computed as Date.now() + peerTimeoutMs. The config is
   // stored as a private field so close() can read peerTimeoutMs from it.
   const { client } = makeMockClient();
-  const conn = new FileSyncConnection(client, { verbose: -1 });
+  let conn!: FileSyncConnection;
   const before = Date.now();
-  await conn.open({
-    channel: "sftp",
-    server: { host: "sftp.example.org" },
-    options: { peerTimeoutMs: 45_000 },
+  // Capture suppresses the incidental unpinned-host-key WARN (see above).
+  await withCapturedLogs(async () => {
+    conn = new FileSyncConnection(client, { verbose: -1 });
+    await conn.open({
+      channel: "sftp",
+      server: { host: "sftp.example.org" },
+      options: { peerTimeoutMs: 45_000 },
+    });
   });
   const after = Date.now();
   const ttl = conn.options.timeToLive!.getTime();
@@ -411,7 +462,9 @@ test("open (sftp): the connect debug log records only that a username is set, no
         const conn = new FileSyncConnection(client, { verbose: 1 });
         await conn.open(config);
       },
-      (level) => level === "DEBUG",
+      // Also claim WARN so the incidental unpinned-host-key WARN this unpinned
+      // open() emits is captured here rather than leaking past the DEBUG filter.
+      (level) => level === "DEBUG" || level === "WARN",
     );
     const debugLines = logs.map((l) => l.message).join("\n");
     // The connect line was captured (guards against a level-setup mistake that
@@ -451,7 +504,9 @@ test("open (sftp): the connect debug log escapes control bytes in the host and p
         const conn = new FileSyncConnection(client, { verbose: 1 });
         await conn.open(config);
       },
-      (level) => level === "DEBUG",
+      // Also claim WARN so the incidental unpinned-host-key WARN this unpinned
+      // open() emits is captured here rather than leaking past the DEBUG filter.
+      (level) => level === "DEBUG" || level === "WARN",
     );
     const connectLine = logs
       .map((l) => l.message)
@@ -529,7 +584,9 @@ test("synchronize: the 'synchronizing at path' info log escapes control bytes in
         await conn.open(config);
         await conn.synchronize().catch(() => {});
       },
-      (level) => level === "INFO",
+      // Also claim WARN so the incidental unpinned-host-key WARN the open() above
+      // emits is captured here rather than leaking past the INFO filter.
+      (level) => level === "INFO" || level === "WARN",
     );
     const syncLine = logs
       .map((l) => l.message)
@@ -548,6 +605,15 @@ test("synchronize: the 'synchronizing at path' info log escapes control bytes in
 // Capture the options object an sftp open() passes to client.connect, so the
 // allowlist tests can assert exactly what reaches ssh2-sftp-client. The mock's
 // connect is a no-op; here it records its single argument instead.
+//
+// The connection is constructed inside withCapturedLogs so its logger binds to
+// the interceptor: open() emits a WARN for each dropped providerOptions key,
+// plus the unpinned-host-key warning, and capturing them here keeps the
+// allowlist option-assertion tests below from leaking that noise to the suite
+// output. The "a dropped providerOptions key / algorithms sub-key is logged"
+// tests wrap this helper in their own capture to assert those WARNs -- the
+// shared interceptor delivers each WARN to that outer capture too, so
+// suppressing here does not hide them from the tests that prove they fire.
 async function captureSftpConnectOptions(
   config: SFTPConnectionConfig,
 ): Promise<Record<string, unknown>> {
@@ -556,8 +622,10 @@ async function captureSftpConnectOptions(
   client.connect = async (options: Record<string, unknown>) => {
     captured = options;
   };
-  const conn = new FileSyncConnection(client, { verbose: -1 });
-  await conn.open(config);
+  await withCapturedLogs(async () => {
+    const conn = new FileSyncConnection(client, { verbose: -1 });
+    await conn.open(config);
+  });
   if (captured === undefined) throw new Error("client.connect was not called");
   return captured;
 }
@@ -696,13 +764,23 @@ test("providerOptions algorithms with no allowed sub-keys is dropped entirely", 
 
 test("providerOptions algorithms that is not an object of categories is dropped", async () => {
   // A malformed algorithms value (here a bare string) is not an object of
-  // algorithm categories, so it is dropped rather than forwarded to ssh2.
-  const opts = await captureSftpConnectOptions({
-    channel: "sftp",
-    server: { host: "sftp.example.org" },
-    providerOptions: { algorithms: "aes256-gcm@openssh.com" },
+  // algorithm categories, so it is dropped rather than forwarded to ssh2. This
+  // branch's warn is distinct from the per-key drop loop (which the dropped-key
+  // tests pin), so capture and assert it here -- the helper's inner capture tees
+  // each WARN to this outer one too.
+  const [, logs] = await withCapturedLogs(async () => {
+    const opts = await captureSftpConnectOptions({
+      channel: "sftp",
+      server: { host: "sftp.example.org" },
+      providerOptions: { algorithms: "aes256-gcm@openssh.com" },
+    });
+    expect(opts["algorithms"]).toBeUndefined();
   });
-  expect(opts["algorithms"]).toBeUndefined();
+  expect(
+    logs.some((l) =>
+      l.message.includes("expected an object of algorithm categories"),
+    ),
+  ).toBe(true);
 });
 
 test("providerOptions algorithms accepts ssh2's append/prepend/remove object form", async () => {


### PR DESCRIPTION
## Summary

`npm run test` printed order-dependent WARN/ERROR lines to the console from unit tests that deliberately exercise error paths, with nothing marking them expected, so a reader could not tell intended output from a real problem. This PR makes those tests capture and assert the logs they intend to produce (and suppress the incidental ones), so a clean run surfaces only genuinely unexpected output, deterministically in any test order. It is test-only; no production code changes.

Implements [195584169](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=195584169).

## Changes

- packages/core/test/fileSyncConnection.test.ts: capture and assert the "superseding earlier buffered error" WARN in both buffered-error tests; assert the unpinned-host-key WARN once in the connect test and suppress that incidental WARN in the sibling open() tests; capture the per-dropped-key providerOptions WARNs at the shared captureSftpConnectOptions helper and pin the distinct "expected an object of algorithm categories" branch; widen the connect/synchronize escape-log capture filters to also claim WARN.
- apps/web/test/unit/exchangeLifecycle.test.ts: replace getLogger via the @psilink/core mock so the lifecycle ERRORs are captured; assert the two teardown ERRORs; add a test that drives the previously-uncovered early-broker-disconnect throw and asserts its ERROR.
- apps/cli/test/unit/ssh2SftpAdapter.test.ts: give the connecting mocks the nested ssh2 client the real ssh2-sftp-client exposes (no-op setNoDelay) so the faithful mock no longer warns at its source; stub adapter.log in the deadline/idle tests to suppress the incidental slow-operation WARN (whose content is asserted in the dedicated slow-operation describe block).
- apps/cli/test/unit/protocolDisplaySanitization.test.ts: run runProtocol under withCapturedLogs via a runProtocolCapturingConnLogs wrapper so the real FileSyncConnection's host-key WARN is captured rather than leaked, while the sanitization assertions still read the mocked getLogger.
- apps/cli/test/unit/recordFile.test.ts: replace getLogger via the @psilink/core mock and assert the non-fatal "audit record could not be written" WARN.

## Test plan

Ran: `npm test -w packages/core` (1275), `npm run test:unit -w apps/cli` (688), `npm run test:unit -w apps/web` (160), and `npm run test:integration -w apps/cli` (27 pass, 3 skipped); plus typecheck, lint, format. Confirmed zero WARN/ERROR console leaks across all three unit suites under randomized order (a throwaway console recorder wired into the unit projects, run with `--sequence.shuffle` across multiple seeds, then reverted) -- the only reliable check, since vitest swallows passing-test console output.

New tests cover: the previously-uncovered early-broker-disconnect throw path (web exchangeLifecycle) and the providerOptions "expected an object of algorithm categories" WARN (core). Existing error-path tests gain capture-assertions on the superseding-buffered-error WARN, the unpinned-host-key WARN, the slow-operation and audit-record WARNs, and the lifecycle teardown ERRORs, so each fails if its log stops being emitted.

## Background

The leak set was measured rather than taken from the ticket, which had drifted: the "re-emitting the same buffered error" test does emit the superseding WARN (the cause-cycle guard gates only the cause mutation, not the log), and the second exchangeLifecycle ERROR is the teardown peer-disconnect, not the early-broker one. Those corrections and the expanded scope (the full current leak set across core/cli/web, not only the named sites) are recorded on the board item. The fix uses per-test capture (`withCapturedLogs` for fresh per-connection loggers; the `getLogger` mock for module-level/fixed-name loggers; a faithful mock for the setNoDelay warning) and introduces no global blanket log-silence.

## Out of scope / follow-on

- Quiet CLI integration-test console output (the integration analogue; the suite still emits the host-key WARN and a rotation ERROR): [201551543](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=201551543).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed (test-only change).
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-only change, no operator- or reviewer-visible behavior, flag, format, or default changed (CONTRIBUTING excludes test/CI changes).
- [x] Security review -- no production security surface is modified (test-only), so none of the Dependency-Policy triggers apply; as due diligence an independent security review was run over the touched security-relevant tests (SFTP adapter, host-key warning, providerOptions default-deny allowlist, log/terminal-injection sanitization, liveness/DoS bounds, audit-record disclosure) and found no regression -- every control's assertion remains present and was confirmed to fail under a production mutation.
