### PR TITLE
Fix native-sshd flake: isolate stuck-joiner SFTP test

### DIFF
--- a/apps/cli/test/integration/sftpConnection.test.ts
+++ b/apps/cli/test/integration/sftpConnection.test.ts
@@ -34,6 +34,19 @@ log.setLevel(log.levels.DEBUG);
 // both come from the running server rather than a fixed path. ensureNamespace
 // creates the host directory before any party connects, since the connection
 // does not create remote directories.
+//
+// SFTP_PATH is a SHARED namespace: the persistent serverConn/clientConn
+// rendezvous here across the first tests, and the raw-op tests target it for
+// non-exchange file operations. That sharing stays safe only while nothing
+// drops a foreign file into it during a persistent-pair poll -- an unexpected
+// file observed by poll() trips the directory-exclusivity guard ("must be
+// dedicated to a single exchange"), the residue/straddle flake of board items
+// 200576628 and 201583776. So, for any future test: one that stands up its own
+// exchange MUST use freshRendezvous() (below), never SFTP_PATH; and nothing may
+// plant into SFTP_PATH while serverConn/clientConn may still be polling it (the
+// "message deliverable" window). Re-introducing shared-namespace exchange use
+// re-opens that flake -- this is why the self-connecting tests each get their
+// own mkdtemp directory.
 const srv = sftpServer();
 const NS = "sftp";
 const SFTP_LOCAL_DIRECTORY = localPath(srv, NS);

--- a/apps/cli/test/integration/sftpConnection.test.ts
+++ b/apps/cli/test/integration/sftpConnection.test.ts
@@ -333,7 +333,15 @@ test("lock starter aborts on a stuck mid-arrival joiner over real SFTP", async (
   // put/delete/rename runs under the hood whenever a real joiner arrives second
   // in the lock tests above; this exercises the failure side, which those do
   // not.)
-  await cleanServer();
+  //
+  // Runs on its own freshRendezvous() directory, not the shared `sftp`
+  // namespace: the planted `-joining.json` sentinel and the starter's polling
+  // would otherwise outlive this test as residue/a late poll and trip another
+  // exchange's directory-exclusivity guard on the shared path -- the same
+  // cross-test residue race #161 (board item 200576628) fixed for the other
+  // self-connecting tests, which left this pair sharing SFTP_PATH (board item
+  // 201583776).
+  const remote = await freshRendezvous();
 
   const abortSFTP = new SSH2SFTPClientAdapter();
   // joinerRecoveryMs well under the peer timeout so the bounded-window abort
@@ -348,7 +356,7 @@ test("lock starter aborts on a stuck mid-arrival joiner over real SFTP", async (
       host: srv.host,
       port: srv.port,
       ...serverAuth(srv.usera),
-      path: SFTP_PATH,
+      path: remote,
     },
     options: { peerTimeoutMs: 8_000 },
   });
@@ -363,17 +371,19 @@ test("lock starter aborts on a stuck mid-arrival joiner over real SFTP", async (
   try {
     // Wait until the starter's hello has landed, then simulate the stuck joiner
     // using the already-connected serverSFTP session (a separate SFTP client, so
-    // it does not contend with the starter's own polling on abortSFTP): delete
-    // the hello and drop a sentinel from a different id in its place.
+    // it does not contend with the starter's own polling on abortSFTP; its
+    // operations take absolute paths, so it reaches this test's dedicated
+    // rendezvous): delete the hello and drop a sentinel from a different id in
+    // its place.
     await waitFor(async () =>
-      (await serverSFTP.list(SFTP_PATH)).some((f) => f.name === helloName),
+      (await serverSFTP.list(remote)).some((f) => f.name === helloName),
     );
-    await serverSFTP.safeDelete(`${SFTP_PATH}/${helloName}`);
+    await serverSFTP.safeDelete(`${remote}/${helloName}`);
     await serverSFTP.put(
       Buffer.from(
         JSON.stringify({ locklessRendezvous: false, retainFiles: false }),
       ),
-      `${SFTP_PATH}/${sentinelName}`,
+      `${remote}/${sentinelName}`,
     );
 
     const err = await syncPromise.catch((e: unknown) => e);
@@ -387,9 +397,10 @@ test("lock starter aborts on a stuck mid-arrival joiner over real SFTP", async (
     // be caught over the real transport too.
     expect(err).not.toBeInstanceOf(UsageError);
   } finally {
-    await serverSFTP.safeDelete(`${SFTP_PATH}/${sentinelName}`);
+    // Best-effort sweep of the sentinel, then drain the starter via close(); the
+    // dedicated rendezvous directory itself is removed in afterAll.
+    await serverSFTP.safeDelete(`${remote}/${sentinelName}`);
     await abortConn.close();
-    await cleanServer();
   }
 });
 


### PR DESCRIPTION
## Summary

Fix a recurring native-sshd CI flake in the CLI SFTP integration suite. The "lock starter aborts on a stuck mid-arrival joiner over real SFTP" test was the last self-connecting test running on the shared `sftp` rendezvous namespace; its foreign-id `-joining.json` sentinel on that shared path could be observed by a poll over the same directory and trip the directory-exclusivity guard ("the directory must be dedicated to a single exchange"), failing a neighboring test. The slower chroot and restricted-crypto handshakes widen the window, so those two legs flaked while the faster profiles and the in-process backend stayed green. Moving the test onto its own dedicated rendezvous directory removes the shared-namespace coupling rather than narrowing the timing window. Test-only: no product, protocol, or SFTP-stack change.

Implements [201583776](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=201583776).

## Changes

- apps/cli/test/integration/sftpConnection.test.ts: move the stuck-joiner abort test onto a per-test `freshRendezvous()` mkdtemp directory (the isolation #161 already applied to the public-key and terminal-frame legs), planting its sentinel through the already-connected `serverSFTP` session against that dedicated path; drop the now-unneeded shared-namespace `cleanServer()` calls; and document the remaining shared `SFTP_PATH` hazard at the constant so a future test cannot silently re-introduce the flake.

## Test plan

Ran: `npm run test:integration -w apps/cli -- sftpConnection` (in-process, 10/10 pass); the same with `PSILINK_SFTP_BACKEND=native PSILINK_SFTP_NATIVE_PROFILE=restricted-crypto` (the flaking leg, 5 consecutive runs, no residue) and `PSILINK_SFTP_NATIVE_PROFILE=allowlist`; plus `npm run typecheck`, `npm run lint`, `npm run format`. The chroot leg needs root and skips locally; CI exercises it.
New tests cover: n/a -- isolation fix, no new behavior. The moved test asserts the same bounded-recovery-window abort and transport-failure-not-`UsageError` behavior as before, now on a dedicated directory.

## Background

The directory-exclusivity guard is a product invariant, raised only from `FileSyncConnection.poll()`: a rendezvous directory must be dedicated to a single exchange. Sharing one `sftp` namespace across sequential test exchanges runs the product in the mode that guard forbids and worked only by careful inter-test cleanup; this change makes the test honor the invariant the product enforces, the same direction as #161 (board item 200576628).

## Out of scope / follow-on

- The persistent serverConn/clientConn and the raw-op tests still share `SFTP_PATH`, which is currently inert (no remaining test plants a foreign file there while a connection polls it). Fully retiring the shared namespace is hygiene, not a flake fix; it is deferred and documented in-code at the `SFTP_PATH` constant rather than tracked as a separate board item.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed; test-only isolation fix.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test/CI change, no operator- or reviewer-visible change (CONTRIBUTING, Changelog).
- [x] Security review -- n/a: none of the security-review areas touched; the ssh2 contract assertions and the directory-exclusivity guard's strict policy are unchanged.
