### PR TITLE
Guard persistHostKeyFingerprint against non-sftp configs

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -515,6 +515,14 @@ export function saveConfig(configPath: string, spec: ExchangeSpec): void {
  * convention. Throws if the file cannot be read or parsed -- the caller has just
  * loaded the same file, so a failure here is unexpected and must not be silently
  * swallowed (it would leave the operator believing the pin was saved).
+ *
+ * Fails closed on a non-sftp config: a host-key fingerprint is an sftp-only pin
+ * (`connection.server` is the sftp shape), so a `connection.channel` other than
+ * `sftp` is rejected with a {@link UsageError} before anything is written. The
+ * sole caller {@link establishHostKeyTrust} already no-ops off sftp, so this
+ * never fires today; it enforces the invariant at the function for a future
+ * direct caller that would otherwise synthesize a bogus pin and a `server`
+ * mapping a filedrop/webrtc schema does not expect.
  */
 export function persistHostKeyFingerprint(
   configPath: string,
@@ -529,6 +537,22 @@ export function persistHostKeyFingerprint(
     fs.readFileSync(configPath, "utf8"),
     `config file ${configPath}`,
     (doc) => {
+      // Read the channel discriminant off the parsed document (not a
+      // schema-loaded spec) and reject anything but sftp before the write, so
+      // the function -- not its caller -- holds the sftp-only invariant. The
+      // channel is a non-secret discriminant, so echoing it is consistent with
+      // the channel-mismatch errors elsewhere (e.g. protocol.ts); a missing or
+      // non-scalar channel is reported generically rather than echoed.
+      const channel = doc.getIn(["connection", "channel"]);
+      if (channel !== "sftp") {
+        const found =
+          typeof channel === "string" ? `"${channel}"` : "absent or non-scalar";
+        throw new UsageError(
+          `config file ${configPath} has a non-sftp connection.channel ` +
+            `(${found}); a host-key fingerprint is an sftp-only pin and must ` +
+            `not be written to a non-sftp config.`,
+        );
+      }
       // setIn creates the connection/server path nodes if absent; for an sftp
       // config loaded by the exchange command they already exist, so this updates
       // the one field. snake_case path matches the written convention (see

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -14,6 +14,7 @@ import {
   safeParseFileSyncOptions,
   safeParseLinkageTerms,
   safeParseMetadata,
+  sanitizeForDisplay,
   snakeizeKeys,
   StandardizationSchema,
   UsageError,
@@ -540,18 +541,21 @@ export function persistHostKeyFingerprint(
       // Read the channel discriminant off the parsed document (not a
       // schema-loaded spec) and reject anything but sftp before the write, so
       // the function -- not its caller -- holds the sftp-only invariant. The
-      // channel is a non-secret discriminant, so echoing it is consistent with
-      // the channel-mismatch errors elsewhere (e.g. protocol.ts); a missing or
-      // non-scalar channel is reported generically rather than echoed.
-      // getIn does not resolve aliases, so an alias-spelled channel (or an
-      // aliased connection block) reads as a non-string node and is rejected
+      // channel is a non-secret discriminant; echo it (sanitized for display,
+      // as the rest of this trust flow treats config-derived values -- see
+      // hostKeyTrust.ts) so the operator sees which channel was rejected. A
+      // missing or non-scalar channel is reported generically rather than
+      // echoed. getIn does not resolve aliases, so an alias-spelled channel (or
+      // an aliased connection block) reads as a non-string node and is rejected
       // even when it would resolve to sftp -- the safe direction (refuse, not
       // mis-pin), and not a form a hand-authored config uses. Resolving it
       // would mean materializing the document, which this module avoids.
       const channel = doc.getIn(["connection", "channel"]);
       if (channel !== "sftp") {
         const found =
-          typeof channel === "string" ? `"${channel}"` : "absent or non-scalar";
+          typeof channel === "string"
+            ? `"${sanitizeForDisplay(channel)}"`
+            : "absent or non-scalar";
         throw new UsageError(
           `config file ${configPath} has a non-sftp connection.channel ` +
             `(${found}); a host-key fingerprint is an sftp-only pin and must ` +

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -543,6 +543,11 @@ export function persistHostKeyFingerprint(
       // channel is a non-secret discriminant, so echoing it is consistent with
       // the channel-mismatch errors elsewhere (e.g. protocol.ts); a missing or
       // non-scalar channel is reported generically rather than echoed.
+      // getIn does not resolve aliases, so an alias-spelled channel (or an
+      // aliased connection block) reads as a non-string node and is rejected
+      // even when it would resolve to sftp -- the safe direction (refuse, not
+      // mis-pin), and not a form a hand-authored config uses. Resolving it
+      // would mean materializing the document, which this module avoids.
       const channel = doc.getIn(["connection", "channel"]);
       if (channel !== "sftp") {
         const found =

--- a/apps/cli/test/unit/config.test.ts
+++ b/apps/cli/test/unit/config.test.ts
@@ -589,6 +589,39 @@ test("persistHostKeyFingerprint rejects a non-sftp config and leaves the file un
   }
 });
 
+test("persistHostKeyFingerprint sanitizes the echoed channel for display", () => {
+  // The rejected channel is echoed so the operator sees what was wrong, but it
+  // is operator-authored config text that can carry control bytes -- an ESC that
+  // drives an ANSI sequence, or a newline usable for log-line spoofing. The
+  // error is display-bound (it reaches a terminal/log), so the channel is run
+  // through sanitizeForDisplay and emitted escaped, never raw.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
+  try {
+    const configPath = path.join(dir, "psilink.yaml");
+    // A double-quoted YAML scalar whose value decodes to x<ESC><LF>y.
+    const source = 'connection:\n  channel: "x\\x1b\\ny"\n';
+    fs.writeFileSync(configPath, source);
+    let caught: unknown;
+    try {
+      persistHostKeyFingerprint(configPath, FP_A);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(UsageError);
+    const message = (caught as Error).message;
+    // The raw control bytes never reach the message ...
+    expect(message).not.toContain("\u001b");
+    expect(message).not.toContain("\n");
+    // ... they are shown as visible escapes instead.
+    expect(message).toContain("\\x1b");
+    expect(message).toContain("\\x0a");
+    // The file is left untouched (the throw precedes the write).
+    expect(fs.readFileSync(configPath, "utf8")).toBe(source);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("persistHostKeyFingerprint round-trips a fingerprint containing + and /", () => {
   // The SHA256 fingerprint alphabet includes '+' and '/'; the serializer must
   // quote as needed so the value re-parses byte-for-byte -- a mis-quoted pin

--- a/apps/cli/test/unit/config.test.ts
+++ b/apps/cli/test/unit/config.test.ts
@@ -492,7 +492,7 @@ test("persistHostKeyFingerprint does not echo an inline credential via an unreso
     const configPath = path.join(dir, "psilink.yaml");
     fs.writeFileSync(
       configPath,
-      `connection:\n  server:\n    password: *${SECRET}\n`,
+      `connection:\n  channel: sftp\n  server:\n    password: *${SECRET}\n`,
     );
     let caught: unknown;
     try {
@@ -513,20 +513,65 @@ test("persistHostKeyFingerprint does not echo an inline credential via an unreso
 });
 
 test("persistHostKeyFingerprint raises a UsageError when connection.server is not a mapping", () => {
-  // A config that PARSES but whose connection is a scalar (not a mapping) makes
-  // YAML's setIn throw a raw library error; the function must surface it as the
-  // actionable UsageError its contract promises, not an opaque stack trace, and
-  // must leave the original file untouched (the throw precedes the write).
+  // A sftp config that PARSES (so it clears the channel guard) but whose
+  // connection.server is a scalar (not a mapping) makes YAML's setIn throw a raw
+  // library error; the function must surface it as the actionable UsageError its
+  // contract promises, not an opaque stack trace, and must leave the original
+  // file untouched (the throw precedes the write).
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
   try {
     const configPath = path.join(dir, "psilink.yaml");
-    fs.writeFileSync(configPath, "connection: sftp\n");
+    const original = "connection:\n  channel: sftp\n  server: nope\n";
+    fs.writeFileSync(configPath, original);
     expect(() => persistHostKeyFingerprint(configPath, FP_A)).toThrow(
       UsageError,
     );
-    expect(fs.readFileSync(configPath, "utf8")).toBe("connection: sftp\n");
+    expect(fs.readFileSync(configPath, "utf8")).toBe(original);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("persistHostKeyFingerprint rejects a non-sftp config and leaves the file untouched", () => {
+  // The host-key pin is an sftp-only concept: connection.server is the sftp
+  // shape, so persisting a fingerprint onto a filedrop (no server) or webrtc
+  // (a different server shape) config would synthesize a bogus pin and a mapping
+  // that channel's schema does not expect. The guard fails closed before any
+  // write, echoing the offending channel, so the operator's file is left
+  // byte-for-byte intact.
+  const fixtures = [
+    {
+      channel: "filedrop",
+      source: "connection:\n  channel: filedrop\n  path: /mnt/share\n",
+    },
+    {
+      channel: "webrtc",
+      source:
+        "connection:\n  channel: webrtc\n  server:\n    signaling: wss://signal.example.org\n",
+    },
+  ];
+  for (const { channel, source } of fixtures) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
+    try {
+      const configPath = path.join(dir, "psilink.yaml");
+      fs.writeFileSync(configPath, source);
+      let caught: unknown;
+      try {
+        persistHostKeyFingerprint(configPath, FP_A);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(UsageError);
+      expect((caught as Error).message).toContain(`"${channel}"`);
+      expect((caught as Error).message).toContain("sftp");
+      // Not mutated: the bytes are exactly what the operator wrote -- no pin
+      // synthesized, no server mapping fabricated on the filedrop config.
+      const after = fs.readFileSync(configPath, "utf8");
+      expect(after).toBe(source);
+      expect(after).not.toContain("host_key_fingerprint");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   }
 });
 

--- a/apps/cli/test/unit/config.test.ts
+++ b/apps/cli/test/unit/config.test.ts
@@ -541,16 +541,30 @@ test("persistHostKeyFingerprint rejects a non-sftp config and leaves the file un
   // byte-for-byte intact.
   const fixtures = [
     {
-      channel: "filedrop",
+      // A string channel is echoed verbatim so the operator sees which channel
+      // was rejected.
       source: "connection:\n  channel: filedrop\n  path: /mnt/share\n",
+      expectInMessage: '"filedrop"',
     },
     {
-      channel: "webrtc",
       source:
         "connection:\n  channel: webrtc\n  server:\n    signaling: wss://signal.example.org\n",
+      expectInMessage: '"webrtc"',
+    },
+    {
+      // No channel key at all: the guard reports it generically, never echoing
+      // `undefined`.
+      source: "connection:\n  server:\n    host: h\n",
+      expectInMessage: "absent or non-scalar",
+    },
+    {
+      // A channel that parses to a collection (here a sequence) is not a string,
+      // so it takes the same generic branch rather than being echoed.
+      source: "connection:\n  channel:\n    - sftp\n  server:\n    host: h\n",
+      expectInMessage: "absent or non-scalar",
     },
   ];
-  for (const { channel, source } of fixtures) {
+  for (const { source, expectInMessage } of fixtures) {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
     try {
       const configPath = path.join(dir, "psilink.yaml");
@@ -562,7 +576,7 @@ test("persistHostKeyFingerprint rejects a non-sftp config and leaves the file un
         caught = err;
       }
       expect(caught).toBeInstanceOf(UsageError);
-      expect((caught as Error).message).toContain(`"${channel}"`);
+      expect((caught as Error).message).toContain(expectInMessage);
       expect((caught as Error).message).toContain("sftp");
       // Not mutated: the bytes are exactly what the operator wrote -- no pin
       // synthesized, no server mapping fabricated on the filedrop config.


### PR DESCRIPTION
## Summary

`persistHostKeyFingerprint` now fails closed on a non-sftp config: it rejects any `connection.channel` other than `sftp` with a `UsageError` before it writes anything to disk. The host-key pin is an sftp-only concept (`connection.server` is the sftp shape), so this enforces the invariant at the function itself rather than leaving it to the sole caller to never reach -- closing a latent footgun a future direct caller would otherwise hit by synthesizing a bogus pin and a `server` mapping a filedrop/webrtc schema does not expect.

Implements [201614154](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=201614154).

## Changes

- `apps/cli/src/config.ts`: read `connection.channel` off the parsed YAML document and throw a `UsageError` before the write when it is not `sftp`; the echoed channel is run through `sanitizeForDisplay`, consistent with how the rest of the host-key trust flow treats config-derived values. An alias-spelled channel reads as a non-string node and is rejected (the safe direction), documented in place.
- `apps/cli/test/unit/config.test.ts`: add rejection coverage (filedrop and webrtc, absent channel, non-scalar channel, and control-char sanitization of the echo), asserting the file is left byte-for-byte intact; keep the unresolved-alias and scalar-server tests exercising their original paths by giving their fixtures a valid sftp channel.

## Test plan

Ran: `npx vitest run apps/cli/test/unit/config.test.ts` (70 passed), plus `npm run typecheck`, `npm run lint`, and `npm run format` (clean).
New tests cover: rejection of filedrop / webrtc / absent / non-scalar channels with the on-disk file unchanged and no pin or `server` mapping synthesized, and that a channel carrying control bytes is emitted escaped rather than raw in the error.

## Background

The guard is not reachable on any current call path: the sole caller `establishHostKeyTrust` (`apps/cli/src/hostKeyTrust.ts`) no-ops for `connection.channel !== "sftp"`, and on the exchange path the schema load rejects a `server` mapping on a non-sftp config before persist runs. The in-code comment at the write site already anticipated "a future caller that skips validation"; this closes that gap defensively. The function edits the file through the YAML document model to preserve operator comments and key order, so the channel is read from the parsed document rather than a schema-loaded spec, which keeps the function self-contained.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; the guard is an internal defensive check with no operator-facing effect on any current path.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: the guard is not reachable on any current call path, so there is no operator- or reviewer-visible behavior change to act on.
- [x] Security review -- independent adversarial review of the host-key trust property plus a comprehensive diff review; both PASS. Confirmed fail-closed before any write (original file byte-for-byte intact), no secret disclosure through the error channel (alias/anchor/merge-key channels read as non-string and are not echoed), the echoed channel is sanitized for display, and no forged/wrong pin or new DoS surface is introduced.
