### PR TITLE
Add dependency-review-action PR gate

### DIFF
--- a/.github/workflows/dependency_review.yaml
+++ b/.github/workflows/dependency_review.yaml
@@ -1,0 +1,57 @@
+name: Dependency Review
+
+# Supply-chain gate for every pull request. GitHub's dependency-review-action
+# diffs the PR's dependency graph (via the Dependency Review API) and fails the
+# check when the PR introduces a dependency carrying a known security advisory at
+# or above the severity threshold below. It complements Dependabot, which only
+# opens update PRs for dependencies already present, and the manual `npm audit`
+# step in the Dependency Policy: this catches a vulnerable *new* dependency at the
+# moment it is added, as an automated PR gate. It is distinct from the CodeQL SAST
+# spike -- this gates the dependency-graph diff of a PR, not first-party code.
+#
+# Kept as its own workflow (rather than a job in static_checks.yaml) so it carries
+# a dedicated status-check name and stays focused on supply-chain review. Like
+# static_checks.yaml it is intentionally NOT path-filtered: it is a near-free,
+# always-on control -- on a PR that changes no dependency the graph diff is empty
+# and the check passes near-instantly -- and an unfiltered run avoids the
+# required-check "stays pending on a path-skip" footgun the path-scoped build
+# workflows document.
+#
+# The check reads GitHub's Dependency Review API, which requires the repository's
+# Dependency Graph feature to be enabled. That is free on public repositories
+# (georgetown-mdi/jspsi is public), so this needs no GitHub Advanced Security
+# license -- but the graph must stay enabled (default-on for public repos, yet
+# disableable since 2025-05) or the action fails closed on every PR.
+
+on:
+  pull_request:
+    branches: [main, staging]
+
+# Cancel a superseded run when a newer commit lands on the same PR/branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: the action reads the dependency graph and the repo, and writes
+# its findings to the Actions job summary -- neither needs more than read. Posting
+# the findings as a PR comment (comment-summary-in-pr) would require
+# pull-requests: write, so that is deliberately not enabled.
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v5
+        with:
+          # Fail a PR that newly introduces a dependency with a moderate-or-higher
+          # advisory. This is effectively the only automated supply-chain PR gate
+          # (npm audit is a manual Dependency Policy step), and it fires only on
+          # what a PR adds, not the existing tree, so a strict-ish threshold adds
+          # little friction. License enforcement is left to the manual Dependency
+          # Policy review (no allow/deny list here yet).
+          fail-on-severity: moderate


### PR DESCRIPTION
## Summary

Add an always-on pull-request gate that runs GitHub's dependency-review-action, failing any PR that newly introduces a dependency carrying a known security advisory at or above moderate severity before it can merge. This is the project's first automated supply-chain PR control, complementing Dependabot (which only opens update PRs for dependencies already present) and the manual npm audit step in the Dependency Policy.

Implements [199794568](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=199794568).

## Changes

- .github/workflows/dependency_review.yaml: new pull_request workflow (targeting main/staging) running actions/dependency-review-action@v5 with fail-on-severity: moderate, least-privilege contents: read, and no path filter so it always reports a status. Mirrors static_checks.yaml conventions (concurrency cancel-in-progress, permissions block).

## Test plan

Ran: npm run typecheck, npm run lint, npm run formatcheck (all green); npx prettier --check on the new file; YAML parse check. Verified actions/dependency-review-action@v5 resolves to a real major ref and that pinning matches the repo's tag-pinning convention; Dependabot's github-actions updater already tracks it.
New tests cover: n/a -- a CI workflow definition with no unit-testable first-party code; the action runs against the live dependency-graph diff on each real PR.

## Background

The action is pinned to the v5 major ref (upstream publishes it as a branch ref), matching the repo convention (actions/checkout@v6) so Dependabot tracks it. The check is fail-closed: a disabled Dependency Graph or an API outage surfaces as a failed check, never a silent pass. Two prerequisites live in repo settings, not this diff: the Dependency Graph must stay enabled (default-on, free on public repos), and the gate only blocks merge once "Dependency Review" is marked a required status check on main/staging.

## Out of scope / follow-on

- Automated license enforcement (deny-licenses) in the same workflow: [202236259](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=202236259).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: CI-only gate, no operator-facing or spec-level documented behavior changed; the workflow is self-documented in its header comments.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: CI/tooling change, not visible to an operator/deployer or security reviewer (per the Changelog rules in CONTRIBUTING.md).
- [x] Security review -- security-relevant dependency: adds actions/dependency-review-action to the CI trust boundary. Two independent security reviews performed (supply-chain/configuration and control-efficacy/threat-model lenses); no blockers, control confirmed fail-closed. Final maintainer sign-off pending on this PR.
