### PR TITLE
Quiet CLI integration-test console output (intended WARN/ERROR)

### DIFF
--- a/apps/cli/test/integration/abortMarkerExchange.test.ts
+++ b/apps/cli/test/integration/abortMarkerExchange.test.ts
@@ -73,6 +73,7 @@ import {
   ConnectionError,
 } from "@psilink/core";
 import type { ExchangeDataSpec, LinkageTerms } from "@psilink/core";
+import { withCapturedLogs } from "@psilink/core/testing";
 
 import { runProtocol, type ProtocolConnectionConfig } from "../../src/protocol";
 import { saveKeyFile } from "../../src/keyFile";
@@ -130,6 +131,10 @@ interface AbortScenarioOutcome {
   reasons: unknown[];
   /** Count of `<id>-abort.json` files left in the shared directory. */
   markerCount: number;
+  /** WARN/ERROR lines the run emits -- captured so the faulting party's
+   *  intended recovery advisory is asserted rather than leaked to the suite
+   *  console (see expectFastPeerAbort). */
+  capturedLogs: string[];
 }
 
 // Drives two real runProtocol parties against a shared directory, lets the
@@ -147,24 +152,34 @@ async function runAbortScenario(
   saveKeyFile(keyA, { sharedSecret: INITIAL_SECRET });
   saveKeyFile(keyB, { sharedSecret: INITIAL_SECRET });
 
-  const [resA, resB] = await Promise.allSettled([
-    runProtocol(
-      makeConfig(),
-      { sharedSecret: INITIAL_SECRET, keyFilePath: keyA },
-      preparedFor("Party A"),
-      path.join(work, "a-out.csv"),
-      -1,
-      "abort-a",
-    ),
-    runProtocol(
-      makeConfig(),
-      { sharedSecret: INITIAL_SECRET, keyFilePath: keyB },
-      preparedFor("Party B"),
-      path.join(work, "b-out.csv"),
-      -1,
-      "abort-b",
-    ),
-  ]);
+  // The faulting party's catch emits an ERROR recovery advisory (its token
+  // rotated before the fault). Run the parties under withCapturedLogs so that
+  // intended line is captured for assertion below rather than printed to the
+  // suite console; both per-party loggers are created (by name) inside this
+  // wrapped call, so they bind to the capture's interceptor.
+  const [settled, capturedLogs] = await withCapturedLogs(
+    () =>
+      Promise.allSettled([
+        runProtocol(
+          makeConfig(),
+          { sharedSecret: INITIAL_SECRET, keyFilePath: keyA },
+          preparedFor("Party A"),
+          path.join(work, "a-out.csv"),
+          -1,
+          "abort-a",
+        ),
+        runProtocol(
+          makeConfig(),
+          { sharedSecret: INITIAL_SECRET, keyFilePath: keyB },
+          preparedFor("Party B"),
+          path.join(work, "b-out.csv"),
+          -1,
+          "abort-b",
+        ),
+      ]),
+    (level) => level === "WARN" || level === "ERROR",
+  );
+  const [resA, resB] = settled;
 
   expect(resA.status).toBe("rejected");
   expect(resB.status).toBe("rejected");
@@ -174,7 +189,11 @@ async function runAbortScenario(
     n.endsWith("-abort.json"),
   ).length;
 
-  return { reasons, markerCount };
+  return {
+    reasons,
+    markerCount,
+    capturedLogs: capturedLogs.map((l) => l.message),
+  };
 }
 
 // The shared assertions. Each side is identified positively by error TYPE: the
@@ -202,6 +221,16 @@ function expectFastPeerAbort(outcome: AbortScenarioOutcome): void {
   // The real marker write landed exactly once (the path the Buffer-wrap fix
   // repaired) and was not echoed by the waiting peer.
   expect(outcome.markerCount).toBe(1);
+
+  // Exactly one intended WARN/ERROR fired: the faulting party's recovery
+  // advisory (its token rotated before the synthetic fault, so it tells the
+  // operator to retry without re-inviting). The waiting peer's PeerAbortError is
+  // hint-tagged and emits none. Asserting the captured set proves intent and
+  // guards against a different, genuine error slipping through unsuppressed.
+  expect(outcome.capturedLogs).toHaveLength(1);
+  expect(outcome.capturedLogs[0]).toContain(
+    "The shared secret was already rotated and saved before this error.",
+  );
 }
 
 let work: string;

--- a/apps/cli/test/integration/abortMarkerOutputFailure.test.ts
+++ b/apps/cli/test/integration/abortMarkerOutputFailure.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, expect, test } from "vitest";
 
 import { prepareForExchange } from "@psilink/core";
 import type { ExchangeDataSpec, LinkageTerms } from "@psilink/core";
+import { withCapturedLogs } from "@psilink/core/testing";
 
 import { runProtocol, type ProtocolConnectionConfig } from "../../src/protocol";
 import { saveKeyFile } from "../../src/keyFile";
@@ -84,25 +85,35 @@ test("a result-write failure after a completed exchange writes no abort marker",
   });
 
   // Party A's output path has a missing parent directory, so its writeOutput
-  // throws ENOENT after the exchange completes; Party B's path is valid.
-  const [resA, resB] = await Promise.allSettled([
-    runProtocol(
-      makeConfig(),
-      { sharedSecret: INITIAL_SECRET, keyFilePath: keyA },
-      preparedFor("Party A"),
-      path.join(work, "missing-parent", "a-out.csv"),
-      -1,
-      "noabort-a",
-    ),
-    runProtocol(
-      makeConfig(),
-      { sharedSecret: INITIAL_SECRET, keyFilePath: keyB },
-      preparedFor("Party B"),
-      path.join(work, "b-out.csv"),
-      -1,
-      "noabort-b",
-    ),
-  ]);
+  // throws ENOENT after the exchange completes; Party B's path is valid. Party
+  // A's token rotated before that local failure, so runProtocol emits a recovery
+  // advisory at ERROR; run both parties under withCapturedLogs so that intended
+  // line is captured for assertion below rather than leaked to the suite
+  // console (the per-party loggers are created by name inside this wrapped call,
+  // so they bind to the capture's interceptor).
+  const [settled, capturedLogs] = await withCapturedLogs(
+    () =>
+      Promise.allSettled([
+        runProtocol(
+          makeConfig(),
+          { sharedSecret: INITIAL_SECRET, keyFilePath: keyA },
+          preparedFor("Party A"),
+          path.join(work, "missing-parent", "a-out.csv"),
+          -1,
+          "noabort-a",
+        ),
+        runProtocol(
+          makeConfig(),
+          { sharedSecret: INITIAL_SECRET, keyFilePath: keyB },
+          preparedFor("Party B"),
+          path.join(work, "b-out.csv"),
+          -1,
+          "noabort-b",
+        ),
+      ]),
+    (level) => level === "WARN" || level === "ERROR",
+  );
+  const [resA, resB] = settled;
 
   // A failed on its local output write -- specifically the ENOENT from the
   // missing parent directory, not some masked earlier fault -- while B completed
@@ -123,4 +134,13 @@ test("a result-write failure after a completed exchange writes no abort marker",
 
   // B's result was actually written -- it was not poisoned by A's failure.
   expect(fs.existsSync(path.join(work, "b-out.csv"))).toBe(true);
+
+  // Exactly one intended WARN/ERROR fired: A's "rotated before this error"
+  // recovery advisory (its token was saved before the post-exchange output
+  // write failed). B completed cleanly and emits none. Asserting the captured
+  // set proves intent and guards against a different error slipping through.
+  expect(capturedLogs).toHaveLength(1);
+  expect(capturedLogs[0].message).toContain(
+    "The shared secret was already rotated and saved before this error.",
+  );
 }, 30_000);

--- a/apps/cli/test/integration/onlineInviteAccept.test.ts
+++ b/apps/cli/test/integration/onlineInviteAccept.test.ts
@@ -25,6 +25,7 @@ import type {
   FileDropConnectionConfig,
   SFTPConnectionConfig,
 } from "@psilink/core";
+import { withCapturedLogs } from "@psilink/core/testing";
 
 import {
   resolveInvitePositionals,
@@ -652,41 +653,52 @@ test("filedrop: a shared-secret mismatch aborts the handshake, persisting no con
   // handshake must still produce neither. Both artifacts are written only after the
   // exchange completes (writeOutput / writeExchangeRecord), which an aborted
   // handshake never reaches, so this pins that nothing partial leaks on failure.
-  const [inviteOutcome, acceptOutcome] = await Promise.allSettled([
-    runOnlineBootstrap({
-      connection: inviteReady.connection,
-      dataSpec: inviteReady.dataSpec,
-      prepared: inviteReady.prepared,
-      sharedSecret: inviteReady.sharedSecret,
-      expires: inviteReady.expires,
-      keyPath: inviteOptions.keyFile,
-      configPath: inviteOptions.configFile,
-      output: inviteReady.output,
-      verbosity: 0,
-      loggerName: "invite",
-      recordOutput: resolveRecordOutput({
-        enabled: inviteOptions.record,
-        recordFile: inviteOptions.recordFile,
-      }),
-    }),
-    runOnlineBootstrap({
-      connection: acceptReady.connection,
-      dataSpec: acceptReady.dataSpec,
-      prepared: acceptReady.prepared,
-      sharedSecret: wrongSecret,
-      expires: acceptReady.token.expires,
-      keyPath: acceptOptions.keyFile,
-      configPath: acceptOptions.configFile,
-      output: acceptReady.output,
-      verbosity: 0,
-      loggerName: "accept",
-      recordOutput: resolveRecordOutput({
-        enabled: acceptOptions.record,
-        recordFile: acceptOptions.recordFile,
-      }),
-      reuseExistingConfig: acceptReady.reuseExistingConfig,
-    }),
-  ]);
+  // Both sides abort mid-handshake with their token un-rotated, so each emits a
+  // "key exchange was in progress" recovery advisory at ERROR. Run them under
+  // withCapturedLogs so those intended lines are captured for assertion below
+  // rather than leaked to the suite console. The logger names are unique to this
+  // test (the happy-path test above already created "invite"/"accept", and a
+  // logger created before the capture's interceptor is installed would bypass
+  // it -- a fresh name guarantees both loggers bind to the interceptor here).
+  const [[inviteOutcome, acceptOutcome], capturedLogs] = await withCapturedLogs(
+    () =>
+      Promise.allSettled([
+        runOnlineBootstrap({
+          connection: inviteReady.connection,
+          dataSpec: inviteReady.dataSpec,
+          prepared: inviteReady.prepared,
+          sharedSecret: inviteReady.sharedSecret,
+          expires: inviteReady.expires,
+          keyPath: inviteOptions.keyFile,
+          configPath: inviteOptions.configFile,
+          output: inviteReady.output,
+          verbosity: 0,
+          loggerName: "mismatch-invite",
+          recordOutput: resolveRecordOutput({
+            enabled: inviteOptions.record,
+            recordFile: inviteOptions.recordFile,
+          }),
+        }),
+        runOnlineBootstrap({
+          connection: acceptReady.connection,
+          dataSpec: acceptReady.dataSpec,
+          prepared: acceptReady.prepared,
+          sharedSecret: wrongSecret,
+          expires: acceptReady.token.expires,
+          keyPath: acceptOptions.keyFile,
+          configPath: acceptOptions.configFile,
+          output: acceptReady.output,
+          verbosity: 0,
+          loggerName: "mismatch-accept",
+          recordOutput: resolveRecordOutput({
+            enabled: acceptOptions.record,
+            recordFile: acceptOptions.recordFile,
+          }),
+          reuseExistingConfig: acceptReady.reuseExistingConfig,
+        }),
+      ]),
+    (level) => level === "WARN" || level === "ERROR",
+  );
 
   // The handshake aborts on both sides: neither saves the rotated key, so neither
   // fires the config-writing hook. No key, no config, on either side. Pin each
@@ -712,6 +724,18 @@ test("filedrop: a shared-secret mismatch aborts the handshake, persisting no con
   // CommonBootstrapOptions, so it is checked here rather than in the helper).
   expect(fs.existsSync(inviteOut)).toBe(false);
   expect(fs.existsSync(acceptOut)).toBe(false);
+
+  // Both sides' aborted handshakes emit the "key exchange was in progress"
+  // recovery advisory at ERROR -- the only intended WARN/ERROR of this run.
+  // Asserting the captured set proves intent (each is the known advisory) and
+  // guards against a genuine, unexpected error being suppressed unseen.
+  const advisories = capturedLogs.map((l) => l.message);
+  expect(advisories).toHaveLength(2);
+  for (const message of advisories) {
+    expect(message).toContain(
+      "The key exchange was in progress when this error occurred.",
+    );
+  }
 }, 60_000);
 
 // --- Happy path: sftp ---------------------------------------------------------


### PR DESCRIPTION
## Summary

The CLI integration suite drives its abort/rotation and shared-secret-mismatch paths and emits intended recovery advisories at ERROR with nothing marking them expected, so a reader cannot tell an expected advisory from a real failure -- vitest swallows passing-test console output and loglevel's per-worker level made the leak order-dependent. This makes the suite emit no intended WARN/ERROR: each advisory is captured and asserted by the test that produces it, proving intent rather than blindly silencing, with no global log-silence.

Implements [201551543](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=201551543).

## Changes

- apps/cli/test/integration/abortMarkerExchange.test.ts: run the two parties under `withCapturedLogs` and assert the single rotation-recovery advisory the faulting party emits.
- apps/cli/test/integration/abortMarkerOutputFailure.test.ts: same capture-and-assert for the post-exchange output-failure advisory.
- apps/cli/test/integration/onlineInviteAccept.test.ts: capture and assert the two "key exchange was in progress" advisories in the shared-secret-mismatch test, and rename its loggers so they are created inside the capture and bind to the interceptor.

## Test plan

Ran: `npm run test:integration -w apps/cli` (32 passed, 3 skipped); the three modified files repeatedly to confirm the exact-count assertions are stable; `npm run typecheck`, `npm run lint`, `npm run format`.
New tests cover: that each abort/rotation and mismatch path emits exactly its intended advisory and nothing else at WARN/ERROR. The live leak set was re-measured with a throwaway console recorder before and after; the suite now emits zero intended WARN/ERROR.

## Background

The issue's original measurement was stale: the unpinned-host-key WARNs it listed no longer fire (the fixtures now pin a host-key fingerprint and the no-pin path fails closed), and the real leaks were five ERROR advisories in different files than its affected-areas list named. The live set was re-measured, as the issue instructed.

## Out of scope / follow-on

- The ssh2-sftp-client "Global ... listener" LOG-level lines (outside this issue's WARN/ERROR scope) are routed off the console separately in [202393052](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=202393052).
- A standing console-output guard and the `withCapturedLogs` logger-ordering footgun: [202392824](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=202392824), [202392910](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=202392910).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: test-only change, no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-only change, no operator- or reviewer-visible behavior change.
- [x] Security review -- n/a: test-only change; it adds assertions to existing tests and alters no product behavior or coverage, touching no cryptographic code, channel-security control, credential/disclosure surface, or security-relevant dependency.
