### PR TITLE
Remove the withCapturedLogs logger-ordering footgun

### DIFF
--- a/apps/cli/test/integration/capturedLogs.setup.ts
+++ b/apps/cli/test/integration/capturedLogs.setup.ts
@@ -1,0 +1,14 @@
+import { installCapturedLogsInterceptor } from "@psilink/core/testing";
+
+// A `setupFiles` entry, so this runs once in EACH integration file's worker (the
+// integration project uses the `forks` pool: one process per file), before the
+// test module -- and thus any named logger it constructs at import time -- is
+// loaded. loglevel binds a logger's methods from the methodFactory live at
+// getLogger time, so installing the withCapturedLogs interceptor here, ahead of
+// every logger, makes capture independent of creation order: a logger
+// materialized before the suite's first withCapturedLogs call is still routed
+// through capture rather than silently leaking past it. Without this eager
+// install, withCapturedLogs would install the interceptor lazily on its first
+// call, by which point an earlier-created logger has already bound to the bare
+// factory and can never be captured.
+installCapturedLogsInterceptor();

--- a/apps/cli/test/integration/capturedLogsEagerInstall.test.ts
+++ b/apps/cli/test/integration/capturedLogsEagerInstall.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import { getLogger } from "@psilink/core";
+import { withCapturedLogs } from "@psilink/core/testing";
+
+// Materialize a named logger at module load -- before this file's first
+// withCapturedLogs call. loglevel binds a logger's methods from the methodFactory
+// live at getLogger time, so this logger routes through capture only because the
+// integration setup (capturedLogs.setup.ts) installs the withCapturedLogs
+// interceptor eagerly, ahead of any logger. Remove that eager install and this
+// logger binds to the bare factory at creation and its output bypasses capture --
+// the ordering footgun this test pins, which would re-fail the assertion below
+// (and leak the WARN past the console sentinel). The name is unique so it cannot
+// collide with a logger another integration file constructs.
+const preCreatedLog = getLogger("eager-install-precreated");
+
+describe("withCapturedLogs eager install", () => {
+  test("captures a named logger created before the first withCapturedLogs call", () => {
+    // Pin the level so the WARN is delivered to methodFactory regardless of the
+    // ambient default; setLevel rebinds methods through the logger's existing
+    // methodFactory, so it does not change which factory (capture vs bare) the
+    // logger bound to at creation -- the property actually under test.
+    preCreatedLog.setLevel("warn");
+
+    const sentinel = "eager-install capture sentinel";
+    const [, logs] = withCapturedLogs(
+      () => {
+        preCreatedLog.warn(sentinel);
+      },
+      (level) => level === "WARN",
+    );
+
+    // The logger bound to capture despite being created before this call, so its
+    // WARN landed in the capture (and was suppressed from the console) rather than
+    // leaking past the interceptor.
+    expect(logs.some((entry) => entry.message.includes(sentinel))).toBe(true);
+  });
+});

--- a/apps/cli/test/integration/onlineInviteAccept.test.ts
+++ b/apps/cli/test/integration/onlineInviteAccept.test.ts
@@ -679,10 +679,11 @@ test("filedrop: a shared-secret mismatch aborts the handshake, persisting no con
   // Both sides abort mid-handshake with their token un-rotated, so each emits a
   // "key exchange was in progress" recovery advisory at ERROR. Run them under
   // withCapturedLogs so those intended lines are captured for assertion below
-  // rather than leaked to the suite console. The logger names are unique to this
-  // test (the happy-path test above already created "invite"/"accept", and a
-  // logger created before the capture's interceptor is installed would bypass
-  // it -- a fresh name guarantees both loggers bind to the interceptor here).
+  // rather than leaked to the suite console. The natural "invite"/"accept" names
+  // are safe to reuse even though the happy-path test above already created those
+  // loggers: the integration setup installs the withCapturedLogs interceptor
+  // eagerly (capturedLogs.setup.ts), so a logger binds to capture regardless of
+  // when it was first materialized.
   const [[inviteOutcome, acceptOutcome], capturedLogs] = await withCapturedLogs(
     () =>
       Promise.allSettled([
@@ -696,7 +697,7 @@ test("filedrop: a shared-secret mismatch aborts the handshake, persisting no con
           configPath: inviteOptions.configFile,
           output: inviteReady.output,
           verbosity: 0,
-          loggerName: "mismatch-invite",
+          loggerName: "invite",
           recordOutput: resolveRecordOutput({
             enabled: inviteOptions.record,
             recordFile: inviteOptions.recordFile,
@@ -712,7 +713,7 @@ test("filedrop: a shared-secret mismatch aborts the handshake, persisting no con
           configPath: acceptOptions.configFile,
           output: acceptReady.output,
           verbosity: 0,
-          loggerName: "mismatch-accept",
+          loggerName: "accept",
           recordOutput: resolveRecordOutput({
             enabled: acceptOptions.record,
             recordFile: acceptOptions.recordFile,
@@ -909,11 +910,11 @@ describe("sftp", () => {
       // in-place mutation, the clone for the live connect, the handshake, and the
       // post-handshake saveConfig -- runs live. Each side emits one "authenticity
       // of host ... cannot be established" WARN carrying the presented fingerprint;
-      // capture WARNs so they are asserted rather than leaked to the suite console.
-      // The "fu-invite"/"fu-accept" logger names are unique to this test, so both
-      // bind to the capture interceptor (a logger created before it would bypass
-      // capture). The isTTY and stub mutations are set inside the try so the
-      // finally rolls both back even if a setup step throws.
+      // capture WARNs so they are asserted rather than leaked to the suite console
+      // (capture binds regardless of when these loggers were first materialized,
+      // because the integration setup installs the interceptor eagerly). The isTTY
+      // and stub mutations are set inside the try so the finally rolls both back
+      // even if a setup step throws.
       const originalIsTTY = process.stdin.isTTY;
       try {
         process.stdin.isTTY = true;

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -21,11 +21,25 @@ export default defineConfig({
           // chdir in one file could corrupt a concurrently-running sibling's cwd.
           // Forks gives each file its own process, the isolation safety needs.
           pool: "forks",
-          // Installs the standing console sentinel in every integration file's
-          // worker: it wraps console directly and fails the file at afterAll on
-          // any un-allowlisted console.log/warn/error (the inverse of blanket
-          // silencing). Scoped to this project, so the unit project is unaffected.
-          setupFiles: ["./test/integration/consoleSentinel.setup.ts"],
+          // Per-file worker setup, scoped to this project so the unit project is
+          // unaffected. capturedLogs installs the withCapturedLogs interceptor
+          // eagerly, before any test logger is constructed, so loglevel-based
+          // capture works regardless of logger creation order. consoleSentinel
+          // wraps console directly and fails the file at afterAll on any
+          // un-allowlisted console.log/warn/error (the inverse of blanket
+          // silencing) -- the complementary layer that sees third-party console
+          // output loglevel capture cannot.
+          //
+          // Order is load-bearing: capturedLogs MUST precede consoleSentinel.
+          // consoleSentinel's import chain pulls in @psilink/core, whose
+          // module-load loggers (e.g. getLogger("cleaning") in standardization.ts)
+          // are materialized on that first import; if the sentinel setup ran
+          // first, those loggers would bind to the bare factory before the
+          // interceptor exists and bypass capture for the rest of the run.
+          setupFiles: [
+            "./test/integration/capturedLogs.setup.ts",
+            "./test/integration/consoleSentinel.setup.ts",
+          ],
           // Starts the SFTP test server (the in-process backend by default, or
           // the native sshd backend when PSILINK_SFTP_BACKEND=native) before the
           // suite and stops it after, handing the conformance tests its

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,28 @@ function scopeToDir(dir, configs) {
   });
 }
 
+// Ban emitting through loglevel's bare root logger (the `logLibrary` default
+// import) in source that runs inside the CLI integration workers. The suite's
+// two leak-detection backstops -- the console sentinel and withCapturedLogs
+// capture -- only observe NAMED loggers: a named logger binds the
+// sentinel-wrapped console (and the capture interceptor) at getLogger time,
+// whereas the eager capture install rebinds the root logger against the raw,
+// pre-sentinel console (capturedLogs.setup.ts runs before the sentinel wraps
+// console). So a bare `logLibrary.<level>(...)` would silently escape BOTH
+// backstops. This rule is the executable form of that invariant -- the prose
+// "nothing emits through the bare root logger" the eager-install ordering rests
+// on -- so a future bare-root emit fails the lint check instead of quietly
+// reopening the blind spot. Emit through getLogger / getLoggerForVerbosity; the
+// root `logLibrary` is for setLevel / levels / getLogger only. (In core/src and
+// cli/src the loglevel default is uniformly imported as `logLibrary` and is
+// never a named-logger variable, so keying on that identifier is exact.)
+const noBareRootLoglevelEmit = {
+  selector:
+    "CallExpression[callee.object.name='logLibrary'][callee.property.name=/^(trace|debug|info|warn|error)$/]",
+  message:
+    "Do not emit through the bare root logger (logLibrary.<level>()): the CLI integration console sentinel and withCapturedLogs capture only see named loggers, so a bare-root emit escapes both leak-detection backstops. Use getLogger / getLoggerForVerbosity; logLibrary is for setLevel / levels / getLogger only.",
+};
+
 export default tseslint.config(
   {
     ignores: [
@@ -66,6 +88,7 @@ export default tseslint.config(
           message:
             "Parse credential files through apps/cli/src/sensitiveFile.ts (parseSensitiveJson); raw JSON.parse can echo a leading span of the source. Non-sensitive parse: eslint-disable-next-line with a one-line justification.",
         },
+        noBareRootLoglevelEmit,
       ],
       // Close the named-import bypass (`import { parse } from "yaml"`); the
       // chokepoint imports the YAML default, so this never hits legitimate code.
@@ -82,6 +105,17 @@ export default tseslint.config(
           ],
         },
       ],
+    },
+  },
+  {
+    // The bare-root-logger emit ban also covers core/src, which runs inside the
+    // CLI integration workers; cli/src gets the same selector folded into its
+    // no-restricted-syntax block above. Separate block because flat config
+    // replaces (does not merge) a rule's options across blocks, and cli/src
+    // already owns a no-restricted-syntax block for the sensitive-parse ban.
+    files: ["packages/core/src/**/*.ts"],
+    rules: {
+      "no-restricted-syntax": ["error", noBareRootLoglevelEmit],
     },
   },
   ...scopeToDir("apps/web", webConfig),

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -34,11 +34,19 @@ const captures: Array<{
 }> = [];
 let interceptorInstalled = false;
 
-function ensureInterceptor(): void {
+/** Installs the loglevel `methodFactory` interceptor that backs `withCapturedLogs`,
+ * idempotently. `withCapturedLogs` calls this on its first use, so a standalone
+ * caller never needs it; call it eagerly from test setup -- before any named logger
+ * is constructed -- to close the creation-order gap noted on `withCapturedLogs`.
+ * loglevel binds a logger's methods from the factory live at `getLogger` time, so a
+ * named logger built before the interceptor exists never routes through capture;
+ * installing here first makes every later-created logger bind to capture regardless
+ * of creation order. */
+export function installCapturedLogsInterceptor(): void {
   if (interceptorInstalled) return;
   interceptorInstalled = true;
   // Snapshot the current factory here, not at module load, so any third-party
-  // wrappers installed before the first withCapturedLogs call are included.
+  // wrappers installed before the interceptor is materialized are included.
   const rootFactory = logLibrary.methodFactory;
   logLibrary.methodFactory = (methodName, level, loggerName) => {
     const original = rootFactory(methodName, level, loggerName);
@@ -69,8 +77,11 @@ function ensureInterceptor(): void {
  * concurrent calls do not affect each other's observable output.
  * If `fn` rejects, captured logs are discarded and the rejection propagates.
  * Limitations: messages below loglevel's current threshold are never delivered to
- * `methodFactory` (loglevel assigns `noop` directly) and will not be captured; named
- * child loggers created before the first call to this function also bypass capture. */
+ * `methodFactory` (loglevel assigns `noop` directly) and will not be captured; a
+ * named logger created before the interceptor is installed binds to the pre-install
+ * factory and bypasses capture -- call `installCapturedLogsInterceptor` from test
+ * setup, ahead of any logger, to close that creation-order gap (the CLI integration
+ * suite does, so its loggers are captured regardless of creation order). */
 export function withCapturedLogs<T>(
   fn: () => Promise<T>,
   levelFilter?: (level: string) => boolean,
@@ -83,7 +94,7 @@ export function withCapturedLogs<T>(
   fn: () => T | Promise<T>,
   levelFilter?: (level: string) => boolean,
 ): [T, LogEntry[]] | Promise<[T, LogEntry[]]> {
-  ensureInterceptor();
+  installCapturedLogsInterceptor();
   const logs: LogEntry[] = [];
   const entry = {
     filter: levelFilter ?? ((level: string) => level === "WARN"),


### PR DESCRIPTION
## Summary

The CLI integration suite's loglevel capture (`withCapturedLogs`) now works regardless of logger creation order. The interceptor was installed lazily on the first `withCapturedLogs` call, so a named logger built earlier bound to the bare factory and silently bypassed capture -- a footgun that forced a logger-rename workaround under the shared-secret-mismatch test and would have hidden a future log leak whenever creation order shifted. Installing the interceptor eagerly at worker startup closes the gap, lets the rename revert to its natural names, and is backed by a regression test plus a lint guard for the one invariant the fix newly relies on.

Implements [202392910](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=202392910).

## Changes

- packages/core/src/testing.ts: expose `installCapturedLogsInterceptor` (the eager-install hook `withCapturedLogs` already calls lazily) and update the pre-creation-logger caveat to point at it.
- apps/cli/test/integration/capturedLogs.setup.ts (new): a `setupFiles` entry that installs the interceptor at worker startup, before any named logger is constructed.
- apps/cli/vitest.config.ts: wire the new setup file first and document why the order is load-bearing (consoleSentinel's import chain materializes core module-load loggers, which must bind after the interceptor).
- apps/cli/test/integration/onlineInviteAccept.test.ts: revert the `mismatch-invite`/`mismatch-accept` rename to `invite`/`accept`; refresh comments that asserted the old footgun.
- apps/cli/test/integration/capturedLogsEagerInstall.test.ts (new): regression test -- a logger created at module load is captured, and re-fails if the eager install is removed.
- eslint.config.mjs: ban bare-root logger emits (`logLibrary.<level>()`) in core/src and cli/src, encoding the "named loggers only" invariant the eager-install ordering relies on.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format`; core unit (`packages/core`, 1436), CLI unit (855), CLI integration (35 passed, 3 skipped). Verified the eager-install regression test fails when the interceptor install is removed, and that the new lint rule fires on a bare-root emit in both core/src and cli/src while the existing credential-leak YAML/JSON parse ban still triggers.

New tests cover: a named logger created before the first `withCapturedLogs` call is captured (the ordering footgun -- the test re-fails without the eager install).

## Background

loglevel binds a logger's methods from the `methodFactory` live at `getLogger` time, so the lazily-installed interceptor never reached a logger materialized earlier. Installing it eagerly, ahead of every logger, makes capture creation-order-independent. The eager install also rebinds loglevel's root logger against the raw console before the integration console sentinel wraps it; that is safe only while nothing emits through the bare root logger, so the lint guard encodes that invariant as a check rather than prose.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented or operational behavior changed; the only doc surface, the `withCapturedLogs` caveat, lives in code and is updated here.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-infrastructure plus a `@psilink/core` testing-subpath API reshape and an ESLint rule; no operator- or reviewer-visible runtime change.
- [x] Security review -- done (pre-review): independent disclosure/leak-detection review of the test log-capture change and the eslint-config edit confirmed no production logging path changes and that the co-located credential-leak sensitive-parse control is preserved; no production security surface (crypto/AEAD/credential/auth/wire) is touched.