### PR TITLE
Add a shared content-width seam for chrome and route content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ cosign.key
 .tanstack
 .output
 .vitest-attachments
+# Vitest browser-mode failure screenshots.
+__screenshots__
 *.swp
 terraform.tfvars
 scratch

--- a/apps/web/src/components/AcceptInvitation.tsx
+++ b/apps/web/src/components/AcceptInvitation.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { Container, Paper, Title } from "@mantine/core";
+import { Paper, Title } from "@mantine/core";
 
 import { describeDecodeError } from "@psilink/core";
 
@@ -17,6 +17,10 @@ import type { DecodeState } from "@components/AcceptInvitationPanel";
  * holds the consent state, and gates the dialing {@link Exchange} behind explicit
  * consent. Kept as a component (rather than inline in the route file) so it can be
  * mounted and driven in a browser test without the router.
+ *
+ * The content width (a narrower single-column reading width) is declared by the
+ * route and supplied by the shell's container, so this page renders only its
+ * content -- no `Container` of its own.
  */
 export function AcceptInvitation() {
   const [decode, setDecode] = useState<DecodeState>({ status: "pending" });
@@ -108,27 +112,22 @@ export function AcceptInvitation() {
     ) : undefined;
 
   return (
-    // Single-column reading width ("lg"): narrower than the home route on
-    // purpose, so the dense linkage terms sit at a legible measure rather than
-    // running the full two-column width.
-    <Container size="lg">
-      <Paper>
-        {/* A generic page h1 rather than the party-specific "Invitation from X"
-            (which is the terms section's h2 below): it must read sensibly in the
-            pending and error states too, where no party name is decoded yet. */}
-        <Title order={1}>Accept an invitation</Title>
-        <AcceptInvitationPanel
-          decode={decode}
-          headingRef={readyHeadingRef}
-          errorRef={errorRef}
-          consented={consented}
-          onConsentedChange={setConsented}
-          acceptorName={acceptorName}
-          onAcceptorNameChange={setAcceptorName}
-          onAccept={handleAccept}
-          exchange={exchange}
-        />
-      </Paper>
-    </Container>
+    <Paper>
+      {/* A generic page h1 rather than the party-specific "Invitation from X"
+          (which is the terms section's h2 below): it must read sensibly in the
+          pending and error states too, where no party name is decoded yet. */}
+      <Title order={1}>Accept an invitation</Title>
+      <AcceptInvitationPanel
+        decode={decode}
+        headingRef={readyHeadingRef}
+        errorRef={errorRef}
+        consented={consented}
+        onConsentedChange={setConsented}
+        acceptorName={acceptorName}
+        onAcceptorNameChange={setAcceptorName}
+        onAccept={handleAccept}
+        exchange={exchange}
+      />
+    </Paper>
   );
 }

--- a/apps/web/src/components/HomePage.tsx
+++ b/apps/web/src/components/HomePage.tsx
@@ -1,4 +1,4 @@
-import { Container, Group, Title } from "@mantine/core";
+import { Group, Title } from "@mantine/core";
 
 import AcceptForm from "@components/AcceptForm";
 import { InvitePanel } from "@components/InvitePanel";
@@ -9,18 +9,18 @@ import { InvitePanel } from "@components/InvitePanel";
  * the two side-by-side panels. Kept as a component (rather than inline in the
  * route file) so it can be mounted in a render test, mirroring
  * {@link AcceptInvitation}.
+ *
+ * The content width (wide) is declared by the route and supplied by the shell's
+ * container, so this page renders only its content -- no `Container` of its own.
  */
 export function HomePage() {
   return (
-    // Wide ("xl"): this route lays out two panels side by side and shows the
-    // long invitation code/link, so it wants more room than the single-column
-    // reading width the accept route uses.
-    <Container size="xl">
+    <>
       <Title order={1}>Start a private data exchange</Title>
       <Group justify="space-between" align="flex-start" grow mt="md">
         <InvitePanel />
         <AcceptForm />
       </Group>
-    </Container>
+    </>
   );
 }

--- a/apps/web/src/components/Shell.tsx
+++ b/apps/web/src/components/Shell.tsx
@@ -1,8 +1,11 @@
 import { Container } from "@mantine/core";
 import { Link } from "@tanstack/react-router";
 
+import { DEFAULT_CONTENT_WIDTH } from "@components/contentWidth";
+
 import classes from "./Shell.module.css";
 
+import type { ContainerWidth } from "@theme";
 import type { ReactNode } from "react";
 
 /** The id shared by the skip link's target and the `<main>` landmark, declared
@@ -16,11 +19,23 @@ const MAIN_CONTENT_ID = "main-content";
  * the router `Outlet`, so each route supplies only its own page content and its
  * own single `<h1>`.
  *
+ * `contentWidth` is the seam that keeps chrome and content aligned: the header
+ * and the content container both size to this one value (see
+ * {@link resolveContentWidth}), so their left/right edges line up whether a route
+ * runs wide or narrows to a single legible column. The route supplies plain
+ * content; it does not pick its own `Container` width.
+ *
  * Built as a plain layout rather than Mantine's AppShell, whose responsive
  * navbar/aside machinery is unneeded for a single header link; revisit that
  * choice if the planned IA restructure adds real navigation or nested layouts.
  */
-export function Shell({ children }: { children: ReactNode }) {
+export function Shell({
+  children,
+  contentWidth = DEFAULT_CONTENT_WIDTH,
+}: {
+  children: ReactNode;
+  contentWidth?: ContainerWidth;
+}) {
   return (
     // position: relative (in the stylesheet) anchors the absolutely positioned
     // skip link's containing block here rather than to an arbitrary ancestor.
@@ -46,15 +61,18 @@ export function Shell({ children }: { children: ReactNode }) {
         Skip to content
       </a>
       <header className={classes.header}>
-        <Container size="xl">
+        <Container size={contentWidth}>
           <Link to="/" className={classes.brand}>
             PSI-Link
           </Link>
         </Container>
       </header>
-      {/* tabIndex -1 so the skip link can move focus into the landmark itself. */}
+      {/* tabIndex -1 so the skip link can move focus into the landmark itself.
+          The single <main> landmark stays full-width (the focus outline and
+          padding live on it); the content container inside it, sized to the same
+          contentWidth as the header above, is what aligns the two edges. */}
       <main id={MAIN_CONTENT_ID} tabIndex={-1} className={classes.main}>
-        {children}
+        <Container size={contentWidth}>{children}</Container>
       </main>
     </div>
   );

--- a/apps/web/src/components/contentWidth.ts
+++ b/apps/web/src/components/contentWidth.ts
@@ -1,0 +1,43 @@
+import type { ContainerWidth } from "@theme";
+
+/**
+ * The content-width seam between a route and the application shell.
+ *
+ * A route declares the width its content column wants once, in its
+ * `staticData.contentWidth`; the shell reads that one value (via
+ * {@link resolveContentWidth}) and sizes both its chrome -- the header, and any
+ * navigation/breadcrumbs the IA restructure adds -- and the route's content to
+ * it, so their left/right edges align regardless of which width the route picks.
+ * This replaces each route choosing a `Container size` independently of the
+ * shell's, which left the chrome and a narrower route's content misaligned.
+ */
+declare module "@tanstack/react-router" {
+  interface StaticDataRouteOption {
+    /** The named content width this route renders at; the shell sizes its
+     * chrome to match. Omit to inherit {@link DEFAULT_CONTENT_WIDTH}. */
+    contentWidth?: ContainerWidth;
+  }
+}
+
+/**
+ * The width the shell uses for a route that declares none -- the wide default
+ * the home route sits at and the bare wordmark falls back to.
+ */
+export const DEFAULT_CONTENT_WIDTH: ContainerWidth = "xl";
+
+/**
+ * Resolve the content width for the active route from its match chain: the
+ * deepest match that declares a `contentWidth` wins, so a leaf route narrows the
+ * chrome to its column, falling back to {@link DEFAULT_CONTENT_WIDTH} when no
+ * match declares one. Pure over the matches so the shell and its test both drive
+ * it the same way.
+ */
+export function resolveContentWidth(
+  matches: ReadonlyArray<{ staticData?: { contentWidth?: ContainerWidth } }>,
+): ContainerWidth {
+  for (let i = matches.length - 1; i >= 0; i -= 1) {
+    const width = matches[i]?.staticData?.contentWidth;
+    if (width !== undefined) return width;
+  }
+  return DEFAULT_CONTENT_WIDTH;
+}

--- a/apps/web/src/components/contentWidth.ts
+++ b/apps/web/src/components/contentWidth.ts
@@ -11,7 +11,12 @@ import type { ContainerWidth } from "@theme";
  * This replaces each route choosing a `Container size` independently of the
  * shell's, which left the chrome and a narrower route's content misaligned.
  */
-declare module "@tanstack/react-router" {
+// Augment the module that DECLARES StaticDataRouteOption (router-core), not the
+// one that merely re-exports it (react-router). Augmenting the re-export happens
+// to merge today, but the base interface is empty, so if a future version
+// stopped re-exporting it the augmentation would silently become a no-op a green
+// typecheck would not catch; merging into the declaring module is robust to that.
+declare module "@tanstack/router-core" {
   interface StaticDataRouteOption {
     /** The named content width this route renders at; the shell sizes its
      * chrome to match. Omit to inherit {@link DEFAULT_CONTENT_WIDTH}. */

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import {
   Outlet,
   Scripts,
   createRootRoute,
+  useMatches,
 } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 
@@ -19,6 +20,7 @@ import { DefaultCatchBoundary } from "@components/DefaultCatchBoundary";
 import { NotFound } from "@components/NotFound";
 import { Shell } from "@components/Shell";
 import { mantineTheme } from "@theme";
+import { resolveContentWidth } from "@components/contentWidth";
 import { seo } from "@utils/seo";
 
 import type { ReactNode } from "react";
@@ -67,9 +69,14 @@ export const Route = createRootRoute({
 });
 
 function RootComponent() {
+  // Read the active route's declared content width here, above the shell, so the
+  // header chrome and the route's content are sized from one value (the route
+  // cannot pass it up from inside the Outlet). select returns a primitive, so the
+  // root re-renders only when the resolved width actually changes.
+  const contentWidth = useMatches({ select: resolveContentWidth });
   return (
     <RootDocument>
-      <Shell>
+      <Shell contentWidth={contentWidth}>
         <Outlet />
       </Shell>
     </RootDocument>

--- a/apps/web/src/routes/accept.tsx
+++ b/apps/web/src/routes/accept.tsx
@@ -7,4 +7,8 @@ export const Route = createFileRoute("/accept")({
   // so decoding and rendering must happen client-side only.
   ssr: false,
   component: AcceptInvitation,
+  // Narrower single-column reading width: the dense linkage terms sit at a
+  // legible measure rather than running the full two-column width. The shell
+  // brings its chrome edges in to match.
+  staticData: { contentWidth: "lg" },
 });

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -4,4 +4,8 @@ import { HomePage } from "@components/HomePage";
 
 export const Route = createFileRoute("/")({
   component: HomePage,
+  // Wide: the home page lays out two panels side by side and shows the long
+  // invitation code/link, so it wants more room than a single-column reading
+  // width. The shell sizes its chrome to match.
+  staticData: { contentWidth: "xl" },
 });

--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -8,7 +8,7 @@ import {
 } from "@mantine/core";
 import type { MantineThemeOverride } from "@mantine/core";
 
-const CONTAINER_SIZES: Record<string, string> = {
+const CONTAINER_SIZES = {
   xxs: rem("200px"),
   xs: rem("300px"),
   sm: rem("400px"),
@@ -17,6 +17,14 @@ const CONTAINER_SIZES: Record<string, string> = {
   xl: rem("1400px"),
   xxl: rem("1600px"),
 };
+
+/**
+ * A named content width in the {@link CONTAINER_SIZES} scale. The single
+ * vocabulary the content-width seam speaks: a route declares one of these and
+ * the shell sizes both its chrome and the route's content to it, so neither side
+ * names a raw pixel width.
+ */
+export type ContainerWidth = keyof typeof CONTAINER_SIZES;
 
 export const mantineTheme: MantineThemeOverride = createTheme({
   /** Put your mantine theme override here */
@@ -51,7 +59,7 @@ export const mantineTheme: MantineThemeOverride = createTheme({
           "--container-size": fluid
             ? "100%"
             : size !== undefined && size in CONTAINER_SIZES
-              ? CONTAINER_SIZES[size]
+              ? CONTAINER_SIZES[size as ContainerWidth]
               : rem(size),
         },
       }),

--- a/apps/web/test/browser/appShell.test.ts
+++ b/apps/web/test/browser/appShell.test.ts
@@ -7,7 +7,7 @@ import { page } from "vitest/browser";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MantineProvider } from "@mantine/core";
+import { Container, MantineProvider } from "@mantine/core";
 
 import {
   encodeInvitation,
@@ -18,6 +18,7 @@ import {
 import { AcceptInvitation } from "@components/AcceptInvitation";
 import { HomePage } from "@components/HomePage";
 import { Shell } from "@components/Shell";
+import { mantineTheme } from "@theme";
 
 import type { ReactNode } from "react";
 import type { Root } from "react-dom/client";
@@ -176,4 +177,85 @@ describe("application shell", () => {
     // since main is otherwise outside the tab order.
     expect(main && getComputedStyle(main).outlineWidth).not.toBe("0px");
   });
+});
+
+// Mount under the real app theme so the Container size scale (CONTAINER_SIZES)
+// resolves to its production widths, the way the running app does.
+function mountThemed(node: ReactNode) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  root.render(createElement(MantineProvider, { theme: mantineTheme }, node));
+}
+
+// The resolved width of a rendered Container: the --container-size custom
+// property Mantine's theme derives from the named size. The authored inline
+// value is read (not getComputedStyle), since this suite does not load Mantine's
+// global stylesheet that defines the --mantine-scale the value multiplies by --
+// without it the computed value is invalid/empty, but the inline value still
+// distinguishes the named widths. Tracks the named scale, not a pixel snapshot.
+function containerWidth(el: Element | null | undefined): string {
+  const width =
+    el instanceof HTMLElement
+      ? el.style.getPropertyValue("--container-size").trim()
+      : "";
+  expect(width).not.toBe("");
+  return width;
+}
+
+describe("content width seam", () => {
+  // The header chrome and the route's content both size to the one width the
+  // route declares, so their left/right edges align; a route choosing a
+  // different width moves both together. The route-declaration -> resolved-width
+  // half is covered in test/unit/contentWidth.test.ts.
+  test.each(["lg", "xl"] as const)(
+    "sizes chrome and content to the declared %s width",
+    async (width) => {
+      const other = width === "lg" ? "xl" : "lg";
+      mountThemed(
+        createElement(
+          "div",
+          null,
+          createElement(Shell, {
+            contentWidth: width,
+            children: "page content",
+          }),
+          // Reference containers at each named size, so the assertion ties the
+          // seam to the theme's named scale without hard-coding pixel widths.
+          createElement(
+            "div",
+            { "data-testid": "ref-same" },
+            createElement(Container, { size: width }),
+          ),
+          createElement(
+            "div",
+            { "data-testid": "ref-other" },
+            createElement(Container, { size: other }),
+          ),
+        ),
+      );
+
+      // Wait for React to commit the mount before reading the rendered DOM.
+      await expect.element(page.getByText("page content")).toBeInTheDocument();
+
+      const header = containerWidth(
+        document.querySelector("header")?.firstElementChild,
+      );
+      const main = containerWidth(
+        document.querySelector("main")?.firstElementChild,
+      );
+      const sameSize = containerWidth(
+        document.querySelector('[data-testid="ref-same"]')?.firstElementChild,
+      );
+      const otherSize = containerWidth(
+        document.querySelector('[data-testid="ref-other"]')?.firstElementChild,
+      );
+
+      // Chrome and content resolve to one shared width: their edges align.
+      expect(header).toBe(main);
+      // ...and it is exactly the route's declared named size, not the other one.
+      expect(main).toBe(sameSize);
+      expect(sameSize).not.toBe(otherSize);
+    },
+  );
 });

--- a/apps/web/test/browser/appShell.test.ts
+++ b/apps/web/test/browser/appShell.test.ts
@@ -194,12 +194,14 @@ function mountThemed(node: ReactNode) {
 // global stylesheet that defines the --mantine-scale the value multiplies by --
 // without it the computed value is invalid/empty, but the inline value still
 // distinguishes the named widths. Tracks the named scale, not a pixel snapshot.
-function containerWidth(el: Element | null | undefined): string {
+function containerWidth(label: string, el: Element | null | undefined): string {
   const width =
     el instanceof HTMLElement
       ? el.style.getPropertyValue("--container-size").trim()
       : "";
-  expect(width).not.toBe("");
+  // Name the element in the assertion: four call sites read different elements,
+  // so a missing one must say which rather than surface an opaque empty string.
+  expect(width, `${label} container --container-size`).not.toBe("");
   return width;
 }
 
@@ -239,15 +241,19 @@ describe("content width seam", () => {
       await expect.element(page.getByText("page content")).toBeInTheDocument();
 
       const header = containerWidth(
+        "header",
         document.querySelector("header")?.firstElementChild,
       );
       const main = containerWidth(
+        "main",
         document.querySelector("main")?.firstElementChild,
       );
       const sameSize = containerWidth(
+        "ref-same",
         document.querySelector('[data-testid="ref-same"]')?.firstElementChild,
       );
       const otherSize = containerWidth(
+        "ref-other",
         document.querySelector('[data-testid="ref-other"]')?.firstElementChild,
       );
 

--- a/apps/web/test/integration/contentWidthSsr.test.ts
+++ b/apps/web/test/integration/contentWidthSsr.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+
+// The content-width seam exercised end to end through the real router, at the
+// SSR boundary: a route declares its width in staticData, the root route
+// resolves it (useMatches -> resolveContentWidth), and the shell sizes both its
+// header chrome and the content container to that one value. The unit test
+// covers the resolver and the browser test covers the shell with a mocked
+// router; only this test drives the real router -> RootComponent -> staticData
+// -> shell path. It needs no browser: the shell is server-rendered, so the
+// declared width is already in the HTML. The accept route is ssr:false for its
+// component, but the shell still server-renders, so its width appears too.
+//
+// The port matches the dev-server globalSetup, which derives it the same way.
+const port = parseInt(process.env.PORT ?? "3000", 10);
+const base = `http://127.0.0.1:${port}`;
+
+// Each Mantine Container the shell renders carries an inline --container-size;
+// pull every value out of the server-rendered HTML.
+function containerWidths(html: string): Array<string> {
+  return [...html.matchAll(/--container-size:\s*([^;"}]+)/g)].map((match) =>
+    match[1].trim(),
+  );
+}
+
+// The rem magnitude inside a value (e.g. "calc(87.5rem * ...)" -> 87.5), so two
+// named widths compare without pinning the exact pixel scale.
+function remMagnitude(value: string): number {
+  const match = value.match(/([\d.]+)rem/);
+  if (match === null) throw new Error(`no rem magnitude in "${value}"`);
+  return Number(match[1]);
+}
+
+async function shellContainerWidths(path: string): Promise<Array<string>> {
+  const response = await fetch(`${base}${path}`);
+  expect(response.status).toBe(200);
+  return containerWidths(await response.text());
+}
+
+describe("content width seam (SSR, real router)", () => {
+  test("chrome and content render at the route's one declared width", async () => {
+    const home = await shellContainerWidths("/");
+    const accept = await shellContainerWidths("/accept");
+
+    // The header chrome and the content container, both server-rendered.
+    expect(home.length).toBeGreaterThanOrEqual(2);
+    expect(accept.length).toBeGreaterThanOrEqual(2);
+
+    // Within a route every container resolves to one shared width, so the chrome
+    // and content edges align.
+    expect(new Set(home).size).toBe(1);
+    expect(new Set(accept).size).toBe(1);
+
+    // The seam is per-route, not a fixed width: home stays wide while accept
+    // narrows to its single-column reading width.
+    expect(remMagnitude(home[0])).toBeGreaterThan(remMagnitude(accept[0]));
+  });
+});

--- a/apps/web/test/unit/contentWidth.test.ts
+++ b/apps/web/test/unit/contentWidth.test.ts
@@ -20,9 +20,20 @@ describe("resolveContentWidth", () => {
     ).toBe("lg");
   });
 
-  test("uses the deepest match that declares a width", () => {
-    // A leaf that declares none inherits the nearest ancestor that does, so a
-    // shared layout route can set a default its leaves narrow from.
+  test("uses the deepest match when several declare a width", () => {
+    // The leaf wins over an ancestor that also declares one, so a leaf route can
+    // narrow from a width a shared layout route sets.
+    expect(
+      resolveContentWidth([
+        { staticData: { contentWidth: "xl" } },
+        { staticData: { contentWidth: "lg" } },
+      ]),
+    ).toBe("lg");
+  });
+
+  test("falls back to an ancestor's width when the leaf declares none", () => {
+    // A leaf that declares nothing inherits the nearest ancestor that does, so a
+    // shared layout route can set a default its leaves keep.
     expect(
       resolveContentWidth([
         { staticData: { contentWidth: "lg" } },

--- a/apps/web/test/unit/contentWidth.test.ts
+++ b/apps/web/test/unit/contentWidth.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  DEFAULT_CONTENT_WIDTH,
+  resolveContentWidth,
+} from "@components/contentWidth";
+
+// The route-side half of the content-width seam: a route declares its width in
+// staticData, and resolveContentWidth projects the active match chain to the one
+// value the shell sizes both chrome and content to. The render side -- that the
+// value reaches both the header and the content container -- is covered in
+// test/browser/appShell.test.ts.
+describe("resolveContentWidth", () => {
+  test("returns the leaf route's declared width", () => {
+    expect(
+      resolveContentWidth([
+        { staticData: {} },
+        { staticData: { contentWidth: "lg" } },
+      ]),
+    ).toBe("lg");
+  });
+
+  test("uses the deepest match that declares a width", () => {
+    // A leaf that declares none inherits the nearest ancestor that does, so a
+    // shared layout route can set a default its leaves narrow from.
+    expect(
+      resolveContentWidth([
+        { staticData: { contentWidth: "lg" } },
+        { staticData: {} },
+      ]),
+    ).toBe("lg");
+  });
+
+  test("falls back to the default when no match declares a width", () => {
+    expect(resolveContentWidth([{ staticData: {} }, {}])).toBe(
+      DEFAULT_CONTENT_WIDTH,
+    );
+    expect(resolveContentWidth([])).toBe(DEFAULT_CONTENT_WIDTH);
+  });
+
+  test("defaults to the wide width", () => {
+    // The home route's width and the bare-wordmark fallback; the accept route
+    // opts into a narrower one.
+    expect(DEFAULT_CONTENT_WIDTH).toBe("xl");
+  });
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -30,6 +30,7 @@ const srcAliases = {
   "@util": path.resolve(__dirname, "src/util"),
   "@peerjs-server": path.resolve(__dirname, "src/contrib/peerjs-server"),
   "@psi": path.resolve(__dirname, "src/psi"),
+  "@theme": path.resolve(__dirname, "src/theme"),
   "@": path.resolve(__dirname, "src"),
 };
 


### PR DESCRIPTION
## Summary

Give the web app one source of truth for content width so site chrome (the header, and the navigation/breadcrumbs the IA restructure will add) aligns with each route's content column. Before this change the shell mounted its header at a fixed `Container size="xl"` while each route independently picked its own width, so on the narrower accept route the chrome's left/right edges did not line up with the content column. This is foundation work the "Web Exchange Rework" IA restructure needs before it adds navigation that must align to the content edge.

Implements [202267416](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202267416).

## Changes

- apps/web/src/components/contentWidth.ts: new seam -- a `contentWidth` field on TanStack `staticData` (augmented on the declaring module `@tanstack/router-core`) plus a pure `resolveContentWidth` that returns the deepest match's declared width, defaulting to `xl`.
- apps/web/src/components/Shell.tsx: takes a `contentWidth` prop and sizes both the header chrome and a single `Container` wrapping `<main>`'s children to it. The single `<main>` landmark, the skip-link focus target, and the hash-preserving skip behavior are unchanged (the container sits inside `<main>`).
- apps/web/src/routes/__root.tsx: resolves the active route's width with `useMatches({ select: resolveContentWidth })` and passes it to the shell.
- apps/web/src/routes/index.tsx, apps/web/src/routes/accept.tsx: declare `staticData.contentWidth` (`xl` / `lg`); apps/web/src/components/HomePage.tsx and AcceptInvitation.tsx drop their own `Container`.
- apps/web/src/theme.ts: derive a `ContainerWidth` type from the named `CONTAINER_SIZES` scale, so call sites name sizes rather than reintroducing raw pixel widths.
- apps/web/vite.config.ts: add a `@theme` alias so the vitest projects resolve it (no effect on shipped output -- the app already resolved `@theme` via tsconfigPaths).

## Test plan

Ran: `npx vitest run --project unit contentWidth`, `npx vitest run --project browser appShell`, and `npx vitest run --project integration` in apps/web; plus `npm run typecheck && npm run lint && npm run formatcheck` and `npm run build -w apps/web`. All green.
New tests cover: the resolver's width propagation (leaf declares, deepest-of-several wins, ancestor fallback, default); the shell rendering both the header chrome and the content at one named width, with a narrower route bringing both edges in (browser); and the real router -> root -> `staticData` -> shell path end to end at the SSR boundary (home wide, accept narrow).

## Background

Forward-looking foundation for the "Web Exchange Rework" epic's IA restructure, deliberately out of scope for the app-shell branch (202240906), which standardized widths via the theme size scale. The seam references the theme's named `CONTAINER_SIZES` rather than raw pixels and preserves the accept route's narrower single-column terms width; it establishes the width the IA-restructure items will align to without duplicating their flow/screen work.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; the web-app frontend layout is not covered in either doc tier, and this change preserves every route's effective content width.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: pre-release web-app layout refactor with no operator-, deployer-, or reviewer-visible change (no command, flag, config, default, behavior, exit code, or wire/on-disk format change).
- [x] Security review -- n/a: no security-review-scope item touched (no crypto/AEAD/channel/credential/auth/disclosure/dependency change); confirmed by two independent security reviews of the diff, both clear.
