### PR TITLE
Escape linkage-terms parse-error paths at source

### DIFF
--- a/packages/core/src/protocolSetup.ts
+++ b/packages/core/src/protocolSetup.ts
@@ -10,6 +10,7 @@ import {
 import { SHARED_SECRET_REGEX } from "./config/connection";
 import { randomBytes, toBase64Url } from "./utils/crypto";
 import { sanitizeForDisplay } from "./utils/sanitizeForDisplay";
+import { describeDecodeError } from "./utils/describeDecodeError";
 import {
   receiveParsed,
   type MessageConnection,
@@ -283,24 +284,26 @@ export async function exchangeTerms(
       partnerTerms = parseLinkageTerms(msg.linkageTerms);
     } catch (parseErr) {
       await sendAbort(conn, ["partner linkage terms failed to parse"]);
-      // The schema-validation message is NOT routed through sanitizeForDisplay,
-      // because no partner-controlled bytes reach it on this path. Zod's one
-      // default message that echoes a received value is `unrecognized_keys`
-      // ("Unrecognized key: \"<key>\""), and it fires only on a `.strict()`
-      // object; every schema under parseLinkageTerms is a non-strict `z.object`,
-      // which strips unknown keys instead of reporting them (pinned by the
-      // "strips an unknown partner key" test). The other issue codes reachable
-      // here (type mismatch, enum, semver/date format, too_small) report the
-      // expected type/options and the schema path, not the received value.
-      // Leaving the message raw keeps the multi-line report readable for the
-      // common case of an honestly malformed config. (A partner value echoed
-      // into a curated diagnostic IS sanitized -- see validateCompatibility, the
-      // identity log in apps/cli/src/protocol.ts, and endpointKeyError in
-      // invitation.ts, whose strict endpoint objects DO echo a key and so escape
-      // it at the source.)
+      // These terms are genuinely partner-controlled, so the parse error is
+      // rendered through describeDecodeError, which escapes each Zod issue-path
+      // segment via sanitizeForDisplay and relays the schema-fixed message text
+      // (the shared chokepoint contract; see utils/describeDecodeError). The
+      // path escaping is load-bearing, not cosmetic: Zod's `invalid_key` code on
+      // the bounded `z.record` key in `transform.params`
+      // (z.string().max(MAX_NAME_LENGTH)) places the offending raw key VERBATIM
+      // into the issue PATH, which a raw `ZodError.message` JSON-dumps -- so a
+      // partner key carrying bidi-override / zero-width / homoglyph bytes would
+      // otherwise reach the operator unescaped. Escaping at the source makes the
+      // invariant real here rather than leaning on the display-sink backstop.
+      // The message text needs no escaping: unknown keys are stripped by the
+      // non-strict `z.object` schemas rather than echoed via `unrecognized_keys`
+      // (pinned by the "strips an unknown partner key" test), and the other
+      // reachable codes (type mismatch, enum, semver/date format, too_small)
+      // report the expected type/options, not the received value -- only the
+      // path carries partner bytes.
       throw new Error(
         "partner linkage terms failed to parse: " +
-          (parseErr instanceof Error ? parseErr.message : String(parseErr)),
+          describeDecodeError(parseErr),
       );
     }
 
@@ -343,15 +346,16 @@ export async function exchangeTerms(
       partnerHostKeyMalformed = parsed.hostKey.malformed;
       partnerTerms = parseLinkageTerms(parsed.linkageTerms);
     } catch (parseErr) {
-      parseError =
-        parseErr instanceof Error ? parseErr.message : String(parseErr);
+      // describeDecodeError escapes the partner-controlled Zod issue path at the
+      // source (the `invalid_key`/bounded-`z.record`-key path included) and
+      // relays the schema-fixed message text -- see the parse-error note in the
+      // initiator branch above.
+      parseError = describeDecodeError(parseErr);
     }
 
     const { errors, warnings } =
       parseError !== undefined
         ? {
-            // Not sanitized -- the Zod message carries no partner-supplied bytes
-            // (see the parse-error note in the initiator branch above).
             errors: [`partner linkage terms failed to parse: ${parseError}`],
             warnings: [],
           }

--- a/packages/core/src/utils/describeDecodeError.ts
+++ b/packages/core/src/utils/describeDecodeError.ts
@@ -22,16 +22,21 @@ import { sanitizeForDisplay } from "./sanitizeForDisplay";
  * concise relay does not truncate that long guidance text. The contract a caller
  * relies on is therefore that any error message reaching this helper which could
  * carry partner-controlled bytes is escaped at its source; that holds for every
- * error `decodeInvitation` and the invitation schema raise today. A future caller
- * that passes an error whose message echoes unescaped partner-controlled input
- * must escape it at the source rather than expect this helper to, since it relays
- * the message as is.
+ * error `decodeInvitation` and the invitation schema raise, and for the
+ * `parseLinkageTerms` `ZodError` the terms exchange relays (its partner-supplied
+ * bytes land in the issue path -- e.g. the `invalid_key` code on the bounded
+ * `transform.params` record key -- which this helper escapes, while its issue
+ * messages report the expected type/options, not the received value). A future
+ * caller that passes an error whose message echoes unescaped partner-controlled
+ * input must escape it at the source rather than expect this helper to, since it
+ * relays the message as is.
  *
- * Shared by the CLI accept command and the web accept route so both collapse the
- * same failure into the same readable one-liner. Because it escapes the path
- * components it owns rather than relying on a surrounding sanitizer, a caller may
- * display its result directly without a further wrapping pass (which would
- * double-escape those already-escaped components).
+ * Shared by the CLI accept command, the web accept route, and the linkage-terms
+ * exchange (protocolSetup) so each collapses the same failure into the same
+ * readable one-liner. Because it escapes the path components it owns rather than
+ * relying on a surrounding sanitizer, a caller may display its result directly
+ * without a further wrapping pass (which would double-escape those
+ * already-escaped components).
  */
 export function describeDecodeError(err: unknown): string {
   if (err !== null && typeof err === "object" && "issues" in err) {

--- a/packages/core/test/linkageTerms.test.ts
+++ b/packages/core/test/linkageTerms.test.ts
@@ -14,6 +14,7 @@ import {
   DISPLAY_TRUNCATION_MARKER,
   DEFAULT_MAX_DISPLAY_LENGTH,
 } from "../src/utils/sanitizeForDisplay";
+import { describeDecodeError } from "../src/utils/describeDecodeError";
 
 // Minimal valid set of terms used as a base for individual tests.
 const base = {
@@ -206,21 +207,75 @@ test("safeParseLinkageTerms returns success: false on invalid input", () => {
 });
 
 test("a parse error does not echo a partner-supplied received value", () => {
-  // protocolSetup leaves the Zod parse-error message unsanitized because the
-  // issue codes reachable here (type mismatch, enum, semver/date format,
-  // too_small) report the expected type/options and the schema path, not the
-  // received value. Pin that: invalid fields carrying control/ANSI and
-  // bidi-override bytes must not surface raw in the error message.
+  // The terms exchange relays a parse error through describeDecodeError, which
+  // escapes each Zod issue-path segment via sanitizeForDisplay and relays the
+  // schema-fixed message text. Two distinct mechanisms keep partner bytes out
+  // of the operator-facing message; pin both.
+  //
+  // 1. For most codes (type mismatch, enum, semver/date format, too_small) the
+  //    Zod message reports the expected type/options, never the received value,
+  //    so even the RAW `error.message` carries no partner bytes.
   const evil = "\x1b[31mEVIL\x1b[0m‮";
-  const result = safeParseLinkageTerms({
+  const enumSemver = safeParseLinkageTerms({
     ...base,
     algorithm: evil, // invalid enum
     version: evil, // invalid semver
   });
+  expect(enumSemver.success).toBe(false);
+  if (!enumSemver.success) {
+    expect(enumSemver.error.message).not.toContain("\x1b");
+    expect(enumSemver.error.message).not.toContain("‮");
+  }
+
+  // 2. The `invalid_key` code on the bounded `transform.params` record key
+  //    (z.string().max(MAX_NAME_LENGTH)) DOES place the offending key VERBATIM
+  //    in the issue PATH, which the raw `error.message` JSON-dumps -- so here
+  //    the source escaping (describeDecodeError) is load-bearing, not the
+  //    schema. The dangerous bytes lead the key (with padding past the bound
+  //    after them) so escaping, not the display-length cap, is what neutralizes
+  //    them. Assert on the rendered message the exchange actually relays.
+  const evilKey = "\x1b[31m‮" + "x".repeat(MAX_NAME_LENGTH);
+  const invalidKey = safeParseLinkageTerms({
+    ...base,
+    linkageKeys: [
+      {
+        name: "SSN",
+        elements: [
+          {
+            field: "ssn",
+            transform: [{ function: "trim", params: { [evilKey]: 1 } }],
+          },
+        ],
+      },
+    ],
+  });
+  expect(invalidKey.success).toBe(false);
+  if (!invalidKey.success) {
+    // The raw dump leaks the bidi override -- this is exactly the gap the
+    // source escaping closes. (The ESC byte is JSON-escaped by the dump, but a
+    // bidi/zero-width/homoglyph byte is not.)
+    expect(invalidKey.error.message).toContain("‮");
+    const relayed = describeDecodeError(invalidKey.error);
+    expect(relayed).not.toContain("\x1b");
+    expect(relayed).not.toContain("‮");
+    expect(relayed).toContain("\\x1b");
+    expect(relayed).toContain("\\u202e");
+  }
+});
+
+test("a relayed parse error keeps an honest schema path readable", () => {
+  // Acceptance counterpart to the sanitization pin above: the source escaping
+  // must not over-escape an ordinary schema-fixed path. `sanitizeForDisplay`
+  // leaves printable ASCII intact, so the `.` separators and numeric array
+  // index of a path like `linkageFields.0.type` survive unchanged and an
+  // honestly malformed config stays readable.
+  const result = safeParseLinkageTerms({
+    ...base,
+    linkageFields: [{ name: "ssn", type: 123 as unknown as string }],
+  });
   expect(result.success).toBe(false);
   if (!result.success) {
-    expect(result.error.message).not.toContain("\x1b");
-    expect(result.error.message).not.toContain("‮");
+    expect(describeDecodeError(result.error)).toContain("linkageFields.0.type");
   }
 });
 

--- a/packages/core/test/termsExchange.test.ts
+++ b/packages/core/test/termsExchange.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 
 import { exchangeTerms, resolveRole } from "../src/protocolSetup";
+import { MAX_NAME_LENGTH } from "../src/config/linkageTerms";
 import type { LinkageTerms, Output } from "../src/config/linkageTerms";
 import type { PresentedHostKey } from "../src/connection/fileSyncConnection";
 
@@ -296,6 +297,47 @@ test("neither party expects output -> both parties reject", async () => {
   );
   expect(results[0].status).toBe("rejected");
   expect(results[1].status).toBe("rejected");
+});
+
+test("responder neutralizes partner bytes in a linkage-terms parse error", async () => {
+  // End-to-end wiring guard for the source sanitization. The per-call-site unit
+  // pin lives in linkageTerms.test.ts (it exercises describeDecodeError on the
+  // ZodError directly); this proves protocolSetup actually ROUTES the relayed
+  // parse error through it. A partner whose terms fail to parse with bytes in
+  // the issue PATH -- an over-long transform.params key (the invalid_key code)
+  // leading with a bidi override and an ANSI escape -- must have those bytes
+  // neutralized in the rejection the responder relays, never surfaced raw.
+  // Reverting the call site to a raw ZodError.message regresses this (the JSON
+  // dump leaks U+202E verbatim).
+  const evilKey = "\x1b[31m‮" + "x".repeat(MAX_NAME_LENGTH);
+  const [connA, connB] = makeConnections();
+  const responder = exchangeTerms(connB, "responder", termsB);
+  await connA.send({
+    linkageTerms: {
+      ...termsA,
+      linkageKeys: [
+        {
+          name: "SSN",
+          elements: [
+            {
+              field: "ssn",
+              transform: [{ function: "trim", params: { [evilKey]: 1 } }],
+            },
+          ],
+        },
+      ],
+    },
+  });
+  const reason = await responder.then(
+    () => {
+      throw new Error("expected the responder to reject");
+    },
+    (e: unknown) => e as Error,
+  );
+  expect(reason.message).toContain("failed to parse");
+  expect(reason.message).not.toContain("‮");
+  expect(reason.message).not.toContain("\x1b");
+  expect(reason.message).toContain("\\u202e");
 });
 
 // --- Abort-send failure on the responder -------------------------------------


### PR DESCRIPTION
## Summary

Close a latent source-level disclosure invariant on the partner-supplied linkage-terms parse path. Both `parseLinkageTerms` call sites in `protocolSetup.ts` relayed a raw `ZodError.message` into the thrown and abort-relayed error, asserting no partner-controlled bytes could reach it -- false for the `invalid_key` code on the bounded `transform.params` record key, where Zod lands the raw key (which can carry bidi-override, zero-width, or homoglyph bytes) in the issue path that `ZodError.message` JSON-dumps. The bytes were already neutralized at every display sink, so this was a defense-in-depth gap, not a live vulnerability; the fix makes the asserted invariant real at the source rather than seam-dependent, matching the chokepoint contract its operator-config sibling (202541307) established.

Implements [202554679](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202554679).

## Changes

- `packages/core/src/protocolSetup.ts`: route both `parseLinkageTerms` parse-error relays (initiator throw, responder abort + throw) through `describeDecodeError` instead of interpolating the raw `ZodError.message`; rewrite the justifying comment at both sites to acknowledge the `invalid_key` / bounded-`z.record`-key path and state the safety now rests at the source.
- `packages/core/src/utils/describeDecodeError.ts`: extend the JSDoc to record the new caller and confirm the escaping contract holds for the linkage-terms `ZodError` (partner bytes land only in the path, which the helper escapes).
- `packages/core/test/linkageTerms.test.ts`: extend the parse-error pin to cover the `invalid_key` path (an over-long `transform.params` key carrying U+202E and an ANSI byte), keep the enum/semver assertions, and add a counterpart that an honest schema path stays readable.
- `packages/core/test/termsExchange.test.ts`: add an end-to-end guard that the responder routes a partner parse error through the sanitizer (a revert to the raw message regresses it).

## Test plan

Ran: `npm run build -w packages/core`, `npm run typecheck`, `npm run lint`, `npm run format`, `npm test -w packages/core` (1436 passed). Verified the new end-to-end guard fails on a deliberate revert of the call-site change, then restored.
New tests cover: the `invalid_key` over-long-key path is neutralized in the relayed parse error; an honest schema path (`linkageFields.0.type`) renders readable with no over-escaping; the responder's relayed and thrown parse error is sanitized end-to-end through `protocolSetup`.

## Background

The threat surface is the `transform.params` record key, `z.record(z.string().max(256), z.unknown())`: an over-long partner key trips Zod's `invalid_key`, which places the raw key in the issue path. `describeDecodeError` is the existing shared chokepoint (CLI accept/exchange commands, web accept route) that escapes each issue-path segment via `sanitizeForDisplay` and relays the schema-fixed message text; reusing it keeps the path-sanitization coverage uniform across the operator-config and partner-wire instances of the same pattern.

## Out of scope / follow-on

- Bound the `transform.params` entry count to avoid a Zod `RangeError` on a pathological partner payload (unbounded record count; caught harmlessly today and bounded upstream by the frame-size cap): [202609308](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202609308).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed; the parse-error relay text is not a documented wire format, and the path was already display-sanitized at every sink.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: defense-in-depth hardening with no operator- or reviewer-observable change (every display sink already re-sanitizes); mirrors the operator-config sibling PR #214, which also omitted it.
- [x] Security review -- done: within the "what is disclosed" scope (changes what is sent on the wire and displayed). Independent adversarial reviews run across sanitization-leak, disclosure/wire-relay, and robustness/DoS lenses, all clean (no partner bytes reach a sink or the wire unescaped; no new disclosure; `sanitizeForDisplay` is output-bounded and `describeDecodeError` is O(1) in issue count, and neither throws on reachable input; abort and fail-safe control flow preserved). Maintainer security sign-off still required before merge.
