### PR TITLE
Fix web dev HMR loop and signaling socket leak

### DIFF
--- a/apps/web/server/custom-entry.ts
+++ b/apps/web/server/custom-entry.ts
@@ -107,11 +107,14 @@ setupGracefulShutdown(listener, nitroApp);
 // Websocket support
 // https://crossws.unjs.io/adapters/node
 // Dead today: experimental.websocket is unset, so import.meta._websocket is false
-// and this block is tree-shaken out of the build. Enabling it would be UNSAFE while
-// the PeerJS signaling server shares this http server: both attach a bare
-// server.on("upgrade", ...), and PeerJS's `ws` aborts any upgrade whose path is not
-// /api/peerjs -- destroying a crossws socket mid-handshake. Coexisting would need a
-// single path-routed upgrade dispatcher, not two independent listeners.
+// and this block is tree-shaken out of the build. Enabling it would still be UNSAFE
+// while the PeerJS signaling server shares this http server: crossws's node adapter
+// attaches a bare server.on("upgrade", ...) that does not path-check, so it would
+// grab PeerJS's /api/peerjs upgrades too. (PeerJS now path-routes its own upgrades
+// and only closes a non-matching one when it is the sole upgrade listener, so it no
+// longer aborts a foreign socket itself -- but two independent, non-cooperating
+// upgrade listeners still mis-route.) Coexisting would need a single path-routed
+// upgrade dispatcher, not two independent listeners.
 if (import.meta._websocket) {
   const { handleUpgrade } = wsAdapter(nitroApp.h3App.websocket);
   server.on("upgrade", handleUpgrade);

--- a/apps/web/src/contrib/peerjs-server/services/webSocketServer/index.ts
+++ b/apps/web/src/contrib/peerjs-server/services/webSocketServer/index.ts
@@ -52,14 +52,32 @@ export class WebSocketServer extends EventEmitter implements IWebSocketServer {
     const path = this.config.path;
     this.path = `${path}${path.endsWith("/") ? "" : "/"}${WS_PATH}`;
 
+    // Attach to the shared HTTP server via `noServer` + a path-scoped `upgrade`
+    // listener rather than passing `server` to `ws`. Given `{ server, path }`,
+    // `ws` installs its own `upgrade` listener that calls `abortHandshake(socket,
+    // 400)` on every upgrade whose path does not match -- including Vite's HMR
+    // socket at `/`. On the shared dev server that tears HMR down (the socket
+    // 101s, then `ws` destroys it) and Vite drops into a reconnect/full-reload
+    // loop. Routing upgrades ourselves and ignoring non-matching paths leaves
+    // them for the other `upgrade` listeners (Vite's HMR handler).
     const options: WebSocket.ServerOptions = {
       path: this.path,
-      server,
+      noServer: true,
     };
 
     this.socketServer = config.createWebSocketServer
       ? config.createWebSocketServer(options)
       : new Server(options);
+
+    server.on("upgrade", (req, socket, head) => {
+      // shouldHandle() applies the `path` option above. Unmatched upgrades are
+      // returned untouched (not aborted) so co-resident WebSocket servers --
+      // notably Vite HMR at `/` -- can handle them.
+      if (!this.socketServer.shouldHandle(req)) return;
+      this.socketServer.handleUpgrade(req, socket, head, (ws) => {
+        this.socketServer.emit("connection", ws, req);
+      });
+    });
 
     this.socketServer.on("connection", (socket, req) => {
       this._onSocketConnection(socket, req);

--- a/apps/web/src/contrib/peerjs-server/services/webSocketServer/index.ts
+++ b/apps/web/src/contrib/peerjs-server/services/webSocketServer/index.ts
@@ -74,6 +74,9 @@ export class WebSocketServer extends EventEmitter implements IWebSocketServer {
       // returned untouched (not aborted) so co-resident WebSocket servers --
       // notably Vite HMR at `/` -- can handle them.
       if (!this.socketServer.shouldHandle(req)) return;
+      // Bail if the socket was already torn down between the event and here;
+      // handleUpgrade would otherwise write the handshake to a dead socket.
+      if (socket.destroyed) return;
       this.socketServer.handleUpgrade(req, socket, head, (ws) => {
         this.socketServer.emit("connection", ws, req);
       });

--- a/apps/web/src/contrib/peerjs-server/services/webSocketServer/index.ts
+++ b/apps/web/src/contrib/peerjs-server/services/webSocketServer/index.ts
@@ -69,6 +69,13 @@ export class WebSocketServer extends EventEmitter implements IWebSocketServer {
       ? config.createWebSocketServer(options)
       : new Server(options);
 
+    // This listener lives for the life of `server`, with no teardown -- by
+    // design, not omission. The peer server is a per-process singleton
+    // (`usePeerServer`) bound to the process-lived dev/Nitro HTTP server, so this
+    // WebSocketServer is constructed once and shares the server's lifetime; the
+    // socketServer is never closed. There is therefore no reinstantiation that
+    // would stack listeners, and no closed socketServer for a stale listener to
+    // dispatch to.
     server.on("upgrade", (req, socket, head) => {
       // shouldHandle() applies the `path` option above. Unmatched upgrades are
       // returned untouched (not aborted) so co-resident WebSocket servers --

--- a/apps/web/src/contrib/peerjs-server/services/webSocketServer/index.ts
+++ b/apps/web/src/contrib/peerjs-server/services/webSocketServer/index.ts
@@ -77,10 +77,20 @@ export class WebSocketServer extends EventEmitter implements IWebSocketServer {
     // would stack listeners, and no closed socketServer for a stale listener to
     // dispatch to.
     server.on("upgrade", (req, socket, head) => {
-      // shouldHandle() applies the `path` option above. Unmatched upgrades are
-      // returned untouched (not aborted) so co-resident WebSocket servers --
-      // notably Vite HMR at `/` -- can handle them.
-      if (!this.socketServer.shouldHandle(req)) return;
+      if (!this.socketServer.shouldHandle(req)) {
+        // Not our path (shouldHandle() applies the `path` option above). Leave it
+        // for a co-resident `upgrade` listener -- e.g. Vite HMR at `/` in dev. But
+        // when we are the ONLY upgrade listener (the production server, where
+        // nothing else will answer) close it rather than leak an open socket:
+        // Node will not auto-destroy an unhandled upgrade once any `upgrade`
+        // listener exists, and no socket timeout reaps it. This restores the
+        // prompt reject the old `{ server, path }` wiring did, without clobbering
+        // co-resident listeners.
+        if (server.listenerCount("upgrade") === 1 && !socket.destroyed) {
+          socket.destroy();
+        }
+        return;
+      }
       // Bail if the socket was already torn down between the event and here;
       // handleUpgrade would otherwise write the handshake to a dead socket.
       if (socket.destroyed) return;

--- a/apps/web/src/peerServer.ts
+++ b/apps/web/src/peerServer.ts
@@ -1,5 +1,3 @@
-import { lazy } from "@utils/lazy";
-
 import { CreatePeerServerWSOnly } from "@peerjs-server/index";
 
 import { getServer as getHttpServer } from "./httpServer";
@@ -51,4 +49,14 @@ function createPeerServer(): PeerServerInstance {
   });
 }
 
-export const usePeerServer = lazy(createPeerServer);
+// Memoize on globalThis, not in module scope. In dev, Vite can re-evaluate this
+// server module on HMR; a module-scoped memo would reset and build a second peer
+// server, stacking another `upgrade` listener (and its timers) on the long-lived
+// dev HTTP server. A global keeps it to one instance per process.
+declare global {
+  var peerServerInstance: PeerServerInstance | undefined;
+}
+
+export function usePeerServer(): PeerServerInstance {
+  return (globalThis.peerServerInstance ??= createPeerServer());
+}

--- a/apps/web/test/devServer/signalingProbe.ts
+++ b/apps/web/test/devServer/signalingProbe.ts
@@ -82,3 +82,38 @@ export async function waitForColdSignaling(
     await new Promise((r) => setTimeout(r, 500));
   }
 }
+
+/** Dial a websocket upgrade at a NON-signaling path. On the production server the
+ * PeerJS listener is the only `upgrade` listener, so a non-matching upgrade must
+ * be closed -- otherwise the socket is left open with no timeout to reap it (an
+ * unauthenticated FD/socket-exhaustion vector). Resolves true if the server
+ * closes/rejects the connection within `timeoutMs` (the wanted behavior), false
+ * if it is instead left hanging -- no close, no error -- which is the leak, or if
+ * the server unexpectedly completes the handshake on a non-signaling path. */
+export function probeUnmatchedUpgrade(
+  port: number,
+  timeoutMs: number,
+): Promise<boolean> {
+  return new Promise((resolvePromise) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/not-the-signaling-path`);
+    let settled = false;
+    const finish = (closed: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        ws.terminate();
+      } catch {
+        // already gone
+      }
+      resolvePromise(closed);
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    // A non-signaling path must never 101; treat an unexpected open as a failure
+    // to reject. A server-side destroy surfaces as error and/or close -- both mean
+    // the upgrade was rejected rather than leaked.
+    ws.on("open", () => finish(false));
+    ws.on("close", () => finish(true));
+    ws.on("error", () => finish(true));
+  });
+}

--- a/apps/web/test/integration/prodSignaling.test.ts
+++ b/apps/web/test/integration/prodSignaling.test.ts
@@ -6,7 +6,10 @@ import { spawn } from "node:child_process";
 
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 
-import { waitForColdSignaling } from "../devServer/signalingProbe";
+import {
+  probeUnmatchedUpgrade,
+  waitForColdSignaling,
+} from "../devServer/signalingProbe";
 
 import type { ChildProcess } from "node:child_process";
 
@@ -41,6 +44,7 @@ const hasBuild = existsSync(prodEntry);
 
 const READY_TIMEOUT_MS = 30_000;
 const COLD_PROBE_DEADLINE_MS = 20_000;
+const UNMATCHED_PROBE_MS = 3_000;
 const STOP_TIMEOUT_MS = 5_000;
 
 function sleep(ms: number): Promise<void> {
@@ -201,6 +205,21 @@ describe.skipIf(!hasBuild)(
         expect(opened).toBe(true);
       },
       COLD_PROBE_DEADLINE_MS + 10_000,
+    );
+
+    // Regression guard: the signaling listener is the only `upgrade` listener on
+    // the production server, so an upgrade to any non-/api/peerjs path must be
+    // closed rather than left open -- Node does not auto-destroy an unhandled
+    // upgrade once a listener exists, and no socket timeout reaps it, so leaving
+    // it open is an unauthenticated socket-leak/DoS. Verified to fail (the socket
+    // hangs) against the pre-fix routing that simply returned on a path miss.
+    test(
+      "an upgrade to a non-signaling path is rejected, not left to leak a socket",
+      async () => {
+        const closed = await probeUnmatchedUpgrade(port, UNMATCHED_PROBE_MS);
+        expect(closed).toBe(true);
+      },
+      UNMATCHED_PROBE_MS + 10_000,
     );
   },
 );


### PR DESCRIPTION
## Summary

Fix a development-only reload loop in the web app and keep the production signaling server rejecting stray WebSocket upgrades. Constructing the PeerJS signaling server with `{ server, path }` made the `ws` library install its own `upgrade` listener that aborted every non-matching upgrade -- including Vite's HMR socket at `/` -- so `npm run dev` 101'd the HMR connection, immediately reset it, and looped on full-page reloads. This reworks the attachment to cooperate with co-resident upgrade listeners while still closing stray upgrades where the signaling server is the only listener.

## Changes

- apps/web/src/contrib/peerjs-server/services/webSocketServer/index.ts: attach via `noServer` plus a path-scoped `upgrade` listener instead of `{ server, path }`; forward only `/api/peerjs` upgrades, leave non-matching ones for a co-resident listener (Vite HMR), and close a non-matching upgrade only when this is the sole upgrade listener (production) so it cannot leak an open socket; guard against an already-destroyed socket.
- apps/web/src/peerServer.ts: memoize the peer-server instance on `globalThis` so a dev HMR re-evaluation of the module does not build a second instance and stack `upgrade` listeners and background timers.
- apps/web/server/custom-entry.ts: correct the now-stale comment explaining why the crossws upgrade block stays disabled.
- apps/web/test/devServer/signalingProbe.ts, apps/web/test/integration/prodSignaling.test.ts: add a production regression test asserting a non-signaling upgrade is closed rather than left open.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run formatcheck`; `npm run test:unit -w apps/web` (161 passed); `npm run build -w apps/web` then `npx vitest run --project integration test/integration/prodSignaling.test.ts` (2 passed against the built server). Reproduced the production socket-leak before/after against the real built server: a non-`/api/peerjs` upgrade hangs open on the pre-fix routing and is closed by the fix. Manually verified dev HMR coexistence: the HMR socket at `/` stays open while signaling is warmed.

New tests cover: an upgrade to a non-signaling path on the production server is closed, not left to leak a socket -- verified to fail (the socket hangs) against the pre-fix routing.

## Background

`ws` built with `{ server, path }` installs an `upgrade` listener that calls `abortHandshake(socket, 400)` on any path other than `/api/peerjs`. On the shared dev server that destroys Vite's HMR socket (101 then reset), and the Vite client loops reconnect then reload. Switching to `noServer` ends the loop but removes ws's own rejection of stray upgrades; in production the signaling listener is the only `upgrade` listener, so a non-matching upgrade had to be closed explicitly or it would hang open with no socket timeout to reap it -- an unauthenticated socket/FD leak the old wiring did not have. The close is gated on being the sole upgrade listener (`listenerCount("upgrade") === 1`), so it never tears down a co-resident listener's socket; in dev the count is always at least two, so HMR is untouched.

## Out of scope / follow-on

- Harden the web PeerJS signaling upgrade surface -- pre-existing items surfaced during security review (no upgrade-surface timeouts, unauthenticated client registration under the public default key, no Origin/CSWSH check on the handshake): [202207116](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202207116)

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/`; the change is internal signaling upgrade-routing plus a dev-only HMR fix, and no page documents that behavior -- n/a: production's reject-non-matching-upgrade behavior is unchanged versus staging, so no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: internal upgrade-routing refactor and a dev-only HMR fix; production's reject-non-matching-upgrade behavior is unchanged versus staging (the socket leak existed only in this branch's intermediate commits), so no operator- or reviewer-visible change.
- [x] Security review -- done: two independent security reviews (threat-model and implementation audit) of the signaling upgrade-surface change, both SHIP with no introduced findings above nit.
