### PR TITLE
Pin no-secret-echo on the config schema-error branch

### DIFF
--- a/apps/cli/test/unit/config.test.ts
+++ b/apps/cli/test/unit/config.test.ts
@@ -1004,6 +1004,67 @@ test.each([
   },
 );
 
+// The schema-validation error branches (linkage_terms / standardization /
+// metadata) interpolate the Zod issue message, which under Zod v4 names only the
+// expected literals, never the rejected input value. That is what keeps a secret
+// mistakenly placed in one of these blocks out of the error; Zod v3's enum error
+// echoed the received value ("...received '<value>'") and would have leaked it.
+// The YAML-parse leak test above does not cover this branch, so pin it directly:
+// embed a secret as an invalid enum value and assert it never reaches the message.
+// A future Zod that re-embeds the rejected value turns this red instead of
+// silently leaking. Both blocks share the one path-only interpolation; the two
+// cases cover the enum fields that would carry an attacker/operator string. The
+// standardization block has no enum/literal field, so it offers no rejected
+// VALUE a message could echo -- a case there would be vacuous, not coverage.
+// Each case also asserts the rejected FIELD path is named, so the test fails
+// loudly (rather than passing while testing nothing) if the secret ever stops
+// being the value the targeted enum rejects.
+test.each([
+  [
+    "metadata type enum",
+    (s: string) =>
+      YAML.stringify({
+        linkageTerms: getDefaultLinkageTerms("Agency A"),
+        metadata: [{ name: "X", type: s, role: "linkage", isPayload: false }],
+      }),
+    "invalid metadata",
+    "0.type",
+  ],
+  [
+    "linkage_terms algorithm enum",
+    (s: string) =>
+      YAML.stringify({
+        linkageTerms: { ...getDefaultLinkageTerms("Agency A"), algorithm: s },
+      }),
+    "invalid linkage_terms",
+    "algorithm",
+  ],
+])(
+  "loadConfigLinkageSource does not echo a secret in a schema error: %s",
+  (_, mk, expectedFragment, expectedPath) => {
+    const SECRET = "S3cr3tSFTPPassw0rd";
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
+    try {
+      const configPath = path.join(dir, "psilink.yaml");
+      fs.writeFileSync(configPath, mk(SECRET));
+      let caught: unknown;
+      try {
+        loadConfigLinkageSource(configPath);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(UsageError);
+      expect((caught as Error).message).toContain(expectedFragment);
+      // The targeted enum field is the one that rejected -- proves the secret was
+      // the rejected value, so not.toContain below is non-vacuous.
+      expect((caught as Error).message).toContain(expectedPath);
+      expect((caught as Error).message).not.toContain(SECRET);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
 test("loadConfigLinkageSource rejects a non-mapping top-level value", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
   try {


### PR DESCRIPTION
## Summary

Close the one remaining silent failure mode in the config-parse disclosure surface. `loadConfigLinkageSource`'s credential-leak guard test covered only the YAML-parse error path; the schema-validation error branches (linkage_terms / standardization / metadata) were not pinned. Those branches stay leak-free only because Zod v4's enum/type error messages name the expected literals and never the rejected input value -- an assumption nothing tested. This adds a regression test that turns red if a future Zod re-embeds the rejected value, instead of silently leaking a secret mistakenly placed in one of those blocks.

## Changes

- apps/cli/test/unit/config.test.ts: add a `test.each` that embeds a secret as an invalid enum value (the `metadata` `type` field and the `linkage_terms` `algorithm` field) and asserts the secret never reaches the `UsageError` message, while the path-only fragment does.

## Test plan

Ran: `npx vitest run apps/cli/test/unit/config.test.ts` (62 passed); typecheck, lint, format clean. Confirmed out-of-band that the embedded secret is the rejected enum value Zod reports on (`Invalid option: expected one of ...`), so the `not.toContain` assertion is load-bearing -- a v3-style "received '<value>'" message would fail it.

## Background

Surfaced by the final security reviews of #184 (the column-to-field resolution unification): both reviewers flagged that the no-leak property of the config-parse error branches rests on the pinned Zod major version. A downgrade is not the risk -- the codebase uses the v4-only `z.iso.*` namespace, so v3 fails to compile loudly. The only silent path is a future forward version that keeps `z.iso` but reformats messages to re-embed the rejected value; this test makes that loud. Bounded surface: `loadConfigLinkageSource` parses only linkage_terms / standardization / metadata, not the credential-bearing connection block.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: test-only change, no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-only change, nothing operator- or reviewer-visible.
- [x] Security review -- n/a: adds test coverage of an existing disclosure guard; introduces no code, control, or dependency change. The guard itself was reviewed under #184.
