### PR TITLE
Fix web PeerJS signaling cold-start

### DIFF
--- a/apps/web/server/custom-entry.ts
+++ b/apps/web/server/custom-entry.ts
@@ -72,7 +72,10 @@ const listener = server.listen(path ? { path } : { port, host }, (err) => {
     .then(async (res) => {
       // A non-2xx resolves normally (no rejection to .catch): surface it, since
       // it means usePeerServer() did not attach the handler. Release the body
-      // either way -- we read neither.
+      // either way -- we read neither. Unlike the dev warm (vite.config.ts), no
+      // content-type check is needed here: the built server registers this route
+      // eagerly, so a 2xx cannot be a lazily-compiled SPA fallback the way it can
+      // under Vite.
       if (!res.ok)
         log.warn(`peer signaling warm-up returned HTTP ${res.status}`);
       await res.body?.cancel();
@@ -103,6 +106,12 @@ setupGracefulShutdown(listener, nitroApp);
 
 // Websocket support
 // https://crossws.unjs.io/adapters/node
+// Dead today: experimental.websocket is unset, so import.meta._websocket is false
+// and this block is tree-shaken out of the build. Enabling it would be UNSAFE while
+// the PeerJS signaling server shares this http server: both attach a bare
+// server.on("upgrade", ...), and PeerJS's `ws` aborts any upgrade whose path is not
+// /api/peerjs -- destroying a crossws socket mid-handshake. Coexisting would need a
+// single path-routed upgrade dispatcher, not two independent listeners.
 if (import.meta._websocket) {
   const { handleUpgrade } = wsAdapter(nitroApp.h3App.websocket);
   server.on("upgrade", handleUpgrade);

--- a/apps/web/server/custom-entry.ts
+++ b/apps/web/server/custom-entry.ts
@@ -55,6 +55,20 @@ const listener = server.listen(path ? { path } : { port, host }, (err) => {
     console.error(err);
     process.exit(1);
   }
+  // Eagerly warm the PeerJS signaling route now that the HTTP server is listening
+  // (so its address resolves) and registered below. The route runs usePeerServer()
+  // -- which attaches the WebSocket `upgrade` handler -- only when first requested,
+  // and the real client never requests it: it dials the signaling WebSocket with
+  // an explicit, pre-derived id and skips the GET /api/peerjs/id. Without this the
+  // upgrade goes unhandled and the peer reports "Lost connection to server."
+  // localFetch dispatches in-process through the nitro app (no real socket), so it
+  // is independent of bind type (TCP, TLS, unix socket) and of this entry's own
+  // module-alias resolution.
+  void nitroApp
+    .localFetch("/api/peerjs/id")
+    .catch((warmErr: unknown) =>
+      log.warn("peer signaling warm-up failed:", warmErr),
+    );
   const protocol = cert && key ? "https" : "http";
   const addressInfo = listener.address() as AddressInfo;
   if (typeof addressInfo === "string") {

--- a/apps/web/server/custom-entry.ts
+++ b/apps/web/server/custom-entry.ts
@@ -66,6 +66,14 @@ const listener = server.listen(path ? { path } : { port, host }, (err) => {
   // module-alias resolution.
   void nitroApp
     .localFetch("/api/peerjs/id")
+    .then(async (res) => {
+      // A non-2xx resolves normally (no rejection to .catch): surface it, since
+      // it means usePeerServer() did not attach the handler. Release the body
+      // either way -- we read neither.
+      if (!res.ok)
+        log.warn(`peer signaling warm-up returned HTTP ${res.status}`);
+      await res.body?.cancel();
+    })
     .catch((warmErr: unknown) =>
       log.warn("peer signaling warm-up failed:", warmErr),
     );

--- a/apps/web/server/custom-entry.ts
+++ b/apps/web/server/custom-entry.ts
@@ -56,7 +56,10 @@ const listener = server.listen(path ? { path } : { port, host }, (err) => {
     process.exit(1);
   }
   // Eagerly warm the PeerJS signaling route now that the HTTP server is listening
-  // (so its address resolves) and registered below. The route runs usePeerServer()
+  // (so its address resolves). registerServer at the end of this module is
+  // synchronous, so it has already run by the time this callback fires on a later
+  // tick, and usePeerServer's getHttpServer() finds the registered server. The
+  // route runs usePeerServer()
   // -- which attaches the WebSocket `upgrade` handler -- only when first requested,
   // and the real client never requests it: it dials the signaling WebSocket with
   // an explicit, pre-derived id and skips the GET /api/peerjs/id. Without this the

--- a/apps/web/test/devServer/globalSetup.ts
+++ b/apps/web/test/devServer/globalSetup.ts
@@ -183,6 +183,14 @@ export default async function setup({
     if (child.pid === undefined || child.exitCode !== null)
       return Promise.resolve();
     const pid = child.pid;
+    // Re-ref the child while we wait for it to exit. It was unref'd at spawn so a
+    // never-reached teardown would not pin the process; but here we are actively
+    // awaiting its exit, and on the setup-failure path (this fn runs from the
+    // catch below) vitest holds no other ref'd handle. Without the ref, the event
+    // loop would drain and the process would exit 0 mid-await -- before the child
+    // is killed and before the setup error is re-thrown -- turning a failed setup
+    // into a silent pass. The child's exit releases the ref.
+    child.ref();
     return new Promise<void>((resolveStop) => {
       const timer = setTimeout(() => {
         try {

--- a/apps/web/test/devServer/signalingProbe.ts
+++ b/apps/web/test/devServer/signalingProbe.ts
@@ -43,9 +43,19 @@ function coldSignalingAttempt(
       resolvePromise(ok);
     };
     const timer = setTimeout(() => finish(false), perAttemptMs);
-    ws.on("message", (data: WebSocket.RawData) =>
-      finish(data.toString().includes('"type":"OPEN"')),
-    );
+    ws.on("message", (data: WebSocket.RawData) => {
+      // Resolve only on the OPEN frame; ignore any other frame rather than
+      // treating the first message as the verdict (close/timeout cover the
+      // negative cases). Parse the type instead of substring-matching, so JSON
+      // formatting changes cannot silently make this a permanent false negative.
+      let type: unknown;
+      try {
+        type = (JSON.parse(data.toString()) as { type?: unknown }).type;
+      } catch {
+        return;
+      }
+      if (type === "OPEN") finish(true);
+    });
     ws.on("close", () => finish(false));
     ws.on("error", () => finish(false));
   });

--- a/apps/web/test/devServer/signalingProbe.ts
+++ b/apps/web/test/devServer/signalingProbe.ts
@@ -42,6 +42,9 @@ function coldSignalingAttempt(
       }
       resolvePromise(ok);
     };
+    // `finish` closes over `timer` but is only ever invoked asynchronously (from a
+    // ws event or this timeout), so the reference is resolved well after this
+    // line; a `const` here keeps prefer-const happy without a TDZ in practice.
     const timer = setTimeout(() => finish(false), perAttemptMs);
     ws.on("message", (data: WebSocket.RawData) => {
       // Resolve only on the OPEN frame; ignore any other frame rather than
@@ -62,8 +65,11 @@ function coldSignalingAttempt(
 }
 
 /** Poll {@link coldSignalingAttempt} until signaling answers OPEN or `deadlineMs`
- * elapses; returns whether it opened. Used by the production signaling smoke test
- * to assert the built server warms signaling at startup. */
+ * elapses; returns whether it opened. `deadlineMs` bounds when polling stops, not
+ * total runtime: an attempt in flight when it passes runs to completion, so the
+ * call can overrun by up to one attempt (`perAttemptMs`) plus the inter-attempt
+ * sleep. Used by the production signaling smoke test to assert the built server
+ * warms signaling at startup. */
 export async function waitForColdSignaling(
   port: number,
   options: { deadlineMs: number; perAttemptMs?: number },

--- a/apps/web/test/devServer/signalingProbe.ts
+++ b/apps/web/test/devServer/signalingProbe.ts
@@ -1,0 +1,68 @@
+import WebSocket from "ws";
+
+// A cold dial of the PeerJS signaling WebSocket: it connects the upgrade
+// directly, exactly as the real client does (which uses an explicit, pre-derived
+// id and so never makes the GET /api/peerjs/id that would lazily load the route
+// module). A WebSocket upgrade does NOT run that route handler, so this probe
+// never warms the server -- it only observes whether signaling was already warmed
+// at startup. That is what lets it stand in for the masked-by-an-HTTP-warm gap:
+// the server must warm signaling itself (the dev-server-snagger in vite.config,
+// or the nitro entry's localFetch in production) for this to ever answer OPEN.
+
+// Process-wide so every attempt registers under a distinct broker id: a retry
+// that lands before the server has reaped a prior probe's socket would otherwise
+// be rejected ID_TAKEN rather than OPEN.
+let probeSeq = 0;
+
+/** One cold dial. Resolves true if the server answers with the PeerJS OPEN frame
+ * (the upgrade was handled and the peer registered), false on close/error or if
+ * `perAttemptMs` elapses with no answer (an unhandled upgrade stalls rather than
+ * refusing). Terminates the socket without removing listeners, so a late `error`
+ * from tearing down a still-connecting probe is swallowed by the settled-guarded
+ * handler rather than left unhandled. */
+function coldSignalingAttempt(
+  port: number,
+  perAttemptMs: number,
+): Promise<boolean> {
+  return new Promise((resolvePromise) => {
+    const id = `signaling-probe-${(probeSeq += 1)}`;
+    const url =
+      `ws://127.0.0.1:${port}/api/peerjs` +
+      `?key=peerjs&id=${id}&token=tok&version=1.5.5`;
+    const ws = new WebSocket(url);
+    let settled = false;
+    const finish = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        ws.terminate();
+      } catch {
+        // already gone
+      }
+      resolvePromise(ok);
+    };
+    const timer = setTimeout(() => finish(false), perAttemptMs);
+    ws.on("message", (data: WebSocket.RawData) =>
+      finish(data.toString().includes('"type":"OPEN"')),
+    );
+    ws.on("close", () => finish(false));
+    ws.on("error", () => finish(false));
+  });
+}
+
+/** Poll {@link coldSignalingAttempt} until signaling answers OPEN or `deadlineMs`
+ * elapses; returns whether it opened. Used by the production signaling smoke test
+ * to assert the built server warms signaling at startup. */
+export async function waitForColdSignaling(
+  port: number,
+  options: { deadlineMs: number; perAttemptMs?: number },
+): Promise<boolean> {
+  const perAttemptMs = options.perAttemptMs ?? 2_500;
+  const deadline = Date.now() + options.deadlineMs;
+  for (;;) {
+    if (await coldSignalingAttempt(port, perAttemptMs)) return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+}

--- a/apps/web/test/integration/prodSignaling.test.ts
+++ b/apps/web/test/integration/prodSignaling.test.ts
@@ -69,7 +69,9 @@ async function httpAccepts(url: string, timeoutMs: number): Promise<boolean> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    await fetch(url, { signal: controller.signal });
+    const res = await fetch(url, { signal: controller.signal });
+    // Release the socket: this polls every 250ms and we read neither body.
+    await res.body?.cancel();
     return true;
   } catch {
     return false;
@@ -136,7 +138,15 @@ describe.skipIf(!hasBuild)(
 
     afterAll(async () => {
       const c = child;
-      if (!c || c.pid === undefined || c.exitCode !== null) return;
+      // Already gone if it exited (exitCode) or was signalled (signalCode);
+      // checking only exitCode would miss a SIGKILLed child and kill a dead group.
+      if (
+        !c ||
+        c.pid === undefined ||
+        c.exitCode !== null ||
+        c.signalCode !== null
+      )
+        return;
       const pid = c.pid;
       // Re-ref the child (unref'd at spawn) while awaiting its exit, so the event
       // loop cannot drain mid-teardown and leave an orphaned server -- the same

--- a/apps/web/test/integration/prodSignaling.test.ts
+++ b/apps/web/test/integration/prodSignaling.test.ts
@@ -42,7 +42,11 @@ function sleep(ms: number): Promise<void> {
 }
 
 /** Ask the OS for a free loopback TCP port so this server never collides with
- * the shared globalSetup dev server (or anything else). */
+ * the shared globalSetup dev server (or anything else). There is a small,
+ * accepted TOCTOU window between closing this probe and the spawned server's own
+ * bind; nothing here contends for ephemeral ports (the dev server uses a fixed
+ * port), so a collision is improbable, and waitForRoot surfaces it promptly as an
+ * early-exit error rather than a confusing readiness timeout. */
 function getFreePort(): Promise<number> {
   return new Promise((resolvePort, reject) => {
     const probe = createServer();
@@ -68,9 +72,17 @@ async function httpAccepts(url: string, timeoutMs: number): Promise<boolean> {
   }
 }
 
-async function waitForRoot(url: string): Promise<void> {
+async function waitForRoot(url: string, proc: ChildProcess): Promise<void> {
   const deadline = Date.now() + READY_TIMEOUT_MS;
   for (;;) {
+    // Surface an early exit (a port collision, a missing/broken build) with its
+    // real cause, instead of polling a server that is never coming up until the
+    // readiness deadline and then reporting a misleading timeout.
+    if (proc.exitCode !== null || proc.signalCode !== null)
+      throw new Error(
+        `production server exited before becoming ready ` +
+          `(code ${proc.exitCode}, signal ${proc.signalCode})`,
+      );
     if (await httpAccepts(url, 1_000)) return;
     if (Date.now() >= deadline)
       throw new Error(`production server did not answer ${url} in time`);
@@ -95,16 +107,17 @@ describe.skipIf(!hasBuild)(
         PORT: String(port),
         NITRO_HOST: "127.0.0.1",
       };
-      child = spawn("node", [prodEntry], {
+      const proc = spawn("node", [prodEntry], {
         cwd: webRoot,
         env,
         detached: true,
         stdio: "ignore",
       });
-      child.unref();
+      child = proc;
+      proc.unref();
 
       let launchError: Error | undefined;
-      child.once("error", (err) => {
+      proc.once("error", (err) => {
         launchError = err;
       });
       await new Promise<void>((r) => setImmediate(r));
@@ -112,7 +125,7 @@ describe.skipIf(!hasBuild)(
 
       // Readiness is the ROOT route only -- deliberately not /api/peerjs/*, which
       // would warm signaling and defeat the test.
-      await waitForRoot(`http://127.0.0.1:${port}/`);
+      await waitForRoot(`http://127.0.0.1:${port}/`, proc);
     }, READY_TIMEOUT_MS + 10_000);
 
     afterAll(async () => {

--- a/apps/web/test/integration/prodSignaling.test.ts
+++ b/apps/web/test/integration/prodSignaling.test.ts
@@ -27,6 +27,12 @@ import type { ChildProcess } from "node:child_process";
 // the web app before this suite runs (eb_build_and_test.yaml: "Build server"
 // precedes "Web integration and browser tests"), so this runs there; a local
 // `npm run test:integration` without a prior build skips it rather than failing.
+//
+// A non-skipped LOCAL run tests whatever `.output` currently holds: if you change
+// the startup warm and re-run without rebuilding, an OLD build still on disk makes
+// this pass green against stale code. To validate a warm change locally, rebuild
+// first (`npm run build -w apps/web`); CI always rebuilds before this suite, so it
+// is unaffected.
 const here = dirname(fileURLToPath(import.meta.url));
 // apps/web/test/integration -> apps/web is two levels up.
 const webRoot = resolve(here, "../..");
@@ -80,12 +86,20 @@ async function httpAccepts(url: string, timeoutMs: number): Promise<boolean> {
   }
 }
 
-async function waitForRoot(url: string, proc: ChildProcess): Promise<void> {
+async function waitForRoot(
+  url: string,
+  proc: ChildProcess,
+  getLaunchError: () => Error | undefined,
+): Promise<void> {
   const deadline = Date.now() + READY_TIMEOUT_MS;
   for (;;) {
     // Surface an early exit (a port collision, a missing/broken build) with its
     // real cause, instead of polling a server that is never coming up until the
-    // readiness deadline and then reporting a misleading timeout.
+    // readiness deadline and then reporting a misleading timeout. A spawn/exec
+    // failure that surfaces as a child `error` event (rather than an exit) leaves
+    // exitCode/signalCode null, so also re-throw a captured launch error here.
+    const launchError = getLaunchError();
+    if (launchError) throw launchError;
     if (proc.exitCode !== null || proc.signalCode !== null)
       throw new Error(
         `production server exited before becoming ready ` +
@@ -124,8 +138,12 @@ describe.skipIf(!hasBuild)(
       child = proc;
       proc.unref();
 
+      // Capture child `error` events for the process's whole life (not just the
+      // launch tick): a persistent listener both lets waitForRoot surface a
+      // post-launch spawn/exec failure and prevents a stray child error from
+      // throwing as an unhandled EventEmitter `error` and crashing the worker.
       let launchError: Error | undefined;
-      proc.once("error", (err) => {
+      proc.on("error", (err) => {
         launchError = err;
       });
       await new Promise<void>((r) => setImmediate(r));
@@ -133,7 +151,7 @@ describe.skipIf(!hasBuild)(
 
       // Readiness is the ROOT route only -- deliberately not /api/peerjs/*, which
       // would warm signaling and defeat the test.
-      await waitForRoot(`http://127.0.0.1:${port}/`, proc);
+      await waitForRoot(`http://127.0.0.1:${port}/`, proc, () => launchError);
     }, READY_TIMEOUT_MS + 10_000);
 
     afterAll(async () => {

--- a/apps/web/test/integration/prodSignaling.test.ts
+++ b/apps/web/test/integration/prodSignaling.test.ts
@@ -1,0 +1,159 @@
+import { dirname, resolve } from "node:path";
+import { createServer } from "node:net";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import { waitForColdSignaling } from "../devServer/signalingProbe";
+
+import type { ChildProcess } from "node:child_process";
+
+// Regression guard for the "create an invitation -> Lost connection to server"
+// bug on the DEPLOYED app. The PeerJS signaling server attaches its WebSocket
+// `upgrade` handler only when its /api/peerjs route first runs usePeerServer(),
+// and the real client dials that WebSocket with an explicit, pre-derived id --
+// it never makes the GET /api/peerjs/id that would load the route. So the server
+// must warm signaling itself at startup; the nitro production entry
+// (server/custom-entry.ts) does this via nitroApp.localFetch. This spawns the
+// real built server and connects the upgrade COLD (never an HTTP request to
+// /api/peerjs/*), so it only passes if that startup warm attached the handler.
+//
+// Verified to fail (assertion, exit 1) when the custom-entry warm is removed and
+// the server rebuilt, so this is a real guard rather than a no-op.
+//
+// Build-gated: the production entry exists only after `npm run build`. CI builds
+// the web app before this suite runs (eb_build_and_test.yaml: "Build server"
+// precedes "Web integration and browser tests"), so this runs there; a local
+// `npm run test:integration` without a prior build skips it rather than failing.
+const here = dirname(fileURLToPath(import.meta.url));
+// apps/web/test/integration -> apps/web is two levels up.
+const webRoot = resolve(here, "../..");
+const prodEntry = resolve(webRoot, ".output/server/index.mjs");
+const hasBuild = existsSync(prodEntry);
+
+const READY_TIMEOUT_MS = 30_000;
+const COLD_PROBE_DEADLINE_MS = 20_000;
+const STOP_TIMEOUT_MS = 5_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Ask the OS for a free loopback TCP port so this server never collides with
+ * the shared globalSetup dev server (or anything else). */
+function getFreePort(): Promise<number> {
+  return new Promise((resolvePort, reject) => {
+    const probe = createServer();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      probe.close(() => resolvePort(port));
+    });
+  });
+}
+
+async function httpAccepts(url: string, timeoutMs: number): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    await fetch(url, { signal: controller.signal });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function waitForRoot(url: string): Promise<void> {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  for (;;) {
+    if (await httpAccepts(url, 1_000)) return;
+    if (Date.now() >= deadline)
+      throw new Error(`production server did not answer ${url} in time`);
+    await sleep(250);
+  }
+}
+
+describe.skipIf(!hasBuild)(
+  "the production server warms PeerJS signaling at startup",
+  () => {
+    let child: ChildProcess | undefined;
+    let port = 0;
+
+    beforeAll(async () => {
+      port = await getFreePort();
+      // node .output/server/index.mjs is a single process, but spawn it as its
+      // own group so teardown can SIGTERM the whole tree. NITRO_HOST pins the
+      // loopback bind; PORT pins the free port (the nitro entry reads it straight
+      // from process.env, no dotenv override).
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        PORT: String(port),
+        NITRO_HOST: "127.0.0.1",
+      };
+      child = spawn("node", [prodEntry], {
+        cwd: webRoot,
+        env,
+        detached: true,
+        stdio: "ignore",
+      });
+      child.unref();
+
+      let launchError: Error | undefined;
+      child.once("error", (err) => {
+        launchError = err;
+      });
+      await new Promise<void>((r) => setImmediate(r));
+      if (launchError) throw launchError;
+
+      // Readiness is the ROOT route only -- deliberately not /api/peerjs/*, which
+      // would warm signaling and defeat the test.
+      await waitForRoot(`http://127.0.0.1:${port}/`);
+    }, READY_TIMEOUT_MS + 10_000);
+
+    afterAll(async () => {
+      const c = child;
+      if (!c || c.pid === undefined || c.exitCode !== null) return;
+      const pid = c.pid;
+      // Re-ref the child (unref'd at spawn) while awaiting its exit, so the event
+      // loop cannot drain mid-teardown and leave an orphaned server -- the same
+      // guard the dev-server globalSetup uses on its stop path.
+      c.ref();
+      await new Promise<void>((resolveStop) => {
+        const timer = setTimeout(() => {
+          try {
+            process.kill(-pid, "SIGKILL");
+          } catch {
+            // already gone
+          }
+        }, STOP_TIMEOUT_MS);
+        timer.unref();
+        c.once("exit", () => {
+          clearTimeout(timer);
+          resolveStop();
+        });
+        try {
+          process.kill(-pid, "SIGTERM");
+        } catch {
+          clearTimeout(timer);
+          resolveStop();
+        }
+      });
+    });
+
+    test(
+      "a cold /api/peerjs upgrade answers OPEN without a prior /api/peerjs/* request",
+      async () => {
+        const opened = await waitForColdSignaling(port, {
+          deadlineMs: COLD_PROBE_DEADLINE_MS,
+        });
+        expect(opened).toBe(true);
+      },
+      COLD_PROBE_DEADLINE_MS + 10_000,
+    );
+  },
+);

--- a/apps/web/test/integration/prodSignaling.test.ts
+++ b/apps/web/test/integration/prodSignaling.test.ts
@@ -53,7 +53,13 @@ function getFreePort(): Promise<number> {
     probe.once("error", reject);
     probe.listen(0, "127.0.0.1", () => {
       const address = probe.address();
-      const port = typeof address === "object" && address ? address.port : 0;
+      if (typeof address !== "object" || address === null) {
+        probe.close(() =>
+          reject(new Error("could not determine a free port from the probe")),
+        );
+        return;
+      }
+      const port = address.port;
       probe.close(() => resolvePort(port));
     });
   });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -46,9 +46,14 @@ const srcAliases = {
 async function warmPeerSignaling(port: number): Promise<void> {
   const url = `http://127.0.0.1:${port}/api/peerjs/id`;
   const deadline = Date.now() + 60_000;
+  const perAttemptMs = 2_000;
   for (;;) {
+    // Bound each attempt so a hung in-flight request cannot stall the loop past
+    // the outer deadline (the deadline is only re-checked between attempts).
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), perAttemptMs);
     try {
-      const res = await fetch(url);
+      const res = await fetch(url, { signal: controller.signal });
       const ready =
         res.ok && !!res.headers.get("content-type")?.includes("text/plain");
       // Release the socket: we read only status/headers, never the body. Left
@@ -57,7 +62,9 @@ async function warmPeerSignaling(port: number): Promise<void> {
       await res.body?.cancel();
       if (ready) return;
     } catch {
-      // Server still coming up; fall through to the deadline check and retry.
+      // Server still coming up, or this attempt aborted; retry.
+    } finally {
+      clearTimeout(timer);
     }
     if (Date.now() >= deadline) {
       logLibrary.warn("peer signaling warm-up did not complete within 60s");
@@ -165,11 +172,17 @@ export default defineConfig((_configEnv) => {
                   // leaving the handler unattached.
                   server.httpServer.once("listening", () => {
                     const address = server.httpServer?.address();
-                    const boundPort =
-                      typeof address === "object" && address
-                        ? address.port
-                        : config.PORT;
-                    void warmPeerSignaling(boundPort);
+                    // The dev server binds TCP (host + port above), so address is
+                    // an AddressInfo. If it is ever a string (unix socket) or
+                    // null, a TCP warm cannot reach it -- warn and skip rather
+                    // than silently warming the wrong port.
+                    if (typeof address !== "object" || address === null) {
+                      logLibrary.warn(
+                        "dev server bound a non-TCP address; skipping signaling warm-up",
+                      );
+                      return;
+                    }
+                    void warmPeerSignaling(address.port);
                   });
                 } else {
                   console.warn("http server is undefined");

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -33,6 +33,35 @@ const srcAliases = {
   "@": path.resolve(__dirname, "src"),
 };
 
+// The PeerJS signaling server attaches its WebSocket `upgrade` handler only when
+// the /api/peerjs route module first runs usePeerServer() -- triggered by an HTTP
+// GET to /api/peerjs/id|peers. The real client dials the signaling WebSocket with
+// an explicit, pre-derived id, so it never makes that GET; the upgrade then goes
+// unhandled and surfaces to the peer as "Lost connection to server." Warm the id
+// endpoint at dev-server startup to load the module and attach the handler before
+// any peer connects. Mirrors test/devServer/globalSetup's warmPeerSignaling (kept
+// separate: that one bootstraps the test harness, this one fixes a plain
+// `npm run dev`). Retries until the route answers text/plain, since Vite compiles
+// the route module lazily and the first hits may fall through to the SPA fallback.
+async function warmPeerSignaling(port: number): Promise<void> {
+  const url = `http://127.0.0.1:${port}/api/peerjs/id`;
+  const deadline = Date.now() + 60_000;
+  for (;;) {
+    try {
+      const res = await fetch(url);
+      if (res.ok && res.headers.get("content-type")?.includes("text/plain"))
+        return;
+    } catch {
+      // Server still coming up; fall through to the deadline check and retry.
+    }
+    if (Date.now() >= deadline) {
+      logLibrary.warn("peer signaling warm-up did not complete within 60s");
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+}
+
 export default defineConfig((_configEnv) => {
   // Vitest evaluates this config but starts no dev/preview server, so the server
   // snagger plugins below have no httpServer to capture (the hook would just warn
@@ -123,6 +152,12 @@ export default defineConfig((_configEnv) => {
               configureServer(server: ViteDevServer) {
                 if (server.httpServer) {
                   registerServer(server.httpServer);
+                  // Once listening, warm the signaling module so its WebSocket
+                  // `upgrade` handler is attached before any peer dials it (see
+                  // warmPeerSignaling).
+                  server.httpServer.once("listening", () => {
+                    void warmPeerSignaling(config.PORT);
+                  });
                 } else {
                   console.warn("http server is undefined");
                 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -49,8 +49,13 @@ async function warmPeerSignaling(port: number): Promise<void> {
   for (;;) {
     try {
       const res = await fetch(url);
-      if (res.ok && res.headers.get("content-type")?.includes("text/plain"))
-        return;
+      const ready =
+        res.ok && !!res.headers.get("content-type")?.includes("text/plain");
+      // Release the socket: we read only status/headers, never the body. Left
+      // unconsumed, undici holds the socket open until GC, and the SPA-fallback
+      // retries (before the route module compiles) hit this path repeatedly.
+      await res.body?.cancel();
+      if (ready) return;
     } catch {
       // Server still coming up; fall through to the deadline check and retry.
     }
@@ -154,9 +159,17 @@ export default defineConfig((_configEnv) => {
                   registerServer(server.httpServer);
                   // Once listening, warm the signaling module so its WebSocket
                   // `upgrade` handler is attached before any peer dials it (see
-                  // warmPeerSignaling).
+                  // warmPeerSignaling). Read the actual bound port: Vite does not
+                  // set strictPort, so if config.PORT is occupied it auto-
+                  // increments, and config.PORT would then warm the wrong port,
+                  // leaving the handler unattached.
                   server.httpServer.once("listening", () => {
-                    void warmPeerSignaling(config.PORT);
+                    const address = server.httpServer?.address();
+                    const boundPort =
+                      typeof address === "object" && address
+                        ? address.port
+                        : config.PORT;
+                    void warmPeerSignaling(boundPort);
                   });
                 } else {
                   console.warn("http server is undefined");


### PR DESCRIPTION
## Summary

Fix the web app's "Create an invitation" flow, which failed with "Exchange failed: Lost connection to server" because the embedded PeerJS signaling server never attached its WebSocket `upgrade` handler in production. The server now warms signaling at startup, so the handler is attached before any peer dials, restoring the invitation-based WebRTC exchange.

## Changes

- apps/web/server/custom-entry.ts: warm signaling at startup in the `listen` callback via `nitroApp.localFetch("/api/peerjs/id")` (in-process, bind-type independent); note why the prod warm needs no content-type check and why the crossws upgrade block would be unsafe if `experimental.websocket` were enabled.
- apps/web/vite.config.ts: warm the dev server's signaling route once it is listening, reading the actual bound port (Vite has no `strictPort`); retry until the route module compiles and answers `text/plain`.
- apps/web/test/integration/prodSignaling.test.ts: new build-gated regression test that spawns the built production server and asserts a cold WebSocket `/api/peerjs` upgrade answers OPEN with no prior `/api/peerjs/*` HTTP request.
- apps/web/test/devServer/signalingProbe.ts: new cold-signaling probe helper backing the regression test.
- apps/web/test/devServer/globalSetup.ts: ref the child while awaiting its exit so a setup failure cannot drain the event loop and exit 0 (a false green).

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format` (all clean); `npm run build -w apps/web`; `npm run test:integration -w apps/web` (6 passed, including prodSignaling against the rebuilt entry); `npx vitest run --project browser test/browser/invitedPSI.test.ts` (real WebRTC PSI exchange, passed).
New tests cover: a cold WebSocket `/api/peerjs` upgrade answers the PeerJS OPEN frame at production startup without any prior `/api/peerjs/*` HTTP request -- the exact regression -- verified to fail (assertion, exit 1) when the startup warm is removed and the server rebuilt.

## Background

Root cause: the PeerJS signaling server attaches its WebSocket `upgrade` handler lazily, the first time the `/api/peerjs` route runs `usePeerServer()`. The real client dials the signaling WebSocket with a pre-derived id and never makes the `GET /api/peerjs/id` that would load the route, so in production the upgrade went unhandled and surfaced to the peer as "Lost connection to server." Warming the route at startup attaches the handler before any peer connects. The fix is bind-type independent in prod (in-process `localFetch`) and reads the actual bound port in dev.

The vendored PeerJS signaling server's lack of DoS/abuse hardening (no per-IP connection cap, no `ws` `maxPayload`, unbounded offline-message queue) is pre-existing and intentionally not addressed here: the vendored server is slated for removal in favor of on-demand provisioning, so hardening it now would be throwaway work.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; this restores the intended behavior of the already-documented web invitation exchange, and the startup-warm is an internal server-entry mechanism with no doc tier.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: repairs an unreleased feature (the web invitation exchange, listed under `[Unreleased]` Added); it never shipped, so there is no released behavior change an operator or reviewer acts on.
- [x] Security review -- none of the enumerated security-review-scope controls are touched: this is an availability fix to the untrusted signaling broker, with crypto, the AEAD, the channel-hardening bounds, credential handling, the auth gate, and what is disclosed on the wire all unchanged (PSI confidentiality/integrity rest on the `sharedSecret`-authenticated X25519 handshake, untouched). Independent review was performed out of caution -- trust-model, exposure/abuse, whole-diff regression, and secrets/logging and fail-safety passes, all no-regression; the new startup warm-up log lines were checked to carry only an HTTP status or error object, no secrets or rendezvous ids. Pre-existing vendored-broker DoS accepted out of scope (server being removed).
