### PR TITLE
Add nightly CI job for core PSI stress tests

### DIFF
--- a/.github/workflows/cli_build_and_test.yaml
+++ b/.github/workflows/cli_build_and_test.yaml
@@ -70,7 +70,7 @@ jobs:
   # `test` job above are unchanged. Integration tests import the adapter from src
   # (vitest transpiles) and consume @psilink/core from the setup action's build,
   # so no CLI build step is needed. If the added CI minutes prove too costly, trim
-  # this matrix per board-10 item 199637670.
+  # this matrix -- the three hardened profiles are independent legs.
   hardened-native:
     name: Hardened native sshd (${{ matrix.profile }})
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly_core_stress.yaml
+++ b/.github/workflows/nightly_core_stress.yaml
@@ -1,0 +1,70 @@
+name: Nightly Core Stress Tests
+
+# Scheduled nightly run of the core PSI stress tier -- packages/core's `stress`
+# vitest project (npm run test:stress -w packages/core). That tier is
+# deliberately excluded from `npm run test` and from every PR gate so the
+# merge-time path stays fast; the tests exercise the seclink fork's large-dataset
+# path -- e.g. Server#createSetupMessage past the ~125k spread-argument cliff that
+# once threw "Maximum call stack size exceeded" -- which is too heavy to run on
+# every push. A nightly schedule is where that coverage belongs, catching a
+# regression in the large-N path without slowing the PR gate.
+#
+# Runs only on `schedule` and manual `workflow_dispatch` -- never on push or
+# pull_request -- so the PR gate is unaffected. It invokes the whole `stress`
+# project, so any future stress test added under test/stress/ is picked up here
+# automatically, not just today's two.
+
+on:
+  schedule:
+    # 04:17 UTC nightly. No other scheduled workflow exists in this repo, so there
+    # is no cross-job contention; the off-the-hour minute follows GitHub's guidance
+    # to avoid top-of-hour congestion on the shared scheduler. Two GitHub behaviors
+    # to know: a `schedule` trigger only fires from the workflow as it exists on the
+    # default branch, so no nightly runs until this file lands there (use the manual
+    # dispatch below to exercise it before then); and GitHub disables a scheduled
+    # workflow after ~60 days without repo activity, emailing the last committer --
+    # re-enable it from the Actions tab if a long-quiet repo needs this guard back.
+    - cron: "17 4 * * *"
+  # On-demand run, e.g. to confirm a stress fix without waiting for the schedule.
+  workflow_dispatch:
+
+# One stress run at a time per ref; do not cancel an in-flight run (it is doing
+# real, minutes-long work) -- this only guards a manual dispatch racing the
+# nightly schedule.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+# Least privilege: this test job only needs to read the repo.
+permissions:
+  contents: read
+
+jobs:
+  stress:
+    name: Core PSI stress tests
+    runs-on: ubuntu-latest
+    # Upper bound on a hung run. The work fits well under this: each stress test
+    # has its own 300s timeout (packages/core/vitest.config.ts), and install plus
+    # the core build add only a couple of minutes.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      # Pins Node, installs from the lockfile, and builds @psilink/core so the
+      # stress tests run against the compiled fork in dist/.
+      - uses: ./.github/actions/setup
+      - name: Stress tests (core PSI)
+        run: npm run test:stress -w packages/core
+        env:
+          # Raise the createSetupMessage permutation run above the 200k local
+          # default for heavier nightly coverage past the ~125k overflow cliff.
+          # The ceiling is the stress project's 300s per-test timeout: that test
+          # is a synchronous WASM call vitest cannot interrupt, so a value large
+          # enough to push it past 300s would run to completion and only then be
+          # marked failed. At ~0.46ms/element locally, 250k (~120s) leaves margin
+          # on a slower hosted runner. Going higher (toward the 1_000_000 the task
+          # cited as an example) also needs packages/core's stress testTimeout
+          # raised; that shared-config change is out of scope for this CI job.
+          # PSI_STRESS_E2E_N (the full-round test) is intentionally left at its
+          # 25k default -- a heavier end-to-end round costs minutes and would need
+          # the same timeout raise.
+          PSI_STRESS_N: "250000"


### PR DESCRIPTION
## Summary

Add a scheduled nightly GitHub Actions workflow that runs the core PSI stress tier (`npm run test:stress -w packages/core`), so regressions in the large-dataset PSI path are caught off the PR critical path. The stress vitest project is excluded from `npm run test` and from every PR gate to keep merge-time fast, which left its large-N coverage -- the seclink fork's `createSetupMessage` past the ~125k overflow cliff, and the full `identifyIntersection` round -- running nowhere in CI; this restores it on a daily cadence without slowing the gate.

Implements [199637670](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=199637670).

## Changes

- `.github/workflows/nightly_core_stress.yaml`: new workflow. Triggers only on `schedule` (04:17 UTC) and manual `workflow_dispatch`, never on push or pull_request, so the PR gate is unchanged. Reuses the shared `./.github/actions/setup` composite (Node, install, build core), then runs the whole `stress` project so any future stress test is picked up automatically. Sets `PSI_STRESS_N=250000` for heavier-than-default nightly coverage, with least-privilege `contents: read`, a 30-minute job ceiling, and non-cancelling concurrency. Inline comments record the two scheduled-workflow caveats: it only fires from the file on the default branch, and GitHub auto-disables a scheduled workflow after ~60 days of repo inactivity.
- `.github/workflows/cli_build_and_test.yaml`: drive-by correctness fix -- the hardened-native job comment cross-referenced a board item that is actually this nightly task, not a matrix-trim task. Drop the stale reference and keep the standing rationale as prose.

## Test plan

Ran: `PSI_STRESS_N=250000 npm run test:stress -w packages/core` (the exact nightly command and env) -- 2 passed in ~117s, each test well under its 300s per-test timeout. Sized the value against a measured cost curve (200k ~93s, 350k ~165s, 500k ~231s; ~0.46ms/element), and ran `createSetupMessage` at 1,000,000 to completion out-of-band to confirm the value ceiling is a vitest-timeout interaction, not a defect (returned ok in ~470s: permutation filled to 1e6, 35 MB serialized, no error). `npm run typecheck`, `npm run lint`, and `npm run formatcheck` all green.

New tests cover: n/a -- this wires the existing stress tests (`packages/core/test/stress/*.stress.test.ts`, already on staging) into a scheduled CI job; no new test code.

## Background

`createSetupMessage` is a synchronous WASM call that vitest's 300s per-test timer cannot interrupt, so `PSI_STRESS_N` is bounded: a value large enough to push the call past 300s runs to completion and only then registers as a timeout failure regardless of runner. 250k (~120s local) leaves margin on a slower hosted runner; reaching the 1,000,000 the task cited as an example would also require raising core's shared stress `testTimeout`, which is out of scope for a CI-only change. `PSI_STRESS_E2E_N` (the full-round test) is left at its 25k default for the same reason. The tier guards a fixed regression: the fork's `Server#createSetupMessage` once threw `RangeError: Maximum call stack size exceeded` past ~125k elements (it spread the sorting permutation into `push(...)`).

## Out of scope / follow-on

- Pinning GitHub Actions to commit SHAs -- a repo-wide supply-chain hardening item, not specific to this file (every workflow pins by tag today); untracked by design, no board item.
- `createSetupMessage`'s synchronous ~0.46ms/element cost (a multi-million-key starter blocks for minutes) is a performance characteristic this PR does not address; untracked by design, no board item.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: CI-only addition, no documented behavior changed (the sole workflow reference in docs, RELEASES.md, covers the release pipeline, not test CI).
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: CI/tooling change, not visible to an operator/deployer or security reviewer.
- [x] Security review -- n/a: adds a CI workflow that runs existing tests; touches no cryptographic code, channel-security control, credential or disclosure surface, or security-relevant dependency (no new npm dependency, and the GitHub Actions used are pinned by tag consistent with every existing workflow).
