### PR TITLE
Sanitize config parse-error issue paths

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -805,7 +805,13 @@ export function loadConfigLinkageSource(
             // Prefix each issue with its field path (e.g. "linkageKeys.0.name")
             // so the user can locate the offending field, mirroring accept's
             // decode-error formatting. The path is relative to linkage_terms.
-            const at = i.path.length > 0 ? `${i.path.join(".")}: ` : "";
+            // Escape each path segment through sanitizeForDisplay before joining,
+            // matching describeDecodeError's contract: harden the path components
+            // this formatter owns, relay the issue message unchanged.
+            const at =
+              i.path.length > 0
+                ? `${i.path.map((p) => sanitizeForDisplay(String(p))).join(".")}: `
+                : "";
             return `${at}${i.message}`;
           })
           .join("; "),
@@ -824,7 +830,11 @@ export function loadConfigLinkageSource(
         `config file ${configPath} has invalid standardization: ` +
           stdResult.error.issues
             .map((i) => {
-              const at = i.path.length > 0 ? `${i.path.join(".")}: ` : "";
+              // Escape each path segment, like the linkage_terms branch above.
+              const at =
+                i.path.length > 0
+                  ? `${i.path.map((p) => sanitizeForDisplay(String(p))).join(".")}: `
+                  : "";
               return `${at}${i.message}`;
             })
             .join("; "),
@@ -846,7 +856,11 @@ export function loadConfigLinkageSource(
         `config file ${configPath} has invalid metadata: ` +
           metaResult.error.issues
             .map((i) => {
-              const at = i.path.length > 0 ? `${i.path.join(".")}: ` : "";
+              // Escape each path segment, like the linkage_terms branch above.
+              const at =
+                i.path.length > 0
+                  ? `${i.path.map((p) => sanitizeForDisplay(String(p))).join(".")}: `
+                  : "";
               return `${at}${i.message}`;
             })
             .join("; "),

--- a/apps/cli/test/unit/config.test.ts
+++ b/apps/cli/test/unit/config.test.ts
@@ -5,6 +5,7 @@ import { expect, test } from "vitest";
 import YAML from "yaml";
 import {
   getDefaultLinkageTerms,
+  MAX_NAME_LENGTH,
   parseExchangeSpec,
   UsageError,
 } from "@psilink/core";
@@ -1270,6 +1271,74 @@ test("loadConfigLinkageSource rejects invalid linkage_terms", () => {
     expect(() => loadConfigLinkageSource(configPath)).toThrow(
       "invalid linkage_terms",
     );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// The three parse-error formatters route every issue-path segment through
+// sanitizeForDisplay, like describeDecodeError, so a control/ANSI or
+// deceptive-Unicode byte in a path can never reach the operator raw. No reachable
+// failure produces such a path today (the linkage schemas are non-strict, so
+// unrecognized keys are stripped before they can appear), so this drives the one
+// schema position that can carry a partner-style string into a path -- a
+// transform `params` record key, whose key schema bounds length -- with an
+// over-long key built from control and bidi-override bytes. The guard must escape
+// it; the two tests below pin both the escaping and the absence of over-escaping.
+test("loadConfigLinkageSource escapes control/ANSI bytes in a linkage_terms issue path", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
+  try {
+    const configPath = path.join(dir, "psilink.yaml");
+    const terms = cloneTerms(getDefaultLinkageTerms("Agency A"));
+    // An ESC-driven ANSI sequence and a right-to-left override (U+202E). The key
+    // must exceed MAX_NAME_LENGTH so the record-key schema rejects it and Zod
+    // surfaces the offending key in the issue path.
+    const badKey = "\x1b[31m‮evil" + "x".repeat(MAX_NAME_LENGTH + 10);
+    terms.linkageKeys[0].elements[0].transform = [
+      { function: "noop", params: { [badKey]: 1 } },
+    ];
+    fs.writeFileSync(configPath, YAML.stringify({ linkage_terms: terms }));
+    let caught: unknown;
+    try {
+      loadConfigLinkageSource(configPath);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(UsageError);
+    const message = (caught as Error).message;
+    expect(message).toContain("invalid linkage_terms");
+    // The fixed path prefix passes through verbatim; only the partner-style key
+    // segment is escaped.
+    expect(message).toContain("linkageKeys.0.elements.0.transform.0.params.");
+    // The raw bytes are neutralized: their escaped forms appear, never the bytes.
+    expect(message).not.toContain("\x1b");
+    expect(message).not.toContain("‮");
+    expect(message).toContain("\\x1b");
+    expect(message).toContain("\\u202e");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadConfigLinkageSource leaves a schema-fixed linkage_terms issue path unescaped", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
+  try {
+    const configPath = path.join(dir, "psilink.yaml");
+    const terms = cloneTerms(getDefaultLinkageTerms("Agency A"));
+    // An empty name fails the linkage-key `name` min-length, locating the issue
+    // at the schema-fixed path linkageKeys.0.name (field names + a numeric index).
+    terms.linkageKeys[0].name = "";
+    fs.writeFileSync(configPath, YAML.stringify({ linkage_terms: terms }));
+    let caught: unknown;
+    try {
+      loadConfigLinkageSource(configPath);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(UsageError);
+    // Ordinary path components survive untouched: the `.` separators and the
+    // numeric index are not over-escaped.
+    expect((caught as Error).message).toContain("linkageKeys.0.name");
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Close the one operator-facing parse-error formatter that did not route its Zod issue-path components through the project's display-sanitization chokepoint, so all such formatters are now uniform. `loadConfigLinkageSource` built three messages (invalid `linkage_terms`, `standardization`, `metadata`) by joining each issue's path raw; it now escapes each segment through `sanitizeForDisplay` before joining, matching `describeDecodeError`'s contract. Defense-in-depth: the reachable issue paths are schema-fixed today, so this changes no message under normal use while making the chokepoint coverage complete for the next schema or caller change.

Implements [202541307](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202541307).

## Changes

- `apps/cli/src/config.ts`: in `loadConfigLinkageSource`, the three parse-error branches now build the issue prefix as `i.path.map((p) => sanitizeForDisplay(String(p))).join(".")` instead of `i.path.join(".")`; the relayed issue `message` is left verbatim, per the same escaping contract as `describeDecodeError`.
- `apps/cli/test/unit/config.test.ts`: add two tests. One drives a `transform.params` record key built from control, ANSI, and bidi-override (U+202E) bytes into a `linkage_terms` issue path (via the bounded-record-key `invalid_key` route) and asserts the raw bytes are neutralized in the thrown `UsageError` while the fixed prefix passes through; the other pins an ordinary schema-fixed path (`linkageKeys.0.name`) rendering unescaped, so dot separators and numeric indices are not over-escaped.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npx prettier --check` on the two files (all clean); `npx vitest run apps/cli/test/unit/config.test.ts` (82 passed); `npm run test -w apps/cli` (857 passed).
New tests cover: per-segment escaping of control/ANSI/bidi bytes in a `linkage_terms` issue path, and absence of over-escaping on a schema-fixed path.

## Background

The project maintains a deliberate invariant that config/linkage parse errors are static and located by issue path, never echoing an unsanitized partner-controlled value; `sanitizeForDisplay` is the chokepoint and `describeDecodeError` is the invitation-side instance. This config formatter was the remaining exception. It is harmless today because it parses the operator's own `psilink.yaml` and the reachable paths are schema-fixed (the linkage schemas are non-strict, so unknown keys are stripped before they can appear in a path). Closing it keeps coverage uniform so a future schema admitting a partner-controlled string into a path, or a future caller pointed at partner input, inherits the guard.

## Out of scope / follow-on

- A final security review found the partner/wire-side sibling: `protocolSetup.ts` interpolates a partner-supplied linkage-terms `parseErr.message` raw, and its safety comment omits the `invalid_key` bounded-record-key path through which a partner key (incl. raw U+202E) reaches the message; mitigated today only because the CLI display sinks re-sanitize. Filed as follow-on [202554679](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202554679).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; the escaping contract is documented in code at `describeDecodeError.ts` and this mirrors it.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: no operator- or reviewer-observable change under reachable inputs (defense-in-depth consistency hardening of a display surface); the existing umbrella entry already states operator-facing errors escape untrusted strings.
- [x] Security review -- done: display/disclosure surface (operator-facing error formatting). light-review (clean) plus three independent final security reviewers, all empirically verified: PASS on the diff (sanitizer neutralizes the full surface, guard is load-bearing, display-only invariant preserved, no over-escaping, no DoS amplification). The one adjacent, pre-existing finding is filed as 202554679, not in this diff.
