### PR TITLE
Add web browser test step to CI

### DIFF
--- a/.github/workflows/eb_build_and_test.yaml
+++ b/.github/workflows/eb_build_and_test.yaml
@@ -94,10 +94,11 @@ jobs:
       # Docker; integration hits the HTTP/SSE routes in node, browser drives
       # Chromium). Running both projects in ONE vitest process lets that setup
       # start the server once and the second project reuse it, rather than two
-      # invocations each paying a full cold start -- so keep them combined.
-      # Splitting back into separate test:integration + test:browser steps
-      # reintroduces the second cold start. vitest still reports per project/file,
-      # so a failure names the suite that broke.
+      # invocations each paying a full cold start -- so keep them combined via the
+      # dedicated test:integration:browser script (which names both projects
+      # explicitly). Splitting back into separate test:integration + test:browser
+      # steps reintroduces the second cold start. vitest still reports per
+      # project/file, so a failure names the suite that broke.
       #
       # The integration project gates the web deploy on the app's own behavior
       # (independent of the CLI, whose tests live in release.yaml); the browser
@@ -108,7 +109,7 @@ jobs:
       # regression would otherwise ship unnoticed. Both run on the PR gate and this
       # workflow's push/deploy path, so the deploy artifact is gated on them too.
       - name: Web integration and browser tests
-        run: npm run test:browser -w apps/web -- --project integration
+        run: npm run test:integration:browser -w apps/web
       - name: Package for Elastic Beanstalk
         run: |
           cp -a apps/web/deploy/aws_eb/. apps/web/.output

--- a/.github/workflows/eb_build_and_test.yaml
+++ b/.github/workflows/eb_build_and_test.yaml
@@ -59,6 +59,15 @@ env:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    # Bound the job: this is the one CI job that drives a real browser and a live
+    # WebRTC exchange through a spawned dev server -- workloads that can wedge in
+    # ways the suite's own 60s timeouts do not all catch (a stuck browser or
+    # teardown, a stalled data channel). Without this the default 6h timeout
+    # applies, and since eb_deploy.yaml gates its deploy on this job via
+    # workflow_call, a hang would also stall a production deploy. 30 min sits far
+    # above a normal run (install + builds + tests + browser provisioning) yet
+    # cuts a true hang short.
+    timeout-minutes: 30
     outputs:
       artifactName: ${{steps.artifact-name.outputs.artifactName}}
     steps:

--- a/.github/workflows/eb_build_and_test.yaml
+++ b/.github/workflows/eb_build_and_test.yaml
@@ -79,35 +79,36 @@ jobs:
       # a web-unit regression gives a clear failure signal of its own.
       - name: Web unit tests
         run: npm run test:unit -w apps/web
-      # Web integration tests gate the web deploy on the app's own behavior,
-      # independent of the CLI (whose tests live in release.yaml). The suite is
-      # self-managing -- a vitest globalSetup spawns the dev server, waits for
-      # readiness, and tears it down -- and needs no Docker (it runs in the node
-      # environment and hits the HTTP/SSE routes), so a stock runner suffices.
-      - name: Web integration tests
-        run: npm run test:integration -w apps/web
-      # Web browser tests run in real Chromium via Playwright: the web PSI
-      # exchange, the cross-implementation record-vector checks, and the
-      # security-relevant accept-screen controls (the consent gate over the PII
-      # exchange and the decode-error escaping). No other CI job covers these --
-      # they need a DOM the node-based unit and integration projects do not have,
-      # so a browser-only regression would otherwise ship unnoticed. The browser
-      # project is self-managing like the integration one above (a vitest
-      # globalSetup spawns the dev server, waits for readiness, reuses a running
-      # one, and tears it down), so no manual dev-server step is needed. Runs on
-      # both the PR gate and this workflow's push/deploy path, so the deploy
-      # artifact is gated on browser behavior too.
-      #
-      # The stock ubuntu-latest runner ships no browser, so provision Chromium
-      # and the apt libraries it links against here (the dev container does this
-      # separately and is maintained independently). --with-deps installs those
-      # apt libraries; on Node 26 this needs playwright >= 1.60 (earlier versions
-      # hang extracting the browser archive, microsoft/playwright#40724) -- the
-      # lockfile pins >= 1.61, so do not downgrade.
+      # The browser project (below) drives real Chromium; the stock ubuntu-latest
+      # runner ships none, so provision it and the apt libraries it links against
+      # here, before that project runs. --with-deps installs those apt libraries;
+      # on Node 26 this needs playwright >= 1.60 (earlier versions hang extracting
+      # the browser archive, microsoft/playwright#40724) -- the lockfile pins
+      # >= 1.61, so do not downgrade. (The dev container provisions Chromium
+      # separately and is maintained independently.)
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
-      - name: Web browser tests
-        run: npm run test:browser -w apps/web
+      # Integration and browser tests both stand up the web dev server through a
+      # shared, self-managing vitest globalSetup (it spawns the server, waits for
+      # readiness, reuses a running one, and tears it down -- no manual step and no
+      # Docker; integration hits the HTTP/SSE routes in node, browser drives
+      # Chromium). Running both projects in ONE vitest process lets that setup
+      # start the server once and the second project reuse it, rather than two
+      # invocations each paying a full cold start -- so keep them combined.
+      # Splitting back into separate test:integration + test:browser steps
+      # reintroduces the second cold start. vitest still reports per project/file,
+      # so a failure names the suite that broke.
+      #
+      # The integration project gates the web deploy on the app's own behavior
+      # (independent of the CLI, whose tests live in release.yaml); the browser
+      # project covers the security-relevant accept-screen controls (the consent
+      # gate over the PII exchange and the decode-error escaping) plus the live PSI
+      # exchange and cross-implementation vectors -- behavior no other CI job
+      # covers, since it needs a DOM the node projects lack, so a browser-only
+      # regression would otherwise ship unnoticed. Both run on the PR gate and this
+      # workflow's push/deploy path, so the deploy artifact is gated on them too.
+      - name: Web integration and browser tests
+        run: npm run test:browser -w apps/web -- --project integration
       - name: Package for Elastic Beanstalk
         run: |
           cp -a apps/web/deploy/aws_eb/. apps/web/.output

--- a/.github/workflows/eb_build_and_test.yaml
+++ b/.github/workflows/eb_build_and_test.yaml
@@ -86,6 +86,28 @@ jobs:
       # environment and hits the HTTP/SSE routes), so a stock runner suffices.
       - name: Web integration tests
         run: npm run test:integration -w apps/web
+      # Web browser tests run in real Chromium via Playwright: the web PSI
+      # exchange, the cross-implementation record-vector checks, and the
+      # security-relevant accept-screen controls (the consent gate over the PII
+      # exchange and the decode-error escaping). No other CI job covers these --
+      # they need a DOM the node-based unit and integration projects do not have,
+      # so a browser-only regression would otherwise ship unnoticed. The browser
+      # project is self-managing like the integration one above (a vitest
+      # globalSetup spawns the dev server, waits for readiness, reuses a running
+      # one, and tears it down), so no manual dev-server step is needed. Runs on
+      # both the PR gate and this workflow's push/deploy path, so the deploy
+      # artifact is gated on browser behavior too.
+      #
+      # The stock ubuntu-latest runner ships no browser, so provision Chromium
+      # and the apt libraries it links against here (the dev container does this
+      # separately and is maintained independently). --with-deps installs those
+      # apt libraries; on Node 26 this needs playwright >= 1.60 (earlier versions
+      # hang extracting the browser archive, microsoft/playwright#40724) -- the
+      # lockfile pins >= 1.61, so do not downgrade.
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Web browser tests
+        run: npm run test:browser -w apps/web
       - name: Package for Elastic Beanstalk
         run: |
           cp -a apps/web/deploy/aws_eb/. apps/web/.output

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,9 +129,10 @@ dev`, and otherwise starts and stops its own.
 npm run test:browser -w apps/web    # auto-starts, waits for, and stops the dev server
 ```
 
-It is not part of CI; run it locally when changing the web PSI exchange, the
-cross-implementation vectors, or a web UI component it covers (such as the accept
-consent gate).
+It runs in CI as part of the web build-and-test gate (`eb_build_and_test.yaml`),
+which provisions Chromium on the runner; run it locally too when changing the web
+PSI exchange, the cross-implementation vectors, or a web UI component it covers
+(such as the accept consent gate).
 
 ## Code Conventions
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,8 @@
     "test": "vitest run --project unit",
     "test:browser": "vitest run --project browser",
     "test:unit": "vitest run --project unit",
-    "test:integration": "vitest run --project integration"
+    "test:integration": "vitest run --project integration",
+    "test:integration:browser": "vitest run --project integration --project browser"
   },
   "keywords": [
     "private set intersection",

--- a/apps/web/test/browser/invitedPSI.test.ts
+++ b/apps/web/test/browser/invitedPSI.test.ts
@@ -136,10 +136,20 @@ beforeAll(async () => {
   const inviterId = await deriveRendezvousPeerId(sharedSecret, "inviter");
   const acceptorId = await deriveRendezvousPeerId(sharedSecret, "acceptor");
 
+  // Hermetic ICE: both peers run in one browser on one machine, so a loopback
+  // host candidate is all they need. Configure no STUN/TURN, so the exchange
+  // contacts no external server (PeerJS's default config would otherwise reach
+  // public Google STUN, and on a runner with open egress Chromium would probe
+  // it). This makes the loopback host candidate the only one available, which is
+  // exactly why the browser project disables Chromium's mDNS host-candidate
+  // obfuscation (see vite.config.ts); without that the candidate is an
+  // unresolvable `.local` name and the connection cannot open. Production
+  // configures real STUN for cross-network peers (src/psi/rendezvous.ts).
   const inviterPeer = new Peer(inviterId, {
     host: addressInfo.address,
     path: "/api/",
     port: addressInfo.port,
+    config: { iceServers: [] },
   });
   await peerOpened(inviterPeer);
 
@@ -173,6 +183,7 @@ beforeAll(async () => {
     host: addressInfo.address,
     path: "/api/",
     port: addressInfo.port,
+    config: { iceServers: [] }, // hermetic ICE -- see inviterPeer above
   });
   const acceptorConn: DataConnection = await new Promise<DataConnection>(
     (resolve, reject) => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -82,15 +82,14 @@ export default defineConfig((_configEnv) => {
             globalSetup: ["./test/devServer/globalSetup.ts"],
             browser: {
               // invitedPSI opens a real WebRTC DataConnection between two
-              // same-machine peers. Chromium otherwise obfuscates host ICE
-              // candidates as `.local` mDNS names, which do not resolve in
-              // containers/CI (no mDNS responder), and the dev-container egress
-              // firewall blocks the external STUN/TURN that would supply
-              // server-reflexive candidates instead -- so with no usable
-              // candidate the connection never opens and the exchange hangs.
-              // Disabling the mDNS obfuscation exposes the real loopback host
-              // candidate, so the peers connect directly with no external
-              // network (hermetic). Test browser only -- no effect on the dev
+              // same-machine peers that configure no STUN/TURN (hermetic -- see
+              // invitedPSI.test.ts), so a loopback host candidate is the only way
+              // they can connect. Chromium otherwise obfuscates host candidates
+              // as `.local` mDNS names that do not resolve in containers/CI (no
+              // mDNS responder), leaving no usable candidate -- the connection
+              // never opens and the exchange hangs. Disabling the mDNS
+              // obfuscation exposes the real loopback host candidate so the peers
+              // connect directly. Test browser only -- no effect on the dev
               // server or `npm run build`.
               provider: playwright({
                 launchOptions: {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -81,7 +81,22 @@ export default defineConfig((_configEnv) => {
             // second one. The server-less vector suites pay a reuse-aware probe.
             globalSetup: ["./test/devServer/globalSetup.ts"],
             browser: {
-              provider: playwright(),
+              // invitedPSI opens a real WebRTC DataConnection between two
+              // same-machine peers. Chromium otherwise obfuscates host ICE
+              // candidates as `.local` mDNS names, which do not resolve in
+              // containers/CI (no mDNS responder), and the dev-container egress
+              // firewall blocks the external STUN/TURN that would supply
+              // server-reflexive candidates instead -- so with no usable
+              // candidate the connection never opens and the exchange hangs.
+              // Disabling the mDNS obfuscation exposes the real loopback host
+              // candidate, so the peers connect directly with no external
+              // network (hermetic). Test browser only -- no effect on the dev
+              // server or `npm run build`.
+              provider: playwright({
+                launchOptions: {
+                  args: ["--disable-features=WebRtcHideLocalIpsWithMdns"],
+                },
+              }),
               headless: true,
               enabled: true,
               instances: [{ browser: "chromium" }],


### PR DESCRIPTION
## Summary

Wire the web app's browser test suite (`test:browser`, real Chromium via Playwright) into the web build-and-test CI gate, so the browser-only controls it exercises are enforced on every web-affecting PR and on the deploy path. The suite covers the accept-screen consent gate over the PII exchange and the decode-error escaping of partner-controlled values, plus the live PSI exchange and the cross-implementation record vectors -- behavior no other CI job covers, since it needs a DOM the node-based projects lack, so a browser-only regression would otherwise ship unnoticed. The suite is self-managing (a vitest globalSetup spawns and tears down the dev server), so no manual dev-server step is added.

Implements [198699664](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=198699664).

## Changes

- `.github/workflows/eb_build_and_test.yaml`: add a `playwright install --with-deps chromium` step to provision the browser on the stock runner; run the integration and browser projects in one vitest invocation so their shared globalSetup pays a single dev-server cold start; cap the job at `timeout-minutes: 30` so a hung browser/WebRTC run cannot ride the 6h default into a stalled deploy.
- `apps/web/package.json`: add a `test:integration:browser` script that names both projects explicitly (the CI step calls it).
- `apps/web/vite.config.ts`: launch the test Chromium with `--disable-features=WebRtcHideLocalIpsWithMdns` so the WebRTC PSI test connects over a loopback host candidate in CI/containers. Test browser only -- the production ICE config is untouched.
- `apps/web/test/browser/invitedPSI.test.ts`: give the test peers an empty `iceServers` config so the exchange stays on loopback and contacts no external STUN.
- `CONTRIBUTING.md`: note the browser suite now runs in CI.

## Test plan

Ran: `npm run test:integration:browser -w apps/web` (47 tests pass, one shared dev-server cold start), plus `npm run typecheck`, `npm run lint`, and `npm run formatcheck` -- all green.
New tests cover: n/a -- this wires the existing browser tests (consent gate, decode-error escaping, live PSI exchange, cross-implementation vectors) into CI rather than adding tests; the empty-`iceServers` change is verified by the existing invitedPSI suite still passing over loopback.

## Background

The browser suite became viable in CI once its dev server self-managed (PR #81). Its one networked test, invitedPSI, opens a real WebRTC DataConnection between two same-machine peers; Chromium otherwise obfuscates host ICE candidates as `.local` mDNS names that do not resolve in containers/CI, so the launch flag exposes the real loopback candidate. With the test peers configured for no STUN, that loopback candidate is the only one needed and the exchange stays hermetic -- it contacts no external server.

## Out of scope / follow-on

- Runner-time tuning (Playwright/Vite caches, parallel browser job, prebuilt runner image): [201636292](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=201636292).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: CI/test-tooling change, no documented product behavior changed; CONTRIBUTING.md's test section was updated to note the browser suite now runs in CI.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test/CI tooling change, no operator- or reviewer-visible behavior change.
- [x] Security review -- n/a: no security-review-scope area is touched (CI/test-only; the mDNS launch flag and empty `iceServers` are confined to the test browser, and the production crypto/channel/credential/auth/disclosure surfaces are unchanged). Two independent security reviews (app/protocol and CI/supply-chain) were run regardless: no regression, and no formal review required.
