### PR TITLE
Route raw-client SFTP teardown off the console sentinel

### DIFF
--- a/apps/cli/test/integration/consoleAllowlist.ts
+++ b/apps/cli/test/integration/consoleAllowlist.ts
@@ -34,9 +34,12 @@ export const SENTINEL_GATED_LEVELS: readonly ConsoleLevel[] = [
  *   - The ssh2-sftp-client "Global ... listener" lines (`Global error listener:
  *     <msg>` on `console.error`; `Global end listener: end event raised` /
  *     `Global close listener: close event raised` on `console.log`) are routed
- *     to the adapter's project logger by `SSH2SFTPClientAdapter`'s constructor
- *     callbacks, so they no longer reach the console for an adapter-driven
- *     connection.
+ *     to the project logger by constructor callbacks rather than reaching the
+ *     console: `SSH2SFTPClientAdapter`'s callbacks for an adapter-driven
+ *     connection, and `createRawSftpClient`'s (`test/rawSftpClient.ts`) for the
+ *     few integration tests that must drive a bare client -- so neither path
+ *     leaks the teardown ECONNRESET the sentinel could otherwise only catch
+ *     best-effort.
  *   - The former unpinned-host-key WARN is gone: the no-pin host-key path now
  *     fails closed rather than warn-and-proceed.
  *

--- a/apps/cli/test/integration/nativeHardening.test.ts
+++ b/apps/cli/test/integration/nativeHardening.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "vitest";
 import { FileSyncConnection } from "@psilink/core";
-import Ssh2SftpClient from "ssh2-sftp-client";
 
 import { SSH2SFTPClientAdapter } from "../../src/connection/ssh2SftpAdapter";
+import { createRawSftpClient } from "../rawSftpClient";
 import { selectedBackend, selectedNativeProfile } from "../sftpServer";
 import { remotePath, sftpServer } from "../sftpServer/testContext";
 
@@ -76,7 +76,9 @@ allowlistOnly(
 chrootOnly(
   "confines the session: a path outside the served root is unreachable",
   async () => {
-    const client = new Ssh2SftpClient();
+    // A raw client (not the adapter) so the chroot is exercised directly; its
+    // teardown diagnostics are routed off the console -- see createRawSftpClient.
+    const client = createRawSftpClient();
     await client.connect({
       host: srv.host,
       port: srv.port,
@@ -113,7 +115,12 @@ restrictedCryptoOnly(
     // the handshake would succeed, and this test would fail red. (A legacy kex
     // like diffie-hellman-group14-sha1 would not catch that regression, since a
     // modern OpenSSH default already excludes it.)
-    const client = new Ssh2SftpClient();
+    //
+    // A raw client (not the adapter) so the forced handshake failure is exercised
+    // directly; the connection reset its teardown emits is routed off the console
+    // rather than landing as an async-late `Global error listener: read
+    // ECONNRESET` -- see createRawSftpClient.
+    const client = createRawSftpClient();
     await expect(
       client.connect({
         host: srv.host,

--- a/apps/cli/test/rawSftpClient.ts
+++ b/apps/cli/test/rawSftpClient.ts
@@ -1,0 +1,67 @@
+import Ssh2SftpClient from "ssh2-sftp-client";
+import { getLogger, sanitizeErrorForDisplay } from "@psilink/core";
+
+/**
+ * Constructs a raw {@link Ssh2SftpClient} whose lifecycle diagnostics are routed
+ * to the project logger instead of ssh2-sftp-client's default console sinks.
+ *
+ * A few integration tests must drive a BARE ssh2-sftp-client -- bypassing
+ * {@link SSH2SFTPClientAdapter} -- to exercise a server profile's refusal or
+ * confinement directly (a kex the policy excludes, a chroot jail). The trouble is
+ * the bare constructor: with no callbacks, ssh2-sftp-client installs defaults that
+ * `console.error`/`console.log` the underlying ssh2 Client's error/end/close
+ * events whenever they fire OUTSIDE a high-level operation. On a deliberately
+ * refused or torn-down test connection that surfaces as an async-late
+ * `Global error listener: read ECONNRESET` on `console.error` during teardown. The
+ * integration console sentinel can only catch that best-effort -- it races the
+ * bounded `afterAll` drain -- so a line that lands past the budget reds the run
+ * non-deterministically.
+ *
+ * Routing the three events to the project logger closes the leak at the source,
+ * exactly as {@link SSH2SFTPClientAdapter}'s constructor callbacks do for an
+ * adapter-driven connection: the line never reaches the console regardless of WHEN
+ * the event fires, the deterministic guarantee the sentinel cannot give on its
+ * own. The callbacks REPLACE ssh2-sftp-client's console defaults as a set (its
+ * `globalListener` runs `eventCallbacks?.<evt>` and is otherwise a no-op), and are
+ * purely observational -- the handled-flag bookkeeping and `this.sftp` cleanup run
+ * inside `globalListener` regardless.
+ *
+ * All three route to TRACE, which the project logger keeps a no-op: this named
+ * logger's level is fixed at WARN when it is created here and does NOT track later
+ * root-level changes, so the line stays off the console even when an integration
+ * file raises the root level (the suite's noisiest do, to DEBUG). That
+ * non-propagation -- not merely the trace-below-DEBUG margin -- is what makes the
+ * suppression deterministic rather than dependent on the suite's log level; it is
+ * asserted in `test/unit/rawSftpClient.test.ts` (which forces root to its most
+ * verbose level and confirms the teardown still touches no console sink). It
+ * surfaces only if this logger itself is set to trace.
+ *
+ * Routing all three to trace differs from the adapter, which keeps an escaped
+ * `error` at error: there an unhandled client error is an operator-actionable
+ * fault, whereas here the teardown ECONNRESET is an EXPECTED artifact of a test
+ * that purposely refuses or ends the connection -- the same benign-lifecycle
+ * category the adapter already routes to trace for end/close. The error message is
+ * server-controlled (ssh2 rides an SSH_MSG_DISCONNECT description on `err.message`),
+ * so it is escaped through {@link sanitizeErrorForDisplay} before logging,
+ * mirroring the adapter.
+ *
+ * Covered by `test/unit/rawSftpClient.test.ts`, which drives the constructed
+ * client's callbacks and asserts they reach neither `console.error` nor
+ * `console.log`; reverting a call site to a bare `new Ssh2SftpClient()` re-fails
+ * it.
+ */
+const log = getLogger("raw-sftp-test-client");
+
+export function createRawSftpClient(): Ssh2SftpClient {
+  return new Ssh2SftpClient("sftp", {
+    error: (err: unknown) =>
+      log.trace(
+        "raw ssh2-sftp-client error outside an operation: " +
+          sanitizeErrorForDisplay(err),
+      ),
+    end: () =>
+      log.trace("raw ssh2-sftp-client connection ended outside an operation"),
+    close: () =>
+      log.trace("raw ssh2-sftp-client connection closed outside an operation"),
+  });
+}

--- a/apps/cli/test/unit/rawSftpClient.test.ts
+++ b/apps/cli/test/unit/rawSftpClient.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, expect, test, vi } from "vitest";
+import logLibrary from "loglevel";
+
+import { createRawSftpClient } from "../rawSftpClient";
+
+// The lifecycle callbacks ssh2-sftp-client stores from the constructor; the
+// teardown events its `globalListener` invokes. Typed minimally so the test can
+// fire them directly without a live connection.
+interface RawClientCallbacks {
+  eventCallbacks: {
+    error: (err: unknown) => void;
+    end: () => void;
+    close: () => void;
+  };
+}
+
+// Restore the root log level after any test that raises it (the verbose-root
+// case below), so a mutation cannot leak into a sibling unit file sharing the
+// worker. Captured before the level is touched.
+const originalRootLevel = logLibrary.getLevel();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  logLibrary.setLevel(originalRootLevel, false);
+});
+
+// Fire the three teardown events the constructor's callbacks handle -- including
+// the read ECONNRESET that flaked the suite -- with console.error/console.log
+// spied, and assert neither was touched. Returns nothing; the assertions are the
+// point. Reading the callbacks the constructor actually stored (rather than
+// asserting on the routing in the abstract) means a raw client reverted to the
+// bare `new Ssh2SftpClient()` -- whose default callbacks call console.error/
+// console.log at fire time -- re-fails this.
+function expectTeardownStaysOffConsole(): void {
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  const { eventCallbacks } =
+    createRawSftpClient() as unknown as RawClientCallbacks;
+
+  eventCallbacks.error(new Error("read ECONNRESET"));
+  eventCallbacks.end();
+  eventCallbacks.close();
+
+  expect(errorSpy).not.toHaveBeenCalled();
+  expect(logSpy).not.toHaveBeenCalled();
+}
+
+// Regression guard for the native-hardening console flake (board item 202617870):
+// a bare `new Ssh2SftpClient()` leaves ssh2-sftp-client's default callbacks
+// writing `Global error listener: read ECONNRESET` (and the end/close lines) to
+// the console on teardown, which the integration sentinel catches only
+// best-effort. createRawSftpClient must route those off the console at the source.
+test("createRawSftpClient routes teardown diagnostics off the console", () => {
+  expectTeardownStaysOffConsole();
+});
+
+// The suppression must be DETERMINISTIC, not contingent on the suite's log level:
+// the whole point of routing (over draining) is that the line never reaches the
+// console regardless of timing OR verbosity. The integration suite's noisiest
+// files raise the ROOT log level (mixedConnection/sftpConnection set it to DEBUG);
+// forks isolation keeps them in separate processes, but the property that makes
+// this safe is local -- createRawSftpClient's named logger pins its own level at
+// creation and does NOT track later root changes, so its trace stays a no-op even
+// when root is raised. Assert that directly by forcing root to the MOST verbose
+// level (stronger than the DEBUG the suite reaches) and confirming the teardown
+// still touches no console sink. If the helper ever switched to a logger that
+// tracked root (e.g. getLoggerForVerbosity) or this logger were bumped, this fails
+// red -- turning the determinism claim into a check rather than a comment.
+test("teardown stays off the console even at the most verbose root level", () => {
+  logLibrary.setLevel(logLibrary.levels.TRACE, false);
+  expectTeardownStaysOffConsole();
+});


### PR DESCRIPTION
## Summary

The native-sshd CLI integration legs (`nativeHardening.test.ts`) intermittently red on a console-sentinel failure that is a test-quality artifact, not a product or test-target defect. The raw `new Ssh2SftpClient()` test clients leave ssh2-sftp-client's default `globalListener` writing `Global error listener: read ECONNRESET` to `console.error` on async-late connection teardown; when that line lands inside the sentinel's bounded `afterAll` settle window it reds the run, and when it lands after it escapes -- a timing race. This routes those raw test clients' teardown diagnostics to the project logger at the source so the line can never reach the console, closing the flake deterministically rather than race-dependently.

Implements [202617870](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=202617870).

## Changes

- `apps/cli/test/rawSftpClient.ts`: new shared helper `createRawSftpClient` constructs the raw client with `error`/`end`/`close` constructor callbacks routing to the project logger at trace (off the console), mirroring `SSH2SFTPClientAdapter`; the server-controlled error message is escaped through `sanitizeErrorForDisplay`. All three route to trace because the teardown ECONNRESET is an expected artifact of a deliberately refused or ended connection, and the named logger's level is pinned at creation so its trace stays a no-op even when an integration file raises the root level.
- `apps/cli/test/integration/nativeHardening.test.ts`: the two raw-client sites (chroot confinement, kex exclusion) build through the helper; the username-allowlist rejection test was already adapter-driven and so already routed.
- `apps/cli/test/unit/rawSftpClient.test.ts`: regression tests fire the constructed callbacks and assert neither `console.error` nor `console.log` is touched -- one at the default level (so reverting a site to a bare `new Ssh2SftpClient()` re-fails), one with the root level forced to its most verbose (encoding the log-level-independent determinism as a check).
- `apps/cli/test/integration/consoleAllowlist.ts`: update the Global-listener note to record the raw test clients are now routed too; `INTEGRATION_CONSOLE_ALLOWLIST` stays empty (no allowlist matcher added).

## Test plan

Ran:
- `npx vitest run apps/cli/test/unit/rawSftpClient.test.ts` -- 2 passed; verified it fails red when the helper is reverted to a bare `new Ssh2SftpClient()` (fails on the exact `Global error listener: read ECONNRESET` line).
- CLI unit project (`npx vitest run --project unit` in `apps/cli`) -- 859 passed.
- `PSILINK_SFTP_BACKEND=native PSILINK_SFTP_NATIVE_PROFILE=restricted-crypto npx vitest run --project integration test/integration/nativeHardening.test.ts` -- kex-exclusion passes, sentinel clean.
- Same against the `allowlist` profile -- the adapter-driven allowlist rejection test passes, sentinel clean.
- `npm run typecheck && npm run lint && npm run format` -- clean.
- The `chroot` profile needs `sshd` as root (skips locally); CI runs it under sudo. It shares the same teardown shape and goes through the same helper.

New tests cover: the raw-client teardown callbacks reach neither `console.error` nor `console.log`, deterministically and independent of the root log level, so dropping the routing re-fails.

## Background

Not introduced by #217 (loglevel-only); that PR only surfaced a latent flake. ssh2-sftp-client's default `globalListener` `console.error`s out-of-band ssh2-`Client` error events; the adapter path was already routed off the console (PR #189), but that change was scoped to `ssh2SftpAdapter.ts` and never touched these raw test clients. The sentinel is deterministic for synchronous/in-hook output but only best-effort for async-late "Global ... listener" teardown lines (a bounded `afterAll` settle, not a hard guarantee), so the fix is at the source per the suite's route-at-the-source convention, not a new allowlist matcher. The one remaining bare `new Ssh2SftpClient()` (`sftpConnection.test.ts`) is intentionally untouched: it is a clean successful-connect-then-`end()` path on the in-process backend, not the deliberate-refusal/forced-teardown shape that produces the async-late line.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; this is a test-only de-flake and the only prose touched is an in-code test note (`consoleAllowlist.ts`).
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-only change, no operator- or reviewer-visible behavior (the routing affects test clients, not what the product logs or discloses).
- [x] Security review -- n/a: no production control in the security-review scope is touched (the production adapter already routes these lines identically; nothing the product sends, logs, displays, or writes to disk changes). Precautionary: because the diff handles server-controlled error strings in test teardown, ran two independent security reviews of it (defense-in-depth/test-integrity and information-disclosure/log-injection) -- both cleared it, a net improvement (sanitized + key-redacted vs the prior raw `console.error`).
