### PR TITLE
Bound transform.params entry count at the schema

### DIFF
--- a/packages/core/src/config/linkageTerms.ts
+++ b/packages/core/src/config/linkageTerms.ts
@@ -10,17 +10,33 @@ import { sanitizeForDisplay } from "../utils/sanitizeForDisplay.js";
 // These terms travel inside an invitation token, which the decoder accepts from
 // a counterparty whose token passed only a transcription checksum -- a check
 // anyone can recompute over a crafted payload, not an authenticity guarantee
-// (see invitation.ts). The rule below: every partner-controlled free-text string
-// carries a generous length `.max()`, and the two top-level arrays
-// (`linkageFields` and `linkageKeys`) carry a count `.max()`. What is left to the
-// boundary cap MAX_ENCODED_INVITATION_LENGTH in invitation.ts rather than a
-// per-field bound is the deeper collection COUNTS -- per-element `transform`
-// steps, each constraint's `exclude` list, the `payload` send/receive arrays, and
-// the `transform` `params` record's entries -- and the `params` value content
-// (typed `z.unknown()`, with no clean content bound). Their legitimate sizes vary
-// (a denylist can hold hundreds of values), so an invented count risks rejecting
-// a real config, and the boundary cap already bounds the whole payload before any
-// field is parsed. The bounds are defense-in-depth, not semantic limits.
+// (see invitation.ts) -- and they are parsed a second time off the exchange wire
+// (protocolSetup), where the binding size cap is the far larger
+// MAX_FRAME_SIZE_BYTES (~512 MiB, connection/frameSize.ts), not the 64 KiB
+// MAX_ENCODED_INVITATION_LENGTH of the token path. The rule below: every
+// partner-controlled free-text string carries a generous length `.max()`; the two
+// top-level arrays (`linkageFields` and `linkageKeys`) and the `transform.params`
+// record carry a count `.max()`. What is still left to those boundary caps rather
+// than a per-field bound is the deeper collection COUNTS -- per-element
+// `transform` steps, each constraint's `exclude` list, the `payload` send/receive
+// arrays, and a key's `elements` -- and the `params` VALUE content (typed
+// `z.unknown()`, with no clean content bound). Their legitimate sizes vary (a
+// denylist can hold hundreds of values), so an invented count risks rejecting a
+// real config. The `transform.params` ENTRY count is the exception now bounded
+// (MAX_PARAMS_ENTRIES): under the wire-path frame cap a payload of ~130k invalid
+// keys fits, and Zod overflows its own call stack accumulating and spreading one
+// issue per key before it can return a structured failure -- a schema count bound
+// forestalls that. The deferred counts nested beneath an OUTER array -- `exclude`
+// (under `linkageFields`), and `transform` steps and `elements` (under
+// `linkageKeys`) -- share that exposure: the inner issue array is spread through
+// two array frames, so a partner can still drive the same Zod-internal RangeError
+// there. The outermost `payload` send/receive arrays sit one array frame below the
+// root object, so they do not overflow at counts the frame cap admits (they stay
+// unbounded only for uniformity, not because they share the exposure). Every
+// reachable case is caught harmlessly in protocolSetup's parse-error catch (a
+// RangeError has no `.issues`, so it renders via the message fallback and the
+// exchange aborts cleanly). Bounding the deferred counts is a surveyed follow-on,
+// not done here. The bounds are defense-in-depth, not semantic limits.
 
 /**
  * Generous upper bound on a short partner-controlled string -- the identifier-
@@ -52,6 +68,19 @@ export const MAX_TEXT_LENGTH = 1024;
  * most-to-least-precise ordering of `linkageKeys` are unaffected.
  */
 export const MAX_LINKAGE_ENTRIES = 256;
+
+/**
+ * Generous upper bound on the COUNT of entries in a transform step's `params`
+ * record. A standardizing function takes a handful of parameters (the bundled
+ * functions use one to three); 256 is far above any real parameter list yet
+ * refuses a record padded with tens of thousands of keys. The bound is enforced
+ * BEFORE the per-key length validation (see {@link TransformStep}'s schema): an
+ * over-count record is rejected with a single issue rather than one issue per
+ * key, so a pathological-count payload on the wide wire-path frame cannot make
+ * Zod overflow its call stack accumulating an issue per key. See the
+ * untrusted-input bounds note above.
+ */
+export const MAX_PARAMS_ENTRIES = 256;
 
 // --- Output ------------------------------------------------------------------
 
@@ -291,9 +320,25 @@ const TransformStepSchema: z.ZodType<TransformStep> = z.object({
   function: z.string().min(1).max(MAX_NAME_LENGTH),
   // The record's KEYS are partner-controlled strings (parameter names), so they
   // are length-bounded like every other free-text string; the VALUE content is
-  // `z.unknown()` with no clean per-field bound and the entry COUNT is left to
-  // the boundary cap (see the bounds-section note above).
-  params: z.record(z.string().max(MAX_NAME_LENGTH), z.unknown()).optional(),
+  // `z.unknown()` with no clean per-field bound. The entry COUNT is bounded at
+  // MAX_PARAMS_ENTRIES, and -- critically -- that gate runs BEFORE the per-key
+  // length check: a first permissive `z.record` accepts the keys unvalidated, so
+  // the count refine sees the whole set and rejects an over-count payload with a
+  // single issue; `.pipe` then re-validates the now count-capped keys against the
+  // length bound. Bounding the count on the length-bounded record directly would
+  // not help -- Zod accumulates one length issue per bad key during that record's
+  // own parse, before any refine runs, and on the wide wire-path frame
+  // (MAX_FRAME_SIZE_BYTES, far above the 64 KiB invitation cap) ~130k such keys
+  // overflow Zod's call stack as it spreads that issue array up through the
+  // nesting. The pipe keeps the post-cap `invalid_key` path -- and its parse-error
+  // sanitization (item 202554679) -- intact for an in-range over-long key.
+  params: z
+    .record(z.string(), z.unknown())
+    .refine((rec) => Object.keys(rec).length <= MAX_PARAMS_ENTRIES, {
+      message: `transform params must not exceed ${MAX_PARAMS_ENTRIES} entries`,
+    })
+    .pipe(z.record(z.string().max(MAX_NAME_LENGTH), z.unknown()))
+    .optional(),
 });
 
 /**

--- a/packages/core/test/linkageTerms.test.ts
+++ b/packages/core/test/linkageTerms.test.ts
@@ -8,6 +8,7 @@ import {
   MAX_NAME_LENGTH,
   MAX_TEXT_LENGTH,
   MAX_LINKAGE_ENTRIES,
+  MAX_PARAMS_ENTRIES,
 } from "../src/config/linkageTerms";
 import type { LinkageTerms } from "../src/config/linkageTerms";
 import {
@@ -1333,6 +1334,69 @@ test("rejects an over-long transform params key", () => {
       ],
     }),
   ).toThrow(ZodError);
+});
+
+const paramsTerms = (params: Record<string, unknown>) => ({
+  ...base,
+  linkageKeys: [
+    {
+      name: "SSN",
+      elements: [{ field: "ssn", transform: [{ function: "trim", params }] }],
+    },
+  ],
+});
+
+test("accepts a transform params record at exactly the maximum entry count", () => {
+  const params: Record<string, unknown> = {};
+  for (let i = 0; i < MAX_PARAMS_ENTRIES; i++) params[`k${i}`] = 1;
+  expect(() => parseLinkageTerms(paramsTerms(params))).not.toThrow();
+});
+
+test("rejects a transform params record over the maximum entry count", () => {
+  const params: Record<string, unknown> = {};
+  for (let i = 0; i <= MAX_PARAMS_ENTRIES; i++) params[`k${i}`] = 1;
+  expect(() => parseLinkageTerms(paramsTerms(params))).toThrow(ZodError);
+});
+
+test("a pathological-count transform params record fails cleanly, not with a RangeError", () => {
+  // Regression for the Zod issue-accumulation overflow: a record of ~200k keys
+  // each too long for the per-key bound. On the unbounded-count schema Zod built
+  // one issue per key and overflowed the call stack spreading that array up
+  // through the nesting -- the RangeError escaped even safeParse (it converts a
+  // ZodError to a result but not an internal throw). The count gate, applied
+  // before the per-key length check, must turn this into one clean, bounded
+  // issue. ~200k keys clears the empirical overflow threshold (~130k); a smaller
+  // over-count would reject without ever exercising the overflow path.
+  const params: Record<string, unknown> = {};
+  const overlong = "k".repeat(MAX_NAME_LENGTH + 1);
+  for (let i = 0; i < 200_000; i++) params[overlong + i] = 1;
+
+  let result: ReturnType<typeof safeParseLinkageTerms> | undefined;
+  expect(() => {
+    result = safeParseLinkageTerms(paramsTerms(params));
+  }).not.toThrow();
+  expect(result?.success).toBe(false);
+  if (result && !result.success) {
+    // A single count-bound issue, not one per key, and it carries no partner key
+    // bytes (the over-long keys never reach the per-key validation).
+    expect(
+      result.error.issues.some((i) => /must not exceed/.test(i.message)),
+    ).toBe(true);
+    expect(describeDecodeError(result.error)).toContain("params");
+  }
+});
+
+test("an over-long transform params key within the count bound is still rejected per-key", () => {
+  // The count gate must not mask the per-key length bound for an in-range record:
+  // a single over-long key still trips the post-pipe `invalid_key` path, the one
+  // item 202554679's parse-error sanitization relies on.
+  const result = safeParseLinkageTerms(
+    paramsTerms({ ["k".repeat(MAX_NAME_LENGTH + 1)]: 1 }),
+  );
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues[0].code).toBe("invalid_key");
+  }
 });
 
 test("rejects an over-long version string", () => {


### PR DESCRIPTION
## Summary

Bound the partner-parsed `transform.params` record's entry count so a pathological linkage-terms payload fails as a clean, bounded Zod rejection instead of forcing an internally-thrown RangeError. A partner could previously send a `transform.params` record with a very large number of invalid keys; Zod accumulated one issue per key and overflowed its own call stack spreading that array up through the schema nesting. The overflow was caught harmlessly today (no crash, no disclosure), so this is defense-in-depth robustness rather than a live fix -- but the source now enforces the guarantee instead of leaning on an incidental catch.

Implements [202609308](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202609308).

## Changes

- packages/core/src/config/linkageTerms.ts: add `MAX_PARAMS_ENTRIES` (256) and bound the `transform.params` entry count with a two-stage schema -- a permissive `z.record` whose `.refine` rejects an over-count payload with a single issue, then `.pipe` into the original length-bounded record. Reconcile the untrusted-input bounds note and the `TransformStep` inline comment to name the bound and record which sibling collections share the wire-path exposure.
- packages/core/test/linkageTerms.test.ts: add the pathological-count regression plus the count-boundary and in-range-key cases.

## Test plan

Ran: `npm run typecheck && npm run lint && npm run format`; `npx vitest run packages/core/test/linkageTerms.test.ts` (99 passed); `npm test -w packages/core` (1440 unit passed).
New tests cover: a ~200k-key payload fails cleanly rather than throwing a RangeError out of `safeParse`; the count boundary accepts 256 and rejects 257; an in-range over-long key still trips the per-key `invalid_key` path the parse-error sanitization (202554679) relies on.

## Background

The count gate must run before the per-key length validation. A `.refine` on the length-bounded record would not help, because Zod builds one length issue per bad key during that record's own parse, before any refine runs, and on the wide wire-path frame (`MAX_FRAME_SIZE_BYTES`, far above the 64 KiB invitation cap) ~130k such keys overflow the stack. The permissive-then-`.pipe` form gates the count first and keeps the post-cap `invalid_key`-in-path behavior intact. The deferred sibling counts (`exclude`, `transform` steps, `elements`) nested beneath an outer array share the same exposure; the outermost `payload` arrays do not.

## Out of scope / follow-on

- Bound the remaining partner-parsed unbounded collections (linkage-terms siblings plus the post-handshake wire messages): [202615892](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202615892).
- Guard `camelizeKeys` against a distinct pre-Zod deep-nesting stack overflow: [202617716](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202617716).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed; the schema bound constants are code-only (no `docs/` or `docs/spec/` page enumerates the `MAX_*` linkage-terms bounds, and a real config never reaches the limit).
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: internal @psilink/core robustness hardening with no operator-, deployer-, or reviewer-observable change (the exchange aborts cleanly before and after) and not a headline security entry; matches the no-entry precedent of sibling hardening items #216 and #214.
- [x] Security review -- independent multi-agent review on the final branch (a merge-gate security reviewer and an adversarial bypass verifier, after earlier security/adversarial/completeness passes): both cleared (APPROVE / HOLDS). This change bounds partner-parsed untrusted input (a channel-hardening control) and preserves the 202554679 issue-path sanitization at the source; no disclosure, AEAD, credential, auth, or crypto surface changed.
