### PR TITLE
Split CLI ConnectionOverrides into server/options

### DIFF
--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -1471,24 +1471,35 @@ export type ConnectionOverrideOptions = Pick<
   | "outboundPath"
 >;
 
-/** Map the parsed common options to the connection-override shape. */
+/**
+ * Map the parsed (flat) common options to the structured connection-override
+ * shape, fanning the `server-*`/`--outbound-path` flags into the server
+ * sub-group and the timeout/toggle flags into the options sub-group. The
+ * synthesized `extra.peerTimeout` (from `--accept-timeout` on the online invite
+ * path) belongs to the options sub-group and takes precedence over the parsed
+ * `--peer-timeout`.
+ */
 export function connectionOverridesFrom(
   options: ConnectionOverrideOptions,
   extra: { peerTimeout?: number } = {},
 ): ConnectionOverrides {
   return {
-    connectionTimeout: options.connectionTimeout,
-    peerTimeout: extra.peerTimeout ?? options.peerTimeout,
-    maxReconnectAttempts: options.maxReconnectAttempts,
-    serverUsername: options.serverUsername,
-    serverPassword: options.serverPassword,
-    serverPrivateKey: options.serverPrivateKey,
-    serverPort: options.serverPort,
-    locklessRendezvous: options.locklessRendezvous,
-    peerId: options.peerId,
-    timestampInFilename: options.timestampInFilename,
-    retainFiles: options.retainFiles,
-    outboundPath: options.outboundPath,
+    server: {
+      username: options.serverUsername,
+      password: options.serverPassword,
+      privateKey: options.serverPrivateKey,
+      port: options.serverPort,
+      outboundPath: options.outboundPath,
+    },
+    options: {
+      connectionTimeout: options.connectionTimeout,
+      peerTimeout: extra.peerTimeout ?? options.peerTimeout,
+      maxReconnectAttempts: options.maxReconnectAttempts,
+      locklessRendezvous: options.locklessRendezvous,
+      peerId: options.peerId,
+      timestampInFilename: options.timestampInFilename,
+      retainFiles: options.retainFiles,
+    },
   };
 }
 

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -32,18 +32,24 @@ import { parseSensitiveYaml, editSensitiveYamlDocument } from "./sensitiveFile";
  */
 export const DEFAULT_CONFIG_PATH = "./psilink.yaml";
 
-export interface ConnectionOverrides {
-  connectionTimeout?: number;
-  peerTimeout?: number;
-  maxReconnectAttempts?: number;
-  serverUsername?: string;
-  serverPassword?: string;
-  serverPrivateKey?: string;
-  serverPort?: number;
-  locklessRendezvous?: boolean;
-  peerId?: string;
-  retainFiles?: boolean;
-  timestampInFilename?: boolean;
+/**
+ * The server/credential overrides {@link applyConnectionOverrides} writes into a
+ * connection's `connection.server` block (host/port/credentials) and its
+ * channel directory paths -- WHERE the rendezvous is and HOW to authenticate to
+ * it. This is one half of the {@link ConnectionOverrides} seam, mirroring the
+ * config schema's `server` + path fields as distinct from the tuning/toggle
+ * {@link ConnectionOptionsOverrides} that land in `connection.options`.
+ *
+ * Named "server", not "locator": this set is credential-BEARING
+ * (username/password/private-key), so it is deliberately NOT the credential-free
+ * `ConnectionEndpoint` "locator" an invitation may carry -- the same "server"
+ * label {@link OfflineIgnoredServerOverrides} uses for exactly this set.
+ */
+export interface ConnectionServerOverrides {
+  username?: string;
+  password?: string;
+  privateKey?: string;
+  port?: number;
   /**
    * Outbound (self-written) directory for a split-directory exchange. When set,
    * the connection's single shared directory (the server URL/positional path, or
@@ -55,21 +61,60 @@ export interface ConnectionOverrides {
   outboundPath?: string;
 }
 
+/**
+ * The tuning/toggle overrides {@link applyConnectionOverrides} writes into a
+ * connection's `connection.options` block: the SharedOptions timeouts/reconnect
+ * bound applied on every channel (`connectionTimeout`, `peerTimeout`,
+ * `maxReconnectAttempts`) and the FileSyncOptions toggles gated to the file-sync
+ * channels (`locklessRendezvous`, `peerId`, `retainFiles`,
+ * `timestampInFilename`). `connectionTimeout`/`peerTimeout` are in seconds here;
+ * the apply step scales them to the schema's milliseconds. This is the
+ * `connection.options` half of the {@link ConnectionOverrides} seam, as distinct
+ * from the server/credential {@link ConnectionServerOverrides}.
+ */
+export interface ConnectionOptionsOverrides {
+  connectionTimeout?: number;
+  peerTimeout?: number;
+  maxReconnectAttempts?: number;
+  locklessRendezvous?: boolean;
+  peerId?: string;
+  retainFiles?: boolean;
+  timestampInFilename?: boolean;
+}
+
+/**
+ * CLI overrides applied to a base connection by {@link applyConnectionOverrides},
+ * split along the same seam the config schema keeps: the server/credential set
+ * (plus directory paths) that lands in `connection.server`
+ * ({@link ConnectionServerOverrides}), and the tuning/toggle set that lands in
+ * `connection.options` ({@link ConnectionOptionsOverrides}). Each sub-group is
+ * optional and itself sparse; an absent group (or field) applies no override.
+ */
+export interface ConnectionOverrides {
+  server?: ConnectionServerOverrides;
+  options?: ConnectionOptionsOverrides;
+}
+
 export function applyConnectionOverrides(
   connection: ConnectionConfig,
   overrides: ConnectionOverrides,
 ): ConnectionConfig {
   const result = structuredClone(connection);
+  // The override seam: the server/credential sub-group feeds connection.server
+  // and the directory paths; the options sub-group feeds connection.options.
+  // Default each to empty so an absent group simply applies nothing.
+  const { server: serverOverrides = {}, options: optionsOverrides = {} } =
+    overrides;
 
   if (result.channel === "sftp") {
     const { server } = result;
-    if (overrides.serverUsername !== undefined)
-      server.username = overrides.serverUsername;
-    if (overrides.serverPassword !== undefined)
-      server.password = overrides.serverPassword;
-    if (overrides.serverPrivateKey !== undefined)
-      server.privateKey = overrides.serverPrivateKey;
-    if (overrides.serverPort !== undefined) server.port = overrides.serverPort;
+    if (serverOverrides.username !== undefined)
+      server.username = serverOverrides.username;
+    if (serverOverrides.password !== undefined)
+      server.password = serverOverrides.password;
+    if (serverOverrides.privateKey !== undefined)
+      server.privateKey = serverOverrides.privateKey;
+    if (serverOverrides.port !== undefined) server.port = serverOverrides.port;
   }
 
   // Tracks whether any override merged into result.options, so the single
@@ -78,20 +123,20 @@ export function applyConnectionOverrides(
   let optionsModified = false;
 
   if (
-    overrides.peerTimeout !== undefined ||
-    overrides.connectionTimeout !== undefined ||
-    overrides.maxReconnectAttempts !== undefined
+    optionsOverrides.peerTimeout !== undefined ||
+    optionsOverrides.connectionTimeout !== undefined ||
+    optionsOverrides.maxReconnectAttempts !== undefined
   ) {
     result.options = {
       ...result.options,
-      ...(overrides.peerTimeout !== undefined && {
-        peerTimeoutMs: overrides.peerTimeout * 1000,
+      ...(optionsOverrides.peerTimeout !== undefined && {
+        peerTimeoutMs: optionsOverrides.peerTimeout * 1000,
       }),
-      ...(overrides.connectionTimeout !== undefined && {
-        serverConnectTimeoutMs: overrides.connectionTimeout * 1000,
+      ...(optionsOverrides.connectionTimeout !== undefined && {
+        serverConnectTimeoutMs: optionsOverrides.connectionTimeout * 1000,
       }),
-      ...(overrides.maxReconnectAttempts !== undefined && {
-        maxReconnectAttempts: overrides.maxReconnectAttempts,
+      ...(optionsOverrides.maxReconnectAttempts !== undefined && {
+        maxReconnectAttempts: optionsOverrides.maxReconnectAttempts,
       }),
     };
     optionsModified = true;
@@ -103,24 +148,24 @@ export function applyConnectionOverrides(
   // SharedOptions that apply to all channels including webrtc.
   if (
     (result.channel === "sftp" || result.channel === "filedrop") &&
-    (overrides.locklessRendezvous !== undefined ||
-      overrides.peerId !== undefined ||
-      overrides.retainFiles !== undefined ||
-      overrides.timestampInFilename !== undefined)
+    (optionsOverrides.locklessRendezvous !== undefined ||
+      optionsOverrides.peerId !== undefined ||
+      optionsOverrides.retainFiles !== undefined ||
+      optionsOverrides.timestampInFilename !== undefined)
   ) {
     result.options = {
       ...result.options,
-      ...(overrides.locklessRendezvous !== undefined && {
-        locklessRendezvous: overrides.locklessRendezvous,
+      ...(optionsOverrides.locklessRendezvous !== undefined && {
+        locklessRendezvous: optionsOverrides.locklessRendezvous,
       }),
-      ...(overrides.peerId !== undefined && {
-        peerId: overrides.peerId,
+      ...(optionsOverrides.peerId !== undefined && {
+        peerId: optionsOverrides.peerId,
       }),
-      ...(overrides.retainFiles !== undefined && {
-        retainFiles: overrides.retainFiles,
+      ...(optionsOverrides.retainFiles !== undefined && {
+        retainFiles: optionsOverrides.retainFiles,
       }),
-      ...(overrides.timestampInFilename !== undefined && {
-        timestampInFilename: overrides.timestampInFilename,
+      ...(optionsOverrides.timestampInFilename !== undefined && {
+        timestampInFilename: optionsOverrides.timestampInFilename,
       }),
     };
 
@@ -172,17 +217,17 @@ export function applyConnectionOverrides(
   // outbound. Applied here, the single chokepoint every bootstrap command routes
   // its connection through, so the four commands share one mapping rather than
   // re-deriving it per command. Only the file-sync channels carry a directory.
-  if (overrides.outboundPath !== undefined) {
+  if (serverOverrides.outboundPath !== undefined) {
     if (result.channel === "sftp") {
       const { server } = result;
       // An already-split config (inbound set) keeps its inbound; a shared config
       // contributes its `path`. The single `path` cannot coexist with the pair.
       server.inboundPath = server.inboundPath ?? server.path;
-      server.outboundPath = overrides.outboundPath;
+      server.outboundPath = serverOverrides.outboundPath;
       delete server.path;
     } else if (result.channel === "filedrop") {
       result.inboundPath = result.inboundPath ?? result.path;
-      result.outboundPath = overrides.outboundPath;
+      result.outboundPath = serverOverrides.outboundPath;
       delete result.path;
     } else {
       // webrtc has no directory, so the flag is meaningless there. Only

--- a/apps/cli/test/unit/bootstrap.test.ts
+++ b/apps/cli/test/unit/bootstrap.test.ts
@@ -220,8 +220,8 @@ test("connectionFromURL and diffConnectionAgainstTarget agree on an encoded URL"
 
 test("connectionFromURL: --outbound-path splits an sftp URL path into inbound/outbound", () => {
   const target = connectionFromURL(new URL("sftp://host/drop-in"), {
-    retainFiles: true,
-    outboundPath: "/drop-out",
+    options: { retainFiles: true },
+    server: { outboundPath: "/drop-out" },
   });
   expect(target.channel).toBe("sftp");
   if (target.channel !== "sftp") return;
@@ -232,8 +232,8 @@ test("connectionFromURL: --outbound-path splits an sftp URL path into inbound/ou
 
 test("connectionFromURL: --outbound-path splits a filedrop URL directory", () => {
   const target = connectionFromURL(new URL("file:///mnt/share/in"), {
-    retainFiles: true,
-    outboundPath: "/mnt/share/out",
+    options: { retainFiles: true },
+    server: { outboundPath: "/mnt/share/out" },
   });
   expect(target.channel).toBe("filedrop");
   if (target.channel !== "filedrop") return;
@@ -934,7 +934,7 @@ test("applyEndpointSplitDirectories: preserves URL-derived options under the ret
   // A --connection-timeout carried on the URL connection must survive the merge:
   // the retain trio is layered over the existing options, not substituted for it.
   const urlConnection = connectionFromURL(new URL("sftp://host/in"), {
-    connectionTimeout: 45,
+    options: { connectionTimeout: 45 },
   });
   const endpoint: ConnectionEndpoint = {
     channel: "sftp",
@@ -1054,9 +1054,11 @@ test("endpointFromConnection: no credential rides along on the emitted endpoint"
   // the endpoint must carry only the public locator. This is the producer side of
   // the invitation's no-credentials invariant.
   const connection = connectionFromURL(new URL("sftp://host:2200/drop"), {
-    serverUsername: "alice",
-    serverPassword: "hunter2",
-    serverPrivateKey: "@/home/alice/.ssh/id_ed25519",
+    server: {
+      username: "alice",
+      password: "hunter2",
+      privateKey: "@/home/alice/.ssh/id_ed25519",
+    },
   });
   const endpoint = endpointFromConnection(connection);
   expect(Object.keys(endpoint).sort()).toEqual([
@@ -1103,8 +1105,8 @@ test.each(["sftp", "filedrop"] as const)(
         ? new URL("sftp://host/inviter-in")
         : new URL("file:///inviter-in");
     const connection = connectionFromURL(url, {
-      outboundPath: "/inviter-out",
-      retainFiles: true,
+      options: { retainFiles: true },
+      server: { outboundPath: "/inviter-out" },
     });
     const endpoint = endpointFromConnection(connection);
     if (endpoint.channel !== channel) throw new Error(`expected ${channel}`);
@@ -1119,8 +1121,8 @@ test("endpointFromConnection -> connectionFromEndpoint round-trips a split pair 
   // acceptor's single swap site lands the inviter's outbound on the acceptor's
   // inbound (item 202418344's dormant consumer, now exercised by the producer).
   const connection = connectionFromURL(new URL("file:///inviter-in"), {
-    outboundPath: "/inviter-out",
-    retainFiles: true,
+    options: { retainFiles: true },
+    server: { outboundPath: "/inviter-out" },
   });
   const endpoint = endpointFromConnection(connection);
   const { connection: seeded } = connectionFromEndpoint(endpoint);
@@ -1153,8 +1155,8 @@ test("endpointFromConnection: an over-long path is a clean usage error", () => {
 test("endpointFromConnection: an over-long split outbound_path is a clean usage error", () => {
   // The split pair is bounded too; --outbound-path supplies the outbound half.
   const connection = connectionFromURL(new URL("file:///inviter-in"), {
-    outboundPath: `/${"o".repeat(4097)}`,
-    retainFiles: true,
+    options: { retainFiles: true },
+    server: { outboundPath: `/${"o".repeat(4097)}` },
   });
   expect(() => endpointFromConnection(connection)).toThrow(/outbound_path/);
 });

--- a/apps/cli/test/unit/config.test.ts
+++ b/apps/cli/test/unit/config.test.ts
@@ -37,27 +37,33 @@ const baseWebRTC: ConnectionConfig = {
 // --- timeout / reconnect overrides -------------------------------------------
 
 test("peerTimeout is converted to peerTimeoutMs in milliseconds", () => {
-  const result = applyConnectionOverrides(baseSFTP, { peerTimeout: 30 });
+  const result = applyConnectionOverrides(baseSFTP, {
+    options: { peerTimeout: 30 },
+  });
   expect(result.options?.peerTimeoutMs).toBe(30_000);
 });
 
 test("connectionTimeout is converted to serverConnectTimeoutMs in milliseconds", () => {
-  const result = applyConnectionOverrides(baseSFTP, { connectionTimeout: 10 });
+  const result = applyConnectionOverrides(baseSFTP, {
+    options: { connectionTimeout: 10 },
+  });
   expect(result.options?.serverConnectTimeoutMs).toBe(10_000);
 });
 
 test("maxReconnectAttempts is passed through unchanged", () => {
   const result = applyConnectionOverrides(baseSFTP, {
-    maxReconnectAttempts: 5,
+    options: { maxReconnectAttempts: 5 },
   });
   expect(result.options?.maxReconnectAttempts).toBe(5);
 });
 
 test("multiple timeout overrides are merged into options", () => {
   const result = applyConnectionOverrides(baseSFTP, {
-    peerTimeout: 60,
-    connectionTimeout: 15,
-    maxReconnectAttempts: 2,
+    options: {
+      peerTimeout: 60,
+      connectionTimeout: 15,
+      maxReconnectAttempts: 2,
+    },
   });
   expect(result.options?.peerTimeoutMs).toBe(60_000);
   expect(result.options?.serverConnectTimeoutMs).toBe(15_000);
@@ -71,7 +77,7 @@ test("existing options are preserved when adding timeout overrides", () => {
     options: { pollIntervalMs: 5000 },
   };
   const result = applyConnectionOverrides(base, {
-    peerTimeout: 20,
+    options: { peerTimeout: 20 },
   }) as SFTPConnectionConfig;
   expect(result.options?.pollIntervalMs).toBe(5000);
   expect(result.options?.peerTimeoutMs).toBe(20_000);
@@ -86,20 +92,20 @@ test("a non-positive peerTimeout override is rejected with a UsageError", () => 
   // peerTimeout 0 -> peerTimeoutMs 0, which violates the schema's positivity
   // floor. The CLI duration parser already rejects this upstream; the schema
   // re-parse closes the same hole for any non-CLI override path.
-  expect(() => applyConnectionOverrides(baseSFTP, { peerTimeout: 0 })).toThrow(
-    UsageError,
-  );
-  expect(() => applyConnectionOverrides(baseSFTP, { peerTimeout: -1 })).toThrow(
-    UsageError,
-  );
+  expect(() =>
+    applyConnectionOverrides(baseSFTP, { options: { peerTimeout: 0 } }),
+  ).toThrow(UsageError);
+  expect(() =>
+    applyConnectionOverrides(baseSFTP, { options: { peerTimeout: -1 } }),
+  ).toThrow(UsageError);
 });
 
 test("a non-positive connectionTimeout override is rejected with a UsageError", () => {
   expect(() =>
-    applyConnectionOverrides(baseSFTP, { connectionTimeout: 0 }),
+    applyConnectionOverrides(baseSFTP, { options: { connectionTimeout: 0 } }),
   ).toThrow(UsageError);
   expect(() =>
-    applyConnectionOverrides(baseSFTP, { connectionTimeout: -1 }),
+    applyConnectionOverrides(baseSFTP, { options: { connectionTimeout: -1 } }),
   ).toThrow(UsageError);
 });
 
@@ -108,15 +114,14 @@ test("maxReconnectAttempts 0 passes re-validation (nonnegative, not positive)", 
   // schema floor is nonnegative, not positive -- so the new re-validation path
   // must accept it rather than reject it alongside the non-positive timeouts.
   const result = applyConnectionOverrides(baseSFTP, {
-    maxReconnectAttempts: 0,
+    options: { maxReconnectAttempts: 0 },
   });
   expect(result.options?.maxReconnectAttempts).toBe(0);
 });
 
 test("a valid timeout override still passes through unchanged on webrtc", () => {
   const result = applyConnectionOverrides(baseWebRTC, {
-    peerTimeout: 30,
-    connectionTimeout: 15,
+    options: { peerTimeout: 30, connectionTimeout: 15 },
   });
   expect(result.options?.peerTimeoutMs).toBe(30_000);
   expect(result.options?.serverConnectTimeoutMs).toBe(15_000);
@@ -127,7 +132,7 @@ test("a non-positive timeout override is rejected on webrtc too", () => {
   // timeout block's own re-validation. FileSyncOptionsSchema is a safe superset
   // for a webrtc SharedOptions object (its FileSync-only refines cannot fire).
   expect(() =>
-    applyConnectionOverrides(baseWebRTC, { peerTimeout: 0 }),
+    applyConnectionOverrides(baseWebRTC, { options: { peerTimeout: 0 } }),
   ).toThrow(UsageError);
 });
 
@@ -142,12 +147,16 @@ test("the two override blocks agree on a non-positive peerTimeoutMs floor", () =
   };
   // Reached via the FileSync-field block (overriding peerId triggers its re-parse).
   expect(() =>
-    applyConnectionOverrides(withBadPeerTimeout, { peerId: "agency-a" }),
+    applyConnectionOverrides(withBadPeerTimeout, {
+      options: { peerId: "agency-a" },
+    }),
   ).toThrow(UsageError);
   // Reached via the timeout block (overriding connectionTimeout leaves the
   // invalid peerTimeoutMs in the merged options).
   expect(() =>
-    applyConnectionOverrides(withBadPeerTimeout, { connectionTimeout: 10 }),
+    applyConnectionOverrides(withBadPeerTimeout, {
+      options: { connectionTimeout: 10 },
+    }),
   ).toThrow(UsageError);
 });
 
@@ -155,14 +164,16 @@ test("the two override blocks agree on a non-positive peerTimeoutMs floor", () =
 
 test("serverUsername overrides the connection username", () => {
   const result = applyConnectionOverrides(baseSFTP, {
-    serverUsername: "alice",
+    server: { username: "alice" },
   });
   if (result.channel !== "sftp") return;
   expect(result.server.username).toBe("alice");
 });
 
 test("serverPort overrides the connection port", () => {
-  const result = applyConnectionOverrides(baseSFTP, { serverPort: 2222 });
+  const result = applyConnectionOverrides(baseSFTP, {
+    server: { port: 2222 },
+  });
   if (result.channel !== "sftp") return;
   expect(result.server.port).toBe(2222);
 });
@@ -179,7 +190,10 @@ test("the input connection object is not mutated", () => {
     channel: "sftp",
     server: { host: "sftp.example.org" },
   };
-  applyConnectionOverrides(input, { peerTimeout: 10, serverUsername: "bob" });
+  applyConnectionOverrides(input, {
+    options: { peerTimeout: 10 },
+    server: { username: "bob" },
+  });
   expect(input.options).toBeUndefined();
   if (input.channel !== "sftp") return;
   expect(input.server.username).toBeUndefined();
@@ -193,7 +207,9 @@ test("peerId override accepted when timestampInFilename is already set in config
     server: { host: "sftp.example.org" },
     options: { timestampInFilename: true },
   };
-  const result = applyConnectionOverrides(base, { peerId: "agency-a" });
+  const result = applyConnectionOverrides(base, {
+    options: { peerId: "agency-a" },
+  });
   if (result.channel !== "sftp") return;
   expect(result.options?.peerId).toBe("agency-a");
 });
@@ -205,17 +221,17 @@ test("peerId 'temp' is rejected by applyConnectionOverrides", () => {
     options: { timestampInFilename: true },
   };
   // Invalid option combinations are usage errors (CLI exit 64), not exit 69.
-  expect(() => applyConnectionOverrides(base, { peerId: "temp" })).toThrow(
-    UsageError,
-  );
-  expect(() => applyConnectionOverrides(base, { peerId: "temp" })).toThrow(
-    "reserved",
-  );
+  expect(() =>
+    applyConnectionOverrides(base, { options: { peerId: "temp" } }),
+  ).toThrow(UsageError);
+  expect(() =>
+    applyConnectionOverrides(base, { options: { peerId: "temp" } }),
+  ).toThrow("reserved");
 });
 
 test("peerId without timestampInFilename is rejected by applyConnectionOverrides", () => {
   expect(() =>
-    applyConnectionOverrides(baseSFTP, { peerId: "agency-a" }),
+    applyConnectionOverrides(baseSFTP, { options: { peerId: "agency-a" } }),
   ).toThrow("timestamp_in_filename");
 });
 
@@ -224,9 +240,9 @@ test("peerId without timestampInFilename is rejected on filedrop too", () => {
     channel: "filedrop",
     path: "/mnt/share",
   };
-  expect(() => applyConnectionOverrides(base, { peerId: "agency-a" })).toThrow(
-    "timestamp_in_filename",
-  );
+  expect(() =>
+    applyConnectionOverrides(base, { options: { peerId: "agency-a" } }),
+  ).toThrow("timestamp_in_filename");
 });
 
 test("empty peerId is rejected by applyConnectionOverrides", () => {
@@ -235,13 +251,17 @@ test("empty peerId is rejected by applyConnectionOverrides", () => {
     server: { host: "sftp.example.org" },
     options: { timestampInFilename: true },
   };
-  expect(() => applyConnectionOverrides(base, { peerId: "" })).toThrow();
+  expect(() =>
+    applyConnectionOverrides(base, { options: { peerId: "" } }),
+  ).toThrow();
 });
 
 // --- retainFiles implication --------------------------------------------------
 
 test("retainFiles: true with unset lockless and timestamp implies both true", () => {
-  const result = applyConnectionOverrides(baseSFTP, { retainFiles: true });
+  const result = applyConnectionOverrides(baseSFTP, {
+    options: { retainFiles: true },
+  });
   if (result.channel !== "sftp") return;
   expect(result.options?.retainFiles).toBe(true);
   expect(result.options?.locklessRendezvous).toBe(true);
@@ -254,7 +274,9 @@ test("retainFiles: true preserves an already-set locklessRendezvous: true", () =
     server: { host: "sftp.example.org" },
     options: { locklessRendezvous: true, timestampInFilename: true },
   };
-  const result = applyConnectionOverrides(base, { retainFiles: true });
+  const result = applyConnectionOverrides(base, {
+    options: { retainFiles: true },
+  });
   if (result.channel !== "sftp") return;
   expect(result.options?.locklessRendezvous).toBe(true);
 });
@@ -262,14 +284,12 @@ test("retainFiles: true preserves an already-set locklessRendezvous: true", () =
 test("retainFiles: true with explicit locklessRendezvous: false throws", () => {
   expect(() =>
     applyConnectionOverrides(baseSFTP, {
-      retainFiles: true,
-      locklessRendezvous: false,
+      options: { retainFiles: true, locklessRendezvous: false },
     }),
   ).toThrow(UsageError);
   expect(() =>
     applyConnectionOverrides(baseSFTP, {
-      retainFiles: true,
-      locklessRendezvous: false,
+      options: { retainFiles: true, locklessRendezvous: false },
     }),
   ).toThrow("lockless_rendezvous");
 });
@@ -288,8 +308,8 @@ const baseFiledrop: ConnectionConfig = {
 
 test("outboundPath splits an sftp shared path into inbound/outbound", () => {
   const result = applyConnectionOverrides(baseSFTPWithPath, {
-    retainFiles: true,
-    outboundPath: "/drop/out",
+    options: { retainFiles: true },
+    server: { outboundPath: "/drop/out" },
   });
   if (result.channel !== "sftp") return;
   expect(result.server.inboundPath).toBe("/drop/in");
@@ -301,8 +321,8 @@ test("outboundPath splits an sftp shared path into inbound/outbound", () => {
 
 test("outboundPath splits a filedrop shared path into inbound/outbound", () => {
   const result = applyConnectionOverrides(baseFiledrop, {
-    retainFiles: true,
-    outboundPath: "/mnt/share/out",
+    options: { retainFiles: true },
+    server: { outboundPath: "/mnt/share/out" },
   });
   if (result.channel !== "filedrop") return;
   expect(result.inboundPath).toBe("/mnt/share/in");
@@ -322,7 +342,7 @@ test("outboundPath overrides only the outbound on an already-split config", () =
     },
   };
   const result = applyConnectionOverrides(base, {
-    outboundPath: "/mnt/share/new-out",
+    server: { outboundPath: "/mnt/share/new-out" },
   });
   if (result.channel !== "filedrop") return;
   expect(result.inboundPath).toBe("/mnt/share/in");
@@ -332,15 +352,22 @@ test("outboundPath overrides only the outbound on an already-split config", () =
 
 test("outboundPath without retain mode is rejected naming --retain-files", () => {
   expect(() =>
-    applyConnectionOverrides(baseSFTPWithPath, { outboundPath: "/drop/out" }),
+    applyConnectionOverrides(baseSFTPWithPath, {
+      server: { outboundPath: "/drop/out" },
+    }),
   ).toThrow(UsageError);
   expect(() =>
-    applyConnectionOverrides(baseSFTPWithPath, { outboundPath: "/drop/out" }),
+    applyConnectionOverrides(baseSFTPWithPath, {
+      server: { outboundPath: "/drop/out" },
+    }),
   ).toThrow("--retain-files");
 });
 
 test("outboundPath equal to the inbound path is rejected", () => {
-  const overrides = { retainFiles: true, outboundPath: "/mnt/share/in" };
+  const overrides = {
+    options: { retainFiles: true },
+    server: { outboundPath: "/mnt/share/in" },
+  };
   expect(() => applyConnectionOverrides(baseFiledrop, overrides)).toThrow(
     UsageError,
   );
@@ -350,7 +377,10 @@ test("outboundPath equal to the inbound path is rejected", () => {
 });
 
 test("a relative filedrop outbound path is rejected (filedrop requires absolute)", () => {
-  const overrides = { retainFiles: true, outboundPath: "relative/out" };
+  const overrides = {
+    options: { retainFiles: true },
+    server: { outboundPath: "relative/out" },
+  };
   expect(() => applyConnectionOverrides(baseFiledrop, overrides)).toThrow(
     UsageError,
   );
@@ -361,8 +391,8 @@ test("a relative filedrop outbound path is rejected (filedrop requires absolute)
 
 test("a relative sftp outbound path is allowed (sftp permits relative paths)", () => {
   const result = applyConnectionOverrides(baseSFTPWithPath, {
-    retainFiles: true,
-    outboundPath: "outgoing",
+    options: { retainFiles: true },
+    server: { outboundPath: "outgoing" },
   });
   if (result.channel !== "sftp") return;
   expect(result.server.inboundPath).toBe("/drop/in");
@@ -373,8 +403,8 @@ test("outboundPath on an sftp login-home (no inbound path) is rejected as set-to
   // baseSFTP has no server.path, so the inbound half is unset; a split needs both.
   expect(() =>
     applyConnectionOverrides(baseSFTP, {
-      retainFiles: true,
-      outboundPath: "/drop/out",
+      options: { retainFiles: true },
+      server: { outboundPath: "/drop/out" },
     }),
   ).toThrow("set together");
 });
@@ -385,7 +415,7 @@ test("outboundPath on a webrtc connection is rejected", () => {
     server: { host: "peer.example.org" },
   };
   expect(() =>
-    applyConnectionOverrides(webrtc, { outboundPath: "/out" }),
+    applyConnectionOverrides(webrtc, { server: { outboundPath: "/out" } }),
   ).toThrow("sftp and filedrop");
 });
 


### PR DESCRIPTION
## Summary

The CLI's `ConnectionOverrides` type is now split into two named sub-groups -- a server/credential group (plus directory paths) and a tuning/toggle options group -- mirroring the config schema's `connection.server` vs `connection.options` seam, so the fan-out into those two destinations is explicit in the type system instead of holding only by convention inside `applyConnectionOverrides`. This is an internal refactor with no observable CLI behavior change.

Implements [202519035](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202519035).

## Changes

- apps/cli/src/config.ts: replace the flat `ConnectionOverrides` with `ConnectionServerOverrides` (username/password/privateKey/port/outboundPath) and `ConnectionOptionsOverrides` (timeouts, reconnect bound, file-sync toggles), composed as `{ server?, options? }`; `applyConnectionOverrides` destructures the two groups (each defaulted to empty) and reads each existing branch from its corresponding group, leaving the `--retain-files` implications and the single schema re-validation untouched.
- apps/cli/src/commands/bootstrap.ts: `connectionOverridesFrom` fans the flat parsed options into the two sub-groups, preserving the synthesized `extra.peerTimeout` precedence in the options group. The flat parsed-option types (`CommonBootstrapOptions`, `ConnectionOverrideOptions`, `OfflineIgnoredServerOverrides`) and the warning helpers stay as they were.
- apps/cli/test/unit/config.test.ts, apps/cli/test/unit/bootstrap.test.ts: re-nest each override construction to the new shape; every destination-field assertion is unchanged.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format`, `npx vitest run apps/cli/test/unit/config.test.ts apps/cli/test/unit/bootstrap.test.ts`, and `npm run test:unit -w apps/cli` (817 passed).
New tests cover: n/a -- behavior-preserving refactor; the existing `applyConnectionOverrides` and override-mapping tests are retained and updated only for the type reshape, still asserting each flag's destination field on each channel.

## Background

The flat bag conflated two structurally distinct override destinations, so the offline-warn scope of item 202433910 (server/credential overrides only) had to be hand-justified in prose rather than falling out of the type. Splitting the type makes that seam load-bearing. The options sub-group is deliberately kept as a single channel-gated group rather than further split along SharedOptions/FileSyncOptions, the minimal match to the prior code.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; this is a CLI-internal type reshape with identical runtime behavior.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: internal refactor, no operator- or reviewer-visible change (no command, flag, default, behavior, exit code, or on-disk/wire format changed).
- [x] Security review -- independent multi-reviewer security review conducted (the reshaped `server` group is credential-bearing); judged out of formal scope: a compile-time type split that changes no credential source, sink, logging, redaction, transmission, or channel gating, and leaves the credential-free `ConnectionEndpoint` invariant intact (asserted by an unchanged, passing producer test).
