### PR TITLE
Fix stale host-key warning assertion in core test

### DIFF
--- a/apps/cli/test/unit/protocolDisplaySanitization.test.ts
+++ b/apps/cli/test/unit/protocolDisplaySanitization.test.ts
@@ -86,11 +86,9 @@ import { runProtocol } from "../../src/protocol";
 const minimalPrepared = {} as unknown as PreparedExchange;
 
 // runProtocol constructs a real FileSyncConnection, which logs through the
-// (un-mocked) getLoggerForVerbosity -- notably the unpinned-host-key WARN every
-// sftp open() emits. Run it under withCapturedLogs so that connection-level
-// chatter is captured rather than leaked to the suite output; runProtocol's own
-// logs still reach mockState through the mocked getLogger. The host-key
-// warning's content is covered by core's fileSyncConnection tests, and the
+// (un-mocked) getLoggerForVerbosity. Run it under withCapturedLogs so that
+// connection-level chatter is captured rather than leaked to the suite output;
+// runProtocol's own logs still reach mockState through the mocked getLogger. The
 // failure-path rejection propagates unchanged (withCapturedLogs rethrows), so
 // callers still assert `.rejects`.
 function runProtocolCapturingConnLogs(

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -295,43 +295,28 @@ test("re-emitting the same buffered error does not create a self-referential cau
 // --- open (sftp) -------------------------------------------------------------
 
 test("open connects and sets path from sftp config", async () => {
+  // The mock client's connect() is a no-op, so the no-pin fail-closed
+  // hostVerifier open() installs is never invoked and no host-key log is
+  // emitted on this path; the fail-closed refusal itself is covered by the
+  // host-key verification tests below (which drive the verifier).
   const { client } = makeMockClient();
-  let conn!: FileSyncConnection;
-  // Opening an sftp target with no host_key_fingerprint pinned warns that the
-  // server identity is unverified. This test owns the assertion that the warning
-  // fires (proving intent); the other unpinned-open tests below suppress the
-  // same incidental WARN through the same capture rather than re-asserting it.
-  const [, logs] = await withCapturedLogs(async () => {
-    conn = new FileSyncConnection(client, { verbose: -1 });
-    await conn.open({
-      channel: "sftp",
-      server: { host: "sftp.example.org", path: "/exchanges" },
-    });
+  const conn = new FileSyncConnection(client, { verbose: -1 });
+  await conn.open({
+    channel: "sftp",
+    server: { host: "sftp.example.org", path: "/exchanges" },
   });
   expect(conn.connected).toBe(true);
   expect(conn.path).toBe("/exchanges");
-  expect(
-    logs.some((l) =>
-      l.message.includes(
-        "SFTP server identity is NOT verified: no host_key_fingerprint is pinned",
-      ),
-    ),
-  ).toBe(true);
 });
 
 test("open maps peerTimeoutMs to timeToLive for sftp config", async () => {
   const { client } = makeMockClient();
-  let conn!: FileSyncConnection;
+  const conn = new FileSyncConnection(client, { verbose: -1 });
   const before = Date.now();
-  // Capture suppresses the incidental unpinned-host-key WARN (asserted by the
-  // "open connects and sets path" test above); this test is about timeToLive.
-  await withCapturedLogs(async () => {
-    conn = new FileSyncConnection(client, { verbose: -1 });
-    await conn.open({
-      channel: "sftp",
-      server: { host: "sftp.example.org" },
-      options: { peerTimeoutMs: 60_000 },
-    });
+  await conn.open({
+    channel: "sftp",
+    server: { host: "sftp.example.org" },
+    options: { peerTimeoutMs: 60_000 },
   });
   const after = Date.now();
   const ttl = conn.options.timeToLive!.getTime();
@@ -341,15 +326,11 @@ test("open maps peerTimeoutMs to timeToLive for sftp config", async () => {
 
 test("open maps pollIntervalMs to pollingFrequency for sftp config", async () => {
   const { client } = makeMockClient();
-  let conn!: FileSyncConnection;
-  // Capture suppresses the incidental unpinned-host-key WARN (see above).
-  await withCapturedLogs(async () => {
-    conn = new FileSyncConnection(client, { verbose: -1 });
-    await conn.open({
-      channel: "sftp",
-      server: { host: "sftp.example.org" },
-      options: { pollIntervalMs: 15_000 },
-    });
+  const conn = new FileSyncConnection(client, { verbose: -1 });
+  await conn.open({
+    channel: "sftp",
+    server: { host: "sftp.example.org" },
+    options: { pollIntervalMs: 15_000 },
   });
   expect(conn.options.pollingFrequency).toBe(15_000);
 });
@@ -360,18 +341,14 @@ test("open preserves constructor timeToLive and stores config peerTimeoutMs when
   // close() can read peerTimeoutMs from it for a fresh drain deadline.
   const { client } = makeMockClient();
   const constructorTtl = new Date(Date.now() + 9_999_999);
-  let conn!: FileSyncConnection;
-  // Capture suppresses the incidental unpinned-host-key WARN (see above).
-  await withCapturedLogs(async () => {
-    conn = new FileSyncConnection(client, {
-      verbose: -1,
-      timeToLive: constructorTtl,
-    });
-    await conn.open({
-      channel: "sftp",
-      server: { host: "sftp.example.org" },
-      options: { peerTimeoutMs: 30_000 },
-    });
+  const conn = new FileSyncConnection(client, {
+    verbose: -1,
+    timeToLive: constructorTtl,
+  });
+  await conn.open({
+    channel: "sftp",
+    server: { host: "sftp.example.org" },
+    options: { peerTimeoutMs: 30_000 },
   });
   expect(conn.options.timeToLive).toBe(constructorTtl);
   expect(
@@ -389,17 +366,13 @@ test("open preserves constructor timeToLive and leaves peerTimeoutMs undefined w
   // to DEFAULT_PEER_TIMEOUT_MS for the drain deadline.
   const { client } = makeMockClient();
   const constructorTtl = new Date(Date.now() + 9_999_999);
-  let conn!: FileSyncConnection;
-  // Capture suppresses the incidental unpinned-host-key WARN (see above).
-  await withCapturedLogs(async () => {
-    conn = new FileSyncConnection(client, {
-      verbose: -1,
-      timeToLive: constructorTtl,
-    });
-    await conn.open({
-      channel: "sftp",
-      server: { host: "sftp.example.org" },
-    });
+  const conn = new FileSyncConnection(client, {
+    verbose: -1,
+    timeToLive: constructorTtl,
+  });
+  await conn.open({
+    channel: "sftp",
+    server: { host: "sftp.example.org" },
   });
   expect(conn.options.timeToLive).toBe(constructorTtl);
   expect(
@@ -416,16 +389,12 @@ test("open derives timeToLive from config peerTimeoutMs when no constructor time
   // -> timeToLive is computed as Date.now() + peerTimeoutMs. The config is
   // stored as a private field so close() can read peerTimeoutMs from it.
   const { client } = makeMockClient();
-  let conn!: FileSyncConnection;
+  const conn = new FileSyncConnection(client, { verbose: -1 });
   const before = Date.now();
-  // Capture suppresses the incidental unpinned-host-key WARN (see above).
-  await withCapturedLogs(async () => {
-    conn = new FileSyncConnection(client, { verbose: -1 });
-    await conn.open({
-      channel: "sftp",
-      server: { host: "sftp.example.org" },
-      options: { peerTimeoutMs: 45_000 },
-    });
+  await conn.open({
+    channel: "sftp",
+    server: { host: "sftp.example.org" },
+    options: { peerTimeoutMs: 45_000 },
   });
   const after = Date.now();
   const ttl = conn.options.timeToLive!.getTime();
@@ -463,9 +432,7 @@ test("open (sftp): the connect debug log records only that a username is set, no
         const conn = new FileSyncConnection(client, { verbose: 1 });
         await conn.open(config);
       },
-      // Also claim WARN so the incidental unpinned-host-key WARN this unpinned
-      // open() emits is captured here rather than leaking past the DEBUG filter.
-      (level) => level === "DEBUG" || level === "WARN",
+      (level) => level === "DEBUG",
     );
     const debugLines = logs.map((l) => l.message).join("\n");
     // The connect line was captured (guards against a level-setup mistake that
@@ -505,9 +472,7 @@ test("open (sftp): the connect debug log escapes control bytes in the host and p
         const conn = new FileSyncConnection(client, { verbose: 1 });
         await conn.open(config);
       },
-      // Also claim WARN so the incidental unpinned-host-key WARN this unpinned
-      // open() emits is captured here rather than leaking past the DEBUG filter.
-      (level) => level === "DEBUG" || level === "WARN",
+      (level) => level === "DEBUG",
     );
     const connectLine = logs
       .map((l) => l.message)
@@ -585,9 +550,7 @@ test("synchronize: the 'synchronizing at path' info log escapes control bytes in
         await conn.open(config);
         await conn.synchronize().catch(() => {});
       },
-      // Also claim WARN so the incidental unpinned-host-key WARN the open() above
-      // emits is captured here rather than leaking past the INFO filter.
-      (level) => level === "INFO" || level === "WARN",
+      (level) => level === "INFO",
     );
     const syncLine = logs
       .map((l) => l.message)
@@ -608,13 +571,13 @@ test("synchronize: the 'synchronizing at path' info log escapes control bytes in
 // connect is a no-op; here it records its single argument instead.
 //
 // The connection is constructed inside withCapturedLogs so its logger binds to
-// the interceptor: open() emits a WARN for each dropped providerOptions key,
-// plus the unpinned-host-key warning, and capturing them here keeps the
-// allowlist option-assertion tests below from leaking that noise to the suite
-// output. The "a dropped providerOptions key / algorithms sub-key is logged"
-// tests wrap this helper in their own capture to assert those WARNs -- the
-// shared interceptor delivers each WARN to that outer capture too, so
-// suppressing here does not hide them from the tests that prove they fire.
+// the interceptor: open() emits a WARN for each dropped providerOptions key, and
+// capturing them here keeps the allowlist option-assertion tests below from
+// leaking that noise to the suite output. The "a dropped providerOptions key /
+// algorithms sub-key is logged" tests wrap this helper in their own capture to
+// assert those WARNs -- the shared interceptor delivers each WARN to that outer
+// capture too, so suppressing here does not hide them from the tests that prove
+// they fire.
 async function captureSftpConnectOptions(
   config: SFTPConnectionConfig,
 ): Promise<Record<string, unknown>> {


### PR DESCRIPTION
## Summary

Restore the core unit suite to green on staging. A semantic merge-order conflict between two already-merged PRs left a core test asserting a log warning the source no longer emits, so `npm test -w packages/core` fails on staging even though each PR passed its own CI. This fix updates the stale test expectation; no production behavior changes.

## Changes

- packages/core/test/fileSyncConnection.test.ts: drop the obsolete "SFTP server identity is NOT verified: no host_key_fingerprint is pinned" assertion, and revert the now-dead `withCapturedLogs` wrappers and `|| WARN` level widenings that existed only to suppress that warning. The still-needed providerOptions dropped-key WARN captures are kept.
- apps/cli/test/unit/protocolDisplaySanitization.test.ts: correct a stale comment that described the removed unpinned-host-key WARN as still emitted on every sftp open().

## Test plan

Ran: `npx vitest run packages/core/test/fileSyncConnection.test.ts` (289 passed), `npm test -w packages/core` (full unit suite green), `npm run test:unit -w apps/cli` (703 passed), plus `npm run typecheck`, `npm run lint`, and `npm run format` (clean).
New tests cover: n/a -- test-only fix removing a stale assertion. Fail-closed behavior remains covered by the verifier-driving tests #164 added (no-pin fails closed, matching pin connects, mismatched pin rejected), which are unchanged.

## Background

PR #163 (Capture intended logs in error-path unit tests) added the assertion that an unpinned sftp open() logs the warn-and-proceed "SFTP server identity is NOT verified" message, and wrapped the neighboring sftp-open tests to suppress that incidental warning. PR #164 (SFTP host-key TOFU, default fail closed) then changed the unpinned-host-key default to fail closed, removing that warning from the source. Each PR was green against its own base; the contradiction only materializes once both are on staging, and the per-PR checks ran in a different order than the PRs landed, so neither run saw the conflict. The source fail-closed behavior is correct and is left unchanged -- only the stale test expectation is corrected. PR #165 is unrelated.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed (test/comment-only).
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-only fix, no operator- or reviewer-visible change.
- [x] Security review -- n/a: diff is confined to `*.test.ts` files and one comment; the host-key fail-closed control in `packages/core/src` is unchanged and its security-relevant assertions (fail-closed on no pin, reject on mismatch) are preserved.