### PR TITLE
Add web app shell, heading outline, and consistent widths

### DIFF
--- a/apps/web/src/components/AcceptForm.tsx
+++ b/apps/web/src/components/AcceptForm.tsx
@@ -1,7 +1,7 @@
 import { useForm } from "@tanstack/react-form";
 import { useNavigate } from "@tanstack/react-router";
 
-import { Button, Center, Paper, Stack, Text, Textarea } from "@mantine/core";
+import { Button, Center, Paper, Stack, Textarea, Title } from "@mantine/core";
 
 /**
  * Peel the encoded invitation token out of what the user pasted. A deep-link URL
@@ -39,7 +39,7 @@ export default function AcceptForm() {
 
   return (
     <Paper>
-      <Text size="md">Accept an invitation you were sent</Text>
+      <Title order={2}>Accept an invitation you were sent</Title>
       <form
         onSubmit={(e) => {
           e.preventDefault();

--- a/apps/web/src/components/AcceptInvitation.tsx
+++ b/apps/web/src/components/AcceptInvitation.tsx
@@ -113,6 +113,9 @@ export function AcceptInvitation() {
     // running the full two-column width.
     <Container size="lg">
       <Paper>
+        {/* A generic page h1 rather than the party-specific "Invitation from X"
+            (which is the terms section's h2 below): it must read sensibly in the
+            pending and error states too, where no party name is decoded yet. */}
         <Title order={1}>Accept an invitation</Title>
         <AcceptInvitationPanel
           decode={decode}

--- a/apps/web/src/components/AcceptInvitation.tsx
+++ b/apps/web/src/components/AcceptInvitation.tsx
@@ -108,9 +108,9 @@ export function AcceptInvitation() {
     ) : undefined;
 
   return (
-    <Container size="sm" mt="md">
+    <Container size="lg">
       <Paper>
-        <Title order={2}>Accept an invitation</Title>
+        <Title order={1}>Accept an invitation</Title>
         <AcceptInvitationPanel
           decode={decode}
           headingRef={readyHeadingRef}

--- a/apps/web/src/components/AcceptInvitation.tsx
+++ b/apps/web/src/components/AcceptInvitation.tsx
@@ -108,6 +108,9 @@ export function AcceptInvitation() {
     ) : undefined;
 
   return (
+    // Single-column reading width ("lg"): narrower than the home route on
+    // purpose, so the dense linkage terms sit at a legible measure rather than
+    // running the full two-column width.
     <Container size="lg">
       <Paper>
         <Title order={1}>Accept an invitation</Title>

--- a/apps/web/src/components/HomePage.tsx
+++ b/apps/web/src/components/HomePage.tsx
@@ -1,0 +1,23 @@
+import { Container, Group, Title } from "@mantine/core";
+
+import AcceptForm from "@components/AcceptForm";
+import { InvitePanel } from "@components/InvitePanel";
+
+/**
+ * The home route's page: a single `<h1>` framing the two ways to start an
+ * exchange -- invite a partner, or accept an invitation you were sent -- above
+ * the two side-by-side panels. Kept as a component (rather than inline in the
+ * route file) so it can be mounted in a render test, mirroring
+ * {@link AcceptInvitation}.
+ */
+export function HomePage() {
+  return (
+    <Container size="xl">
+      <Title order={1}>Start a private data exchange</Title>
+      <Group justify="space-between" align="flex-start" grow mt="md">
+        <InvitePanel />
+        <AcceptForm />
+      </Group>
+    </Container>
+  );
+}

--- a/apps/web/src/components/HomePage.tsx
+++ b/apps/web/src/components/HomePage.tsx
@@ -12,6 +12,9 @@ import { InvitePanel } from "@components/InvitePanel";
  */
 export function HomePage() {
   return (
+    // Wide ("xl"): this route lays out two panels side by side and shows the
+    // long invitation code/link, so it wants more room than the single-column
+    // reading width the accept route uses.
     <Container size="xl">
       <Title order={1}>Start a private data exchange</Title>
       <Group justify="space-between" align="flex-start" grow mt="md">

--- a/apps/web/src/components/InvitationTerms.tsx
+++ b/apps/web/src/components/InvitationTerms.tsx
@@ -176,7 +176,7 @@ export function InvitationTerms({
   const summary = summarizeInvitation(token);
   return (
     <Stack gap="sm">
-      <Title order={3} ref={headingRef} tabIndex={-1}>
+      <Title order={2} ref={headingRef} tabIndex={-1}>
         Invitation from {summary.invitingParty}
       </Title>
       <Text size="sm" c="dimmed">

--- a/apps/web/src/components/InvitePanel.tsx
+++ b/apps/web/src/components/InvitePanel.tsx
@@ -158,7 +158,7 @@ export function InvitePanel() {
 
   return (
     <Paper>
-      <Text size="md">Invite someone to join you in a data exchange</Text>
+      <Title order={2}>Invite someone to join you in a data exchange</Title>
       <form
         onSubmit={(e) => {
           e.preventDefault();

--- a/apps/web/src/components/Shell.module.css
+++ b/apps/web/src/components/Shell.module.css
@@ -35,10 +35,12 @@
 
 /* main only ever receives focus from the skip link (it is tabIndex -1, so it is
    not in the tab order otherwise); give that landing a visible indicator. The
-   offset is negative so the outline sits inside the full-width region rather
-   than overflowing the viewport. */
+   text color is used (not the primary) so the outline clears the 3:1 non-text
+   contrast bar in both color schemes -- the cyan primary is only ~2.8:1 on the
+   light background. The offset is negative so the outline sits inside the
+   full-width region rather than overflowing the viewport. */
 .main:focus {
-  outline: 2px solid var(--mantine-primary-color-filled);
+  outline: 2px solid var(--mantine-color-text);
   outline-offset: -2px;
 }
 
@@ -67,4 +69,9 @@
 
 .skipLink:focus {
   top: var(--mantine-spacing-sm);
+  /* An explicit, sufficiently contrasting focus ring: the link is a raw <a>, so
+     it does not inherit Mantine's component focus styles and would otherwise
+     rely on the UA default alone. */
+  outline: 2px solid var(--mantine-color-text);
+  outline-offset: 2px;
 }

--- a/apps/web/src/components/Shell.module.css
+++ b/apps/web/src/components/Shell.module.css
@@ -1,3 +1,12 @@
+/* A flex column at least as tall as the viewport, with the main region growing
+   to fill, so the footer rests at the bottom rather than floating mid-page on
+   short routes. */
+.shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
 .header {
   border-bottom: 1px solid var(--mantine-color-default-border);
   padding-top: var(--mantine-spacing-sm);
@@ -16,6 +25,7 @@
 }
 
 .main {
+  flex: 1;
   padding-top: var(--mantine-spacing-lg);
   padding-bottom: var(--mantine-spacing-lg);
 }

--- a/apps/web/src/components/Shell.module.css
+++ b/apps/web/src/components/Shell.module.css
@@ -1,13 +1,13 @@
-/* A flex column at least as tall as the viewport, with the main region growing
-   to fill, so the footer rests at the bottom rather than floating mid-page on
-   short routes. position: relative anchors the absolutely positioned skip link's
-   containing block here, rather than to whichever ancestor happens to be
-   positioned. */
+/* Shell styling lives in a CSS module (the repo's only one) because the skip
+   link's off-screen-until-focused reveal, the focus rings, and the brand hover
+   are pseudo-state styles that Mantine props and inline styles cannot express.
+   Everything else reuses Mantine's design tokens (the spacing and color CSS
+   vars) and Mantine components (Container) rather than re-inventing them. */
+
+/* position: relative anchors the absolutely positioned skip link's containing
+   block here, rather than to whichever ancestor happens to be positioned. */
 .shell {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
 }
 
 .header {
@@ -28,7 +28,6 @@
 }
 
 .main {
-  flex: 1;
   padding-top: var(--mantine-spacing-lg);
   padding-bottom: var(--mantine-spacing-lg);
 }
@@ -42,13 +41,6 @@
 .main:focus {
   outline: 2px solid var(--mantine-color-text);
   outline-offset: -2px;
-}
-
-.footer {
-  border-top: 1px solid var(--mantine-color-default-border);
-  margin-top: var(--mantine-spacing-xl);
-  padding-top: var(--mantine-spacing-md);
-  padding-bottom: var(--mantine-spacing-md);
 }
 
 /* The skip link sits first in the tab order but is pulled off-screen until it

--- a/apps/web/src/components/Shell.module.css
+++ b/apps/web/src/components/Shell.module.css
@@ -1,0 +1,48 @@
+.header {
+  border-bottom: 1px solid var(--mantine-color-default-border);
+  padding-top: var(--mantine-spacing-sm);
+  padding-bottom: var(--mantine-spacing-sm);
+}
+
+.brand {
+  font-weight: 700;
+  font-size: var(--mantine-font-size-lg);
+  color: var(--mantine-color-text);
+  text-decoration: none;
+}
+
+.brand:hover {
+  text-decoration: underline;
+}
+
+.main {
+  padding-top: var(--mantine-spacing-lg);
+  padding-bottom: var(--mantine-spacing-lg);
+}
+
+.footer {
+  border-top: 1px solid var(--mantine-color-default-border);
+  margin-top: var(--mantine-spacing-xl);
+  padding-top: var(--mantine-spacing-md);
+  padding-bottom: var(--mantine-spacing-md);
+}
+
+/* The skip link sits first in the tab order but is pulled off-screen until it
+   takes focus, when it snaps into the top-left corner -- the standard
+   keyboard-only "skip to content" affordance, done in CSS so it needs no JS and
+   works under SSR. */
+.skipLink {
+  position: absolute;
+  top: -3rem;
+  left: var(--mantine-spacing-sm);
+  z-index: 1000;
+  padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+  background-color: var(--mantine-color-body);
+  color: var(--mantine-color-text);
+  border: 1px solid var(--mantine-color-default-border);
+  border-radius: var(--mantine-radius-sm);
+}
+
+.skipLink:focus {
+  top: var(--mantine-spacing-sm);
+}

--- a/apps/web/src/components/Shell.module.css
+++ b/apps/web/src/components/Shell.module.css
@@ -1,7 +1,10 @@
 /* A flex column at least as tall as the viewport, with the main region growing
    to fill, so the footer rests at the bottom rather than floating mid-page on
-   short routes. */
+   short routes. position: relative anchors the absolutely positioned skip link's
+   containing block here, rather than to whichever ancestor happens to be
+   positioned. */
 .shell {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-height: 100vh;
@@ -28,6 +31,15 @@
   flex: 1;
   padding-top: var(--mantine-spacing-lg);
   padding-bottom: var(--mantine-spacing-lg);
+}
+
+/* main only ever receives focus from the skip link (it is tabIndex -1, so it is
+   not in the tab order otherwise); give that landing a visible indicator. The
+   offset is negative so the outline sits inside the full-width region rather
+   than overflowing the viewport. */
+.main:focus {
+  outline: 2px solid var(--mantine-primary-color-filled);
+  outline-offset: -2px;
 }
 
 .footer {

--- a/apps/web/src/components/Shell.tsx
+++ b/apps/web/src/components/Shell.tsx
@@ -1,0 +1,49 @@
+import { Container, Text } from "@mantine/core";
+import { Link } from "@tanstack/react-router";
+
+import classes from "./Shell.module.css";
+
+import type { ReactNode } from "react";
+
+/** The id shared by the skip link's target and the `<main>` landmark, declared
+ * once so the two cannot drift apart. */
+const MAIN_CONTENT_ID = "main-content";
+
+/**
+ * The application shell shared by every route: a "skip to content" link, a
+ * banner header whose product wordmark links home, the single `<main>` landmark
+ * routes render their page into, and a footer. Mounted once in the root route
+ * around the router `Outlet`, so each route supplies only its own page content
+ * and its own single `<h1>`.
+ */
+export function Shell({ children }: { children: ReactNode }) {
+  return (
+    <>
+      {/* First focusable element in the document, so a keyboard or screen-reader
+          user can jump past the header straight to the page content. Visually
+          hidden until focused (see Shell.module.css). */}
+      <a href={`#${MAIN_CONTENT_ID}`} className={classes.skipLink}>
+        Skip to content
+      </a>
+      <header className={classes.header}>
+        <Container size="xl">
+          <Link to="/" className={classes.brand}>
+            PSI-Link
+          </Link>
+        </Container>
+      </header>
+      {/* tabIndex -1 so the skip link can move focus into the landmark itself. */}
+      <main id={MAIN_CONTENT_ID} tabIndex={-1} className={classes.main}>
+        {children}
+      </main>
+      <footer className={classes.footer}>
+        <Container size="xl">
+          <Text size="xs" c="dimmed">
+            Invitations carry a one-time secret. Share them only over a channel
+            you trust, and never post them publicly.
+          </Text>
+        </Container>
+      </footer>
+    </>
+  );
+}

--- a/apps/web/src/components/Shell.tsx
+++ b/apps/web/src/components/Shell.tsx
@@ -1,4 +1,4 @@
-import { Container, Text } from "@mantine/core";
+import { Container } from "@mantine/core";
 import { Link } from "@tanstack/react-router";
 
 import classes from "./Shell.module.css";
@@ -11,20 +11,19 @@ const MAIN_CONTENT_ID = "main-content";
 
 /**
  * The application shell shared by every route: a "skip to content" link, a
- * banner header whose product wordmark links home, the single `<main>` landmark
- * routes render their page into, and a footer. Mounted once in the root route
- * around the router `Outlet`, so each route supplies only its own page content
- * and its own single `<h1>`.
+ * banner header whose product wordmark links home, and the single `<main>`
+ * landmark routes render their page into. Mounted once in the root route around
+ * the router `Outlet`, so each route supplies only its own page content and its
+ * own single `<h1>`.
  *
- * The wrapper is a flex column at least the viewport tall with the main region
- * flexing to fill, so the footer rests at the bottom on short pages.
- *
- * Built as a plain flex layout rather than Mantine's AppShell, whose responsive
+ * Built as a plain layout rather than Mantine's AppShell, whose responsive
  * navbar/aside machinery is unneeded for a single header link; revisit that
  * choice if the planned IA restructure adds real navigation or nested layouts.
  */
 export function Shell({ children }: { children: ReactNode }) {
   return (
+    // position: relative (in the stylesheet) anchors the absolutely positioned
+    // skip link's containing block here rather than to an arbitrary ancestor.
     <div className={classes.shell}>
       {/* First focusable element in the document, so a keyboard or screen-reader
           user can jump past the header straight to the page content. Visually
@@ -57,20 +56,6 @@ export function Shell({ children }: { children: ReactNode }) {
       <main id={MAIN_CONTENT_ID} tabIndex={-1} className={classes.main}>
         {children}
       </main>
-      <footer className={classes.footer}>
-        <Container size="xl">
-          {/* Role-neutral: the shell renders on both the invite and accept
-              routes, so this avoids the sharer-only "share it over a trusted
-              channel" framing (that inviter-specific guidance lives inline in
-              InvitePanel). Not c="dimmed": this is a confidentiality note, and
-              the dimmed gray falls below the 4.5:1 text-contrast bar on the
-              light background. */}
-          <Text size="xs">
-            Invitations carry a one-time secret. Keep them confidential and
-            never post them publicly.
-          </Text>
-        </Container>
-      </footer>
     </div>
   );
 }

--- a/apps/web/src/components/Shell.tsx
+++ b/apps/web/src/components/Shell.tsx
@@ -55,7 +55,9 @@ export function Shell({ children }: { children: ReactNode }) {
       </main>
       <footer className={classes.footer}>
         <Container size="xl">
-          <Text size="xs" c="dimmed">
+          {/* Not c="dimmed": this is a confidentiality note, and the dimmed gray
+              falls below the 4.5:1 text-contrast bar on the light background. */}
+          <Text size="xs">
             Invitations carry a one-time secret. Share them only over a channel
             you trust, and never post them publicly.
           </Text>

--- a/apps/web/src/components/Shell.tsx
+++ b/apps/web/src/components/Shell.tsx
@@ -15,14 +15,29 @@ const MAIN_CONTENT_ID = "main-content";
  * routes render their page into, and a footer. Mounted once in the root route
  * around the router `Outlet`, so each route supplies only its own page content
  * and its own single `<h1>`.
+ *
+ * The wrapper is a flex column at least the viewport tall with the main region
+ * flexing to fill, so the footer rests at the bottom on short pages.
  */
 export function Shell({ children }: { children: ReactNode }) {
   return (
-    <>
+    <div className={classes.shell}>
       {/* First focusable element in the document, so a keyboard or screen-reader
           user can jump past the header straight to the page content. Visually
-          hidden until focused (see Shell.module.css). */}
-      <a href={`#${MAIN_CONTENT_ID}`} className={classes.skipLink}>
+          hidden until focused (see Shell.module.css). It moves focus to the main
+          landmark in JS rather than letting the browser navigate to the
+          fragment, because the accept route carries the invitation token in
+          window.location.hash -- a default "#main-content" jump would overwrite
+          it, breaking a reload or a copied link. The href is kept so the control
+          is still announced (and works pre-hydration on the hash-free routes). */}
+      <a
+        href={`#${MAIN_CONTENT_ID}`}
+        className={classes.skipLink}
+        onClick={(event) => {
+          event.preventDefault();
+          document.getElementById(MAIN_CONTENT_ID)?.focus();
+        }}
+      >
         Skip to content
       </a>
       <header className={classes.header}>
@@ -44,6 +59,6 @@ export function Shell({ children }: { children: ReactNode }) {
           </Text>
         </Container>
       </footer>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/components/Shell.tsx
+++ b/apps/web/src/components/Shell.tsx
@@ -24,12 +24,14 @@ export function Shell({ children }: { children: ReactNode }) {
     <div className={classes.shell}>
       {/* First focusable element in the document, so a keyboard or screen-reader
           user can jump past the header straight to the page content. Visually
-          hidden until focused (see Shell.module.css). It moves focus to the main
-          landmark in JS rather than letting the browser navigate to the
+          hidden until focused (see Shell.module.css). The onClick moves focus to
+          the main landmark in JS rather than letting the browser navigate to the
           fragment, because the accept route carries the invitation token in
           window.location.hash -- a default "#main-content" jump would overwrite
           it, breaking a reload or a copied link. The href is kept so the control
-          is still announced (and works pre-hydration on the hash-free routes). */}
+          is announced as a link. (The href is the fallback only before this
+          handler is attached; an SPA is interactive post-hydration, which is the
+          realistic production path.) */}
       <a
         href={`#${MAIN_CONTENT_ID}`}
         className={classes.skipLink}

--- a/apps/web/src/components/Shell.tsx
+++ b/apps/web/src/components/Shell.tsx
@@ -18,6 +18,10 @@ const MAIN_CONTENT_ID = "main-content";
  *
  * The wrapper is a flex column at least the viewport tall with the main region
  * flexing to fill, so the footer rests at the bottom on short pages.
+ *
+ * Built as a plain flex layout rather than Mantine's AppShell, whose responsive
+ * navbar/aside machinery is unneeded for a single header link; revisit that
+ * choice if the planned IA restructure adds real navigation or nested layouts.
  */
 export function Shell({ children }: { children: ReactNode }) {
   return (
@@ -55,11 +59,15 @@ export function Shell({ children }: { children: ReactNode }) {
       </main>
       <footer className={classes.footer}>
         <Container size="xl">
-          {/* Not c="dimmed": this is a confidentiality note, and the dimmed gray
-              falls below the 4.5:1 text-contrast bar on the light background. */}
+          {/* Role-neutral: the shell renders on both the invite and accept
+              routes, so this avoids the sharer-only "share it over a trusted
+              channel" framing (that inviter-specific guidance lives inline in
+              InvitePanel). Not c="dimmed": this is a confidentiality note, and
+              the dimmed gray falls below the 4.5:1 text-contrast bar on the
+              light background. */}
           <Text size="xs">
-            Invitations carry a one-time secret. Share them only over a channel
-            you trust, and never post them publicly.
+            Invitations carry a one-time secret. Keep them confidential and
+            never post them publicly.
           </Text>
         </Container>
       </footer>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -17,6 +17,7 @@ import {
 
 import { DefaultCatchBoundary } from "@components/DefaultCatchBoundary";
 import { NotFound } from "@components/NotFound";
+import { Shell } from "@components/Shell";
 import { mantineTheme } from "@theme";
 import { seo } from "@utils/seo";
 
@@ -68,7 +69,9 @@ export const Route = createRootRoute({
 function RootComponent() {
   return (
     <RootDocument>
-      <Outlet />
+      <Shell>
+        <Outlet />
+      </Shell>
     </RootDocument>
   );
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -78,7 +78,7 @@ function RootComponent() {
 
 function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   return (
-    <html {...mantineHtmlProps}>
+    <html lang="en" {...mantineHtmlProps}>
       <head>
         <HeadContent />
         <ColorSchemeScript />

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,20 +1,7 @@
-import { Container, Group } from "@mantine/core";
 import { createFileRoute } from "@tanstack/react-router";
 
-import AcceptForm from "@components/AcceptForm";
-import { InvitePanel } from "@components/InvitePanel";
+import { HomePage } from "@components/HomePage";
 
 export const Route = createFileRoute("/")({
-  component: Home,
+  component: HomePage,
 });
-
-function Home() {
-  return (
-    <Container>
-      <Group justify="space-between" align="flex-start" grow mt="md">
-        <InvitePanel />
-        <AcceptForm />
-      </Group>
-    </Container>
-  );
-}

--- a/apps/web/test/browser/appShell.test.ts
+++ b/apps/web/test/browser/appShell.test.ts
@@ -1,0 +1,147 @@
+/// <reference types="@vitest/browser-playwright/context" />
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { page } from "vitest/browser";
+
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+
+import { MantineProvider } from "@mantine/core";
+
+import {
+  encodeInvitation,
+  generateSharedSecret,
+  getDefaultLinkageTerms,
+} from "@psilink/core";
+
+import { AcceptInvitation } from "@components/AcceptInvitation";
+import { HomePage } from "@components/HomePage";
+import { Shell } from "@components/Shell";
+
+import type { ReactNode } from "react";
+import type { Root } from "react-dom/client";
+
+import type { InvitationToken } from "@psilink/core";
+
+// Stub the dialing exchange (it pulls in peerjs and the PSI WASM and sets up a
+// rendezvous); this suite only renders the static shell and the routes' initial
+// outline. Mirrors acceptConsentGate.test.ts -- vitest hoists vi.mock above the
+// imports, so HomePage's InvitePanel and AcceptInvitation pick up the stub.
+vi.mock("@components/Exchange", () => ({
+  Exchange: () =>
+    createElement("div", { "data-testid": "exchange-mounted" }, "exchange"),
+}));
+
+// Stub the router seams the shell and the home form touch (the shell's home link
+// and the form's navigate). This suite asserts shell structure and the heading
+// outline, not navigation, so rendering the routes directly with createRoot --
+// the acceptConsentGate pattern -- is simpler and avoids a RouterProvider (which
+// trips a duplicate-React dispatcher error under the browser runner).
+vi.mock("@tanstack/react-router", () => ({
+  // The only router seams the rendered graph touches: the shell's home link and
+  // the home form's navigate. NotFound/DefaultCatchBoundary and the route files
+  // (the other react-router importers) are not in this test's import graph.
+  Link: ({
+    to,
+    className,
+    children,
+  }: {
+    to?: string;
+    className?: string;
+    children?: ReactNode;
+  }) =>
+    createElement(
+      "a",
+      { href: typeof to === "string" ? to : "#", className },
+      children,
+    ),
+  useNavigate: () => () => undefined,
+}));
+
+async function encodeAcceptToken(): Promise<string> {
+  const token: InvitationToken = {
+    version: "1",
+    linkageTerms: getDefaultLinkageTerms("County Health Department"),
+    sharedSecret: generateSharedSecret(),
+    connectionEndpoint: {
+      channel: "webrtc",
+      host: "127.0.0.1",
+      port: 3000,
+      path: "/api/",
+    },
+  };
+  return encodeInvitation(token);
+}
+
+let container: HTMLElement | undefined;
+let root: Root | undefined;
+
+// Mount a route's page inside the shell the same way the root route composes
+// <Shell><Outlet /></Shell>, so the assertions exercise shell + page together.
+function mountInShell(content: ReactNode) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  root.render(
+    createElement(MantineProvider, null, createElement(Shell, null, content)),
+  );
+}
+
+afterEach(() => {
+  root?.unmount();
+  container?.remove();
+  root = undefined;
+  container = undefined;
+  window.location.hash = "";
+});
+
+// The shell's structural guarantees, asserted on whichever route is mounted: a
+// single banner header, footer, and <main> landmark, plus a skip link whose
+// fragment resolves to that main landmark.
+function expectShell() {
+  expect(document.querySelectorAll("header").length).toBe(1);
+  expect(document.querySelectorAll("footer").length).toBe(1);
+
+  const mains = document.querySelectorAll("main");
+  expect(mains.length).toBe(1);
+  const main = mains[0];
+  expect(main.id).toBe("main-content");
+
+  const skip = document.querySelector("a[href^='#']");
+  expect(skip?.textContent).toBe("Skip to content");
+  expect(skip?.getAttribute("href")).toBe(`#${main.id}`);
+}
+
+describe("application shell", () => {
+  test("home route renders inside the shell with one h1", async () => {
+    mountInShell(createElement(HomePage));
+
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Start a private data exchange");
+
+    expectShell();
+    expect(document.querySelectorAll("h1").length).toBe(1);
+    // The page content rendered inside the main landmark, not beside it.
+    expect(
+      document.querySelector("main")?.contains(document.querySelector("h1")),
+    ).toBe(true);
+  });
+
+  test("accept route renders inside the shell with one h1", async () => {
+    window.location.hash = await encodeAcceptToken();
+    mountInShell(createElement(AcceptInvitation));
+
+    // The h1 is present immediately; wait for the decode to reveal the terms so
+    // the full ready-state outline (the h1 plus the terms h2) is asserted.
+    await expect
+      .element(page.getByText("Invitation from County Health Department"))
+      .toBeInTheDocument();
+
+    expectShell();
+    const h1s = document.querySelectorAll("h1");
+    expect(h1s.length).toBe(1);
+    expect(h1s[0].textContent).toBe("Accept an invitation");
+  });
+});

--- a/apps/web/test/browser/appShell.test.ts
+++ b/apps/web/test/browser/appShell.test.ts
@@ -108,9 +108,17 @@ function expectShell() {
   const main = mains[0];
   expect(main.id).toBe("main-content");
 
-  const skip = document.querySelector("a[href^='#']");
-  expect(skip?.textContent).toBe("Skip to content");
+  const skip = skipLink();
+  expect(skip).toBeTruthy();
   expect(skip?.getAttribute("href")).toBe(`#${main.id}`);
+}
+
+// The skip link located by its accessible name rather than by attribute, so the
+// lookup stays unambiguous regardless of any other anchors a page renders.
+function skipLink(): HTMLAnchorElement | undefined {
+  return Array.from(document.querySelectorAll("a")).find(
+    (anchor) => anchor.textContent === "Skip to content",
+  );
 }
 
 describe("application shell", () => {
@@ -143,5 +151,28 @@ describe("application shell", () => {
     const h1s = document.querySelectorAll("h1");
     expect(h1s.length).toBe(1);
     expect(h1s[0].textContent).toBe("Accept an invitation");
+  });
+
+  test("skip link moves focus to main without clobbering the hash", async () => {
+    // The accept route carries the invitation token in window.location.hash;
+    // activating the skip link must move focus to the main landmark without
+    // overwriting that fragment (which would break a reload or a copied link).
+    window.location.hash = await encodeAcceptToken();
+    mountInShell(createElement(AcceptInvitation));
+
+    await expect
+      .element(page.getByText("Invitation from County Health Department"))
+      .toBeInTheDocument();
+
+    const hashBefore = window.location.hash;
+    // Native click (not a Playwright click): the skip link sits off-screen until
+    // focused, and a native dispatch still drives React's onClick, which
+    // preventDefaults the fragment navigation.
+    skipLink()?.click();
+
+    expect(window.location.hash).toBe(hashBefore);
+    expect(document.activeElement).toBe(
+      document.getElementById("main-content"),
+    );
   });
 });

--- a/apps/web/test/browser/appShell.test.ts
+++ b/apps/web/test/browser/appShell.test.ts
@@ -171,8 +171,10 @@ describe("application shell", () => {
     skipLink()?.click();
 
     expect(window.location.hash).toBe(hashBefore);
-    expect(document.activeElement).toBe(
-      document.getElementById("main-content"),
-    );
+    const main = document.getElementById("main-content");
+    expect(document.activeElement).toBe(main);
+    // The focused landing has a visible indicator (the .main:focus outline),
+    // since main is otherwise outside the tab order.
+    expect(main && getComputedStyle(main).outlineWidth).not.toBe("0px");
   });
 });

--- a/apps/web/test/browser/appShell.test.ts
+++ b/apps/web/test/browser/appShell.test.ts
@@ -97,11 +97,10 @@ afterEach(() => {
 });
 
 // The shell's structural guarantees, asserted on whichever route is mounted: a
-// single banner header, footer, and <main> landmark, plus a skip link whose
-// fragment resolves to that main landmark.
+// single banner header and <main> landmark, plus a skip link whose fragment
+// resolves to that main landmark.
 function expectShell() {
   expect(document.querySelectorAll("header").length).toBe(1);
-  expect(document.querySelectorAll("footer").length).toBe(1);
 
   const mains = document.querySelectorAll("main");
   expect(mains.length).toBe(1);


### PR DESCRIPTION
## Summary

Give the web app a real application shell -- a banner header with the product wordmark, a single `<main>` landmark, and a working "skip to content" link -- a proper document heading outline (one `<h1>` per route, section captions as headings), and standardized container widths, replacing the previous bare `<Outlet>` and the panels that led with plain `<Text>`. This is the foundation for the IA restructure and the first step toward the WCAG 2.1 AA / Section 508 roadmap goal.

Implements [202240906](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202240906).

## Changes

- `routes/__root.tsx`: render every route inside a new `<Shell>` around the `Outlet`; add `lang="en"` to `<html>`.
- `components/Shell.tsx` + `Shell.module.css`: the new shell -- a skip link (moves focus to main in JS so it never rewrites the accept route's token-bearing URL fragment), a banner header with a wordmark home link, and the single `<main id="main-content">` landmark. The CSS module (the repo's first) is confined to the focus/hover pseudo-state styles Mantine props cannot express.
- `components/HomePage.tsx` + `routes/index.tsx`: extract the home page into a component (mirroring `AcceptInvitation`) so it renders in a test, and give it the route's single `<h1>`.
- `components/InvitePanel.tsx`, `AcceptForm.tsx`: promote the panel captions from `<Text>` to `<h2>`.
- `components/AcceptInvitation.tsx`: the title becomes the route `<h1>`; container width `sm` -> `lg` so the dense terms read at a legible measure.
- `components/InvitationTerms.tsx`: the terms caption `<h3>` -> `<h2>` under the new `<h1>`.
- `test/browser/appShell.test.ts`: new render tests covering the outline and the shell.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run formatcheck` (clean); `npm run test:unit -w apps/web` (175 passed); `npx vitest run --project browser test/browser/appShell.test.ts test/browser/acceptConsentGate.test.ts` (7 passed); `npm run build`.
New tests cover: exactly one `<h1>` on `/` and `/accept`, the skip link's fragment resolving to the `<main>` landmark, the skip link moving focus without clobbering the invitation hash, the focused-main indicator, and the shell rendering on both routes.

## Background

The panels (`InvitePanel`, `AcceptForm`) previously led with `<Text size="md">`, so the app had no document outline at all -- load-bearing for the 508/VPAT roadmap item. `/` stays SSR; `/accept` stays `ssr:false`. The footer named in the issue was implemented then removed: its content was an open question, the only candidate copy duplicated guidance that already appears inline, and the owner opted to omit it; it is trivially restored when a real footer need arises.

## Out of scope / follow-on

- Raise web dimmed/secondary text to WCAG AA contrast (the pervasive pre-existing `c="dimmed"` ~3.32:1 pattern): [202267321](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202267321).
- Add a shared content-width seam so chrome aligns with route content: [202267416](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202267416).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented operational or spec behavior changed; this is a presentational shell, and the COMPLIANCE/ROADMAP Section 508 status is deliberately left unchanged.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: presentational web UI with no operator/deployer- or security-reviewer-actionable change (no command, flag, config field, default, behavior, exit code, or wire/on-disk format change).
- [x] Security review -- done: two independent reviews of the displayed-data surface (a disclosure / secret-handling lens and a control-regression / new-surface lens); both found no regression -- the invitation token in `window.location.hash` is not leaked or clobbered, and the partner-data display-sanitization boundary is unchanged.
