### PR TITLE
Drop malformed inert color attr from manifest link

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -59,7 +59,7 @@ export const Route = createRootRoute({
         sizes: "16x16",
         href: "/favicon-16x16.png",
       },
-      { rel: "manifest", href: "/site.webmanifest", color: "#fffff" },
+      { rel: "manifest", href: "/site.webmanifest" },
       { rel: "icon", href: "/favicon.ico" },
     ],
   }),


### PR DESCRIPTION
## Summary

Remove a malformed, inert attribute from the web app's icon links. The `<link rel="manifest">` carried `color: "#fffff"` -- a five-digit (malformed) hex, and an attribute that has no effect on a manifest link (`color` is a `rel="mask-icon"` attribute). It rendered nothing; this drops it rather than fixing the hex in place, since there is no `mask-icon` link or `safari-pinned-tab` asset to move it to. Surfaced during the security review of #191.

## Changes

- apps/web/src/routes/__root.tsx: drop the `color: "#fffff"` attribute from the `rel="manifest"` link object.

## Test plan

Ran: `npm run typecheck && npm run lint && npm run format`; `npm run test:unit -w apps/web` (180 passed) and `npm run test:browser -w apps/web` (47 passed).
New tests cover: n/a -- removal of an inert markup attribute with no behavior; the existing suites exercise the root document and pass.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: the attribute was inert (rendered nothing), so there is no operator- or reviewer-visible change.
- [x] Security review -- n/a: none of the listed surfaces are touched; removing an inert presentational link attribute has no crypto, channel, credential, auth, disclosure, or dependency impact.
