### PR TITLE
Raise web dimmed and placeholder text to WCAG AA contrast

### DIFF
--- a/apps/web/src/components/FileSelect.tsx
+++ b/apps/web/src/components/FileSelect.tsx
@@ -51,8 +51,10 @@ export default function FileSelect(props: FileSelectProps) {
                     "light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6))",
                   borderColor:
                     "light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5))",
-                  color:
-                    "light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-3))",
+                  // Accessible muted text on the disabled surface (gray-0 light
+                  // / dark-6 dark): the dimmed token clears 4.5:1 there, where
+                  // the prior gray-5/dark-3 sat at ~2:1.
+                  color: "var(--mantine-color-dimmed)",
                 },
               }
             : {})}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -16,10 +16,10 @@ import {
   mantineHtmlProps,
 } from "@mantine/core";
 
+import { cssVariablesResolver, mantineTheme } from "@theme";
 import { DefaultCatchBoundary } from "@components/DefaultCatchBoundary";
 import { NotFound } from "@components/NotFound";
 import { Shell } from "@components/Shell";
-import { mantineTheme } from "@theme";
 import { resolveContentWidth } from "@components/contentWidth";
 import { seo } from "@utils/seo";
 
@@ -91,7 +91,10 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
         <ColorSchemeScript />
       </head>
       <body>
-        <MantineProvider theme={mantineTheme}>
+        <MantineProvider
+          theme={mantineTheme}
+          cssVariablesResolver={cssVariablesResolver}
+        >
           {children}
           <TanStackRouterDevtools position="bottom-right" />
           <Scripts />

--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -94,41 +94,55 @@ export const mantineTheme: MantineThemeOverride = createTheme({
 });
 
 /**
- * Accessible value for Mantine's `dimmed` secondary-text token.
+ * Accessible value for Mantine's low-emphasis text tokens -- `dimmed` secondary
+ * text and input `placeholder` text.
  *
  * Mantine's defaults fail WCAG 2.1 AA 1.4.3 (4.5:1 for normal-weight text):
- * the light `dimmed` is gray-6 (#868e96) at 3.32:1 on the white body, and the
- * dark `dimmed` is dark-2 (#828282) at 4.04:1 on the dark-7 (#242424) body.
- * Every `c="dimmed"` site -- and any code reading
- * `var(--mantine-color-dimmed)` directly, e.g. the dropzone icon in
- * FileSelect -- inherits the token, so overriding it via
- * {@link cssVariablesResolver} raises the whole app's secondary text at once
- * rather than editing each call site.
+ * - `dimmed`: gray-6 (#868e96) at 3.32:1 on the white body (light), dark-2
+ *   (#828282) at 4.04:1 on the dark-7 (#242424) body (dark).
+ * - `placeholder`: gray-5 (#adb5bd) at 2.08:1 on the white input (light),
+ *   dark-3 (#696969) at 2.47:1 on the dark-6 (#2e2e2e) input (dark) -- even
+ *   lighter than `dimmed`.
+ *
+ * Both are global tokens, so overriding them via {@link cssVariablesResolver}
+ * raises every `c="dimmed"` site (and any code reading
+ * `var(--mantine-color-dimmed)` directly, e.g. the dropzone icon in FileSelect)
+ * and every input placeholder at once, rather than editing each call site.
  *
  * The palette has no in-scale step that both clears the floor and stays clearly
  * lower-emphasis than the body text (gray-6 fails; gray-7 (#495057) overshoots
  * to 8.18:1 and reads almost as dark as the #000 body), so these are tuned
  * values. Ratios are the WCAG relative-luminance contrast, recomputed against
  * the real surfaces:
- * - light #636b73: 5.41:1 on the white body and 5.13:1 on the lightest
+ * - light #636b73: 5.41:1 on the white body/input, 5.13:1 on the lightest
  *   card/paper surface (gray-0 #f8f9fa); 3.88:1 against the #000 body text, so
- *   it stays visibly dimmed.
- * - dark #92969b: 5.22:1 on the dark-7 (#242424) body; stays dimmer than the
- *   dark-0 (#c9c9c9) body text.
+ *   it stays visibly muted.
+ * - dark #92969b: 5.22:1 on the dark-7 body, 4.56:1 on the dark-6 input (the
+ *   binding dark case); stays dimmer than the dark-0 (#c9c9c9) body text.
+ *
+ * Inputs use Mantine's default variant (light bg white, dark bg dark-6); a
+ * `filled`/`unstyled` input's darker dark-5 bg would not clear 4.5:1 with this
+ * value, but the app uses none.
  */
-const DIMMED_TEXT = {
+const MUTED_TEXT = {
   light: "#636b73",
   dark: "#92969b",
 } as const;
 
 /**
- * Raises the `dimmed` secondary-text token to {@link DIMMED_TEXT} in both color
- * schemes. Mantine deep-merges this over the default resolver, so only the
- * overridden variable need be returned. Passed to `MantineProvider` in the root
- * route.
+ * Raises the `dimmed` and input `placeholder` tokens to {@link MUTED_TEXT} in
+ * both color schemes. Mantine deep-merges this over the default resolver, so
+ * only the overridden variables need be returned. Passed to `MantineProvider`
+ * in the root route.
  */
 export const cssVariablesResolver: CSSVariablesResolver = () => ({
   variables: {},
-  light: { "--mantine-color-dimmed": DIMMED_TEXT.light },
-  dark: { "--mantine-color-dimmed": DIMMED_TEXT.dark },
+  light: {
+    "--mantine-color-dimmed": MUTED_TEXT.light,
+    "--mantine-color-placeholder": MUTED_TEXT.light,
+  },
+  dark: {
+    "--mantine-color-dimmed": MUTED_TEXT.dark,
+    "--mantine-color-placeholder": MUTED_TEXT.dark,
+  },
 });

--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -6,7 +6,8 @@ import {
   createTheme,
   rem,
 } from "@mantine/core";
-import type { MantineThemeOverride } from "@mantine/core";
+
+import type { CSSVariablesResolver, MantineThemeOverride } from "@mantine/core";
 
 const CONTAINER_SIZES = {
   xxs: rem("200px"),
@@ -90,4 +91,44 @@ export const mantineTheme: MantineThemeOverride = createTheme({
   other: {
     style: "mantine",
   },
+});
+
+/**
+ * Accessible value for Mantine's `dimmed` secondary-text token.
+ *
+ * Mantine's defaults fail WCAG 2.1 AA 1.4.3 (4.5:1 for normal-weight text):
+ * the light `dimmed` is gray-6 (#868e96) at 3.32:1 on the white body, and the
+ * dark `dimmed` is dark-2 (#828282) at 4.04:1 on the dark-7 (#242424) body.
+ * Every `c="dimmed"` site -- and any code reading
+ * `var(--mantine-color-dimmed)` directly, e.g. the dropzone icon in
+ * FileSelect -- inherits the token, so overriding it via
+ * {@link cssVariablesResolver} raises the whole app's secondary text at once
+ * rather than editing each call site.
+ *
+ * The palette has no in-scale step that both clears the floor and stays clearly
+ * lower-emphasis than the body text (gray-6 fails; gray-7 (#495057) overshoots
+ * to 8.18:1 and reads almost as dark as the #000 body), so these are tuned
+ * values. Ratios are the WCAG relative-luminance contrast, recomputed against
+ * the real surfaces:
+ * - light #636b73: 5.41:1 on the white body and 5.13:1 on the lightest
+ *   card/paper surface (gray-0 #f8f9fa); 3.88:1 against the #000 body text, so
+ *   it stays visibly dimmed.
+ * - dark #92969b: 5.22:1 on the dark-7 (#242424) body; stays dimmer than the
+ *   dark-0 (#c9c9c9) body text.
+ */
+const DIMMED_TEXT = {
+  light: "#636b73",
+  dark: "#92969b",
+} as const;
+
+/**
+ * Raises the `dimmed` secondary-text token to {@link DIMMED_TEXT} in both color
+ * schemes. Mantine deep-merges this over the default resolver, so only the
+ * overridden variable need be returned. Passed to `MantineProvider` in the root
+ * route.
+ */
+export const cssVariablesResolver: CSSVariablesResolver = () => ({
+  variables: {},
+  light: { "--mantine-color-dimmed": DIMMED_TEXT.light },
+  dark: { "--mantine-color-dimmed": DIMMED_TEXT.dark },
 });


### PR DESCRIPTION
## Summary

Raise the web app's low-emphasis text to the WCAG 2.1 AA 1.4.3 (4.5:1) contrast floor. Mantine's default `dimmed` secondary text (gray-6: 3.32:1 on the light body, 4.04:1 on the dark body) and input `placeholder` text (gray-5: ~2:1) both fell below it, a systematic Section 508 / WCAG AA gap on the documented accessibility roadmap. The fix overrides the two theme tokens once, so every `c="dimmed"` site and every input placeholder inherits an accessible color (light #636b73, dark #92969b) without per-call-site edits, and repoints the disabled dropzone helper text to the corrected token.

Implements [202267321](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202267321).

## Changes

- apps/web/src/theme.ts: add a `cssVariablesResolver` that overrides `--mantine-color-dimmed` and `--mantine-color-placeholder` to an accessible muted value in both color schemes (light #636b73, dark #92969b); the measured contrast ratios against every real surface are recorded in its JSDoc.
- apps/web/src/routes/__root.tsx: pass the resolver to `MantineProvider`.
- apps/web/src/components/FileSelect.tsx: repoint the disabled (submitted) dropzone text color from gray-5/dark-3 (~2:1 on its disabled surface) to the now-accessible `--mantine-color-dimmed` token.

## Test plan

Ran: `npm run typecheck && npm run lint && npm run format`; `npm run test:unit -w apps/web` (180 passed) and `npm run test:browser -w apps/web` (47 passed). Verified the override end to end through Mantine's own merge logic and in real Chromium (computed `--mantine-color-dimmed` / `--mantine-color-placeholder` and an input's `::placeholder` color resolve to #636b73 in the light scheme).
New tests cover: n/a -- a theme color-token change with no new behavior; the existing unit and browser suites exercise the affected components and pass. Contrast conformance is verified by computation (recorded in theme.ts), for which the test harness has no assertion form.

## Background

The contrast floor is enforced at the theme-token level rather than across the roughly 18 call sites, so future `dimmed`/`placeholder` usages inherit the accessible value and cannot silently regress. The palette has no in-scale step that both clears 4.5:1 and stays clearly lower-emphasis than the body text (gray-6 fails; gray-7 overshoots to 8.18:1 and reads almost as dark as the body), so the values are tuned and documented with their ratios. The placeholder and disabled-dropzone surfaces were folded in after independent review found they shared the same sub-floor defect.

## Out of scope / follow-on

- Interactive and status color contrast still below AA in the light scheme (filled primary buttons, the yellow warning Badge/Alert, a latent default anchor color) -- [202426038](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202426038).
- Web error and 404 pages styled with unconfigured Tailwind classes (dead styling) -- [202426101](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202426101).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed; the contrast verification is recorded in the theme.ts code comment (per the issue's acceptance criteria), and docs/COMPLIANCE.md's "not formally evaluated, no VPAT yet" statement remains accurate.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: a UI color-contrast tuning is not an operator- or reviewer-actionable observable change (no command, flag, config field, default, behavior, exit code, wire/on-disk format, or security change).
- [x] Security review -- n/a: none of the listed surfaces are touched (a presentation-only CSS color-token change); two independent security reviews confirmed no crypto, channel, credential, auth, disclosure, or dependency impact.
