### PR TITLE
Warn on ignored server overrides on offline invite/accept

### DIFF
--- a/apps/cli/src/commands/accept.ts
+++ b/apps/cli/src/commands/accept.ts
@@ -50,7 +50,7 @@ import {
   prepareForOnlineExchange,
   runOnlineBootstrap,
   runOrExit,
-  warnConnectionOverridesIgnoredOffline,
+  warnLocatorOverridesIgnoredOffline,
   type CommonBootstrapOptions,
   type ResolvedDataSpec,
   type RunnableConnectionConfig,
@@ -320,11 +320,11 @@ export async function validateAccept(params: {
     };
   }
 
-  // Offline: the connection-block overrides (--server-* and --outbound-path)
+  // Offline: the connection-locator overrides (--server-* and --outbound-path)
   // cannot take effect (the connection block is seeded from the invitation
   // endpoint or a placeholder, not built from a URL), so warn rather than drop a
   // deliberately-passed flag silently.
-  warnConnectionOverridesIgnoredOffline(options, log);
+  warnLocatorOverridesIgnoredOffline(options, log);
 
   // Offline.
   const reuseExistingConfig = reconcileAcceptConfig({

--- a/apps/cli/src/commands/accept.ts
+++ b/apps/cli/src/commands/accept.ts
@@ -50,7 +50,7 @@ import {
   prepareForOnlineExchange,
   runOnlineBootstrap,
   runOrExit,
-  warnOutboundPathIgnoredOffline,
+  warnConnectionOverridesIgnoredOffline,
   type CommonBootstrapOptions,
   type ResolvedDataSpec,
   type RunnableConnectionConfig,
@@ -320,10 +320,11 @@ export async function validateAccept(params: {
     };
   }
 
-  // Offline: --outbound-path cannot take effect (the connection block is seeded
-  // from the invitation endpoint or a placeholder, not built from a URL), so
-  // warn rather than drop a deliberately-passed flag silently.
-  warnOutboundPathIgnoredOffline(options.outboundPath, log);
+  // Offline: the connection-block overrides (--server-* and --outbound-path)
+  // cannot take effect (the connection block is seeded from the invitation
+  // endpoint or a placeholder, not built from a URL), so warn rather than drop a
+  // deliberately-passed flag silently.
+  warnConnectionOverridesIgnoredOffline(options, log);
 
   // Offline.
   const reuseExistingConfig = reconcileAcceptConfig({

--- a/apps/cli/src/commands/accept.ts
+++ b/apps/cli/src/commands/accept.ts
@@ -50,7 +50,7 @@ import {
   prepareForOnlineExchange,
   runOnlineBootstrap,
   runOrExit,
-  warnLocatorOverridesIgnoredOffline,
+  warnServerOverridesIgnoredOffline,
   type CommonBootstrapOptions,
   type ResolvedDataSpec,
   type RunnableConnectionConfig,
@@ -320,11 +320,11 @@ export async function validateAccept(params: {
     };
   }
 
-  // Offline: the connection-locator overrides (--server-* and --outbound-path)
-  // cannot take effect (the connection block is seeded from the invitation
-  // endpoint or a placeholder, not built from a URL), so warn rather than drop a
+  // Offline: the server-block overrides (--server-* and --outbound-path) cannot
+  // take effect (the connection block is seeded from the invitation endpoint or a
+  // placeholder, not built from a URL), so warn rather than drop a
   // deliberately-passed flag silently.
-  warnLocatorOverridesIgnoredOffline(options, log);
+  warnServerOverridesIgnoredOffline(options, log);
 
   // Offline.
   const reuseExistingConfig = reconcileAcceptConfig({

--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -1403,19 +1403,28 @@ export function warnUnsupportedFileSyncFlags(
 }
 
 /**
- * The connection-block overrides that have no effect on an OFFLINE invite/accept,
- * read by {@link warnConnectionOverridesIgnoredOffline}. A structural subset of
- * {@link CommonBootstrapOptions} (which is assignable to it) holding the
- * `--server-*` credential/port flags and `--outbound-path` -- the connection
- * locator/credential overrides this task (item 202433910) scopes to. The
- * connection/exchange tuning overrides (timeouts, `--max-reconnect-attempts`) and
- * the file-sync toggles (`--retain-files`, `--peer-id`, etc.) are ALSO dropped on
- * the offline path -- they land in `connection.options`, the same block the
- * placeholder stands in for -- so warning on them too would be a reasonable
- * extension; it is left out of this set as a deliberate scope line, not because
- * they take effect.
+ * The connection-locator overrides that have no effect on an OFFLINE
+ * invite/accept, read by {@link warnLocatorOverridesIgnoredOffline}. A structural
+ * subset of {@link CommonBootstrapOptions} (which is assignable to it) holding the
+ * `--server-*` flags and `--outbound-path`: the overrides {@link
+ * applyConnectionOverrides} writes into the connection's locator block --
+ * `connection.server` (host/port/credentials) and the channel's directory paths
+ * -- as opposed to `connection.options`. This is precisely the block the offline
+ * placeholder stands in for: {@link connectionFromEndpoint} writes a locator stub
+ * (a `REPLACE_WITH_...` host/username placeholder, or a seeded host/port/path)
+ * with no `options`, so these are the overrides that would have populated a field
+ * the operator edits. Despite the `--server-*` credential flags, this set is NOT
+ * the credential-free public {@link ConnectionEndpoint} "locator": it carries the
+ * username/password/private-key the placeholder marks for replacement.
+ *
+ * The tuning overrides (timeouts, `--max-reconnect-attempts`) and the file-sync
+ * toggles (`--retain-files`, `--peer-id`, etc.) are ALSO dropped offline, but they
+ * write `connection.options` -- a separate block the placeholder does not contain
+ * -- so the right diagnostic for them is a differently-worded one ("set it under
+ * connection.options"), tracked as a follow-up, not folded in here where it would
+ * blur this message's "set the connection details in that block" remedy.
  */
-export type OfflineIgnoredConnectionOverrides = Pick<
+export type OfflineIgnoredLocatorOverrides = Pick<
   CommonBootstrapOptions,
   | "serverUsername"
   | "serverPassword"
@@ -1425,7 +1434,7 @@ export type OfflineIgnoredConnectionOverrides = Pick<
 >;
 
 /**
- * Warn that the connection-block overrides (`--server-username`,
+ * Warn that the connection-locator overrides (`--server-username`,
  * `--server-password`, `--server-private-key`, `--server-port`, and
  * `--outbound-path`) have no effect on an OFFLINE invite/accept. Those paths
  * write a placeholder (invite) or invitation-endpoint-seeded (accept) connection
@@ -1434,12 +1443,14 @@ export type OfflineIgnoredConnectionOverrides = Pick<
  * go through {@link connectionFromEndpoint}, which applies no connection
  * overrides, and these flags would otherwise be parsed and silently dropped. The
  * warning names exactly the flags the operator set; it is a no-op when none are
- * set. Shared between invite and accept so the wording cannot drift, and so the
- * whole `--server-*`/`--outbound-path` set is treated uniformly rather than only
- * the one flag (`--outbound-path`) whose silent loss is the most surprising.
+ * set. Scoped to the locator block these overrides populate (see {@link
+ * OfflineIgnoredLocatorOverrides}); shared between invite and accept so the
+ * wording cannot drift, and so the whole `--server-*`/`--outbound-path` set is
+ * treated uniformly rather than only the one flag (`--outbound-path`) whose silent
+ * loss is the most surprising.
  */
-export function warnConnectionOverridesIgnoredOffline(
-  options: OfflineIgnoredConnectionOverrides,
+export function warnLocatorOverridesIgnoredOffline(
+  options: OfflineIgnoredLocatorOverrides,
   log: { warn: (message: string) => void },
 ): void {
   const ignored: string[] = [];

--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -1455,6 +1455,11 @@ export function warnServerOverridesIgnoredOffline(
   options: OfflineIgnoredServerOverrides,
   log: { warn: (message: string) => void },
 ): void {
+  // Security invariant: push only the flag NAME, never the override value. A
+  // --server-password / --server-private-key value may be an inline secret (or
+  // an unresolved @path), and this warning reaches the terminal and any
+  // --log-file; interpolating a value here would leak it. Keep the emitted
+  // message static apart from this flag-name list.
   const ignored: string[] = [];
   if (options.serverUsername !== undefined) ignored.push("--server-username");
   if (options.serverPassword !== undefined) ignored.push("--server-password");

--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -1403,27 +1403,58 @@ export function warnUnsupportedFileSyncFlags(
 }
 
 /**
- * Warn that `--outbound-path` has no effect on an OFFLINE invite/accept. Those
- * paths write a placeholder (invite) or invitation-endpoint-seeded (accept)
- * connection block for the operator to edit before `psilink exchange`, rather
- * than building a connection from a URL the way the online and zero-setup paths
- * do -- so they go through {@link connectionFromEndpoint}, which applies no
- * connection overrides, and the flag would otherwise be parsed and silently
- * dropped. (The sibling `--server-*` overrides share this offline-blindness; this
- * warning is scoped to `--outbound-path`, whose whole purpose is the connection's
- * directory shape, so its silent loss is the most surprising.) A no-op when the
- * flag is unset. Shared so the wording cannot drift between invite and accept.
+ * The connection-block overrides that have no effect on an OFFLINE invite/accept,
+ * read by {@link warnConnectionOverridesIgnoredOffline}. A structural subset of
+ * {@link CommonBootstrapOptions} (which is assignable to it) holding only the
+ * `--server-*` credential/port flags and `--outbound-path` -- the flags that
+ * shape the connection block built from a URL on the online/zero-setup paths but
+ * are dropped offline. The connection/exchange tuning overrides (timeouts,
+ * `--max-reconnect-attempts`) and the file-sync toggles (`--retain-files`,
+ * `--peer-id`, etc.) are deliberately excluded: they configure `options`, not the
+ * connection locator the offline block is a placeholder for.
  */
-export function warnOutboundPathIgnoredOffline(
-  outboundPath: string | undefined,
+export type OfflineIgnoredConnectionOverrides = Pick<
+  CommonBootstrapOptions,
+  | "serverUsername"
+  | "serverPassword"
+  | "serverPrivateKey"
+  | "serverPort"
+  | "outboundPath"
+>;
+
+/**
+ * Warn that the connection-block overrides (`--server-username`,
+ * `--server-password`, `--server-private-key`, `--server-port`, and
+ * `--outbound-path`) have no effect on an OFFLINE invite/accept. Those paths
+ * write a placeholder (invite) or invitation-endpoint-seeded (accept) connection
+ * block for the operator to edit before `psilink exchange`, rather than building
+ * a connection from a URL the way the online and zero-setup paths do -- so they
+ * go through {@link connectionFromEndpoint}, which applies no connection
+ * overrides, and these flags would otherwise be parsed and silently dropped. The
+ * warning names exactly the flags the operator set; it is a no-op when none are
+ * set. Shared between invite and accept so the wording cannot drift, and so the
+ * whole `--server-*`/`--outbound-path` set is treated uniformly rather than only
+ * the one flag (`--outbound-path`) whose silent loss is the most surprising.
+ */
+export function warnConnectionOverridesIgnoredOffline(
+  options: OfflineIgnoredConnectionOverrides,
   log: { warn: (message: string) => void },
 ): void {
-  if (outboundPath === undefined) return;
+  const ignored: string[] = [];
+  if (options.serverUsername !== undefined) ignored.push("--server-username");
+  if (options.serverPassword !== undefined) ignored.push("--server-password");
+  if (options.serverPrivateKey !== undefined)
+    ignored.push("--server-private-key");
+  if (options.serverPort !== undefined) ignored.push("--server-port");
+  if (options.outboundPath !== undefined) ignored.push("--outbound-path");
+  if (ignored.length === 0) return;
   log.warn(
-    "--outbound-path has no effect on an offline invite/accept: the connection " +
-      "block is written as a placeholder to edit, not built from a URL. " +
-      "Configure the split directory (inbound_path/outbound_path) in that block " +
-      "before running 'psilink exchange', or pass --outbound-path on an online " +
-      "invite/accept, the zero-setup exchange, or 'psilink exchange'.",
+    `${ignored.join(", ")} ${ignored.length === 1 ? "has" : "have"} no effect ` +
+      "on an offline invite/accept: the connection block is written as a " +
+      "placeholder to edit, not built from a URL. Set the connection details " +
+      "directly in that block -- the server host/port/credentials, or the " +
+      "inbound_path/outbound_path split directory -- before running " +
+      "'psilink exchange', or pass these flags on an online invite/accept, the " +
+      "zero-setup exchange, or 'psilink exchange'.",
   );
 }

--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -1450,11 +1450,11 @@ export function warnConnectionOverridesIgnoredOffline(
   if (ignored.length === 0) return;
   log.warn(
     `${ignored.join(", ")} ${ignored.length === 1 ? "has" : "have"} no effect ` +
-      "on an offline invite/accept: the connection block is written as a " +
-      "placeholder to edit, not built from a URL. Set the connection details " +
-      "directly in that block -- the server host/port/credentials, or the " +
-      "inbound_path/outbound_path split directory -- before running " +
-      "'psilink exchange', or pass these flags on an online invite/accept, the " +
-      "zero-setup exchange, or 'psilink exchange'.",
+      "on an offline invite/accept: the connection block is written for you to " +
+      "edit (a placeholder, or seeded from the invitation endpoint), not built " +
+      "from a URL. Set the connection details directly in that block -- the " +
+      "server host/port/credentials, or the inbound_path/outbound_path split " +
+      "directory -- before running 'psilink exchange', or pass these flags on " +
+      "an online invite/accept, the zero-setup exchange, or 'psilink exchange'.",
   );
 }

--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -1403,28 +1403,31 @@ export function warnUnsupportedFileSyncFlags(
 }
 
 /**
- * The connection-locator overrides that have no effect on an OFFLINE
- * invite/accept, read by {@link warnLocatorOverridesIgnoredOffline}. A structural
- * subset of {@link CommonBootstrapOptions} (which is assignable to it) holding the
+ * The server-block overrides that have no effect on an OFFLINE invite/accept,
+ * read by {@link warnServerOverridesIgnoredOffline}. A structural subset of
+ * {@link CommonBootstrapOptions} (which is assignable to it) holding the
  * `--server-*` flags and `--outbound-path`: the overrides {@link
- * applyConnectionOverrides} writes into the connection's locator block --
- * `connection.server` (host/port/credentials) and the channel's directory paths
- * -- as opposed to `connection.options`. This is precisely the block the offline
- * placeholder stands in for: {@link connectionFromEndpoint} writes a locator stub
- * (a `REPLACE_WITH_...` host/username placeholder, or a seeded host/port/path)
- * with no `options`, so these are the overrides that would have populated a field
- * the operator edits. Despite the `--server-*` credential flags, this set is NOT
- * the credential-free public {@link ConnectionEndpoint} "locator": it carries the
- * username/password/private-key the placeholder marks for replacement.
+ * applyConnectionOverrides} writes into `connection.server` (host/port/
+ * credentials) and the channel's directory paths -- the connection's address and
+ * credentials -- as opposed to the tuning/behavior fields it writes into
+ * `connection.options`. This server block is what the offline placeholder stands
+ * in for: {@link connectionFromEndpoint} writes a `REPLACE_WITH_...` host/username
+ * stub, or a seeded host/port/path, so these are the overrides that would have
+ * populated a field the operator edits. (The set carries the
+ * username/password/private-key the placeholder marks for replacement, so it is
+ * NOT the credential-free public {@link ConnectionEndpoint}, which omits them by
+ * construction.)
  *
  * The tuning overrides (timeouts, `--max-reconnect-attempts`) and the file-sync
  * toggles (`--retain-files`, `--peer-id`, etc.) are ALSO dropped offline, but they
- * write `connection.options` -- a separate block the placeholder does not contain
- * -- so the right diagnostic for them is a differently-worded one ("set it under
+ * target the `connection.options` tuning/behavior fields, which the offline flow
+ * never populates from an override -- a split seed pre-seeds only the fixed
+ * retain-mode trio there ({@link SPLIT_SEED_OPTIONS}), never operator tuning. So
+ * the right diagnostic for them is a differently-worded one ("set it under
  * connection.options"), tracked as a follow-up, not folded in here where it would
  * blur this message's "set the connection details in that block" remedy.
  */
-export type OfflineIgnoredLocatorOverrides = Pick<
+export type OfflineIgnoredServerOverrides = Pick<
   CommonBootstrapOptions,
   | "serverUsername"
   | "serverPassword"
@@ -1434,23 +1437,22 @@ export type OfflineIgnoredLocatorOverrides = Pick<
 >;
 
 /**
- * Warn that the connection-locator overrides (`--server-username`,
- * `--server-password`, `--server-private-key`, `--server-port`, and
- * `--outbound-path`) have no effect on an OFFLINE invite/accept. Those paths
- * write a placeholder (invite) or invitation-endpoint-seeded (accept) connection
- * block for the operator to edit before `psilink exchange`, rather than building
- * a connection from a URL the way the online and zero-setup paths do -- so they
- * go through {@link connectionFromEndpoint}, which applies no connection
- * overrides, and these flags would otherwise be parsed and silently dropped. The
- * warning names exactly the flags the operator set; it is a no-op when none are
- * set. Scoped to the locator block these overrides populate (see {@link
- * OfflineIgnoredLocatorOverrides}); shared between invite and accept so the
- * wording cannot drift, and so the whole `--server-*`/`--outbound-path` set is
- * treated uniformly rather than only the one flag (`--outbound-path`) whose silent
- * loss is the most surprising.
+ * Warn that the server-block overrides (`--server-username`, `--server-password`,
+ * `--server-private-key`, `--server-port`, and `--outbound-path`) have no effect
+ * on an OFFLINE invite/accept. Those paths write a placeholder (invite) or
+ * invitation-endpoint-seeded (accept) connection block for the operator to edit
+ * before `psilink exchange`, rather than building a connection from a URL the way
+ * the online and zero-setup paths do -- so they go through {@link
+ * connectionFromEndpoint}, which applies no connection overrides, and these flags
+ * would otherwise be parsed and silently dropped. The warning names exactly the
+ * flags the operator set; it is a no-op when none are set. Scoped to the server
+ * block these overrides populate (see {@link OfflineIgnoredServerOverrides});
+ * shared between invite and accept so the wording cannot drift, and so the whole
+ * `--server-*`/`--outbound-path` set is treated uniformly rather than only the one
+ * flag (`--outbound-path`) whose silent loss is the most surprising.
  */
-export function warnLocatorOverridesIgnoredOffline(
-  options: OfflineIgnoredLocatorOverrides,
+export function warnServerOverridesIgnoredOffline(
+  options: OfflineIgnoredServerOverrides,
   log: { warn: (message: string) => void },
 ): void {
   const ignored: string[] = [];

--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -1405,13 +1405,15 @@ export function warnUnsupportedFileSyncFlags(
 /**
  * The connection-block overrides that have no effect on an OFFLINE invite/accept,
  * read by {@link warnConnectionOverridesIgnoredOffline}. A structural subset of
- * {@link CommonBootstrapOptions} (which is assignable to it) holding only the
- * `--server-*` credential/port flags and `--outbound-path` -- the flags that
- * shape the connection block built from a URL on the online/zero-setup paths but
- * are dropped offline. The connection/exchange tuning overrides (timeouts,
- * `--max-reconnect-attempts`) and the file-sync toggles (`--retain-files`,
- * `--peer-id`, etc.) are deliberately excluded: they configure `options`, not the
- * connection locator the offline block is a placeholder for.
+ * {@link CommonBootstrapOptions} (which is assignable to it) holding the
+ * `--server-*` credential/port flags and `--outbound-path` -- the connection
+ * locator/credential overrides this task (item 202433910) scopes to. The
+ * connection/exchange tuning overrides (timeouts, `--max-reconnect-attempts`) and
+ * the file-sync toggles (`--retain-files`, `--peer-id`, etc.) are ALSO dropped on
+ * the offline path -- they land in `connection.options`, the same block the
+ * placeholder stands in for -- so warning on them too would be a reasonable
+ * extension; it is left out of this set as a deliberate scope line, not because
+ * they take effect.
  */
 export type OfflineIgnoredConnectionOverrides = Pick<
   CommonBootstrapOptions,

--- a/apps/cli/src/commands/invite.ts
+++ b/apps/cli/src/commands/invite.ts
@@ -46,7 +46,7 @@ import {
   runOnlineBootstrap,
   runOrExit,
   unsatisfiedLinkageFields,
-  warnOutboundPathIgnoredOffline,
+  warnConnectionOverridesIgnoredOffline,
   type CommonBootstrapOptions,
   type ResolvedDataSpec,
   type RunnableConnectionConfig,
@@ -311,10 +311,11 @@ export async function validateInvite(params: {
     };
   }
 
-  // Offline: --outbound-path cannot take effect (the connection block is written
-  // as a placeholder to edit, not built from a URL), so warn rather than drop a
-  // deliberately-passed flag silently.
-  warnOutboundPathIgnoredOffline(options.outboundPath, log);
+  // Offline: the connection-block overrides (--server-* and --outbound-path)
+  // cannot take effect (the connection block is written as a placeholder to edit,
+  // not built from a URL), so warn rather than drop a deliberately-passed flag
+  // silently.
+  warnConnectionOverridesIgnoredOffline(options, log);
 
   // Offline. Linkage terms come from a pre-existing config when one is present
   // at the config path, and are inferred from the input file otherwise.

--- a/apps/cli/src/commands/invite.ts
+++ b/apps/cli/src/commands/invite.ts
@@ -46,7 +46,7 @@ import {
   runOnlineBootstrap,
   runOrExit,
   unsatisfiedLinkageFields,
-  warnConnectionOverridesIgnoredOffline,
+  warnLocatorOverridesIgnoredOffline,
   type CommonBootstrapOptions,
   type ResolvedDataSpec,
   type RunnableConnectionConfig,
@@ -311,11 +311,11 @@ export async function validateInvite(params: {
     };
   }
 
-  // Offline: the connection-block overrides (--server-* and --outbound-path)
+  // Offline: the connection-locator overrides (--server-* and --outbound-path)
   // cannot take effect (the connection block is written as a placeholder to edit,
   // not built from a URL), so warn rather than drop a deliberately-passed flag
   // silently.
-  warnConnectionOverridesIgnoredOffline(options, log);
+  warnLocatorOverridesIgnoredOffline(options, log);
 
   // Offline. Linkage terms come from a pre-existing config when one is present
   // at the config path, and are inferred from the input file otherwise.

--- a/apps/cli/src/commands/invite.ts
+++ b/apps/cli/src/commands/invite.ts
@@ -46,7 +46,7 @@ import {
   runOnlineBootstrap,
   runOrExit,
   unsatisfiedLinkageFields,
-  warnLocatorOverridesIgnoredOffline,
+  warnServerOverridesIgnoredOffline,
   type CommonBootstrapOptions,
   type ResolvedDataSpec,
   type RunnableConnectionConfig,
@@ -311,11 +311,11 @@ export async function validateInvite(params: {
     };
   }
 
-  // Offline: the connection-locator overrides (--server-* and --outbound-path)
-  // cannot take effect (the connection block is written as a placeholder to edit,
-  // not built from a URL), so warn rather than drop a deliberately-passed flag
+  // Offline: the server-block overrides (--server-* and --outbound-path) cannot
+  // take effect (the connection block is written as a placeholder to edit, not
+  // built from a URL), so warn rather than drop a deliberately-passed flag
   // silently.
-  warnLocatorOverridesIgnoredOffline(options, log);
+  warnServerOverridesIgnoredOffline(options, log);
 
   // Offline. Linkage terms come from a pre-existing config when one is present
   // at the config path, and are inferred from the input file otherwise.

--- a/apps/cli/test/unit/accept.test.ts
+++ b/apps/cli/test/unit/accept.test.ts
@@ -319,8 +319,10 @@ test("validateAccept: offline warns but proceeds when the CSV satisfies only som
 });
 
 test("validateAccept: offline warns that a --server-* override is ignored", async () => {
-  // The offline path seeds the connection block from the invitation endpoint (or
-  // a placeholder), so a --server-* override cannot take effect; it must be
+  // The offline path builds the connection block from connectionFromEndpoint (a
+  // placeholder here, since sampleToken carries no endpoint; or an endpoint seed
+  // when one is present -- the warning reads only `options`, so it fires the same
+  // way either way), so a --server-* override cannot take effect; it must be
   // surfaced rather than silently dropped.
   const input = writeInputCSV(["first_name", "last_name", "dob", "ssn"]);
   const log = getLogger("accept-offline-override-warn");

--- a/apps/cli/test/unit/accept.test.ts
+++ b/apps/cli/test/unit/accept.test.ts
@@ -318,6 +318,84 @@ test("validateAccept: offline warns but proceeds when the CSV satisfies only som
   }
 });
 
+test("validateAccept: offline warns that a --server-* override is ignored", async () => {
+  // The offline path seeds the connection block from the invitation endpoint (or
+  // a placeholder), so a --server-* override cannot take effect; it must be
+  // surfaced rather than silently dropped.
+  const input = writeInputCSV(["first_name", "last_name", "dob", "ssn"]);
+  const log = getLogger("accept-offline-override-warn");
+  log.setLevel("silent");
+  const warnSpy = vi.spyOn(log, "warn");
+  try {
+    const encoded = await encodeInvitation(sampleToken(FUTURE()));
+    const ready = await validateAccept({
+      resolved: { mode: "offline", invitation: encoded, input },
+      options: testOptions({ serverUsername: "alice" }),
+      log,
+    });
+    expect(ready.mode).toBe("offline");
+    expect(
+      warnSpy.mock.calls.some(
+        (c) =>
+          typeof c[0] === "string" &&
+          c[0].includes("--server-username") &&
+          c[0].includes("no effect on an offline invite/accept"),
+      ),
+    ).toBe(true);
+  } finally {
+    warnSpy.mockRestore();
+    fs.rmSync(input, { force: true });
+  }
+});
+
+test("validateAccept: online does not warn about a --server-* override (it is applied)", async () => {
+  // The online path builds the connection from the URL through
+  // applyConnectionOverrides, so the override takes effect and no
+  // ignored-override warning is emitted.
+  const dir = fs.mkdtempSync(
+    path.join(tmpdir(), "psilink-accept-online-override-"),
+  );
+  const input = path.join(dir, "input.csv");
+  fs.writeFileSync(
+    input,
+    "first_name,last_name,dob,ssn\nAlice,Smith,1990-01-02,123456789\n",
+  );
+  const log = getLogger("accept-online-override-nowarn");
+  log.setLevel("silent");
+  const warnSpy = vi.spyOn(log, "warn");
+  try {
+    const encoded = await encodeInvitation(sampleToken(FUTURE()));
+    const ready = await validateAccept({
+      resolved: {
+        mode: "online",
+        url: new URL("sftp://host/drop"),
+        invitation: encoded,
+        input,
+      },
+      options: testOptions({
+        configFile: path.join(dir, "psilink.yaml"),
+        keyFile: path.join(dir, ".psilink.key"),
+        serverUsername: "alice",
+      }),
+      log,
+    });
+    expect(ready.mode).toBe("online");
+    if (ready.mode !== "online") return;
+    if (ready.connection.channel !== "sftp") throw new Error("expected sftp");
+    expect(ready.connection.server.username).toBe("alice");
+    expect(
+      warnSpy.mock.calls.some(
+        (c) =>
+          typeof c[0] === "string" &&
+          c[0].includes("no effect on an offline invite/accept"),
+      ),
+    ).toBe(false);
+  } finally {
+    warnSpy.mockRestore();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // --- reconciling a pre-existing config ---------------------------------------
 
 /** Write a config whose linkage terms agree with the invitation's by default

--- a/apps/cli/test/unit/bootstrap.test.ts
+++ b/apps/cli/test/unit/bootstrap.test.ts
@@ -32,7 +32,7 @@ import {
   parseCommonBootstrapArgs,
   runOnlineBootstrap,
   runOrExit,
-  warnLocatorOverridesIgnoredOffline,
+  warnServerOverridesIgnoredOffline,
   warnUnsupportedFileSyncFlags,
   type RunnableConnectionConfig,
 } from "../../src/commands/bootstrap";
@@ -316,12 +316,11 @@ test("diffConnectionAgainstTarget: a split config against a shared target names 
   expect(conflicts[0].incoming).toBe("/mnt/shared");
 });
 
-// Each connection-locator override flag, paired with the option field that
-// carries it, so the parametrized test below proves every one is named when set
-// offline.
+// Each server-block override flag, paired with the option field that carries it,
+// so the parametrized test below proves every one is named when set offline.
 const OFFLINE_IGNORED_OVERRIDES: ReadonlyArray<{
   flag: string;
-  option: Parameters<typeof warnLocatorOverridesIgnoredOffline>[0];
+  option: Parameters<typeof warnServerOverridesIgnoredOffline>[0];
 }> = [
   { flag: "--server-username", option: { serverUsername: "alice" } },
   { flag: "--server-password", option: { serverPassword: "hunter2" } },
@@ -331,9 +330,9 @@ const OFFLINE_IGNORED_OVERRIDES: ReadonlyArray<{
 ];
 
 for (const { flag, option } of OFFLINE_IGNORED_OVERRIDES)
-  test(`warnLocatorOverridesIgnoredOffline: warns naming ${flag} when set`, () => {
+  test(`warnServerOverridesIgnoredOffline: warns naming ${flag} when set`, () => {
     const warnings: string[] = [];
-    warnLocatorOverridesIgnoredOffline(option, {
+    warnServerOverridesIgnoredOffline(option, {
       warn: (m) => warnings.push(m),
     });
     expect(warnings).toHaveLength(1);
@@ -341,9 +340,9 @@ for (const { flag, option } of OFFLINE_IGNORED_OVERRIDES)
     expect(warnings[0]).toContain("no effect on an offline invite/accept");
   });
 
-test("warnLocatorOverridesIgnoredOffline: one warning names every set flag", () => {
+test("warnServerOverridesIgnoredOffline: one warning names every set flag", () => {
   const warnings: string[] = [];
-  warnLocatorOverridesIgnoredOffline(
+  warnServerOverridesIgnoredOffline(
     { serverUsername: "alice", serverPort: 2222, outboundPath: "/drop/out" },
     { warn: (m) => warnings.push(m) },
   );
@@ -357,9 +356,9 @@ test("warnLocatorOverridesIgnoredOffline: one warning names every set flag", () 
   expect(warnings[0]).not.toContain("--server-password");
 });
 
-test("warnLocatorOverridesIgnoredOffline: stays silent when no override is set", () => {
+test("warnServerOverridesIgnoredOffline: stays silent when no override is set", () => {
   const warnings: string[] = [];
-  warnLocatorOverridesIgnoredOffline({}, { warn: (m) => warnings.push(m) });
+  warnServerOverridesIgnoredOffline({}, { warn: (m) => warnings.push(m) });
   expect(warnings).toEqual([]);
 });
 

--- a/apps/cli/test/unit/bootstrap.test.ts
+++ b/apps/cli/test/unit/bootstrap.test.ts
@@ -32,7 +32,7 @@ import {
   parseCommonBootstrapArgs,
   runOnlineBootstrap,
   runOrExit,
-  warnConnectionOverridesIgnoredOffline,
+  warnLocatorOverridesIgnoredOffline,
   warnUnsupportedFileSyncFlags,
   type RunnableConnectionConfig,
 } from "../../src/commands/bootstrap";
@@ -316,11 +316,12 @@ test("diffConnectionAgainstTarget: a split config against a shared target names 
   expect(conflicts[0].incoming).toBe("/mnt/shared");
 });
 
-// Each connection-block override flag, paired with the option field that carries
-// it, so the parametrized test below proves every one is named when set offline.
+// Each connection-locator override flag, paired with the option field that
+// carries it, so the parametrized test below proves every one is named when set
+// offline.
 const OFFLINE_IGNORED_OVERRIDES: ReadonlyArray<{
   flag: string;
-  option: Parameters<typeof warnConnectionOverridesIgnoredOffline>[0];
+  option: Parameters<typeof warnLocatorOverridesIgnoredOffline>[0];
 }> = [
   { flag: "--server-username", option: { serverUsername: "alice" } },
   { flag: "--server-password", option: { serverPassword: "hunter2" } },
@@ -330,9 +331,9 @@ const OFFLINE_IGNORED_OVERRIDES: ReadonlyArray<{
 ];
 
 for (const { flag, option } of OFFLINE_IGNORED_OVERRIDES)
-  test(`warnConnectionOverridesIgnoredOffline: warns naming ${flag} when set`, () => {
+  test(`warnLocatorOverridesIgnoredOffline: warns naming ${flag} when set`, () => {
     const warnings: string[] = [];
-    warnConnectionOverridesIgnoredOffline(option, {
+    warnLocatorOverridesIgnoredOffline(option, {
       warn: (m) => warnings.push(m),
     });
     expect(warnings).toHaveLength(1);
@@ -340,9 +341,9 @@ for (const { flag, option } of OFFLINE_IGNORED_OVERRIDES)
     expect(warnings[0]).toContain("no effect on an offline invite/accept");
   });
 
-test("warnConnectionOverridesIgnoredOffline: one warning names every set flag", () => {
+test("warnLocatorOverridesIgnoredOffline: one warning names every set flag", () => {
   const warnings: string[] = [];
-  warnConnectionOverridesIgnoredOffline(
+  warnLocatorOverridesIgnoredOffline(
     { serverUsername: "alice", serverPort: 2222, outboundPath: "/drop/out" },
     { warn: (m) => warnings.push(m) },
   );
@@ -356,9 +357,9 @@ test("warnConnectionOverridesIgnoredOffline: one warning names every set flag", 
   expect(warnings[0]).not.toContain("--server-password");
 });
 
-test("warnConnectionOverridesIgnoredOffline: stays silent when no override is set", () => {
+test("warnLocatorOverridesIgnoredOffline: stays silent when no override is set", () => {
   const warnings: string[] = [];
-  warnConnectionOverridesIgnoredOffline({}, { warn: (m) => warnings.push(m) });
+  warnLocatorOverridesIgnoredOffline({}, { warn: (m) => warnings.push(m) });
   expect(warnings).toEqual([]);
 });
 

--- a/apps/cli/test/unit/bootstrap.test.ts
+++ b/apps/cli/test/unit/bootstrap.test.ts
@@ -32,7 +32,7 @@ import {
   parseCommonBootstrapArgs,
   runOnlineBootstrap,
   runOrExit,
-  warnOutboundPathIgnoredOffline,
+  warnConnectionOverridesIgnoredOffline,
   warnUnsupportedFileSyncFlags,
   type RunnableConnectionConfig,
 } from "../../src/commands/bootstrap";
@@ -316,18 +316,49 @@ test("diffConnectionAgainstTarget: a split config against a shared target names 
   expect(conflicts[0].incoming).toBe("/mnt/shared");
 });
 
-test("warnOutboundPathIgnoredOffline: warns when --outbound-path is set", () => {
-  const warnings: string[] = [];
-  warnOutboundPathIgnoredOffline("/drop/out", {
-    warn: (m) => warnings.push(m),
+// Each connection-block override flag, paired with the option field that carries
+// it, so the parametrized test below proves every one is named when set offline.
+const OFFLINE_IGNORED_OVERRIDES: ReadonlyArray<{
+  flag: string;
+  option: Parameters<typeof warnConnectionOverridesIgnoredOffline>[0];
+}> = [
+  { flag: "--server-username", option: { serverUsername: "alice" } },
+  { flag: "--server-password", option: { serverPassword: "hunter2" } },
+  { flag: "--server-private-key", option: { serverPrivateKey: "@key.pem" } },
+  { flag: "--server-port", option: { serverPort: 2222 } },
+  { flag: "--outbound-path", option: { outboundPath: "/drop/out" } },
+];
+
+for (const { flag, option } of OFFLINE_IGNORED_OVERRIDES)
+  test(`warnConnectionOverridesIgnoredOffline: warns naming ${flag} when set`, () => {
+    const warnings: string[] = [];
+    warnConnectionOverridesIgnoredOffline(option, {
+      warn: (m) => warnings.push(m),
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(flag);
+    expect(warnings[0]).toContain("no effect on an offline invite/accept");
   });
+
+test("warnConnectionOverridesIgnoredOffline: one warning names every set flag", () => {
+  const warnings: string[] = [];
+  warnConnectionOverridesIgnoredOffline(
+    { serverUsername: "alice", serverPort: 2222, outboundPath: "/drop/out" },
+    { warn: (m) => warnings.push(m) },
+  );
+  // A single warning rather than one per flag, so the operator sees the whole
+  // ignored set at once.
   expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain("--server-username");
+  expect(warnings[0]).toContain("--server-port");
   expect(warnings[0]).toContain("--outbound-path");
+  // An unset flag is not named.
+  expect(warnings[0]).not.toContain("--server-password");
 });
 
-test("warnOutboundPathIgnoredOffline: stays silent when --outbound-path is unset", () => {
+test("warnConnectionOverridesIgnoredOffline: stays silent when no override is set", () => {
   const warnings: string[] = [];
-  warnOutboundPathIgnoredOffline(undefined, { warn: (m) => warnings.push(m) });
+  warnConnectionOverridesIgnoredOffline({}, { warn: (m) => warnings.push(m) });
   expect(warnings).toEqual([]);
 });
 

--- a/apps/cli/test/unit/invite.test.ts
+++ b/apps/cli/test/unit/invite.test.ts
@@ -542,6 +542,66 @@ test("validateInvite: with no config and an input file, terms are inferred and w
   }
 });
 
+// --- validateInvite: offline connection-override warning ---------------------
+
+test("validateInvite: offline warns that a --server-* override is ignored", async () => {
+  // The offline path writes a placeholder connection block, so a --server-*
+  // override cannot take effect; it must be surfaced rather than silently dropped.
+  const dir = fs.mkdtempSync(path.join(tmpdir(), "psilink-invite-override-"));
+  tmpDirs.push(dir);
+  const input = writeCsv(dir, "first_name,last_name,dob,ssn");
+  const log = getLogger("invite-offline-override-warn");
+  log.setLevel("warn");
+  const warnSpy = vi.spyOn(log, "warn");
+  await validateInvite({
+    resolved: { mode: "offline", input },
+    options: testOptions({
+      configFile: path.join(dir, "psilink.yaml"),
+      keyFile: path.join(dir, ".psilink.key"),
+      serverUsername: "alice",
+    }),
+    acceptTimeout: 900,
+    log,
+  });
+  expect(
+    warnSpy.mock.calls.some(
+      (c) =>
+        typeof c[0] === "string" &&
+        c[0].includes("--server-username") &&
+        c[0].includes("no effect on an offline invite/accept"),
+    ),
+  ).toBe(true);
+  warnSpy.mockRestore();
+});
+
+test("validateInvite: online does not warn about a --server-* override (it is applied)", async () => {
+  // The online path builds the connection from the URL through
+  // applyConnectionOverrides, so the override takes effect and no ignored-override
+  // warning is emitted.
+  const { input, options } = onlineFixture();
+  const log = getLogger("invite-online-override-nowarn");
+  log.setLevel("warn");
+  const warnSpy = vi.spyOn(log, "warn");
+  const ready = await validateInvite({
+    resolved: { mode: "online", url: new URL("sftp://host/drop"), input },
+    options: { ...options, serverUsername: "alice" },
+    acceptTimeout: 900,
+    log,
+  });
+  expect(ready.mode).toBe("online");
+  if (ready.mode !== "online") return;
+  if (ready.connection.channel !== "sftp") throw new Error("expected sftp");
+  expect(ready.connection.server.username).toBe("alice");
+  expect(
+    warnSpy.mock.calls.some(
+      (c) =>
+        typeof c[0] === "string" &&
+        c[0].includes("no effect on an offline invite/accept"),
+    ),
+  ).toBe(false);
+  warnSpy.mockRestore();
+});
+
 // --- validateInvite: --expires-in override -----------------------------------
 
 test("validateInvite: --expires-in sets the token's expiry to the override", async () => {


### PR DESCRIPTION
## Summary

`psilink invite` and `psilink accept` now warn, on their offline paths, when a server-block connection override (`--server-username`, `--server-password`, `--server-private-key`, `--server-port`, or `--outbound-path`) was passed but cannot take effect. Those paths write a placeholder (invite) or invitation-endpoint-seeded (accept) connection block for the operator to hand-edit before `psilink exchange`, rather than building a connection from a URL, so the overrides were previously parsed and silently dropped. The operator now sees exactly which flags were ignored instead of a silent no-op.

Implements [202433910](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202433910).

## Changes

- apps/cli/src/commands/bootstrap.ts: add the shared helper `warnServerOverridesIgnoredOffline` and its `OfflineIgnoredServerOverrides` type, generalizing the prior `--outbound-path`-only `warnOutboundPathIgnoredOffline` across the whole server-block set. One warning names exactly the flags the operator set; no-op when none are set.
- apps/cli/src/commands/invite.ts, apps/cli/src/commands/accept.ts: call the helper on the offline branch (after the online return), so invite and accept behave identically.
- apps/cli/test/unit/{bootstrap,invite,accept}.test.ts: unit coverage for the helper and both call sites.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format`, and `npx vitest run apps/cli/test/unit/bootstrap.test.ts apps/cli/test/unit/invite.test.ts apps/cli/test/unit/accept.test.ts` (176 passed). CI additionally runs the CLI integration suite; this change is unit-only and does not touch the SFTP adapter or transport.
New tests cover: each server-block flag is named when set (parametrized); a single combined warning names every set flag and omits unset ones; silence when none are set; and that the online invite/accept paths apply the override and emit no offline warning.

## Background

Generalizes the targeted offline `--outbound-path` warning landed for item 201740349. The set is named "server" overrides rather than "locator" because this codebase reserves "locator" for the credential-free public `ConnectionEndpoint`, whereas this set is credential-bearing. The warning emits only flag names, never an override value, so no secret reaches the terminal or `--log-file`; that invariant is documented in the helper.

## Out of scope / follow-on

- Warn on the ignored connection-OPTIONS overrides (timeouts, `--retain-files`, `--peer-id`, etc.) offline, which write `connection.options` and need a differently-worded diagnostic: [202518975](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202518975).
- Split the CLI `ConnectionOverrides` type along the server/options seam so the abstraction mirrors the config: [202519035](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202519035).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed; a per-flag CLI diagnostic, like the predecessor offline `--outbound-path` warning (201740349) which added no doc prose.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: minor UX diagnostic; the structurally identical predecessor offline warning shipped in #195 with no entry, and nothing here changes a command, flag, config field, default, behavior, exit code, or wire/on-disk format an operator/deployer or reviewer acts on beyond the on-screen message.
- [x] Security review -- done: independent three-reviewer panel (disclosure/logging, credential persistence, behavioral integrity), all clean; touches the disclosure surface (adds a logged/displayed line) and names the `--server-password`/`--server-private-key` flags, verified the warning emits only flag names (no credential value) and changes nothing persisted or transmitted.
