### PR TITLE
Warn on ignored options overrides offline

### DIFF
--- a/apps/cli/src/commands/accept.ts
+++ b/apps/cli/src/commands/accept.ts
@@ -51,6 +51,7 @@ import {
   prepareForOnlineExchange,
   runOnlineBootstrap,
   runOrExit,
+  warnOptionsOverridesIgnoredOffline,
   warnServerOverridesIgnoredOffline,
   type CommonBootstrapOptions,
   type ResolvedDataSpec,
@@ -342,11 +343,14 @@ export async function validateAccept(params: {
     };
   }
 
-  // Offline: the server-block overrides (--server-* and --outbound-path) cannot
-  // take effect (the connection block is seeded from the invitation endpoint or a
-  // placeholder, not built from a URL), so warn rather than drop a
-  // deliberately-passed flag silently.
+  // Offline: the server-block overrides (--server-* and --outbound-path) and the
+  // connection-options overrides (timeouts, --max-reconnect-attempts, the
+  // file-sync toggles) cannot take effect (the connection block is seeded from
+  // the invitation endpoint or a placeholder, not built from a URL), so warn
+  // rather than drop a deliberately-passed flag silently. Two diagnostics: the
+  // server block and the connection.options block have distinct remedies.
   warnServerOverridesIgnoredOffline(options, log);
+  warnOptionsOverridesIgnoredOffline(options, log);
 
   // Offline.
   const reuseExistingConfig = reconcileAcceptConfig({

--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -1671,10 +1671,12 @@ export function warnOptionsOverridesIgnoredOffline(
   options: OfflineIgnoredOptionsOverrides,
   log: { warn: (message: string) => void },
 ): void {
-  // Push only the flag NAME, never the override value. None of these is a
-  // secret today, but keeping the emitted message static apart from this
-  // flag-name list mirrors warnServerOverridesIgnoredOffline's discipline and
-  // forecloses leaking any future value-bearing flag added to this set.
+  // Security invariant: push only the flag NAME, never the override value. This
+  // warning reaches the terminal and any --log-file, so interpolating a value
+  // here would leak it. None of these flags is a secret today, but --peer-id is
+  // an operator-supplied free string and the set may grow, so keep the emitted
+  // message static apart from this flag-name list -- the same discipline
+  // warnServerOverridesIgnoredOffline holds for its --server-password/-key.
   const ignored: string[] = [];
   if (options.connectionTimeout !== undefined)
     ignored.push("--connection-timeout");

--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -1612,3 +1612,89 @@ export function warnServerOverridesIgnoredOffline(
       "an online invite/accept, the zero-setup exchange, or 'psilink exchange'.",
   );
 }
+
+/**
+ * The connection-OPTIONS overrides that have no effect on an OFFLINE
+ * invite/accept, read by {@link warnOptionsOverridesIgnoredOffline}. A structural
+ * subset of {@link CommonBootstrapOptions} (assignable to it) holding the
+ * tuning/toggle flags {@link applyConnectionOverrides} writes into
+ * `connection.options`: the SharedOptions timeouts/reconnect bound
+ * (`--connection-timeout`, `--peer-timeout`, `--max-reconnect-attempts`) and the
+ * file-sync toggles (`--lockless-rendezvous`, `--peer-id`, `--retain-files`,
+ * `--timestamp-in-filename`) -- HOW the exchange behaves, as opposed to the
+ * server block's WHERE/credentials that {@link OfflineIgnoredServerOverrides}
+ * covers.
+ *
+ * The offline placeholder has no `options` block on any channel (a split seed
+ * pre-seeds only the fixed retain-mode trio there, {@link SPLIT_SEED_OPTIONS},
+ * never operator tuning), so these overrides are parsed and silently dropped on
+ * the offline paths. They are the `connection.options` half deliberately scoped
+ * out of {@link OfflineIgnoredServerOverrides}: warning for them belongs
+ * in a separate, differently-worded diagnostic ("set them under
+ * connection.options") rather than folded into the server warning's "set the
+ * connection details in that block" remedy.
+ *
+ * Note the synthesized `--accept-timeout` is NOT here: it feeds the override
+ * bag's `peerTimeout` only through {@link connectionOverridesFrom}'s `extra` arg
+ * on the ONLINE invite path. This read is of the parsed `peerTimeout` field
+ * (`--peer-timeout`) directly, so an offline invite with `--accept-timeout` but
+ * no `--peer-timeout` does not warn spuriously.
+ */
+export type OfflineIgnoredOptionsOverrides = Pick<
+  CommonBootstrapOptions,
+  | "connectionTimeout"
+  | "peerTimeout"
+  | "maxReconnectAttempts"
+  | "locklessRendezvous"
+  | "peerId"
+  | "timestampInFilename"
+  | "retainFiles"
+>;
+
+/**
+ * Warn that the connection-OPTIONS overrides (`--connection-timeout`,
+ * `--peer-timeout`, `--max-reconnect-attempts`, `--lockless-rendezvous`,
+ * `--peer-id`, `--timestamp-in-filename`, `--retain-files`) have no effect on an
+ * OFFLINE invite/accept. Like the server-block overrides those paths go through
+ * {@link connectionFromEndpoint}, which applies no connection overrides, but
+ * these target `connection.options` -- a block the offline placeholder does not
+ * contain on any channel -- so they would otherwise be parsed and silently
+ * dropped. The warning names exactly the flags the operator set; it is a no-op
+ * when none are set.
+ *
+ * Kept distinct from {@link warnServerOverridesIgnoredOffline}: that one's remedy
+ * is "set the connection details in that block" (host/port/credentials/paths),
+ * whereas these land under `connection.options`, so the remedy wording points
+ * there instead. Shared between invite and accept so the wording cannot drift.
+ */
+export function warnOptionsOverridesIgnoredOffline(
+  options: OfflineIgnoredOptionsOverrides,
+  log: { warn: (message: string) => void },
+): void {
+  // Push only the flag NAME, never the override value. None of these is a
+  // secret today, but keeping the emitted message static apart from this
+  // flag-name list mirrors warnServerOverridesIgnoredOffline's discipline and
+  // forecloses leaking any future value-bearing flag added to this set.
+  const ignored: string[] = [];
+  if (options.connectionTimeout !== undefined)
+    ignored.push("--connection-timeout");
+  if (options.peerTimeout !== undefined) ignored.push("--peer-timeout");
+  if (options.maxReconnectAttempts !== undefined)
+    ignored.push("--max-reconnect-attempts");
+  if (options.locklessRendezvous !== undefined)
+    ignored.push("--lockless-rendezvous");
+  if (options.peerId !== undefined) ignored.push("--peer-id");
+  if (options.timestampInFilename !== undefined)
+    ignored.push("--timestamp-in-filename");
+  if (options.retainFiles !== undefined) ignored.push("--retain-files");
+  if (ignored.length === 0) return;
+  log.warn(
+    `${ignored.join(", ")} ${ignored.length === 1 ? "has" : "have"} no effect ` +
+      "on an offline invite/accept: the connection block is written for you to " +
+      "edit (a placeholder, or seeded from the invitation endpoint), and these " +
+      "tuning options are not applied to it. Set them under connection.options " +
+      "in the written config before running 'psilink exchange', or pass these " +
+      "flags on an online invite/accept, the zero-setup exchange, or 'psilink " +
+      "exchange'.",
+  );
+}

--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -1681,12 +1681,18 @@ export function warnOptionsOverridesIgnoredOffline(
   if (options.peerTimeout !== undefined) ignored.push("--peer-timeout");
   if (options.maxReconnectAttempts !== undefined)
     ignored.push("--max-reconnect-attempts");
-  if (options.locklessRendezvous !== undefined)
+  // The three toggles gate on `=== true`, not presence: yargs sets the negated
+  // form (--no-retain-files etc.) to `false`, and `false` is the default a fresh
+  // placeholder already carries, so only the enabling form was an override that
+  // could have done something. This matches warnUnsupportedFileSyncFlags's
+  // `=== true` gate on the same toggles and avoids a warning that names
+  // --retain-files when the operator actually typed --no-retain-files.
+  if (options.locklessRendezvous === true)
     ignored.push("--lockless-rendezvous");
   if (options.peerId !== undefined) ignored.push("--peer-id");
-  if (options.timestampInFilename !== undefined)
+  if (options.timestampInFilename === true)
     ignored.push("--timestamp-in-filename");
-  if (options.retainFiles !== undefined) ignored.push("--retain-files");
+  if (options.retainFiles === true) ignored.push("--retain-files");
   if (ignored.length === 0) return;
   log.warn(
     `${ignored.join(", ")} ${ignored.length === 1 ? "has" : "have"} no effect ` +

--- a/apps/cli/src/commands/invite.ts
+++ b/apps/cli/src/commands/invite.ts
@@ -46,6 +46,7 @@ import {
   runOnlineBootstrap,
   runOrExit,
   unsatisfiedLinkageFields,
+  warnOptionsOverridesIgnoredOffline,
   warnServerOverridesIgnoredOffline,
   type CommonBootstrapOptions,
   type ResolvedDataSpec,
@@ -311,11 +312,14 @@ export async function validateInvite(params: {
     };
   }
 
-  // Offline: the server-block overrides (--server-* and --outbound-path) cannot
-  // take effect (the connection block is written as a placeholder to edit, not
-  // built from a URL), so warn rather than drop a deliberately-passed flag
-  // silently.
+  // Offline: the server-block overrides (--server-* and --outbound-path) and the
+  // connection-options overrides (timeouts, --max-reconnect-attempts, the
+  // file-sync toggles) cannot take effect (the connection block is written as a
+  // placeholder to edit, not built from a URL), so warn rather than drop a
+  // deliberately-passed flag silently. Two diagnostics: the server block and the
+  // connection.options block have distinct remedies.
   warnServerOverridesIgnoredOffline(options, log);
+  warnOptionsOverridesIgnoredOffline(options, log);
 
   // Offline. Linkage terms come from a pre-existing config when one is present
   // at the config path, and are inferred from the input file otherwise.

--- a/apps/cli/test/unit/accept.test.ts
+++ b/apps/cli/test/unit/accept.test.ts
@@ -403,6 +403,108 @@ test("validateAccept: online does not warn about a --server-* override (it is ap
   }
 });
 
+test("validateAccept: offline warns that a connection-options override is ignored", async () => {
+  // The offline path builds the connection block from connectionFromEndpoint
+  // (placeholder or endpoint seed), which has no `options` block, so a
+  // connection-options override cannot take effect; it must be surfaced with a
+  // remedy pointing at connection.options, distinct from the server warning.
+  const input = writeInputCSV(["first_name", "last_name", "dob", "ssn"]);
+  const log = getLogger("accept-offline-opt-override-warn");
+  log.setLevel("silent");
+  const warnSpy = vi.spyOn(log, "warn");
+  try {
+    const encoded = await encodeInvitation(sampleToken(FUTURE()));
+    const ready = await validateAccept({
+      resolved: { mode: "offline", invitation: encoded, input },
+      options: testOptions({ retainFiles: true }),
+      log,
+    });
+    expect(ready.mode).toBe("offline");
+    expect(
+      warnSpy.mock.calls.some(
+        (c) =>
+          typeof c[0] === "string" &&
+          c[0].includes("--retain-files") &&
+          c[0].includes("connection.options"),
+      ),
+    ).toBe(true);
+  } finally {
+    warnSpy.mockRestore();
+    fs.rmSync(input, { force: true });
+  }
+});
+
+test("validateAccept: offline does not warn about connection.options when no options flag is set", async () => {
+  // No connection-options flag is set, so the connection.options warning must
+  // stay silent on the offline accept path.
+  const input = writeInputCSV(["first_name", "last_name", "dob", "ssn"]);
+  const log = getLogger("accept-offline-no-opt-warn");
+  log.setLevel("silent");
+  const warnSpy = vi.spyOn(log, "warn");
+  try {
+    const encoded = await encodeInvitation(sampleToken(FUTURE()));
+    const ready = await validateAccept({
+      resolved: { mode: "offline", invitation: encoded, input },
+      options: testOptions(),
+      log,
+    });
+    expect(ready.mode).toBe("offline");
+    expect(
+      warnSpy.mock.calls.some(
+        (c) => typeof c[0] === "string" && c[0].includes("connection.options"),
+      ),
+    ).toBe(false);
+  } finally {
+    warnSpy.mockRestore();
+    fs.rmSync(input, { force: true });
+  }
+});
+
+test("validateAccept: online does not warn about a connection-options override (it is applied)", async () => {
+  // The online path builds the connection from the URL through
+  // applyConnectionOverrides, so a connection-options override takes effect and
+  // no ignored-override warning is emitted.
+  const dir = fs.mkdtempSync(
+    path.join(tmpdir(), "psilink-accept-online-opt-override-"),
+  );
+  const input = path.join(dir, "input.csv");
+  fs.writeFileSync(
+    input,
+    "first_name,last_name,dob,ssn\nAlice,Smith,1990-01-02,123456789\n",
+  );
+  const log = getLogger("accept-online-opt-override-nowarn");
+  log.setLevel("silent");
+  const warnSpy = vi.spyOn(log, "warn");
+  try {
+    const encoded = await encodeInvitation(sampleToken(FUTURE()));
+    const ready = await validateAccept({
+      resolved: {
+        mode: "online",
+        url: new URL("sftp://host/drop"),
+        invitation: encoded,
+        input,
+      },
+      options: testOptions({
+        configFile: path.join(dir, "psilink.yaml"),
+        keyFile: path.join(dir, ".psilink.key"),
+        maxReconnectAttempts: 5,
+      }),
+      log,
+    });
+    expect(ready.mode).toBe("online");
+    if (ready.mode !== "online") return;
+    expect(ready.connection.options?.maxReconnectAttempts).toBe(5);
+    expect(
+      warnSpy.mock.calls.some(
+        (c) => typeof c[0] === "string" && c[0].includes("connection.options"),
+      ),
+    ).toBe(false);
+  } finally {
+    warnSpy.mockRestore();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // --- reconciling a pre-existing config ---------------------------------------
 
 /** Write a config whose linkage terms agree with the invitation's by default

--- a/apps/cli/test/unit/accept.test.ts
+++ b/apps/cli/test/unit/accept.test.ts
@@ -505,6 +505,52 @@ test("validateAccept: online does not warn about a connection-options override (
   }
 });
 
+test("validateAccept: offline split-seed accept does not warn on --no-retain-files (seed forces retain on)", async () => {
+  // A split-directory endpoint seeds the connection with SPLIT_SEED_OPTIONS (the
+  // retain trio = true) and applies no override, so an explicit --no-retain-files
+  // (retainFiles === false) is dropped and the seed's retain_files: true stands.
+  // The `=== true` gate declines to warn on the negated form -- it is not an
+  // enabling override, and warning would name --retain-files for a flag the
+  // operator typed as --no-retain-files. This mirrors the online split path,
+  // which also forces retain on and warns nothing. Pins the SPLIT_SEED_OPTIONS x
+  // gate interaction the helper-level tests do not reach.
+  const input = writeInputCSV(["first_name", "last_name", "dob", "ssn"]);
+  const endpoint: ConnectionEndpoint = {
+    channel: "sftp",
+    host: "inviter-host",
+    inboundPath: "/exchange/inviter-in",
+    outboundPath: "/exchange/inviter-out",
+  };
+  const log = getLogger("accept-offline-split-seed-no-retain");
+  log.setLevel("silent");
+  const warnSpy = vi.spyOn(log, "warn");
+  try {
+    const encoded = await encodeInvitation(sampleToken(FUTURE(), endpoint));
+    const ready = await validateAccept({
+      resolved: { mode: "offline", invitation: encoded, input },
+      options: testOptions({ retainFiles: false }),
+      log,
+    });
+    expect(ready.mode).toBe("offline");
+    if (ready.mode !== "offline") return;
+    if (ready.connection.channel !== "sftp") throw new Error("expected sftp");
+    // The seed forces retain on despite --no-retain-files.
+    expect(ready.connection.options?.retainFiles).toBe(true);
+    // No --retain-files warning: the gate declines on the negated form.
+    expect(
+      warnSpy.mock.calls.some(
+        (c) =>
+          typeof c[0] === "string" &&
+          c[0].includes("--retain-files") &&
+          c[0].includes("connection.options"),
+      ),
+    ).toBe(false);
+  } finally {
+    warnSpy.mockRestore();
+    fs.rmSync(input, { force: true });
+  }
+});
+
 // --- reconciling a pre-existing config ---------------------------------------
 
 /** Write a config whose linkage terms agree with the invitation's by default

--- a/apps/cli/test/unit/bootstrap.test.ts
+++ b/apps/cli/test/unit/bootstrap.test.ts
@@ -33,6 +33,7 @@ import {
   parseCommonBootstrapArgs,
   runOnlineBootstrap,
   runOrExit,
+  warnOptionsOverridesIgnoredOffline,
   warnServerOverridesIgnoredOffline,
   warnUnsupportedFileSyncFlags,
   type RunnableConnectionConfig,
@@ -360,6 +361,60 @@ test("warnServerOverridesIgnoredOffline: one warning names every set flag", () =
 test("warnServerOverridesIgnoredOffline: stays silent when no override is set", () => {
   const warnings: string[] = [];
   warnServerOverridesIgnoredOffline({}, { warn: (m) => warnings.push(m) });
+  expect(warnings).toEqual([]);
+});
+
+// Each connection-OPTIONS override flag, paired with the option field that
+// carries it, so the parametrized test below proves every one is named when set
+// offline. Covers both the SharedOptions timeouts/reconnect bound and the
+// FileSyncOptions toggles -- the offline placeholder has no `options` block on
+// any channel, so the warning is not gated by channel.
+const OFFLINE_IGNORED_OPTIONS_OVERRIDES: ReadonlyArray<{
+  flag: string;
+  option: Parameters<typeof warnOptionsOverridesIgnoredOffline>[0];
+}> = [
+  { flag: "--connection-timeout", option: { connectionTimeout: 30 } },
+  { flag: "--peer-timeout", option: { peerTimeout: 60 } },
+  { flag: "--max-reconnect-attempts", option: { maxReconnectAttempts: 5 } },
+  { flag: "--lockless-rendezvous", option: { locklessRendezvous: true } },
+  { flag: "--peer-id", option: { peerId: "party-a" } },
+  { flag: "--timestamp-in-filename", option: { timestampInFilename: true } },
+  { flag: "--retain-files", option: { retainFiles: true } },
+];
+
+for (const { flag, option } of OFFLINE_IGNORED_OPTIONS_OVERRIDES)
+  test(`warnOptionsOverridesIgnoredOffline: warns naming ${flag} when set`, () => {
+    const warnings: string[] = [];
+    warnOptionsOverridesIgnoredOffline(option, {
+      warn: (m) => warnings.push(m),
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(flag);
+    expect(warnings[0]).toContain("no effect on an offline invite/accept");
+    // The remedy points at connection.options, distinct from the server-override
+    // warning's "set the connection details in that block" remedy.
+    expect(warnings[0]).toContain("connection.options");
+  });
+
+test("warnOptionsOverridesIgnoredOffline: one warning names every set flag", () => {
+  const warnings: string[] = [];
+  warnOptionsOverridesIgnoredOffline(
+    { connectionTimeout: 30, retainFiles: true, peerId: "party-a" },
+    { warn: (m) => warnings.push(m) },
+  );
+  // A single warning rather than one per flag, so the operator sees the whole
+  // ignored set at once.
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain("--connection-timeout");
+  expect(warnings[0]).toContain("--retain-files");
+  expect(warnings[0]).toContain("--peer-id");
+  // An unset flag is not named.
+  expect(warnings[0]).not.toContain("--peer-timeout");
+});
+
+test("warnOptionsOverridesIgnoredOffline: stays silent when no override is set", () => {
+  const warnings: string[] = [];
+  warnOptionsOverridesIgnoredOffline({}, { warn: (m) => warnings.push(m) });
   expect(warnings).toEqual([]);
 });
 

--- a/apps/cli/test/unit/bootstrap.test.ts
+++ b/apps/cli/test/unit/bootstrap.test.ts
@@ -418,6 +418,23 @@ test("warnOptionsOverridesIgnoredOffline: stays silent when no override is set",
   expect(warnings).toEqual([]);
 });
 
+test("warnOptionsOverridesIgnoredOffline: a negated boolean toggle (--no-*) does not warn", () => {
+  // yargs sets the negated form (--no-retain-files etc.) to `false`, the default
+  // a fresh placeholder already carries, so it is not an override that could have
+  // done something: the toggles gate on `=== true`, not presence. Mirrors
+  // warnUnsupportedFileSyncFlags's `=== true` gate on the same toggles.
+  const warnings: string[] = [];
+  warnOptionsOverridesIgnoredOffline(
+    {
+      locklessRendezvous: false,
+      retainFiles: false,
+      timestampInFilename: false,
+    },
+    { warn: (m) => warnings.push(m) },
+  );
+  expect(warnings).toEqual([]);
+});
+
 // --- redactUrlCredentials ----------------------------------------------------
 
 test("redactUrlCredentials: strips an embedded password and username", () => {

--- a/apps/cli/test/unit/invite.test.ts
+++ b/apps/cli/test/unit/invite.test.ts
@@ -602,6 +602,94 @@ test("validateInvite: online does not warn about a --server-* override (it is ap
   warnSpy.mockRestore();
 });
 
+test("validateInvite: offline warns that a connection-options override is ignored", async () => {
+  // The offline path writes a placeholder connection block with no `options`
+  // block, so a --peer-timeout (or any connection-options) override cannot take
+  // effect; it must be surfaced, with a remedy distinct from the server warning's
+  // -- pointing at connection.options.
+  const dir = fs.mkdtempSync(
+    path.join(tmpdir(), "psilink-invite-opt-override-"),
+  );
+  tmpDirs.push(dir);
+  const input = writeCsv(dir, "first_name,last_name,dob,ssn");
+  const log = getLogger("invite-offline-opt-override-warn");
+  log.setLevel("warn");
+  const warnSpy = vi.spyOn(log, "warn");
+  await validateInvite({
+    resolved: { mode: "offline", input },
+    options: testOptions({
+      configFile: path.join(dir, "psilink.yaml"),
+      keyFile: path.join(dir, ".psilink.key"),
+      peerTimeout: 60,
+    }),
+    acceptTimeout: 900,
+    log,
+  });
+  expect(
+    warnSpy.mock.calls.some(
+      (c) =>
+        typeof c[0] === "string" &&
+        c[0].includes("--peer-timeout") &&
+        c[0].includes("connection.options"),
+    ),
+  ).toBe(true);
+  warnSpy.mockRestore();
+});
+
+test("validateInvite: offline does not warn about connection.options when no options flag is set", async () => {
+  // No connection-options flag is set, so the connection.options warning must
+  // stay silent. acceptTimeout is a separate param, NOT a --peer-timeout
+  // override: it feeds peerTimeout only on the online path (via the override
+  // bag's `extra`), so an offline invite that sets it must not warn spuriously
+  // about a dropped --peer-timeout.
+  const dir = fs.mkdtempSync(path.join(tmpdir(), "psilink-invite-no-opt-"));
+  tmpDirs.push(dir);
+  const input = writeCsv(dir, "first_name,last_name,dob,ssn");
+  const log = getLogger("invite-offline-no-opt-warn");
+  log.setLevel("warn");
+  const warnSpy = vi.spyOn(log, "warn");
+  await validateInvite({
+    resolved: { mode: "offline", input },
+    options: testOptions({
+      configFile: path.join(dir, "psilink.yaml"),
+      keyFile: path.join(dir, ".psilink.key"),
+    }),
+    acceptTimeout: 900,
+    log,
+  });
+  expect(
+    warnSpy.mock.calls.some(
+      (c) => typeof c[0] === "string" && c[0].includes("connection.options"),
+    ),
+  ).toBe(false);
+  warnSpy.mockRestore();
+});
+
+test("validateInvite: online does not warn about a connection-options override (it is applied)", async () => {
+  // The online path builds the connection from the URL through
+  // applyConnectionOverrides, so a connection-options override takes effect and
+  // no ignored-override warning is emitted.
+  const { input, options } = onlineFixture();
+  const log = getLogger("invite-online-opt-override-nowarn");
+  log.setLevel("warn");
+  const warnSpy = vi.spyOn(log, "warn");
+  const ready = await validateInvite({
+    resolved: { mode: "online", url: new URL("sftp://host/drop"), input },
+    options: { ...options, maxReconnectAttempts: 5 },
+    acceptTimeout: 900,
+    log,
+  });
+  expect(ready.mode).toBe("online");
+  if (ready.mode !== "online") return;
+  expect(ready.connection.options?.maxReconnectAttempts).toBe(5);
+  expect(
+    warnSpy.mock.calls.some(
+      (c) => typeof c[0] === "string" && c[0].includes("connection.options"),
+    ),
+  ).toBe(false);
+  warnSpy.mockRestore();
+});
+
 // --- validateInvite: --expires-in override -----------------------------------
 
 test("validateInvite: --expires-in sets the token's expiry to the override", async () => {


### PR DESCRIPTION
## Summary

On the offline paths of `psilink invite` and `psilink accept`, the connection-options overrides (`--connection-timeout`, `--peer-timeout`, `--max-reconnect-attempts`, `--lockless-rendezvous`, `--peer-id`, `--timestamp-in-filename`, `--retain-files`) were parsed and then silently dropped: those paths write a placeholder or invitation-endpoint seed for the operator to hand-edit, so `connectionFromEndpoint` never applies an override and nothing reaches `connection.options`. This surfaces them with a diagnostic that names exactly the flags the operator set, closing the gap the server-override warning deliberately left. Minor UX footgun, not a correctness or security bug.

Implements [202518975](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202518975).

## Changes

- `apps/cli/src/commands/bootstrap.ts`: add `warnOptionsOverridesIgnoredOffline` and its `OfflineIgnoredOptionsOverrides` type, a sibling of `warnServerOverridesIgnoredOffline`. Distinct, differently-worded remedy pointing at `connection.options` rather than the server warning's "set the connection details in that block". The three boolean toggles gate on `=== true` (not presence), matching `warnUnsupportedFileSyncFlags`, so the negated form (`--no-retain-files`) does not trip the warning; the timeout/string flags gate on presence. Emits only flag names, never an override value.
- `apps/cli/src/commands/invite.ts`, `apps/cli/src/commands/accept.ts`: call the new helper alongside the existing server-override warning on each offline path, after the online early-return.
- `apps/cli/test/unit/bootstrap.test.ts`: helper-level tests -- each flag named when set, one warning for the whole set, silence when unset, and the negated-toggle silence.
- `apps/cli/test/unit/invite.test.ts`, `apps/cli/test/unit/accept.test.ts`: path-level tests -- offline warns, offline-with-no-flags stays silent (and `--accept-timeout` does not warn spuriously), online applies-and-does-not-warn, and an offline split-seed accept keeps the seeded retain trio without warning on `--no-retain-files`.

## Test plan

Ran: `npx vitest run apps/cli/test/unit/bootstrap.test.ts apps/cli/test/unit/invite.test.ts apps/cli/test/unit/accept.test.ts` (204 passed), plus `npm run test:unit -w apps/cli` (full CLI unit suite green), `npm run typecheck`, `npm run lint`, `npm run format`.
New tests cover: each connection-options override named in its offline warning on both invite and accept; no warning when no options flag is set; the negated-toggle (`--no-*`) silence; the online/zero-setup/exchange paths still applying these overrides and emitting no offline warning; and the split-seed offline accept keeping `retain_files: true` from the seed without warning on `--no-retain-files`.

## Background

This parallels the prior server-override warning (item 202433910), which deliberately scoped out the options overrides because they target `connection.options` -- a block the offline placeholder does not contain -- so the correct remedy wording differs and the two are kept as separate diagnostics rather than folded into one. The wrinkle the implementation guards against: on the online invite path `peerTimeout` is synthesized from `--accept-timeout` via the override bag's `extra` arg, so the offline warning reads the parsed `--peer-timeout` field directly and does not warn spuriously when only `--accept-timeout` is set.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier -- n/a: no documented behavior changed; `docs/CLI.md` does not enumerate the offline-dropped override flags and the prior server-override warning (#208) added none, so this is at parity. The warning is self-documenting at the point of use.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: a new diagnostic that surfaces a previously silently-dropped no-op; the underlying offline behavior is unchanged, the umbrella `invite`/`accept` Added entry already covers the offline write path, and the sibling #208/#209 added none.
- [x] Security review -- done: independent three-lens panel (disclosure/credential-leak, log/terminal injection and sanitization, control-flow/guarantee-weakening), all APPROVE. The change touches "what is disclosed" (a new line to the terminal and any `--log-file`), but emits only static, hardcoded flag names -- never an override value (incl. the operator free-string `--peer-id`) -- on a credential-free offline path; it adds no control flow and weakens no existing guarantee.