### PR TITLE
Pin 'Host denied' connect-retry as terminal

### DIFF
--- a/apps/cli/test/unit/ssh2SftpAdapter.test.ts
+++ b/apps/cli/test/unit/ssh2SftpAdapter.test.ts
@@ -106,6 +106,57 @@ describe("connect retry", () => {
     }
   });
 
+  test("does not retry a 'Host denied' host-key rejection (terminal, one attempt)", async () => {
+    // The connect-retry predicate treats a host-key verification rejection as
+    // terminal by matching the `Host denied` message fragment. The two tests
+    // above pin the other direction -- a transient `connection refused` IS
+    // retried up to maxReconnectAttempts -- so the three together prove the
+    // predicate discriminates rather than disabling retry wholesale. A
+    // regression here (a renamed fatal message, a typo) would silently retry a
+    // host-key failure maxReconnectAttempts times before failing with the same
+    // outcome; CONTRIBUTING.md's "Upgrading the SFTP stack" checklist names
+    // confirming this fragment as a per-bump obligation, which this pins.
+    vi.useFakeTimers();
+    const adapter = new SSH2SFTPClientAdapter();
+    let calls = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (adapter as any).client = {
+      connect: vi.fn().mockImplementation(async () => {
+        calls++;
+        // The fatal handshake message ssh2 raises on a host-key rejection
+        // (hostVerifier calling verify(false)): "Host denied (verification
+        // failed)", from node_modules/ssh2/lib/protocol/kex.js. ssh2 sets no
+        // machine-readable `code` on it, so the predicate keys on the message
+        // fragment. Keep this string in sync with that same kex.js source named
+        // in CONTRIBUTING.md ("Upgrading the SFTP stack"); if a future bump
+        // renames it, that checklist and this string move together.
+        throw new Error("Host denied (verification failed)");
+      }),
+    };
+
+    try {
+      const p = adapter.connect({
+        host: "sftp.example.org",
+        // A non-zero reconnect budget is what makes the single-attempt
+        // assertion meaningful: a working predicate must refuse to spend it on a
+        // host-key rejection, where retrying only re-runs the key exchange
+        // against the same untrusted host.
+        maxReconnectAttempts: 3,
+      });
+      // Attach before advancing so the rejection is not unhandled.
+      const assertion = expect(p).rejects.toThrow("Host denied");
+      // Advance well past several 1 s retry windows: a regressed (always-true)
+      // predicate would have armed a retry timer in this span, lifting the count
+      // above one. The assertion is the observed attempt count via the stub, not
+      // a wall-clock bound on how long the rejection takes.
+      await vi.advanceTimersByTimeAsync(5_000);
+      await assertion;
+      expect(calls).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("strips maxReconnectAttempts from options passed to ssh2", async () => {
     const adapter = new SSH2SFTPClientAdapter();
     let capturedOptions: Record<string, unknown> | undefined;


### PR DESCRIPTION
## Summary

Pin the SFTP connect-retry "Host denied" -> terminal contract with a unit test, closing the documented "confirm the fragment still appears" obligation with an automated CI check instead of a by-hand re-confirmation at every ssh2 bump. The adapter classifies a host-key verification rejection as terminal by matching the `Host denied` message fragment ssh2 raises on a fatal handshake; no test exercised that predicate, so a regression (a renamed fatal message, a typo) would silently stop the terminal classification and retry a host-key failure `maxReconnectAttempts` times before failing with the same outcome.

Implements [202264504](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=202264504).

## Changes

- apps/cli/test/unit/ssh2SftpAdapter.test.ts: add "does not retry a 'Host denied' host-key rejection (terminal, one attempt)" to the existing connect-retry block. It injects a `Host denied` rejection into a stubbed `connect` with `maxReconnectAttempts: 3` and asserts the attempt count is exactly one. The assertion is the observed count via the stub, not a wall-clock bound. A comment ties the hard-coded fragment to the same `kex.js` source CONTRIBUTING.md's "Upgrading the SFTP stack" checklist names, so a future maintainer updating one updates the other.

## Test plan

Ran: `npx vitest run apps/cli/test/unit/ssh2SftpAdapter.test.ts` (64 passed), `npm run typecheck`, `npm run lint`, `npm run format` -- all clean.
New tests cover: a `Host denied` connect rejection is terminal (connect attempted exactly once despite a non-zero reconnect budget). The discriminating direction -- a transient `connection refused` IS retried up to `maxReconnectAttempts` -- is already pinned by the two existing sibling tests in the same block, so both directions sit together. Verified the test kills the mutant: renaming the source fragment to `Host refused` flips the count to 4 and fails the test, confirming the count assertion is load-bearing (the `Host denied` message assertion alone passes under that mutation).

## Background

The predicate is documented in CONTRIBUTING.md ("Upgrading the SFTP stack", the `Host denied` paragraph) and docs/spec/CHANNEL_SECURITY.md as a per-bump re-confirmation obligation, but nothing exercised it. This is a non-security coverage gap: correctness is preserved if the predicate breaks, because core's `fileSyncConnection` re-wraps the same rejection into its `SFTP host-key verification failed:` message regardless and the connection still fails closed -- the only degradation is retry latency and log noise. This task pins the retry-classification predicate, not the host-key security control itself.

## Out of scope / follow-on

- The host-key security control itself (reject-before-auth on mismatch) is pinned separately by the parent task [201260241](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=201260241); this follow-up pins only the orthogonal retry-classification predicate.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; the predicate's contract is already recorded in CONTRIBUTING.md and docs/spec/CHANNEL_SECURITY.md, which this test pins rather than alters.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-only change, no operator- or reviewer-visible behavior, exit code, or wire/on-disk change.
- [x] Security review -- conducted (two independent reviewers, diff-scope and threat-model). Test-only change on the SFTP host-key path that touches no production control; confirmed the diff is the one test file, the production predicate is unchanged from staging, and the fail-closed re-wrap in core's `fileSyncConnection` is independent of this predicate, so the non-security framing holds.
