### PR TITLE
Unify column-to-field resolution behind one primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ This changelog records, per release, the changes that affect how PSI-Link is run
 - Repeating a single-value flag (for example `--server-port`) is now a clean usage error (exit 64) instead of misbehaving. See `docs/CLI.md`.
 - A malformed message from a peer is reported as a protocol error instead of crashing, and a failed exchange surfaces its original cause instead of a generic connection error.
 - The acceptor at accept time, and a recurring `psilink exchange` run, are warned -- or the run is blocked (exit 64) -- when the CSV cannot satisfy the configured linkage terms, instead of silently producing an empty result. See `docs/CLI.md`.
+- `psilink invite` now reconciles an input CSV against a config's explicit `metadata`, resolving columns to linkage fields exactly as the exchange will, instead of falling back to column-name inference. A config that types a non-standard column explicitly is no longer wrongly rejected at invite time, and a CSV the config's metadata cannot satisfy is now caught when the invitation is generated rather than only at the exchange. See `docs/CLI.md`.
 - Linkage terms that pair `output.expects_output: false` with `payload.receive` columns are rejected as incoherent at parse time. See `docs/EXCHANGE_REFERENCE.md`.
 - Linkage terms that reference an undeclared linkage field, or whose `swap` names no element in its key, are rejected as incoherent at decode, instead of silently collapsing the affected key to an empty result. See `docs/EXCHANGE_REFERENCE.md`.
 

--- a/apps/cli/src/commands/invite.ts
+++ b/apps/cli/src/commands/invite.ts
@@ -328,10 +328,16 @@ export async function validateInvite(params: {
       // unsatisfiable fields rather than minting an invitation the input cannot
       // honor.
       const rows = await loadInputRows(resolved.input, { allowStdin: true });
+      // Pass the config's explicit standardization AND metadata so the columns
+      // resolve to linkage fields exactly as the eventual exchange does: metadata
+      // retypes columns for the type fallback, so without it a config that types a
+      // column explicitly (or types an inferred one away) would be checked against
+      // name inference and could mint an invitation the exchange cannot satisfy.
       const unsatisfied = unsatisfiedLinkageFields(
         rows.columns,
         configTerms,
         configSource.standardization,
+        configSource.metadata,
       );
       if (unsatisfied.length > 0)
         throw new UsageError(

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -5,6 +5,7 @@ import type {
   ConnectionConfig,
   ExchangeSpec,
   LinkageTerms,
+  Metadata,
   Standardization,
 } from "@psilink/core";
 import {
@@ -12,6 +13,7 @@ import {
   CanonicalEncodingError,
   safeParseFileSyncOptions,
   safeParseLinkageTerms,
+  safeParseMetadata,
   snakeizeKeys,
   StandardizationSchema,
   UsageError,
@@ -540,15 +542,24 @@ export function persistHostKeyFingerprint(
 /**
  * The portion of a pre-existing config that `invite` uses as the source for an
  * invitation: the linkage terms (which the invitation carries) and the explicit
- * data standardization, if any (which the config-vs-input reconciliation honors
- * so an input column the standardization maps to a linkage field counts as
- * satisfying it). Metadata and the connection block are intentionally omitted --
- * `invite` does not use them.
+ * data standardization and metadata, if any (which the config-vs-input
+ * reconciliation honors so it resolves columns to linkage fields exactly as the
+ * eventual exchange does). The connection block is intentionally omitted --
+ * `invite` does not use it.
  */
 export interface ConfigLinkageSource {
   linkageTerms: LinkageTerms;
   /** The config's explicit `standardization` block, absent when not present. */
   standardization?: Standardization;
+  /**
+   * The config's explicit `metadata` block, absent when not present. Forwarded
+   * to the satisfiability check so it resolves the type fallback against the same
+   * column types the exchange does -- without it, a config that retypes a column
+   * (e.g. names a non-standard column as an `ssn`, or types an inferred column
+   * away) would be checked against name inference and could mint an invitation
+   * for an input the exchange cannot actually satisfy.
+   */
+  metadata?: Metadata;
 }
 
 /**
@@ -645,5 +656,27 @@ export function loadConfigLinkageSource(
     standardization = stdResult.data;
   }
 
-  return { linkageTerms: result.data, standardization };
+  // The explicit metadata is optional. safeParseMetadata camelizes the on-disk
+  // snake_case keys (e.g. `is_payload`) before validating, like linkage_terms
+  // above. An invalid block is surfaced as a usage error rather than silently
+  // dropped, so the satisfiability check cannot fall back to name inference on a
+  // config the operator believes types its columns explicitly.
+  const rawMetadata = obj["metadata"];
+  let metadata: Metadata | undefined;
+  if (rawMetadata !== undefined) {
+    const metaResult = safeParseMetadata(rawMetadata);
+    if (!metaResult.success)
+      throw new UsageError(
+        `config file ${configPath} has invalid metadata: ` +
+          metaResult.error.issues
+            .map((i) => {
+              const at = i.path.length > 0 ? `${i.path.join(".")}: ` : "";
+              return `${at}${i.message}`;
+            })
+            .join("; "),
+      );
+    metadata = metaResult.data;
+  }
+
+  return { linkageTerms: result.data, standardization, metadata };
 }

--- a/apps/cli/test/unit/config.test.ts
+++ b/apps/cli/test/unit/config.test.ts
@@ -855,6 +855,53 @@ test("loadConfigLinkageSource round-trips an explicit standardization block", ()
   }
 });
 
+test("loadConfigLinkageSource round-trips an explicit metadata block", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
+  try {
+    const configPath = path.join(dir, "psilink.yaml");
+    const terms = getDefaultLinkageTerms("Agency A");
+    const metadata = [
+      {
+        name: "tax_id",
+        type: "ssn" as const,
+        role: "linkage" as const,
+        isPayload: false,
+      },
+    ];
+    saveConfig(configPath, {
+      connection: { channel: "filedrop", path: "/mnt/share" },
+      linkageTerms: terms,
+      metadata,
+    });
+    // saveConfig writes is_payload; loadConfigLinkageSource camelizes it back.
+    expect(loadConfigLinkageSource(configPath)?.metadata).toEqual(metadata);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfigLinkageSource rejects a config with an invalid metadata block", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
+  try {
+    const configPath = path.join(dir, "psilink.yaml");
+    // Valid linkage_terms (so the metadata branch is reached) plus a metadata
+    // entry with an unknown semantic type.
+    const yaml = YAML.stringify({
+      linkageTerms: getDefaultLinkageTerms("Agency A"),
+      metadata: [
+        { name: "X", type: "not_a_type", role: "linkage", isPayload: false },
+      ],
+    });
+    fs.writeFileSync(configPath, yaml);
+    expect(() => loadConfigLinkageSource(configPath)).toThrow(UsageError);
+    expect(() => loadConfigLinkageSource(configPath)).toThrow(
+      "invalid metadata",
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("loadConfigLinkageSource rejects a config with no linkage_terms", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
   try {

--- a/apps/cli/test/unit/invite.test.ts
+++ b/apps/cli/test/unit/invite.test.ts
@@ -12,7 +12,7 @@ import {
   inferMetadata,
   UsageError,
 } from "@psilink/core";
-import type { LinkageTerms, Standardization } from "@psilink/core";
+import type { LinkageTerms, Metadata, Standardization } from "@psilink/core";
 
 import {
   handler as inviteHandler,
@@ -254,12 +254,13 @@ function defaultTerms(): LinkageTerms {
 }
 
 // A pre-existing config carrying `terms` (and optionally an explicit
-// `standardization`) is written to a temp dir; the helper returns the paths so a
-// test can point its options at them. The connection is a placeholder -- invite
-// does not use it.
+// `standardization` and/or `metadata`) is written to a temp dir; the helper
+// returns the paths so a test can point its options at them. The connection is a
+// placeholder -- invite does not use it.
 function withConfig(
   terms: LinkageTerms,
   standardization?: Standardization,
+  metadata?: Metadata,
 ): { dir: string; configPath: string; keyPath: string } {
   const dir = fs.mkdtempSync(path.join(tmpdir(), "psilink-invite-cfg-"));
   const configPath = path.join(dir, "psilink.yaml");
@@ -267,6 +268,7 @@ function withConfig(
     connection: { channel: "filedrop", path: "/mnt/share" },
     linkageTerms: terms,
     ...(standardization !== undefined && { standardization }),
+    ...(metadata !== undefined && { metadata }),
   });
   return { dir, configPath, keyPath: path.join(dir, ".psilink.key") };
 }
@@ -350,6 +352,38 @@ test("validateInvite: a config's explicit standardization lets an otherwise-unsa
       steps: [{ function: "trim_whitespace" }],
     },
   ]);
+  try {
+    const input = writeCsv(dir, "first_name,last_name,dob,tax_id");
+    const ready = await validateInvite({
+      resolved: { mode: "offline", input },
+      options: testOptions({ configFile: configPath, keyFile: keyPath }),
+      acceptTimeout: 900,
+      log: silentLog,
+    });
+    expect(ready.mode).toBe("offlineFromConfig");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("validateInvite: a config's explicit metadata lets an otherwise-unsatisfying input pass", async () => {
+  const terms = defaultTerms();
+  // The config's metadata types tax_id as ssn; the input carries tax_id, which
+  // name inference would type as an identifier (not ssn). Without honoring the
+  // config metadata the ssn field would look unsatisfiable and invite would
+  // refuse, even though the exchange (which uses the metadata) can produce it.
+  const metadata: Metadata = [
+    {
+      name: "first_name",
+      type: "firstName",
+      role: "linkage",
+      isPayload: false,
+    },
+    { name: "last_name", type: "lastName", role: "linkage", isPayload: false },
+    { name: "dob", type: "dateOfBirth", role: "linkage", isPayload: false },
+    { name: "tax_id", type: "ssn", role: "linkage", isPayload: false },
+  ];
+  const { dir, configPath, keyPath } = withConfig(terms, undefined, metadata);
   try {
     const input = writeCsv(dir, "first_name,last_name,dob,tax_id");
     const ready = await validateInvite({

--- a/packages/core/src/config/metadata.ts
+++ b/packages/core/src/config/metadata.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { SEMANTIC_TYPES } from "../types";
+import { camelizeKeys } from "../utils/camelizeKeys.js";
 
 import type { SemanticType } from "../types";
 
@@ -31,6 +32,17 @@ const ColumnMetadataSchema: z.ZodType<ColumnMetadata> = z.object({
 export type Metadata = Array<ColumnMetadata>;
 
 export const MetadataSchema = z.array(ColumnMetadataSchema);
+
+/**
+ * Non-throwing parse of a raw value as {@link Metadata}. Snake_case keys (the
+ * on-disk form, e.g. `is_payload`) are converted to camelCase before validation,
+ * so a `metadata` block read straight from a YAML/JSON config can be passed
+ * directly -- mirroring {@link safeParseLinkageTerms} and
+ * {@link safeParseExchangeSpec}. Returns a Zod `SafeParseReturnType`.
+ */
+export function safeParseMetadata(raw: unknown) {
+  return MetadataSchema.safeParse(camelizeKeys(raw));
+}
 
 // ─── Metadata Inference ──────────────────────────────────────────────────────
 interface TypeMeta {

--- a/packages/core/src/defaults/standardization.ts
+++ b/packages/core/src/defaults/standardization.ts
@@ -1,3 +1,5 @@
+import { resolveFieldColumns } from "../standardization.js";
+
 import type {
   Standardization,
   StandardizationStep,
@@ -151,14 +153,22 @@ export function getDefaultStandardization(
   terms: LinkageTerms,
   options: DefaultStandardizationOptions = {},
 ): Standardization {
+  // Derive each field's input column from the same resolution primitive the
+  // builder and satisfiability checker use, so the default-term mapping cannot
+  // diverge from how the exchange actually binds columns. With no explicit
+  // standardization this is the pure type fallback (first metadata column of the
+  // field's type). Fields whose semantic type has no default pipeline
+  // (`identifier`/`other`) are still skipped here and fall through to the
+  // builder's own identity type-fallback at exchange time.
+  const resolution = resolveFieldColumns(terms, undefined, metadata);
   const result: Standardization = [];
 
   for (const field of terms.linkageFields) {
     const steps = stepsForType(field.type, options);
     if (steps === undefined) continue;
-    const col = metadata.find((c) => c.type === field.type);
-    if (!col) continue;
-    result.push({ output: field.name, input: col.name, steps });
+    const column = resolution.get(field.name)?.column;
+    if (column === undefined) continue;
+    result.push({ output: field.name, input: column, steps });
   }
 
   return result;

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -3,6 +3,7 @@ import { sanitizeForDisplay } from "./utils/sanitizeForDisplay.js";
 import type {
   Standardization,
   StandardizationStep,
+  StandardizationTransformation,
 } from "./config/standardization.js";
 import type {
   LinkageField,
@@ -698,17 +699,90 @@ export class StandardizedDataset {
   }
 }
 
+// --- Column resolution -------------------------------------------------------
+
 /**
- * Build a {@link StandardizedDataset} from:
+ * How one declared linkage field resolves to an input column -- the single
+ * binding the dataset builder and the satisfiability checker both consume, so
+ * the two can no longer encode the resolution rules independently and drift (the
+ * detector-vs-runtime divergence class). Produced by {@link resolveFieldColumns}.
+ */
+export interface FieldColumnResolution {
+  /**
+   * The input column the field binds to, regardless of whether that column is
+   * present in the data, or `undefined` when no column resolves the field. The
+   * builder reads rows from this column (an absent column yields no values); a
+   * presence-only consumer (the satisfiability checker) treats the field as
+   * producible exactly when this is defined AND present in the input columns.
+   */
+  column: string | undefined;
+  /**
+   * The explicit standardization transformation that bound the field, when the
+   * binding came from one; `undefined` for a semantic-type-fallback binding. The
+   * builder takes its `steps`; presence-only consumers ignore it.
+   */
+  transform: StandardizationTransformation | undefined;
+}
+
+/**
+ * Resolve every declared linkage field to the input column an exchange would
+ * bind it to, encoding the column-to-field resolution rules in ONE place so the
+ * dataset builder ({@link buildStandardizedDataset}), the satisfiability checker
+ * ({@link unsatisfiedLinkageFields}), and the default-standardization derivation
+ * (`getDefaultStandardization`) cannot drift apart.
  *
- * 1. Explicit `standardizing` transformations (when provided).
- * 2. Identity transformations for linkage fields not covered by an explicit
- *    transformation, resolved by matching the field's semantic type against
- *    column metadata.
+ * The rules, per field:
  *
- * Linkage fields that cannot be resolved by either mechanism are absent from
- * the dataset; records referencing those fields are excluded from the
- * corresponding linkage keys.
+ * 1. Explicit standardization preempts the type fallback: if `standardization`
+ *    carries a transformation whose `output` is the field name, the field binds
+ *    to that transformation's `input` column -- whether or not the column is
+ *    present in the data. (When two transformations name the same output the
+ *    last wins, matching the builder's field map and the checker's old mapping.)
+ * 2. Type fallback: otherwise the field binds to the FIRST `metadata` column of
+ *    its semantic type (`metadata.find(c => c.type === field.type)`), or to
+ *    nothing when no such column exists. First-match -- not "any same-typed
+ *    column" -- because the exchange reads exactly that column.
+ *
+ * Binding is independent of whether the bound column is present in the input:
+ * the builder reads rows from the column and a presence-only consumer layers the
+ * presence test on top. `metadata` is the resolved metadata the caller already
+ * chose (an explicit block or `inferMetadata`); under inferred metadata every
+ * column is present, so the presence test only bites under an explicit block.
+ */
+export function resolveFieldColumns(
+  terms: LinkageTerms,
+  standardization: Standardization | undefined,
+  metadata: ColumnMetadata[],
+): Map<string, FieldColumnResolution> {
+  // Field output -> its explicit transformation; last wins on a duplicate output,
+  // matching both the builder's StandardizedDataset field map and the checker's
+  // former explicitInput map (the schema forbids duplicates, so this only differs
+  // for terms not built through it).
+  const explicit = new Map<string, StandardizationTransformation>();
+  for (const t of standardization ?? []) explicit.set(t.output, t);
+
+  const resolution = new Map<string, FieldColumnResolution>();
+  for (const field of terms.linkageFields) {
+    const transform = explicit.get(field.name);
+    if (transform !== undefined) {
+      resolution.set(field.name, { column: transform.input, transform });
+      continue;
+    }
+    const col = metadata.find((c) => c.type === field.type);
+    resolution.set(field.name, { column: col?.name, transform: undefined });
+  }
+  return resolution;
+}
+
+/**
+ * Build a {@link StandardizedDataset} for the linkage fields in `terms`, binding
+ * each field to an input column via {@link resolveFieldColumns}: an explicit
+ * standardization transformation when one names the field (its steps run on the
+ * bound column), otherwise the identity transformation over the first metadata
+ * column of the field's semantic type.
+ *
+ * Linkage fields that resolve to no column are absent from the dataset; records
+ * referencing those fields are excluded from the corresponding linkage keys.
  */
 export function buildStandardizedDataset(
   standardization: Standardization | undefined,
@@ -716,22 +790,22 @@ export function buildStandardizedDataset(
   metadata: ColumnMetadata[],
   terms: LinkageTerms,
 ): StandardizedDataset {
+  const resolution = resolveFieldColumns(terms, standardization, metadata);
   const fields: StandardizedField[] = [];
-  const covered = new Set<string>();
-
-  for (const t of standardization ?? []) {
-    fields.push(
-      new StandardizedField(t.output, t.input, t.steps ?? [], rawRows),
-    );
-    covered.add(t.output);
-  }
 
   for (const field of terms.linkageFields) {
-    if (covered.has(field.name)) continue;
-    const col = metadata.find((c) => c.type === field.type);
-    if (!col) continue;
-    // Identity transformation: pass the raw column value through unchanged.
-    fields.push(new StandardizedField(field.name, col.name, [], rawRows));
+    const resolved = resolution.get(field.name);
+    if (resolved === undefined || resolved.column === undefined) continue;
+    // Explicit binding carries its own steps; a type-fallback binding is the
+    // identity transformation (pass the raw column value through unchanged).
+    fields.push(
+      new StandardizedField(
+        field.name,
+        resolved.column,
+        resolved.transform?.steps ?? [],
+        rawRows,
+      ),
+    );
   }
 
   return new StandardizedDataset(fields);
@@ -952,24 +1026,24 @@ export function validateStandardizationAgainstTerms(
 }
 
 /**
- * The linkage fields in `terms` that the input `columns` cannot satisfy
- * through the available data standardizations. Mirrors the column-to-field
- * resolution in {@link buildStandardizedDataset}: a field is producible when
+ * The linkage fields in `terms` that the input `columns` cannot satisfy through
+ * the available data standardizations. The verdict is derived from the same
+ * {@link resolveFieldColumns} binding the exchange's {@link buildStandardizedDataset}
+ * uses: a field is producible exactly when the shared resolution bound it to a
+ * column that is present in `columns`. The checker no longer re-derives the
+ * binding itself, so it cannot diverge from the runtime -- the HIGH-severity
+ * direction (a field the builder cannot produce but the checker passes) is
+ * impossible by construction.
  *
- * 1. the spec carries an explicit `standardization` for it whose source input
- *    column is present (the explicit mapping preempts the type fallback), OR
- * 2. the field has NO explicit standardization and the input has a column of a
- *    matching semantic type -- taken from `metadata` when supplied, else inferred
- *    from the column names.
+ * Because the binding is shared, the resolution rules apply unchanged: an
+ * explicit standardization preempts the type fallback (a field whose explicit
+ * source column is absent is unsatisfiable even when a same-typed column exists),
+ * and the type fallback binds to the FIRST metadata column of the field's type.
+ * An empty result means every configured field can be produced; a non-empty
+ * result names the fields that cannot.
  *
- * An explicit standardization preempts the type fallback: a field whose
- * explicit source column is absent is unsatisfiable even when a same-typed
- * column is present -- the exchange would bind it to the missing column and
- * emit no values. An empty result means every configured field can be
- * produced; a non-empty result names the fields that cannot.
- *
- * Pass `metadata` to mirror an exchange that runs from an explicit metadata
- * block (`prepareForExchange` resolves the type fallback against
+ * Pass `metadata` to match an exchange that runs from an explicit metadata block
+ * (`prepareForExchange` resolves the type fallback against
  * `metadata ?? inferMetadata`); omit it to fall back to name-based inference, the
  * accept-path default.
  */
@@ -980,27 +1054,18 @@ export function unsatisfiedLinkageFields(
   metadata?: ColumnMetadata[],
 ): LinkageField[] {
   const present = new Set(columns);
-  const metadataColumns = metadata ?? inferMetadata(columns);
-  // Field name -> the input column its explicit standardization reads. A field
-  // present here is resolved by the explicit transformation (which preempts the
-  // type fallback), so it is producible iff that column exists; a field absent
-  // here falls back to semantic-type coverage.
-  const explicitInput = new Map(
-    (standardization ?? []).map((t) => [t.output, t.input]),
+  const resolution = resolveFieldColumns(
+    terms,
+    standardization,
+    metadata ?? inferMetadata(columns),
   );
+  // A field is producible iff the shared resolution bound it to a column present
+  // in the input. The binding rules (explicit-preempts-fallback, first-match type
+  // fallback) live in resolveFieldColumns, not here, so this verdict cannot drift
+  // from the builder's.
   return terms.linkageFields.filter((f) => {
-    const mapped = explicitInput.get(f.name);
-    if (mapped !== undefined) return !present.has(mapped);
-    // Type fallback: mirror getDefaultStandardization / buildStandardizedDataset,
-    // which bind the field to the FIRST metadata column of its type and read that
-    // column from the rows. Producible iff such a column exists AND is present in
-    // the input. First-match selection (not "any same-typed column is present")
-    // matters when explicit metadata lists an absent same-typed column ahead of a
-    // present one: the exchange binds the absent one and emits nothing, so a set of
-    // present types would wrongly report the field satisfiable. For inferred
-    // metadata every column is present, so the presence check never fires.
-    const col = metadataColumns.find((c) => c.type === f.type);
-    return col === undefined || !present.has(col.name);
+    const column = resolution.get(f.name)?.column;
+    return column === undefined || !present.has(column);
   });
 }
 

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -706,6 +706,10 @@ export class StandardizedDataset {
  * binding the dataset builder and the satisfiability checker both consume, so
  * the two can no longer encode the resolution rules independently and drift (the
  * detector-vs-runtime divergence class). Produced by {@link resolveFieldColumns}.
+ *
+ * @internal The return shape of an internal resolution primitive; exported only
+ * because it is {@link resolveFieldColumns}'s return type, not as a supported
+ * entry point.
  */
 export interface FieldColumnResolution {
   /**
@@ -748,6 +752,12 @@ export interface FieldColumnResolution {
  * presence test on top. `metadata` is the resolved metadata the caller already
  * chose (an explicit block or `inferMetadata`); under inferred metadata every
  * column is present, so the presence test only bites under an explicit block.
+ *
+ * @internal Shared primitive for the resolution's three in-package consumers
+ * (builder, satisfiability checker, default-standardization derivation);
+ * exported for those cross-module imports, not as a supported entry point. The
+ * web and CLI paths consume {@link assessLinkageSatisfiability} /
+ * {@link unsatisfiedLinkageFields}, not this directly.
  */
 export function resolveFieldColumns(
   terms: LinkageTerms,

--- a/packages/core/test/metadata.test.ts
+++ b/packages/core/test/metadata.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "vitest";
 
-import { inferMetadata, ALIAS_TYPE_META_MAP } from "../src/config/metadata";
+import {
+  inferMetadata,
+  ALIAS_TYPE_META_MAP,
+  safeParseMetadata,
+} from "../src/config/metadata";
 
 // ─── inferMetadata: linkage columns ──────────────────────────────────────────
 
@@ -152,4 +156,35 @@ test("ALIAS_TYPE_META_MAP entries have type, role, and isPayload", () => {
 test("ALIAS_TYPE_META_MAP identifier entry has role identifier, not linkage", () => {
   const entry = ALIAS_TYPE_META_MAP["identifier"];
   expect(entry.role).toBe("identifier");
+});
+
+// ─── safeParseMetadata ────────────────────────────────────────────────────────
+
+test("safeParseMetadata camelizes the on-disk snake_case keys", () => {
+  // The form saveConfig writes (is_payload, not isPayload).
+  const result = safeParseMetadata([
+    { name: "SSN", type: "ssn", role: "linkage", is_payload: false },
+  ]);
+  expect(result.success).toBe(true);
+  if (!result.success) return;
+  expect(result.data[0]).toEqual({
+    name: "SSN",
+    type: "ssn",
+    role: "linkage",
+    isPayload: false,
+  });
+});
+
+test("safeParseMetadata also accepts the camelCase form", () => {
+  const result = safeParseMetadata([
+    { name: "SSN", type: "ssn", role: "linkage", isPayload: false },
+  ]);
+  expect(result.success).toBe(true);
+});
+
+test("safeParseMetadata fails on an invalid semantic type", () => {
+  const result = safeParseMetadata([
+    { name: "X", type: "not_a_type", role: "linkage", is_payload: false },
+  ]);
+  expect(result.success).toBe(false);
 });

--- a/packages/core/test/standardization.test.ts
+++ b/packages/core/test/standardization.test.ts
@@ -2,6 +2,7 @@ import { expect, test, describe } from "vitest";
 
 import {
   runPipeline,
+  resolveFieldColumns,
   buildStandardizedDataset,
   buildKeyStrings,
   validateStandardizationAgainstTerms,
@@ -1250,6 +1251,123 @@ describe("validateStandardizationAgainstTerms", () => {
     expect(
       validateStandardizationAgainstTerms(standardization, minimalTerms),
     ).toEqual([]);
+  });
+});
+
+// --- resolveFieldColumns -----------------------------------------------------
+
+// The one binding the dataset builder, the satisfiability checker, and the
+// default-standardization derivation all consume. These pin its observable
+// resolution result directly, so a future change to the rules cannot pass while
+// silently differing from what the builder does. The two named cases below were
+// both live divergence bugs in the hand-maintained second copy this primitive
+// replaced (see #201001899).
+describe("resolveFieldColumns", () => {
+  const col = (name: string, type: ColumnMetadata["type"]): ColumnMetadata => ({
+    name,
+    type,
+    role: "linkage",
+    isPayload: false,
+  });
+
+  // ssn + lastName fields, named by their semantic type for brevity.
+  const terms: LinkageTerms = {
+    version: "1.0.0",
+    identity: "test",
+    date: "2025-01-01",
+    algorithm: "psi",
+    output: { expectsOutput: true, shareWithPartner: false },
+    deduplicate: false,
+    linkageFields: [
+      { name: "ssn", type: "ssn" },
+      { name: "lastName", type: "lastName" },
+    ],
+    linkageKeys: [{ name: "SSN", elements: [{ field: "ssn" }] }],
+  };
+
+  test("explicit mapping preempts the type fallback even when a same-typed column is present", () => {
+    // An ssn column is present, but the explicit mapping points ssn at tax_id.
+    // The binding follows the explicit input, not the present same-typed column,
+    // so an absent tax_id leaves ssn bound to a missing column. (The live bug:
+    // honoring the present ssn column would have wrongly satisfied the field.)
+    const resolution = resolveFieldColumns(
+      terms,
+      [{ output: "ssn", input: "tax_id" }],
+      inferMetadata(["ssn", "last_name"]),
+    );
+    expect(resolution.get("ssn")?.column).toBe("tax_id");
+    expect(resolution.get("ssn")?.transform).toEqual({
+      output: "ssn",
+      input: "tax_id",
+    });
+    // lastName has no explicit mapping, so it type-falls-back to last_name.
+    expect(resolution.get("lastName")?.column).toBe("last_name");
+    expect(resolution.get("lastName")?.transform).toBeUndefined();
+  });
+
+  test("type fallback binds to the FIRST same-typed column, not any present one", () => {
+    // Two ssn-typed columns with the absent one listed first. The binding is the
+    // first match (metadata.find), so ssn binds to absent_ssn even though
+    // present_ssn is a present same-typed column -- the first-match-vs-set-
+    // membership divergence, made observable on the resolution itself.
+    const resolution = resolveFieldColumns(terms, undefined, [
+      col("absent_ssn", "ssn"),
+      col("present_ssn", "ssn"),
+      col("last_name", "lastName"),
+    ]);
+    expect(resolution.get("ssn")?.column).toBe("absent_ssn");
+  });
+
+  test("an explicit mapping binds to its input column", () => {
+    const resolution = resolveFieldColumns(
+      terms,
+      [{ output: "ssn", input: "ssn_src" }],
+      inferMetadata(["ssn_src", "last_name"]),
+    );
+    expect(resolution.get("ssn")?.column).toBe("ssn_src");
+  });
+
+  test("a field with neither an explicit mapping nor a same-typed column resolves to no column", () => {
+    const resolution = resolveFieldColumns(
+      terms,
+      undefined,
+      inferMetadata(["last_name"]),
+    );
+    expect(resolution.get("ssn")?.column).toBeUndefined();
+    expect(resolution.get("lastName")?.column).toBe("last_name");
+  });
+
+  test("inferred metadata types the fallback by column name", () => {
+    const resolution = resolveFieldColumns(
+      terms,
+      undefined,
+      inferMetadata(["ssn", "last_name"]),
+    );
+    expect(resolution.get("ssn")?.column).toBe("ssn");
+  });
+
+  test("explicit metadata that retypes a column away unbinds its field", () => {
+    // The ssn column would infer as ssn, but explicit metadata types it `other`,
+    // so the type fallback finds no ssn column and the field resolves to nothing.
+    const resolution = resolveFieldColumns(terms, undefined, [
+      col("ssn", "other"),
+      col("last_name", "lastName"),
+    ]);
+    expect(resolution.get("ssn")?.column).toBeUndefined();
+  });
+
+  test("a duplicate explicit output binds to the last one", () => {
+    // Not reachable through the schema (it forbids duplicate outputs) but pinned
+    // so the builder's field map and the checker stay in agreement on the rule.
+    const resolution = resolveFieldColumns(
+      terms,
+      [
+        { output: "ssn", input: "first_src" },
+        { output: "ssn", input: "second_src" },
+      ],
+      inferMetadata(["first_src", "second_src"]),
+    );
+    expect(resolution.get("ssn")?.column).toBe("second_src");
   });
 });
 


### PR DESCRIPTION
## Summary

The satisfiability pre-flight that blocks an exchange from running to a silent-empty PSI result was a second, hand-maintained copy of the column-to-field resolution the runtime dataset builder performs, and `getDefaultStandardization` held a third copy of the type-fallback selection. Keeping the three behaviorally identical was a recurring source of detector-vs-runtime drift, including a HIGH-severity false pass (the checker reports a key satisfiable but the builder produces nothing). This PR collapses all three onto one primitive, `resolveFieldColumns`, so that divergence class is structurally impossible rather than caught case by case in review. It also tightens `psilink invite`'s precheck to resolve columns exactly as the exchange does by honoring the config's explicit metadata.

Implements [202250459](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202250459).

## Changes

- packages/core/src/standardization.ts: add `resolveFieldColumns` (the single column-to-field binding rule) and `FieldColumnResolution`; `buildStandardizedDataset` and `unsatisfiedLinkageFields` both consume it instead of re-encoding the explicit-preempts-fallback and first-match rules. Both new symbols are `@internal`.
- packages/core/src/defaults/standardization.ts: `getDefaultStandardization` derives each field's input column from the shared resolution instead of its own `metadata.find`.
- packages/core/src/config/metadata.ts: add `safeParseMetadata` (camelize-then-validate), symmetric with `safeParseLinkageTerms` and `safeParseExchangeSpec`.
- apps/cli/src/config.ts: `loadConfigLinkageSource` now reads the config's `metadata` block (added to `ConfigLinkageSource`) and surfaces an invalid block as a path-only `UsageError`.
- apps/cli/src/commands/invite.ts: forward `configSource.metadata` to the satisfiability check, so the offline invite precheck binds columns to linkage fields exactly as the exchange will.
- CHANGELOG.md: Fixed entry for the invite precheck change.

## Test plan

Ran: `npx vitest run packages/core/test/standardization.test.ts packages/core/test/defaultStandardization.test.ts packages/core/test/metadata.test.ts apps/cli/test/unit/config.test.ts apps/cli/test/unit/invite.test.ts`, plus the full `npm run test` across the three workspaces (core 1343, cli 728, web 175); typecheck, lint, and format clean.
New tests cover: `resolveFieldColumns` observable bindings, with the first-match-vs-set-membership and explicit-mapping-preempts-type-fallback cases (both former live divergence bugs) as named tests; `safeParseMetadata` camelization and validation; `loadConfigLinkageSource` metadata round-trip and invalid-block rejection; and `psilink invite` honoring config metadata (confirmed the test fails if the metadata argument is dropped).

## Background

The drift this removes is not hypothetical: #201001899 surfaced a sequence of divergence bugs in the detector caught only in review (it ignored explicit metadata; then used set-membership instead of the builder's first-match selection, a HIGH-severity false pass; with a residual for default-terms from explicit metadata). The interim differential test added there pins the detector's verdict against a real `buildStandardizedDataset` run and still passes against the unified implementation, confirming the structural fix subsumes the backstop. The primitive stays framework-agnostic in `@psilink/core`, so the web path and both CLI real-exchange paths consume it unchanged.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: CLI.md's invite-reconciliation description stays accurate at the conceptual tier (it already frames the check as producing the configured linkage fields), and the core resolution unification is an internal `@psilink/core` reshape with no doc-tier detail.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- added under Fixed: `psilink invite` now honors the config's explicit metadata in its precheck.
- [x] Security review -- done: independent reviews of guard integrity (false-pass / silent-empty PSI), robustness to hostile partner-controlled terms, and the config-parse disclosure surface; all PASS with no findings. This PR modifies the satisfiability guard and a config-parse surface, both security-relevant.
