### PR TITLE
Add a standing console sentinel to the CLI integration suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,17 @@ PSILINK_SFTP_BACKEND=native PSILINK_SFTP_NATIVE_PROFILE=restricted-crypto npm ru
 sudo --preserve-env=PATH env "PATH=$PATH" npm run test:integration:native-chroot -w apps/cli
 ```
 
+A standing console sentinel guards the CLI integration suite: it wraps `console`
+directly and fails a test file at `afterAll` on any `console.log`/`warn`/`error`
+that no allowlist matcher accepts (the inverse of blanket silencing, and the one
+check that sees third-party `console.*` which the loglevel-based
+`withCapturedLogs` cannot). If your change makes the suite emit new console
+output, the fix is to eliminate it at the source -- route it through the logger
+or assert it under `withCapturedLogs`; accept it as intended only by adding a
+matcher to the allowlist in `apps/cli/test/integration/consoleAllowlist.ts`, a
+visible edit a reviewer sees. A matcher that never fires across a run is reported
+at teardown so the allowlist cannot accumulate dead entries.
+
 Web (dev server managed automatically -- same pattern as the CLI integration tests):
 
 ```sh

--- a/apps/cli/test/consoleSentinel.ts
+++ b/apps/cli/test/consoleSentinel.ts
@@ -279,3 +279,25 @@ export async function flushPendingConsole(timerMs = 25): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, timerMs));
   await new Promise((resolve) => setImmediate(resolve));
 }
+
+/**
+ * Given the raw contents of the cross-file matched-id sink (one matched id per
+ * line, appended by each worker) and the allowlist, returns the entries no
+ * worker matched -- the dead-entry candidates the suite teardown reports. Parses
+ * defensively: blank lines are dropped and each line is trimmed, so a torn or
+ * empty append cannot be mistaken for an id (it also matches the constructor's
+ * id guard, which forbids the newline/whitespace that parsing would mangle).
+ * Pure, so it is unit-tested directly; the teardown supplies the file contents.
+ */
+export function deadAllowlistEntries(
+  sinkContents: string,
+  allowlist: readonly ConsoleAllowEntry[],
+): ConsoleAllowEntry[] {
+  const matched = new Set(
+    sinkContents
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0),
+  );
+  return allowlist.filter((entry) => !matched.has(entry.id));
+}

--- a/apps/cli/test/consoleSentinel.ts
+++ b/apps/cli/test/consoleSentinel.ts
@@ -29,6 +29,8 @@
 
 import { inspect } from "node:util";
 
+import { sanitizeForDisplay } from "@psilink/core";
+
 /** A console sink the sentinel gates. */
 export type ConsoleLevel = "log" | "warn" | "error";
 
@@ -242,7 +244,16 @@ export class ConsoleSentinel {
     const { violations } = this.evaluate();
     if (violations.length === 0) return;
     const shown = violations.slice(0, MAX_REPORTED_VIOLATIONS);
-    const lines = shown.map((v) => `  [${v.level}] ${v.message}`);
+    // Escape each line at this display boundary: a recorded line is whatever
+    // reached the console, which can carry a server- or partner-controlled string
+    // (ssh2 surfaces an SSH_MSG_DISCONNECT description on err.message, for one).
+    // Rendering it raw into the thrown error -- which lands in the CI log -- would
+    // let control bytes (ANSI/bidi/newline) ride in as log injection. The raw
+    // message stays untouched for matching (sanitize only at display, never the
+    // compared value). This mirrors the production sinks' sanitizeErrorForDisplay.
+    const lines = shown.map(
+      (v) => `  [${v.level}] ${sanitizeForDisplay(v.message)}`,
+    );
     if (violations.length > shown.length) {
       lines.push(`  ... and ${violations.length - shown.length} more`);
     }

--- a/apps/cli/test/consoleSentinel.ts
+++ b/apps/cli/test/consoleSentinel.ts
@@ -1,0 +1,185 @@
+/**
+ * A standing console-output sentinel for the CLI integration suite.
+ *
+ * It wraps the three `console` sinks (`log`/`warn`/`error`) directly and, at a
+ * file-level `afterAll` flush, FAILS the run on any line that no allowlist
+ * matcher accepts -- the inverse of blanket silencing. It hides nothing and
+ * makes unexpected output loud; an allowlist of intended-message matchers is
+ * the single reviewable source of truth for "intended noise", so adding an
+ * intended log forces a visible allowlist edit in review.
+ *
+ * Why wrap `console` directly rather than route through loglevel: the per-test
+ * `withCapturedLogs` (`packages/core/src/testing.ts`) intercepts loglevel's
+ * `methodFactory`, so any third-party `console.*` that does NOT go through
+ * loglevel (e.g. ssh2-sftp-client's default constructor callbacks, which
+ * `console.log`/`console.error` "Global ... listener" lines) is structurally
+ * invisible to it. Wrapping `console` is what closes that gap. This sentinel
+ * complements -- it does not replace -- the per-test `withCapturedLogs`
+ * capture-and-assert.
+ *
+ * @internal -- test infrastructure, used by the integration setup file and the
+ * sentinel's own unit tests.
+ */
+
+/** A console sink the sentinel gates. */
+export type ConsoleLevel = "log" | "warn" | "error";
+
+/** Minimal shape the sentinel wraps; the global `console` satisfies it. */
+export interface ConsoleLike {
+  log(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+}
+
+/** One accepted line of intended console output. */
+export interface ConsoleAllowEntry {
+  /** Stable identifier; the dead-entry report and cross-file aggregation key. */
+  id: string;
+  /** Console levels this entry may accept. */
+  levels: readonly ConsoleLevel[];
+  /** Accepts the joined message text. Avoid the `g` flag (stateful lastIndex). */
+  match: RegExp | ((message: string) => boolean);
+  /** Why this output is intended; shown in review and in the dead-entry report. */
+  reason: string;
+}
+
+/** A single recorded console call: its level and joined message text. */
+export interface RecordedConsoleLine {
+  level: ConsoleLevel;
+  message: string;
+}
+
+const ALL_LEVELS: readonly ConsoleLevel[] = ["log", "warn", "error"];
+
+// Cap how many offending lines the assertion error enumerates, so a test that
+// spams output produces a readable failure rather than a wall of text.
+const MAX_REPORTED_VIOLATIONS = 20;
+
+function matchEntry(entry: ConsoleAllowEntry, message: string): boolean {
+  return entry.match instanceof RegExp
+    ? entry.match.test(message)
+    : entry.match(message);
+}
+
+/**
+ * Wraps a {@link ConsoleLike} and records every gated call. Call
+ * {@link ConsoleSentinel.assertClean} once per file at `afterAll` (after a
+ * {@link flushPendingConsole}) to fail on any un-allowlisted line.
+ */
+export class ConsoleSentinel {
+  private readonly allowlist: readonly ConsoleAllowEntry[];
+  private readonly gatedLevels: readonly ConsoleLevel[];
+  private readonly recorded: RecordedConsoleLine[] = [];
+  private readonly matchedIds = new Set<string>();
+  private target: ConsoleLike | null = null;
+  private readonly originals = new Map<
+    ConsoleLevel,
+    (...args: unknown[]) => void
+  >();
+
+  constructor(
+    allowlist: readonly ConsoleAllowEntry[],
+    options: { gatedLevels?: readonly ConsoleLevel[] } = {},
+  ) {
+    this.allowlist = allowlist;
+    this.gatedLevels = options.gatedLevels ?? ALL_LEVELS;
+  }
+
+  /** Wraps `target` (the global `console` by default). Pass-through is preserved
+   * so output still surfaces -- the sentinel adds a failure, it never silences. */
+  install(target: ConsoleLike = console): void {
+    if (this.target) throw new Error("ConsoleSentinel is already installed");
+    this.target = target;
+    for (const level of this.gatedLevels) {
+      const original = target[level].bind(target) as (
+        ...args: unknown[]
+      ) => void;
+      this.originals.set(level, original);
+      target[level] = (...args: unknown[]): void => {
+        this.recorded.push({ level, message: args.map(String).join(" ") });
+        original(...args);
+      };
+    }
+  }
+
+  /** Restores the wrapped methods. Safe to call when not installed. */
+  restore(): void {
+    if (!this.target) return;
+    for (const [level, original] of this.originals) {
+      this.target[level] = original;
+    }
+    this.originals.clear();
+    this.target = null;
+  }
+
+  // Recompute which allowlist entries matched and which recorded lines no entry
+  // accepts. Every entry that accepts a line is credited (so a line shared by
+  // two matchers leaves neither looking dead); a line accepted by none is a
+  // violation.
+  private evaluate(): RecordedConsoleLine[] {
+    this.matchedIds.clear();
+    const violations: RecordedConsoleLine[] = [];
+    for (const line of this.recorded) {
+      let accepted = false;
+      for (const entry of this.allowlist) {
+        if (!entry.levels.includes(line.level)) continue;
+        if (matchEntry(entry, line.message)) {
+          this.matchedIds.add(entry.id);
+          accepted = true;
+        }
+      }
+      if (!accepted) violations.push(line);
+    }
+    return violations;
+  }
+
+  /** Recorded lines that no allowlist matcher accepts. */
+  violations(): RecordedConsoleLine[] {
+    return this.evaluate();
+  }
+
+  /** Allowlist ids matched by at least one recorded line (for aggregation). */
+  matchedAllowlistIds(): string[] {
+    this.evaluate();
+    return [...this.matchedIds];
+  }
+
+  /** Allowlist ids no recorded line matched (dead-entry candidates). */
+  unusedAllowlistIds(): string[] {
+    this.evaluate();
+    return this.allowlist
+      .filter((entry) => !this.matchedIds.has(entry.id))
+      .map((entry) => entry.id);
+  }
+
+  /** Throws if any recorded line is un-allowlisted; no-op otherwise. */
+  assertClean(): void {
+    const violations = this.evaluate();
+    if (violations.length === 0) return;
+    const shown = violations.slice(0, MAX_REPORTED_VIOLATIONS);
+    const lines = shown.map((v) => `  [${v.level}] ${v.message}`);
+    if (violations.length > shown.length) {
+      lines.push(`  ... and ${violations.length - shown.length} more`);
+    }
+    throw new Error(
+      `Console sentinel: ${violations.length} un-allowlisted console line(s) ` +
+        `emitted during this test file. Eliminate each at the source, or -- if ` +
+        `genuinely intended -- accept it with a matcher in the integration ` +
+        `console allowlist (a visible, reviewable edit):\n${lines.join("\n")}`,
+    );
+  }
+}
+
+/**
+ * Lets pending async console output settle before an assertion. The
+ * ssh2-sftp-client "Global ... listener" lines fire on connection-teardown
+ * events emitted asynchronously, so a teardown triggered by one test lands a
+ * tick or two later -- in the NEXT test's window, or after the last test. A
+ * file-level `afterAll` that flushes a macrotask and the microtask queue
+ * attributes such a late line to this file rather than misattributing it to the
+ * following test (or leaking it into the next file).
+ */
+export async function flushPendingConsole(timerMs = 25): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, timerMs));
+  await new Promise((resolve) => setImmediate(resolve));
+}

--- a/apps/cli/test/consoleSentinel.ts
+++ b/apps/cli/test/consoleSentinel.ts
@@ -21,6 +21,8 @@
  * sentinel's own unit tests.
  */
 
+import { inspect } from "node:util";
+
 /** A console sink the sentinel gates. */
 export type ConsoleLevel = "log" | "warn" | "error";
 
@@ -37,9 +39,12 @@ export interface ConsoleAllowEntry {
   id: string;
   /** Console levels this entry may accept. */
   levels: readonly ConsoleLevel[];
-  /** Accepts the joined message text. Must be a flagless-or-non-stateful regex:
+  /** Accepts the joined message text. A regex must be flagless-or-non-stateful:
    * the constructor rejects the `g`/`y` flags, whose `lastIndex` would make
-   * matching depend on evaluation order. */
+   * matching depend on evaluation order. A function matcher must be a pure
+   * predicate -- no side effects, no internal state -- because the sentinel does
+   * not short-circuit: to credit every matcher that accepts a line, it evaluates
+   * each entry's `match` once per recorded line regardless of earlier matches. */
   match: RegExp | ((message: string) => boolean);
   /** Why this output is intended; shown in review and in the dead-entry report. */
   reason: string;
@@ -56,6 +61,19 @@ const ALL_LEVELS: readonly ConsoleLevel[] = ["log", "warn", "error"];
 // Cap how many offending lines the assertion error enumerates, so a test that
 // spams output produces a readable failure rather than a wall of text.
 const MAX_REPORTED_VIOLATIONS = 20;
+
+// Join console arguments into one matchable line. Strings pass through verbatim
+// (so a matcher reads the literal logged text); a non-string is inspected rather
+// than `String()`-coerced, so an object records as `{ key: 'value' }` instead of
+// the useless `[object Object]` a matcher could never usefully match.
+// `breakLength: Infinity` keeps each argument on one line.
+function formatArgs(args: unknown[]): string {
+  return args
+    .map((arg) =>
+      typeof arg === "string" ? arg : inspect(arg, { breakLength: Infinity }),
+    )
+    .join(" ");
+}
 
 function matchEntry(entry: ConsoleAllowEntry, message: string): boolean {
   return entry.match instanceof RegExp
@@ -83,12 +101,16 @@ export class ConsoleSentinel {
     options: { gatedLevels?: readonly ConsoleLevel[] } = {},
   ) {
     for (const entry of allowlist) {
-      // The id is the line-delimited key in the cross-file dead-entry sink, so a
-      // newline in it would split into phantom ids on read; reject it at the
-      // source rather than corrupt the aggregation silently.
-      if (entry.id.includes("\n")) {
+      // The id is the line-delimited key in the cross-file dead-entry sink,
+      // written as `id\n` and read back by splitting on `\n` and trimming each
+      // line. Any id the round-trip would alter -- an embedded newline (splits
+      // into phantom ids) or surrounding whitespace including a trailing `\r`
+      // (the trim strips it, so the entry always reads as dead) -- would corrupt
+      // the aggregation silently, so reject it at the source.
+      if (entry.id.includes("\n") || entry.id.trim() !== entry.id) {
         throw new Error(
-          `ConsoleAllowEntry id must not contain a newline: ` +
+          `ConsoleAllowEntry id must be a single line with no surrounding ` +
+            `whitespace (it keys the line-delimited sink): ` +
             JSON.stringify(entry.id),
         );
       }
@@ -120,7 +142,7 @@ export class ConsoleSentinel {
       ) => void;
       this.originals.set(level, original);
       target[level] = (...args: unknown[]): void => {
-        this.recorded.push({ level, message: args.map(String).join(" ") });
+        this.recorded.push({ level, message: formatArgs(args) });
         original(...args);
       };
     }
@@ -203,9 +225,10 @@ export class ConsoleSentinel {
  * ssh2-sftp-client "Global ... listener" lines fire on connection-teardown
  * events emitted asynchronously, so a teardown triggered by one test lands a
  * tick or two later -- in the NEXT test's window, or after the last test. A
- * file-level `afterAll` that flushes a macrotask and the microtask queue
- * attributes such a late line to this file rather than misattributing it to the
- * following test (or leaking it into the next file).
+ * file-level `afterAll` that waits a timer macrotask and then a check-phase
+ * callback (`setImmediate`) -- with the microtask queue draining automatically
+ * between them -- attributes such a late line to this file rather than
+ * misattributing it to the following test (or leaking it into the next file).
  *
  * Node-only: relies on `setImmediate`, which is not in the DOM lib.
  */

--- a/apps/cli/test/consoleSentinel.ts
+++ b/apps/cli/test/consoleSentinel.ts
@@ -37,7 +37,9 @@ export interface ConsoleAllowEntry {
   id: string;
   /** Console levels this entry may accept. */
   levels: readonly ConsoleLevel[];
-  /** Accepts the joined message text. Avoid the `g` flag (stateful lastIndex). */
+  /** Accepts the joined message text. Must be a flagless-or-non-stateful regex:
+   * the constructor rejects the `g`/`y` flags, whose `lastIndex` would make
+   * matching depend on evaluation order. */
   match: RegExp | ((message: string) => boolean);
   /** Why this output is intended; shown in review and in the dead-entry report. */
   reason: string;
@@ -70,7 +72,6 @@ export class ConsoleSentinel {
   private readonly allowlist: readonly ConsoleAllowEntry[];
   private readonly gatedLevels: readonly ConsoleLevel[];
   private readonly recorded: RecordedConsoleLine[] = [];
-  private readonly matchedIds = new Set<string>();
   private target: ConsoleLike | null = null;
   private readonly originals = new Map<
     ConsoleLevel,
@@ -81,6 +82,29 @@ export class ConsoleSentinel {
     allowlist: readonly ConsoleAllowEntry[],
     options: { gatedLevels?: readonly ConsoleLevel[] } = {},
   ) {
+    for (const entry of allowlist) {
+      // The id is the line-delimited key in the cross-file dead-entry sink, so a
+      // newline in it would split into phantom ids on read; reject it at the
+      // source rather than corrupt the aggregation silently.
+      if (entry.id.includes("\n")) {
+        throw new Error(
+          `ConsoleAllowEntry id must not contain a newline: ` +
+            JSON.stringify(entry.id),
+        );
+      }
+      // A stateful regex (g/y) advances lastIndex across .test() calls, so the
+      // same matcher could accept a line on one evaluation and reject it on the
+      // next. Make the documented footgun a hard guarantee.
+      if (
+        entry.match instanceof RegExp &&
+        (entry.match.global || entry.match.sticky)
+      ) {
+        throw new Error(
+          `ConsoleAllowEntry "${entry.id}" matcher uses a stateful regex flag ` +
+            `(g/y); use a flagless regex so matching is order-independent`,
+        );
+      }
+    }
     this.allowlist = allowlist;
     this.gatedLevels = options.gatedLevels ?? ALL_LEVELS;
   }
@@ -112,49 +136,53 @@ export class ConsoleSentinel {
     this.target = null;
   }
 
-  // Recompute which allowlist entries matched and which recorded lines no entry
-  // accepts. Every entry that accepts a line is credited (so a line shared by
+  // A pure evaluation of the recorded lines against the allowlist: which lines
+  // no entry accepts (violations) and which entries accepted at least one line
+  // (matched). Every entry that accepts a line is credited (so a line shared by
   // two matchers leaves neither looking dead); a line accepted by none is a
-  // violation.
-  private evaluate(): RecordedConsoleLine[] {
-    this.matchedIds.clear();
+  // violation. Returns fresh values rather than mutating shared state, so
+  // sequencing two public methods cannot leak stale results between them.
+  private evaluate(): {
+    violations: RecordedConsoleLine[];
+    matchedIds: Set<string>;
+  } {
+    const matchedIds = new Set<string>();
     const violations: RecordedConsoleLine[] = [];
     for (const line of this.recorded) {
       let accepted = false;
       for (const entry of this.allowlist) {
         if (!entry.levels.includes(line.level)) continue;
         if (matchEntry(entry, line.message)) {
-          this.matchedIds.add(entry.id);
+          matchedIds.add(entry.id);
           accepted = true;
         }
       }
       if (!accepted) violations.push(line);
     }
-    return violations;
+    return { violations, matchedIds };
   }
 
   /** Recorded lines that no allowlist matcher accepts. */
   violations(): RecordedConsoleLine[] {
-    return this.evaluate();
+    return this.evaluate().violations;
   }
 
   /** Allowlist ids matched by at least one recorded line (for aggregation). */
   matchedAllowlistIds(): string[] {
-    this.evaluate();
-    return [...this.matchedIds];
+    return [...this.evaluate().matchedIds];
   }
 
   /** Allowlist ids no recorded line matched (dead-entry candidates). */
   unusedAllowlistIds(): string[] {
-    this.evaluate();
+    const { matchedIds } = this.evaluate();
     return this.allowlist
-      .filter((entry) => !this.matchedIds.has(entry.id))
+      .filter((entry) => !matchedIds.has(entry.id))
       .map((entry) => entry.id);
   }
 
   /** Throws if any recorded line is un-allowlisted; no-op otherwise. */
   assertClean(): void {
-    const violations = this.evaluate();
+    const { violations } = this.evaluate();
     if (violations.length === 0) return;
     const shown = violations.slice(0, MAX_REPORTED_VIOLATIONS);
     const lines = shown.map((v) => `  [${v.level}] ${v.message}`);
@@ -178,6 +206,8 @@ export class ConsoleSentinel {
  * file-level `afterAll` that flushes a macrotask and the microtask queue
  * attributes such a late line to this file rather than misattributing it to the
  * following test (or leaking it into the next file).
+ *
+ * Node-only: relies on `setImmediate`, which is not in the DOM lib.
  */
 export async function flushPendingConsole(timerMs = 25): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, timerMs));

--- a/apps/cli/test/consoleSentinel.ts
+++ b/apps/cli/test/consoleSentinel.ts
@@ -17,6 +17,12 @@
  * complements -- it does not replace -- the per-test `withCapturedLogs`
  * capture-and-assert.
  *
+ * Known limitations (accepted): it gates the three `console` methods, not raw
+ * `process.stdout`/`process.stderr.write`, so a library that writes a file
+ * descriptor directly is not seen; and output that lands after the file-level
+ * afterAll flush settles is not caught (see {@link flushPendingConsole}). Both
+ * are out of scope unless a real offender appears.
+ *
  * @internal -- test infrastructure, used by the integration setup file and the
  * sentinel's own unit tests.
  */
@@ -66,19 +72,37 @@ const MAX_REPORTED_VIOLATIONS = 20;
 // (so a matcher reads the literal logged text); a non-string is inspected rather
 // than `String()`-coerced, so an object records as `{ key: 'value' }` instead of
 // the useless `[object Object]` a matcher could never usefully match.
-// `breakLength: Infinity` keeps each argument on one line.
+// `breakLength: Infinity` keeps each argument on one line. `inspect` can throw on
+// a hostile arg (e.g. a custom `util.inspect.custom` hook that throws), so it is
+// guarded: this runs inside the wrapped console call, and a throw here would turn
+// a benign log into a thrown exception that fails an unrelated test and skips the
+// pass-through. A formatting failure must never do that, so fall back.
 function formatArgs(args: unknown[]): string {
   return args
-    .map((arg) =>
-      typeof arg === "string" ? arg : inspect(arg, { breakLength: Infinity }),
-    )
+    .map((arg) => {
+      if (typeof arg === "string") return arg;
+      try {
+        return inspect(arg, { breakLength: Infinity });
+      } catch {
+        return "[uninspectable]";
+      }
+    })
     .join(" ");
 }
 
+// Apply one matcher to a message. A throwing matcher (a buggy function predicate;
+// the regex form cannot throw) is treated as a non-match rather than allowed to
+// propagate: a throw out of here would crash the file-level assertClean and mask
+// every real violation, whereas counting it as non-matching keeps the gate
+// fail-safe -- the line stays un-allowlisted and the run fails loudly.
 function matchEntry(entry: ConsoleAllowEntry, message: string): boolean {
-  return entry.match instanceof RegExp
-    ? entry.match.test(message)
-    : entry.match(message);
+  try {
+    return entry.match instanceof RegExp
+      ? entry.match.test(message)
+      : entry.match(message);
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -136,6 +160,11 @@ export class ConsoleSentinel {
   install(target: ConsoleLike = console): void {
     if (this.target) throw new Error("ConsoleSentinel is already installed");
     this.target = target;
+    // A fresh install is a fresh observation window: drop any lines recorded in a
+    // prior install/restore cycle so they cannot be attributed to this one. (The
+    // integration setup installs exactly once per worker; this only matters for a
+    // reused instance, e.g. a shared fixture or unit test.)
+    this.recorded.length = 0;
     for (const level of this.gatedLevels) {
       const original = target[level].bind(target) as (
         ...args: unknown[]
@@ -156,6 +185,12 @@ export class ConsoleSentinel {
     }
     this.originals.clear();
     this.target = null;
+  }
+
+  /** How many console lines have been recorded so far. Lets a caller settle
+   * trailing async output by flushing until this count stops growing. */
+  recordedCount(): number {
+    return this.recorded.length;
   }
 
   // A pure evaluation of the recorded lines against the allowlist: which lines
@@ -229,6 +264,14 @@ export class ConsoleSentinel {
  * callback (`setImmediate`) -- with the microtask queue draining automatically
  * between them -- attributes such a late line to this file rather than
  * misattributing it to the following test (or leaking it into the next file).
+ *
+ * This is one drain step, not a guarantee: output that lands more than `timerMs`
+ * after the last drain still escapes -- a finite afterAll cannot wait
+ * unboundedly. The setup file calls this in a settle loop (drain until the
+ * recorded count stops growing, up to a cap) so a teardown that emits in waves
+ * is caught; a lone line arriving past the budget is the residual gap. The
+ * sentinel's firm guarantee is for synchronous output and output within the
+ * settle budget.
  *
  * Node-only: relies on `setImmediate`, which is not in the DOM lib.
  */

--- a/apps/cli/test/integration/consoleAllowlist.ts
+++ b/apps/cli/test/integration/consoleAllowlist.ts
@@ -1,0 +1,57 @@
+import type { ConsoleAllowEntry, ConsoleLevel } from "../consoleSentinel";
+
+declare module "vitest" {
+  interface ProvidedContext {
+    // Path to the suite-wide sink the per-file sentinel appends matched
+    // allowlist ids to, so globalSetup's teardown can report ids that NO file
+    // matched (dead entries). Provided by the integration globalSetup.
+    consoleSentinelSink: string;
+  }
+}
+
+/**
+ * Console levels the integration sentinel gates. We gate all three -- including
+ * `log` -- because the value the sentinel adds over loglevel-based capture is
+ * catching third-party `console.log` that does not go through loglevel (the
+ * ssh2-sftp-client "Global ... listener" lines are emitted on `console.log` /
+ * `console.error`). `log` is the noisiest tier in principle, but the suite
+ * currently emits none, so gating it costs nothing today and closes the gap the
+ * sentinel exists to close.
+ */
+export const SENTINEL_GATED_LEVELS: readonly ConsoleLevel[] = [
+  "log",
+  "warn",
+  "error",
+];
+
+/**
+ * The single reviewable source of truth for "intended" console output in the
+ * CLI integration suite. Adding an entry is a visible, reviewable edit; an
+ * entry that never fires across a whole run is reported at teardown (see
+ * globalSetup) so the list cannot silently accumulate dead matchers.
+ *
+ * EMPTY by design. The integration suite currently reaches `console` with
+ * nothing un-allowlisted, because the messages one might expect here are kept
+ * off the console upstream:
+ *
+ *   - The intended WARN/ERROR diagnostics (e.g. the abort-recovery advisory
+ *     "The shared secret was already rotated and saved before this error.")
+ *     are emitted through loglevel and asserted under `withCapturedLogs`, which
+ *     suppresses them from the console while the capture is active. They reach
+ *     the console only if a regression emits one OUTSIDE a capture -- which is
+ *     exactly what the sentinel should catch, not pre-accept.
+ *   - The ssh2-sftp-client "Global ... listener" lines (`Global error listener:
+ *     <msg>` on `console.error`; `Global end listener: end event raised` /
+ *     `Global close listener: close event raised` on `console.log`) are routed
+ *     to the adapter's project logger by `SSH2SFTPClientAdapter`'s constructor
+ *     callbacks, so they no longer reach the console for an adapter-driven
+ *     connection.
+ *   - The former unpinned-host-key WARN is gone: the no-pin host-key path now
+ *     fails closed rather than warn-and-proceed.
+ *
+ * So seeding those as live matchers would only create dead entries. If one
+ * regresses and starts leaking, the fix is to re-suppress/route it at the
+ * source; accept it here ONLY when the output is genuinely intended on the
+ * console, with the matcher's `reason` explaining why.
+ */
+export const INTEGRATION_CONSOLE_ALLOWLIST: readonly ConsoleAllowEntry[] = [];

--- a/apps/cli/test/integration/consoleAllowlist.ts
+++ b/apps/cli/test/integration/consoleAllowlist.ts
@@ -1,14 +1,5 @@
 import type { ConsoleAllowEntry, ConsoleLevel } from "../consoleSentinel";
 
-declare module "vitest" {
-  interface ProvidedContext {
-    // Path to the suite-wide sink the per-file sentinel appends matched
-    // allowlist ids to, so globalSetup's teardown can report ids that NO file
-    // matched (dead entries). Provided by the integration globalSetup.
-    consoleSentinelSink: string;
-  }
-}
-
 /**
  * Console levels the integration sentinel gates. We gate all three -- including
  * `log` -- because the value the sentinel adds over loglevel-based capture is

--- a/apps/cli/test/integration/consoleSentinel.setup.ts
+++ b/apps/cli/test/integration/consoleSentinel.setup.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+
+import { afterAll, inject } from "vitest";
+
+import { ConsoleSentinel, flushPendingConsole } from "../consoleSentinel";
+import {
+  INTEGRATION_CONSOLE_ALLOWLIST,
+  SENTINEL_GATED_LEVELS,
+} from "./consoleAllowlist";
+
+// A `setupFiles` entry, so this runs once in EACH integration file's worker
+// (the integration project uses the `forks` pool: one process per file). The
+// sentinel is installed at module load -- before any test or top-level import
+// side effect -- so it observes the file's console from the first line.
+const sentinel = new ConsoleSentinel(INTEGRATION_CONSOLE_ALLOWLIST, {
+  gatedLevels: SENTINEL_GATED_LEVELS,
+});
+sentinel.install();
+
+// File-level scope (not per-test): the ssh2-sftp-client "Global ... listener"
+// teardown lines fire asynchronously and land in the NEXT test's window, so a
+// per-test assertion would misattribute them. The `forks` pool already isolates
+// files cross-process, so file scope is sufficient.
+afterAll(async () => {
+  await flushPendingConsole();
+  // Record which allowlist matchers this file exercised to the suite-wide sink
+  // first, so globalSetup's teardown can report matchers no file matched. This
+  // is advisory and must never mask a real violation, so it runs before -- and
+  // cannot throw into -- the assertion.
+  try {
+    const sink = inject("consoleSentinelSink");
+    const matched = sentinel.matchedAllowlistIds();
+    if (sink && matched.length > 0) {
+      fs.appendFileSync(sink, matched.map((id) => `${id}\n`).join(""));
+    }
+  } catch {
+    // No sink (e.g. running this file outside the integration globalSetup): the
+    // dead-entry report is best-effort; the assertion below is what gates CI.
+  }
+  try {
+    sentinel.assertClean();
+  } finally {
+    sentinel.restore();
+  }
+});

--- a/apps/cli/test/integration/consoleSentinel.setup.ts
+++ b/apps/cli/test/integration/consoleSentinel.setup.ts
@@ -40,11 +40,12 @@ afterAll(async () => {
     const sink = inject("consoleSentinelSink");
     const matched = sentinel.matchedAllowlistIds();
     if (sink) {
-      // One O_APPEND write per id, each well under PIPE_BUF, so concurrent
-      // teardowns across fork workers cannot interleave bytes within an id. (A
-      // single joined write would only stay atomic while it fit PIPE_BUF.) The
-      // reader splits on newlines and counts only known ids, so a torn line is
-      // harmless regardless.
+      // One O_APPEND write per id: Linux serializes a short append to a regular
+      // file under the inode lock (a kernel detail, not a POSIX guarantee --
+      // PIPE_BUF is the pipe/FIFO contract, not this), so concurrent teardowns
+      // across fork workers do not interleave bytes within a per-id write. The
+      // reader splits on newlines and counts only known ids, so even a torn line
+      // is harmless; the per-id writes just make that path unreachable here.
       for (const id of matched) {
         fs.appendFileSync(sink, `${id}\n`);
       }

--- a/apps/cli/test/integration/consoleSentinel.setup.ts
+++ b/apps/cli/test/integration/consoleSentinel.setup.ts
@@ -8,6 +8,15 @@ import {
   SENTINEL_GATED_LEVELS,
 } from "./consoleAllowlist";
 
+declare module "vitest" {
+  interface ProvidedContext {
+    // Path to the suite-wide sink this file's afterAll appends matched allowlist
+    // ids to, so globalSetup's teardown can report ids that NO file matched
+    // (dead entries). Provided by the integration globalSetup.
+    consoleSentinelSink: string;
+  }
+}
+
 // A `setupFiles` entry, so this runs once in EACH integration file's worker
 // (the integration project uses the `forks` pool: one process per file). The
 // sentinel is installed at module load -- before any test or top-level import
@@ -30,8 +39,15 @@ afterAll(async () => {
   try {
     const sink = inject("consoleSentinelSink");
     const matched = sentinel.matchedAllowlistIds();
-    if (sink && matched.length > 0) {
-      fs.appendFileSync(sink, matched.map((id) => `${id}\n`).join(""));
+    if (sink) {
+      // One O_APPEND write per id, each well under PIPE_BUF, so concurrent
+      // teardowns across fork workers cannot interleave bytes within an id. (A
+      // single joined write would only stay atomic while it fit PIPE_BUF.) The
+      // reader splits on newlines and counts only known ids, so a torn line is
+      // harmless regardless.
+      for (const id of matched) {
+        fs.appendFileSync(sink, `${id}\n`);
+      }
     }
   } catch {
     // No sink (e.g. running this file outside the integration globalSetup): the

--- a/apps/cli/test/integration/consoleSentinel.setup.ts
+++ b/apps/cli/test/integration/consoleSentinel.setup.ts
@@ -17,6 +17,11 @@ declare module "vitest" {
   }
 }
 
+// Bound on the settle loop below: how many drain rounds to wait for trailing
+// async output before asserting. The common case (no late output) settles in one
+// round; the cap keeps a teardown that keeps emitting from stalling afterAll.
+const MAX_FLUSH_ROUNDS = 5;
+
 // A `setupFiles` entry, so this runs once in EACH integration file's worker
 // (the integration project uses the `forks` pool: one process per file). The
 // sentinel is installed at module load -- before any test or top-level import
@@ -31,28 +36,41 @@ sentinel.install();
 // per-test assertion would misattribute them. The `forks` pool already isolates
 // files cross-process, so file scope is sufficient.
 afterAll(async () => {
-  await flushPendingConsole();
+  // Settle trailing async output in waves: drain, and if the drain surfaced new
+  // lines, drain again, until the recorded count stops growing or the cap is
+  // reached. A single fixed drain can miss the ssh2-sftp-client teardown cascade,
+  // which lands after the last test on async events.
+  let previousCount = -1;
+  for (
+    let round = 0;
+    round < MAX_FLUSH_ROUNDS && sentinel.recordedCount() !== previousCount;
+    round++
+  ) {
+    previousCount = sentinel.recordedCount();
+    await flushPendingConsole();
+  }
   // Record which allowlist matchers this file exercised to the suite-wide sink
   // first, so globalSetup's teardown can report matchers no file matched. This
   // is advisory and must never mask a real violation, so it runs before -- and
-  // cannot throw into -- the assertion.
+  // cannot throw into -- the assertion: appendFileSync can throw (a full disk, a
+  // gone sink dir), and inject returns undefined when no sink was provided (a
+  // single-file run outside globalSetup, handled by the `if (sink)` guard).
   try {
     const sink = inject("consoleSentinelSink");
     const matched = sentinel.matchedAllowlistIds();
     if (sink) {
-      // One O_APPEND write per id: Linux serializes a short append to a regular
-      // file under the inode lock (a kernel detail, not a POSIX guarantee --
-      // PIPE_BUF is the pipe/FIFO contract, not this), so concurrent teardowns
-      // across fork workers do not interleave bytes within a per-id write. The
-      // reader splits on newlines and counts only known ids, so even a torn line
-      // is harmless; the per-id writes just make that path unreachable here.
+      // One O_APPEND write per id: a short append to a regular file is a single
+      // write(2), which Linux serializes under the inode lock (a kernel detail,
+      // not a POSIX guarantee -- PIPE_BUF is the pipe/FIFO contract, not this), so
+      // concurrent teardowns across fork workers do not interleave bytes within an
+      // id. The reader splits on newlines and counts only known ids, so even a
+      // torn line is harmless; the per-id writes just make that path unreachable.
       for (const id of matched) {
         fs.appendFileSync(sink, `${id}\n`);
       }
     }
   } catch {
-    // No sink (e.g. running this file outside the integration globalSetup): the
-    // dead-entry report is best-effort; the assertion below is what gates CI.
+    // The dead-entry report is best-effort; the assertion below is what gates CI.
   }
   try {
     sentinel.assertClean();

--- a/apps/cli/test/sftpServer/globalSetup.ts
+++ b/apps/cli/test/sftpServer/globalSetup.ts
@@ -59,8 +59,12 @@ export default async function setup({
   );
   return async () => {
     await server.stop();
-    reportDeadAllowlistEntries(sentinelSink);
-    fs.rmSync(sentinelSinkDir, { recursive: true, force: true });
+    try {
+      reportDeadAllowlistEntries(sentinelSink);
+    } finally {
+      // Always reclaim the temp dir, even if the advisory report throws.
+      fs.rmSync(sentinelSinkDir, { recursive: true, force: true });
+    }
   };
 }
 

--- a/apps/cli/test/sftpServer/globalSetup.ts
+++ b/apps/cli/test/sftpServer/globalSetup.ts
@@ -1,5 +1,10 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import type { ProvidedContext } from "vitest";
 
+import { INTEGRATION_CONSOLE_ALLOWLIST } from "../integration/consoleAllowlist";
 import {
   selectedBackend,
   selectedNativeProfile,
@@ -27,6 +32,18 @@ export default async function setup({
 }: GlobalSetupContext): Promise<() => Promise<void>> {
   const server = await startSelectedSftpServer();
   provide("sftpServer", server.handle);
+
+  // Suite-wide sink for the console sentinel's dead-entry report. Each file's
+  // worker appends the allowlist matchers it exercised (via the setup file's
+  // afterAll); the teardown below reads the union and reports any matcher that
+  // NO file fired across the whole run -- the `forks` pool isolates files
+  // per-process, so a per-file "unused" view would be misleading.
+  const sentinelSinkDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "psilink-console-sentinel-"),
+  );
+  const sentinelSink = path.join(sentinelSinkDir, "matched-ids.log");
+  fs.writeFileSync(sentinelSink, "");
+  provide("consoleSentinelSink", sentinelSink);
   const backend = selectedBackend();
   // Surface the native profile (other than the default baseline) so a CI leg's
   // log makes clear which hardened configuration ran.
@@ -42,5 +59,38 @@ export default async function setup({
   );
   return async () => {
     await server.stop();
+    reportDeadAllowlistEntries(sentinelSink);
+    fs.rmSync(sentinelSinkDir, { recursive: true, force: true });
   };
+}
+
+// Reports console-sentinel allowlist matchers that no file fired during the run,
+// so the allowlist cannot silently accumulate dead entries. Advisory (a warning,
+// not a failure): a single-file run legitimately fires only a few, and an entry
+// kept against a known-intermittent diagnostic is a judgement call for review,
+// not a hard gate. Runs in the main process, where the sentinel is not
+// installed, so this output does not trip it.
+function reportDeadAllowlistEntries(sink: string): void {
+  let matched: Set<string>;
+  try {
+    matched = new Set(
+      fs
+        .readFileSync(sink, "utf8")
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0),
+    );
+  } catch {
+    return;
+  }
+  const dead = INTEGRATION_CONSOLE_ALLOWLIST.filter(
+    (entry) => !matched.has(entry.id),
+  );
+  if (dead.length === 0) return;
+  console.warn(
+    `[console-sentinel] ${dead.length} allowlist matcher(s) never fired this ` +
+      `run; prune them if permanently dormant, or confirm the intended output ` +
+      `still occurs:\n` +
+      dead.map((entry) => `  - ${entry.id}: ${entry.reason}`).join("\n"),
+  );
 }

--- a/apps/cli/test/sftpServer/globalSetup.ts
+++ b/apps/cli/test/sftpServer/globalSetup.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import type { ProvidedContext } from "vitest";
 
+import { deadAllowlistEntries } from "../consoleSentinel";
 import { INTEGRATION_CONSOLE_ALLOWLIST } from "../integration/consoleAllowlist";
 import {
   selectedBackend,
@@ -84,21 +85,13 @@ export default async function setup({
 // is advisory anyway, even a hypothetical under-count would only drop a warning,
 // never fail the run.
 function reportDeadAllowlistEntries(sink: string): void {
-  let matched: Set<string>;
+  let contents: string;
   try {
-    matched = new Set(
-      fs
-        .readFileSync(sink, "utf8")
-        .split("\n")
-        .map((line) => line.trim())
-        .filter((line) => line.length > 0),
-    );
+    contents = fs.readFileSync(sink, "utf8");
   } catch {
     return;
   }
-  const dead = INTEGRATION_CONSOLE_ALLOWLIST.filter(
-    (entry) => !matched.has(entry.id),
-  );
+  const dead = deadAllowlistEntries(contents, INTEGRATION_CONSOLE_ALLOWLIST);
   if (dead.length === 0) return;
   console.warn(
     `[console-sentinel] ${dead.length} allowlist matcher(s) never fired this ` +

--- a/apps/cli/test/sftpServer/globalSetup.ts
+++ b/apps/cli/test/sftpServer/globalSetup.ts
@@ -58,11 +58,13 @@ export default async function setup({
       `${server.handle.host}:${server.handle.port}`,
   );
   return async () => {
-    await server.stop();
     try {
+      await server.stop();
       reportDeadAllowlistEntries(sentinelSink);
     } finally {
-      // Always reclaim the temp dir, even if the advisory report throws.
+      // Always reclaim the temp dir, even if server.stop() rejects (the native
+      // chroot leg can fail to remove its root-owned jail) or the advisory report
+      // throws -- otherwise an orphaned /tmp dir leaks on every such run.
       fs.rmSync(sentinelSinkDir, { recursive: true, force: true });
     }
   };

--- a/apps/cli/test/sftpServer/globalSetup.ts
+++ b/apps/cli/test/sftpServer/globalSetup.ts
@@ -74,6 +74,13 @@ export default async function setup({
 // kept against a known-intermittent diagnostic is a judgement call for review,
 // not a hard gate. Runs in the main process, where the sentinel is not
 // installed, so this output does not trip it.
+//
+// The sink is complete by the time this runs: vitest invokes a globalSetup
+// teardown only after the whole run finishes -- every file, including its
+// afterAll hooks, has settled -- and the per-file appends are synchronous
+// (appendFileSync), so all matched ids are on disk before this read. Because it
+// is advisory anyway, even a hypothetical under-count would only drop a warning,
+// never fail the run.
 function reportDeadAllowlistEntries(sink: string): void {
   let matched: Set<string>;
   try {

--- a/apps/cli/test/unit/consoleSentinel.test.ts
+++ b/apps/cli/test/unit/consoleSentinel.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ConsoleSentinel,
+  flushPendingConsole,
+  type ConsoleAllowEntry,
+  type ConsoleLike,
+} from "../consoleSentinel";
+
+// A standalone console double so the sentinel's own behavior can be exercised
+// without touching the real (vitest-wrapped) console. Methods are no-ops: the
+// sentinel records the call regardless of what the original does.
+function fakeConsole(): ConsoleLike {
+  return { log: () => {}, warn: () => {}, error: () => {} };
+}
+
+describe("ConsoleSentinel", () => {
+  it("fails the run on an un-allowlisted warn", () => {
+    const fake = fakeConsole();
+    const sentinel = new ConsoleSentinel([]);
+    sentinel.install(fake);
+
+    fake.warn("unexpected diagnostic");
+
+    expect(() => sentinel.assertClean()).toThrowError(
+      /un-allowlisted console line/,
+    );
+    sentinel.restore();
+  });
+
+  it("fails the run on an un-allowlisted error", () => {
+    const fake = fakeConsole();
+    const sentinel = new ConsoleSentinel([]);
+    sentinel.install(fake);
+
+    fake.error("surprise error");
+
+    const violations = sentinel.violations();
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      level: "error",
+      message: "surprise error",
+    });
+    expect(() => sentinel.assertClean()).toThrow();
+    sentinel.restore();
+  });
+
+  it("passes an allowlisted message and credits its matcher", () => {
+    const allowlist: ConsoleAllowEntry[] = [
+      {
+        id: "intended-warn",
+        levels: ["warn"],
+        match: /known intentional warning/,
+        reason: "exercised by this test",
+      },
+    ];
+    const fake = fakeConsole();
+    const sentinel = new ConsoleSentinel(allowlist);
+    sentinel.install(fake);
+
+    fake.warn("a known intentional warning fired");
+
+    expect(() => sentinel.assertClean()).not.toThrow();
+    expect(sentinel.matchedAllowlistIds()).toEqual(["intended-warn"]);
+    expect(sentinel.unusedAllowlistIds()).toEqual([]);
+    sentinel.restore();
+  });
+
+  it("reports an allowlist matcher that never fires", () => {
+    const allowlist: ConsoleAllowEntry[] = [
+      {
+        id: "fired",
+        levels: ["warn"],
+        match: /fires/,
+        reason: "this one fires",
+      },
+      {
+        id: "dormant",
+        levels: ["error"],
+        match: /never seen/,
+        reason: "this one is dead",
+      },
+    ];
+    const fake = fakeConsole();
+    const sentinel = new ConsoleSentinel(allowlist);
+    sentinel.install(fake);
+
+    fake.warn("a matcher that fires");
+
+    expect(() => sentinel.assertClean()).not.toThrow();
+    expect(sentinel.unusedAllowlistIds()).toEqual(["dormant"]);
+    sentinel.restore();
+  });
+
+  it("catches a third-party console.log not routed through loglevel", () => {
+    // The ssh2-sftp-client default constructor callbacks `console.log` their
+    // "Global ... listener" lines directly -- never through loglevel -- so the
+    // loglevel-based `withCapturedLogs` cannot see them. Gating `log` is what
+    // lets the sentinel catch this direct-console source.
+    const fake = fakeConsole();
+    const sentinel = new ConsoleSentinel([]);
+    sentinel.install(fake);
+
+    fake.log("Global close listener: close event raised");
+
+    const violations = sentinel.violations();
+    expect(violations).toEqual([
+      { level: "log", message: "Global close listener: close event raised" },
+    ]);
+    sentinel.restore();
+  });
+
+  it("does not gate a level outside gatedLevels", () => {
+    const fake = fakeConsole();
+    const sentinel = new ConsoleSentinel([], {
+      gatedLevels: ["warn", "error"],
+    });
+    sentinel.install(fake);
+
+    fake.log("an un-gated log line");
+    fake.warn("a gated warn line");
+
+    expect(sentinel.violations().map((v) => v.message)).toEqual([
+      "a gated warn line",
+    ]);
+    sentinel.restore();
+  });
+
+  it("attributes an async-late line at the afterAll flush, not before", async () => {
+    // Models the "Global ... listener" teardown lines: emitted on an async event
+    // a tick after the test that triggered the teardown returns. A per-test
+    // assertion run synchronously at that test's end would miss it; only the
+    // file-level afterAll flush surfaces it -- attributing it to the file rather
+    // than misattributing it to whatever ran next.
+    const fake = fakeConsole();
+    const sentinel = new ConsoleSentinel([]);
+    sentinel.install(fake);
+
+    setTimeout(() => fake.warn("Global error listener: late teardown"), 5);
+
+    // The synchronous boundary of the triggering test: the line has not fired.
+    expect(sentinel.violations()).toEqual([]);
+
+    // The afterAll flush lets the pending timer run, so the late line is caught.
+    await flushPendingConsole();
+    expect(() => sentinel.assertClean()).toThrowError(
+      /Global error listener: late teardown/,
+    );
+    sentinel.restore();
+  });
+
+  it("preserves pass-through to the wrapped method", () => {
+    const seen: string[] = [];
+    const fake: ConsoleLike = {
+      log: (...args: unknown[]) => seen.push(`log:${args.join(" ")}`),
+      warn: () => {},
+      error: () => {},
+    };
+    const sentinel = new ConsoleSentinel([]);
+    sentinel.install(fake);
+
+    fake.log("still", "printed");
+
+    expect(seen).toEqual(["log:still printed"]);
+    sentinel.restore();
+    // After restore the original method is back and recording stops.
+    fake.log("after restore");
+    expect(seen).toEqual(["log:still printed", "log:after restore"]);
+    expect(sentinel.violations()).toHaveLength(1);
+  });
+});

--- a/apps/cli/test/unit/consoleSentinel.test.ts
+++ b/apps/cli/test/unit/consoleSentinel.test.ts
@@ -149,6 +149,48 @@ describe("ConsoleSentinel", () => {
     sentinel.restore();
   });
 
+  it("rejects a stateful (g/y) regex matcher at construction", () => {
+    // A g/y-flagged regex advances lastIndex across .test() calls, so the same
+    // matcher could accept a line on one evaluation and reject it on the next.
+    expect(
+      () =>
+        new ConsoleSentinel([
+          {
+            id: "stateful",
+            levels: ["warn"],
+            match: /repeating/g,
+            reason: "uses the g flag",
+          },
+        ]),
+    ).toThrowError(/stateful regex flag/);
+    expect(
+      () =>
+        new ConsoleSentinel([
+          {
+            id: "sticky",
+            levels: ["warn"],
+            match: /anchored/y,
+            reason: "uses the y flag",
+          },
+        ]),
+    ).toThrow();
+  });
+
+  it("rejects an id containing a newline at construction", () => {
+    // The id is the line-delimited key in the cross-file dead-entry sink.
+    expect(
+      () =>
+        new ConsoleSentinel([
+          {
+            id: "bad\nid",
+            levels: ["warn"],
+            match: /whatever/,
+            reason: "newline in id",
+          },
+        ]),
+    ).toThrowError(/must not contain a newline/);
+  });
+
   it("preserves pass-through to the wrapped method", () => {
     const seen: string[] = [];
     const fake: ConsoleLike = {

--- a/apps/cli/test/unit/consoleSentinel.test.ts
+++ b/apps/cli/test/unit/consoleSentinel.test.ts
@@ -176,19 +176,40 @@ describe("ConsoleSentinel", () => {
     ).toThrow();
   });
 
-  it("rejects an id containing a newline at construction", () => {
-    // The id is the line-delimited key in the cross-file dead-entry sink.
+  it("rejects an id the sink round-trip would alter at construction", () => {
+    // The id is the line-delimited, trim-on-read key in the dead-entry sink, so
+    // an embedded newline or surrounding whitespace (including a trailing \r,
+    // which the readback's trim strips) would corrupt the aggregation.
+    const reject = (id: string) =>
+      expect(
+        () =>
+          new ConsoleSentinel([
+            { id, levels: ["warn"], match: /whatever/, reason: "bad id" },
+          ]),
+      ).toThrowError(/single line with no surrounding whitespace/);
+    reject("bad\nid");
+    reject("trailing-cr\r");
+    reject("  leading-space");
+    // An internal space is fine: trim does not touch it and there is no newline.
     expect(
       () =>
         new ConsoleSentinel([
-          {
-            id: "bad\nid",
-            levels: ["warn"],
-            match: /whatever/,
-            reason: "newline in id",
-          },
+          { id: "ok id", levels: ["warn"], match: /whatever/, reason: "fine" },
         ]),
-    ).toThrowError(/must not contain a newline/);
+    ).not.toThrow();
+  });
+
+  it("records a non-string arg via util.inspect, not [object Object]", () => {
+    const fake = fakeConsole();
+    const sentinel = new ConsoleSentinel([]);
+    sentinel.install(fake);
+
+    fake.warn("context", { code: "ELEAK", count: 2 });
+
+    const [violation] = sentinel.violations();
+    expect(violation.message).toBe("context { code: 'ELEAK', count: 2 }");
+    expect(violation.message).not.toContain("[object Object]");
+    sentinel.restore();
   });
 
   it("preserves pass-through to the wrapped method", () => {

--- a/apps/cli/test/unit/consoleSentinel.test.ts
+++ b/apps/cli/test/unit/consoleSentinel.test.ts
@@ -231,4 +231,71 @@ describe("ConsoleSentinel", () => {
     expect(seen).toEqual(["log:still printed", "log:after restore"]);
     expect(sentinel.violations()).toHaveLength(1);
   });
+
+  it("does not throw out of the wrapped call when inspect throws", () => {
+    // A formatting failure inside the wrapper would turn a benign log into a
+    // thrown exception that fails an unrelated test and skips pass-through.
+    const hostile = {
+      [Symbol.for("nodejs.util.inspect.custom")]() {
+        throw new Error("inspect boom");
+      },
+    };
+    let passedThrough = false;
+    const fake: ConsoleLike = {
+      log: () => {},
+      warn: () => {
+        passedThrough = true;
+      },
+      error: () => {},
+    };
+    const sentinel = new ConsoleSentinel([]);
+    sentinel.install(fake);
+
+    expect(() => fake.warn("ctx", hostile)).not.toThrow();
+    expect(passedThrough).toBe(true);
+    expect(sentinel.violations()[0].message).toBe("ctx [uninspectable]");
+    sentinel.restore();
+  });
+
+  it("treats a throwing matcher as a non-match instead of crashing", () => {
+    // A buggy matcher must not crash assertClean and mask every real violation.
+    const allowlist: ConsoleAllowEntry[] = [
+      {
+        id: "throwing",
+        levels: ["warn"],
+        match: () => {
+          throw new Error("matcher boom");
+        },
+        reason: "buggy matcher",
+      },
+    ];
+    const fake = fakeConsole();
+    const sentinel = new ConsoleSentinel(allowlist);
+    sentinel.install(fake);
+
+    fake.warn("some line");
+
+    // The line stays un-allowlisted (fail-safe) and the matcher error does not
+    // propagate -- assertClean throws the sentinel's own error, not "matcher boom".
+    expect(() => sentinel.assertClean()).toThrowError(/un-allowlisted/);
+    expect(sentinel.unusedAllowlistIds()).toEqual(["throwing"]);
+    sentinel.restore();
+  });
+
+  it("starts a fresh observation window on re-install", () => {
+    const fake = fakeConsole();
+    const sentinel = new ConsoleSentinel([]);
+    sentinel.install(fake);
+    fake.warn("from the first window");
+    expect(sentinel.recordedCount()).toBe(1);
+    sentinel.restore();
+
+    sentinel.install(fake);
+    expect(sentinel.recordedCount()).toBe(0);
+    fake.warn("from the second window");
+    expect(sentinel.violations().map((v) => v.message)).toEqual([
+      "from the second window",
+    ]);
+    sentinel.restore();
+  });
 });

--- a/apps/cli/test/unit/consoleSentinel.test.ts
+++ b/apps/cli/test/unit/consoleSentinel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   ConsoleSentinel,
+  deadAllowlistEntries,
   flushPendingConsole,
   type ConsoleAllowEntry,
   type ConsoleLike,
@@ -22,9 +23,57 @@ describe("ConsoleSentinel", () => {
 
     fake.warn("unexpected diagnostic");
 
+    expect(sentinel.violations()).toEqual([
+      { level: "warn", message: "unexpected diagnostic" },
+    ]);
     expect(() => sentinel.assertClean()).toThrowError(
       /un-allowlisted console line/,
     );
+    sentinel.restore();
+  });
+
+  it("treats a level-mismatched matcher as not accepting the line", () => {
+    // The level filter is load-bearing: an entry scoped to one level must not
+    // accept a same-text line emitted at another level, or the gate has a hole.
+    const allowlist: ConsoleAllowEntry[] = [
+      {
+        id: "error-only",
+        levels: ["error"],
+        match: /shared text/,
+        reason: "scoped to error",
+      },
+    ];
+    const fake = fakeConsole();
+    const sentinel = new ConsoleSentinel(allowlist);
+    sentinel.install(fake);
+
+    fake.warn("a line with shared text at warn level");
+
+    // The warn line is NOT accepted by the error-scoped matcher: it is a
+    // violation, and the matcher stays unused.
+    expect(sentinel.violations()).toEqual([
+      { level: "warn", message: "a line with shared text at warn level" },
+    ]);
+    expect(sentinel.unusedAllowlistIds()).toEqual(["error-only"]);
+    sentinel.restore();
+  });
+
+  it("credits every matcher that accepts a line, not just the first", () => {
+    // evaluate() deliberately does not short-circuit: a line covered by two
+    // matchers credits both, so neither is misreported as a dead entry.
+    const allowlist: ConsoleAllowEntry[] = [
+      { id: "first", levels: ["warn"], match: /shared/, reason: "matches" },
+      { id: "second", levels: ["warn"], match: /line/, reason: "also matches" },
+    ];
+    const fake = fakeConsole();
+    const sentinel = new ConsoleSentinel(allowlist);
+    sentinel.install(fake);
+
+    fake.warn("a shared line");
+
+    expect(() => sentinel.assertClean()).not.toThrow();
+    expect(sentinel.matchedAllowlistIds().sort()).toEqual(["first", "second"]);
+    expect(sentinel.unusedAllowlistIds()).toEqual([]);
     sentinel.restore();
   });
 
@@ -126,12 +175,14 @@ describe("ConsoleSentinel", () => {
     sentinel.restore();
   });
 
-  it("attributes an async-late line at the afterAll flush, not before", async () => {
+  it("surfaces an async-late line at the flush, not at the synchronous boundary", async () => {
     // Models the "Global ... listener" teardown lines: emitted on an async event
-    // a tick after the test that triggered the teardown returns. A per-test
-    // assertion run synchronously at that test's end would miss it; only the
-    // file-level afterAll flush surfaces it -- attributing it to the file rather
-    // than misattributing it to whatever ran next.
+    // a tick after the test that triggered the teardown returns. This proves the
+    // flush is what catches such a line -- absent at the synchronous boundary,
+    // present after flushPendingConsole. (The file-level vs per-test SCOPING that
+    // keeps the line from being blamed on the next test is a property of the
+    // integration setup's afterAll placement, exercised by the integration run,
+    // not this unit.)
     const fake = fakeConsole();
     const sentinel = new ConsoleSentinel([]);
     sentinel.install(fake);
@@ -173,7 +224,7 @@ describe("ConsoleSentinel", () => {
             reason: "uses the y flag",
           },
         ]),
-    ).toThrow();
+    ).toThrowError(/stateful regex flag/);
   });
 
   it("rejects an id the sink round-trip would alter at construction", () => {
@@ -297,5 +348,38 @@ describe("ConsoleSentinel", () => {
       "from the second window",
     ]);
     sentinel.restore();
+  });
+});
+
+describe("deadAllowlistEntries", () => {
+  const allowlist: ConsoleAllowEntry[] = [
+    { id: "alpha", levels: ["warn"], match: /a/, reason: "a" },
+    { id: "beta", levels: ["warn"], match: /b/, reason: "b" },
+    { id: "gamma", levels: ["warn"], match: /c/, reason: "c" },
+  ];
+
+  it("reports entries whose id is absent from the sink", () => {
+    const dead = deadAllowlistEntries("alpha\n", allowlist).map((e) => e.id);
+    expect(dead).toEqual(["beta", "gamma"]);
+  });
+
+  it("reports nothing when every id is present", () => {
+    expect(deadAllowlistEntries("alpha\nbeta\ngamma\n", allowlist)).toEqual([]);
+  });
+
+  it("ignores blank lines, surrounding whitespace, and unknown ids", () => {
+    // A torn or padded append must not be mistaken for an id, and an id from a
+    // since-removed entry must not break the diff.
+    const sink = "\n  alpha  \n\n  \nbeta\nstale-removed-id\n";
+    const dead = deadAllowlistEntries(sink, allowlist).map((e) => e.id);
+    expect(dead).toEqual(["gamma"]);
+  });
+
+  it("treats empty sink contents as all entries dead", () => {
+    expect(deadAllowlistEntries("", allowlist).map((e) => e.id)).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+    ]);
   });
 });

--- a/apps/cli/test/unit/consoleSentinel.test.ts
+++ b/apps/cli/test/unit/consoleSentinel.test.ts
@@ -333,6 +333,34 @@ describe("ConsoleSentinel", () => {
     sentinel.restore();
   });
 
+  it("escapes control bytes in the failure message but matches on raw text", () => {
+    // A recorded line is whatever reached the console -- possibly a server- or
+    // partner-controlled string. The thrown error lands in the CI log, so its
+    // lines are escaped against ANSI/bidi/newline log injection; the raw message
+    // is preserved for matching (sanitize at display only).
+    const fake = fakeConsole();
+    const sentinel = new ConsoleSentinel([]);
+    sentinel.install(fake);
+
+    fake.error("\x1b[31mred\x1b[0m\ninjected line");
+
+    // violations() exposes the raw recorded bytes (used for matching).
+    expect(sentinel.violations()[0].message).toBe(
+      "\x1b[31mred\x1b[0m\ninjected line",
+    );
+    // The thrown message escapes the ESC and newline rather than emitting them.
+    let thrown = "";
+    try {
+      sentinel.assertClean();
+    } catch (e) {
+      thrown = (e as Error).message;
+    }
+    expect(thrown).toContain("\\x1b[31mred\\x1b[0m\\x0ainjected line");
+    expect(thrown).not.toContain("\x1b");
+    expect(thrown).not.toContain("\ninjected line");
+    sentinel.restore();
+  });
+
   it("starts a fresh observation window on re-install", () => {
     const fake = fakeConsole();
     const sentinel = new ConsoleSentinel([]);

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -21,6 +21,11 @@ export default defineConfig({
           // chdir in one file could corrupt a concurrently-running sibling's cwd.
           // Forks gives each file its own process, the isolation safety needs.
           pool: "forks",
+          // Installs the standing console sentinel in every integration file's
+          // worker: it wraps console directly and fails the file at afterAll on
+          // any un-allowlisted console.log/warn/error (the inverse of blanket
+          // silencing). Scoped to this project, so the unit project is unaffected.
+          setupFiles: ["./test/integration/consoleSentinel.setup.ts"],
           // Starts the SFTP test server (the in-process backend by default, or
           // the native sshd backend when PSILINK_SFTP_BACKEND=native) before the
           // suite and stops it after, handing the conformance tests its


### PR DESCRIPTION
## Summary

Add a standing console-output sentinel to the CLI integration suite: it wraps `console` directly and fails a test file at `afterAll` on any `console.log`/`warn`/`error` that no allowlist matcher accepts -- the inverse of blanket silencing. It catches the recurring defect where production diagnostics reach a console sink the tests neither control nor inspect, including third-party `console.*` (e.g. ssh2-sftp-client's default constructor callbacks) that the loglevel-based `withCapturedLogs` structurally cannot see. The allowlist is the single reviewable source of truth for intended noise.

Implements [202392824](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=202392824).

## Changes

- `apps/cli/test/consoleSentinel.ts`: new `ConsoleSentinel` (wrap, record, match, assert), the `flushPendingConsole` drain primitive, and the pure `deadAllowlistEntries` helper.
- `apps/cli/test/integration/consoleAllowlist.ts`: the reviewable allowlist (empty by design today) and the gated levels, with candidate matchers documented.
- `apps/cli/test/integration/consoleSentinel.setup.ts`: `setupFiles` entry -- installs per worker, drains async output in a bounded settle loop, records matched ids to the suite-wide sink, and asserts at a file-level `afterAll`.
- `apps/cli/test/sftpServer/globalSetup.ts`: provisions the sink and reports never-fired matchers at teardown.
- `apps/cli/vitest.config.ts`: wires the sentinel into the integration project only.
- `apps/cli/test/unit/consoleSentinel.test.ts`: unit coverage for the sentinel's own behavior.
- `CONTRIBUTING.md`: a contributor note in the Integration tests section.

## Test plan

Ran: `npx vitest run apps/cli/test/unit/consoleSentinel.test.ts` (21 passed), `npm run test:integration -w apps/cli` (34 passed, 3 skipped), and `npm run typecheck && npm run lint && npm run format` (clean).
New tests cover: un-allowlisted warn/error/log fail the run; an allowlisted message passes and credits its matcher; level-mismatched matcher rejected and multi-matcher crediting; a never-fired matcher reported; a direct `console.log` loglevel cannot see is caught; stateful-regex and malformed-id rejection at construction; inspect-throw guarded; a throwing matcher treated as non-match; the recorded buffer reset on re-install; an async-late line surfaced at the flush; failure-message output escaped at the display boundary; and the `deadAllowlistEntries` sink parse.

## Background

The suite reaches `console` with nothing un-allowlisted today: intended WARN/ERROR diagnostics are asserted under `withCapturedLogs`, the ssh2-sftp-client "Global ... listener" lines are routed off the console by the adapter (PR #189, item 202393052), and the no-pin host-key path fails closed rather than warns. So the allowlist seeds empty and the sentinel stands as a regression guard; candidate matchers are documented for when a leak appears.

The sentinel asserts at a file-level `afterAll` because that is the only point Vitest lets a worker fail the run (a globalSetup teardown throw does not fail the run, and fork workers do not fire process exit hooks). Synchronous, in-test, and hook output is caught deterministically; genuinely-late async output is best-effort within a bounded settle loop. It gates `console` only, not raw `process.stdout`/`stderr.write`.

## Out of scope / follow-on

- Encode the sentinel as the executable invariant that replaces the rot-prone Global-listener prose: [202393129](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=202393129).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented runtime or spec behavior changed (test infrastructure only); added a contributor note to the CONTRIBUTING.md Integration tests section describing the guard.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test/CI/tooling change with no operator- or reviewer-visible behavior, per CONTRIBUTING Changelog.
- [x] Security review -- two independent reviews (disclosure/secret-handling and scope/control-integrity) were conducted and CLEARED, and the change was determined outside the required scope: test infrastructure only, with no production crypto, channel, credential, auth, disclosure, or dependency surface changed (no new dependency). The single disclosure nit -- escaping failure-message output at the display boundary via the shared `sanitizeForDisplay` -- is fixed in this PR.
