### PR TITLE
Give the web transport-failure alert a fixed friendly message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This changelog records, per release, the changes that affect how PSI-Link is run
 - Online `psilink invite` states up front that the printed invitation is acceptable only while the command is waiting. See `docs/CLI.md`.
 - Terminal transport and directory errors (an over-cap frame, a contaminated directory, a stalled server) now end with a concrete next step and suppress the contradictory generic "retry without re-inviting" advisory.
 - The CLI and the web accept screen render an invitation or config validation failure as a readable one-liner instead of a raw schema-error dump.
+- The web exchange screen shows a fixed, friendly, retry-oriented message when a generic transport failure (a dropped or failed connection) ends an exchange, instead of the raw error text; the detailed error stays in the browser console for diagnosis.
 - Documentation is reorganized into `docs/` (overview) and `docs/spec/` (wire formats, byte encodings, constants); some files moved or were renamed, so links to old paths break. See `docs/spec/README.md`.
 
 ### Removed

--- a/apps/web/src/components/Exchange.tsx
+++ b/apps/web/src/components/Exchange.tsx
@@ -353,13 +353,21 @@ export function Exchange(config: ExchangeConfig) {
                 "tampered with. Do not retry; start over with a fresh invitation.",
             });
           } else {
+            // Generic, retryable transport/exchange failure. The raw error reads
+            // as an internal/developer message to an end user -- it can embed
+            // partner-/server-controlled bytes and the `[redacted-peer-id]`
+            // rendezvous-id placeholder, which looks like a bug in an alert -- so
+            // the alert uses a fixed, friendly message instead of the raw text. A
+            // transport drop is generally retryable (unlike the security category
+            // above), so the guidance invites another try. The detailed,
+            // id-redacted error stays in the dev-gated console.error above for
+            // diagnosis.
             setErrorAlert({
               title: "Exchange failed",
-              // A failed exchange can surface a raw transport error whose message
-              // or cause chain embeds partner-/server-controlled bytes (a hostile
-              // message-file path); route it through the display-boundary seam so
-              // the alert cannot render control/ANSI/deceptive-Unicode characters.
-              message: sanitizeErrorForDisplay(error),
+              message:
+                "The exchange could not be completed. This is usually a " +
+                "temporary connection problem rather than an issue with your " +
+                "data. Start over with a fresh invitation to try again.",
             });
           }
         },


### PR DESCRIPTION
## Summary

The web exchange-failure alert now shows a fixed, friendly, retry-oriented message for a generic transport failure instead of rendering the raw `sanitizeErrorForDisplay(error)` text. This keeps developer-oriented transport-error wording -- and the secret-derived rendezvous-id redaction placeholder `[redacted-peer-id]` -- out of a non-technical operator's alert, while the detailed, id-redacted error still reaches the browser console for diagnosis. It aligns the generic transport category with the existing "output" and "security" categories, which already use fixed, non-oracular messages.

Implements [199781720](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=199781720).

## Changes

- apps/web/src/components/Exchange.tsx: replace the `onError` handler's generic transport `else` arm -- previously `message: sanitizeErrorForDisplay(error)` -- with a fixed friendly message ("usually a temporary connection problem ... start over with a fresh invitation to try again"), matching the sibling output/security arms. The dev-gated `console.error(error)` diagnostic is unchanged, and `sanitizeErrorForDisplay` stays in use by the file-read arm.
- CHANGELOG.md: note the alert-message change under Changed.

## Test plan

Ran: `npm run build -w packages/core`, `npm run typecheck`, `npm run lint`, `npm run format`, and `npm run test:unit -w apps/web` (11 files, 161 tests passed).
New tests cover: n/a -- a static UI-copy change to one alert arm. No unit test renders the Exchange failure alerts (the Playwright browser suite exercises Exchange success paths only), so there is no behavior to assert beyond the string. The disclosure and retry-guidance claims were instead verified by independent review.

## Background

The generic ("exchange") category is the `onError` branch that is neither "output" nor "security" -- predominantly a transport drop, but it also catches acquire-phase failures (e.g. a WASM-asset load or a prepare throw), so the wording is hedged ("usually a temporary connection problem rather than an issue with your data"). The retry guidance points to a fresh invitation because the arm leaves `submitted`/`abortRef` set (no in-place retry) and `Exchange` is keyed by the secret, so recovery is a remount -- the same recovery the sibling security arm already names. The `[redacted-peer-id]` placeholder is introduced by sibling redaction work (item 199089586); this task was deliberately deferred out of that branch to keep it focused, and confines the placeholder to the console.

## Out of scope / follow-on

- Dev-gating the raw `console.error(error)` sink in this same handler is tracked separately: [199241451](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=199241451). Same handler, distinct concern (console sink vs. user-facing alert).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; a grep of both tiers found no reference to the web failure-alert wording or these alert strings.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- added under Changed.
- [x] Security review -- in scope (what is disclosed: a change to displayed text). Conducted two independent reviews (disclosure/injection and control-regression); both PASS. The change removes raw, partner-/server-influenced error text and the `[redacted-peer-id]` placeholder from the alert, strictly reducing disclosure; security-category routing, the other arms' sanitization, and the dev-gated console sink are unchanged. Flagged for maintainer security review per the Dependency Policy.
