### PR TITLE
Bound partner-parsed unbounded-count collections

### DIFF
--- a/packages/core/src/config/linkageTerms.ts
+++ b/packages/core/src/config/linkageTerms.ts
@@ -14,29 +14,48 @@ import { sanitizeForDisplay } from "../utils/sanitizeForDisplay.js";
 // (protocolSetup), where the binding size cap is the far larger
 // MAX_FRAME_SIZE_BYTES (~512 MiB, connection/frameSize.ts), not the 64 KiB
 // MAX_ENCODED_INVITATION_LENGTH of the token path. The rule below: every
-// partner-controlled free-text string carries a generous length `.max()`; the two
-// top-level arrays (`linkageFields` and `linkageKeys`) and the `transform.params`
-// record carry a count `.max()`. What is still left to those boundary caps rather
-// than a per-field bound is the deeper collection COUNTS -- per-element
-// `transform` steps, each constraint's `exclude` list, the `payload` send/receive
-// arrays, and a key's `elements` -- and the `params` VALUE content (typed
-// `z.unknown()`, with no clean content bound). Their legitimate sizes vary (a
-// denylist can hold hundreds of values), so an invented count risks rejecting a
-// real config. The `transform.params` ENTRY count is the exception now bounded
-// (MAX_PARAMS_ENTRIES): under the wire-path frame cap a payload of ~130k invalid
-// keys fits, and Zod overflows its own call stack accumulating and spreading one
-// issue per key before it can return a structured failure -- a schema count bound
-// forestalls that. The deferred counts nested beneath an OUTER array -- `exclude`
-// (under `linkageFields`), and `transform` steps and `elements` (under
-// `linkageKeys`) -- share that exposure: the inner issue array is spread through
-// two array frames, so a partner can still drive the same Zod-internal RangeError
-// there. The outermost `payload` send/receive arrays sit one array frame below the
-// root object, so they do not overflow at counts the frame cap admits (they stay
-// unbounded only for uniformity, not because they share the exposure). Every
-// reachable case is caught harmlessly in protocolSetup's parse-error catch (a
-// RangeError has no `.issues`, so it renders via the message fallback and the
-// exchange aborts cleanly). Bounding the deferred counts is a surveyed follow-on,
-// not done here. The bounds are defense-in-depth, not semantic limits.
+// partner-controlled free-text string carries a generous length `.max()`, and
+// every partner-controlled collection carries a count bound. The top-level arrays
+// (`linkageFields` and `linkageKeys`) carry a count `.max()` directly; the deeper
+// collections nested beneath an OUTER array -- each constraint's `exclude` list,
+// a `transform` step list, a key's `elements`, and the `transform.params` record
+// -- are bounded BEFORE per-element validation (see boundedArray and
+// MAX_PARAMS_ENTRIES), because they share a stack-overflow exposure the top-level
+// arrays do not: a payload of more than ~130k invalid elements fits under the
+// wire-path frame cap, and Zod overflows its own call stack accumulating one
+// issue per element and then spreading that issue array up through an enclosing
+// array/record/tuple frame -- which an intervening object frame does not prevent
+// -- before it can return a structured failure (RangeError reproduced on Zod
+// 4.4.3). The top-level arrays carry no such enclosing frame (they sit directly
+// below the root object), so they do not overflow; their count `.max()` is
+// token-padding defense, not overflow defense. Their
+// legitimate sizes vary -- a denylist holds hundreds of values, hence the most
+// generous bound (MAX_EXCLUDE_ENTRIES) -- but each bound is far above any real
+// config and far below the overflow threshold. The `params` VALUE content stays
+// unbounded (typed `z.unknown()`, with no clean content bound).
+//
+// What is deliberately left unbounded: the `payload` send/receive arrays carry no
+// enclosing array/record/tuple frame (only the root object), so a pathological
+// count there cannot drive the ~130k STACK overflow the nested collections hit.
+// They are not wholly RangeError-free -- a far larger count, ~millions of invalid
+// elements still within the frame cap, makes Zod throw building the error string
+// (`RangeError: Invalid string length`) -- but safeParse-then-protocolSetup's
+// parse-error catch renders that harmlessly (see the closing note) and the
+// legitimate counts are frame-cap-bounded, so they stay unbounded as a Low
+// residual. The two post-handshake exchange-wire messages share this class but invert
+// the bound choice: `payloadExchange.ts` `rows` and `participant.ts`
+// `associationTableMessage` ARE overflow-exposed (doubly-nested array,
+// tuple-of-arrays), but are legitimately in the millions, so they are bounded
+// there with a single-issue element validator (utils/singleIssueArray.ts) rather
+// than a count `.max()` no real result could pass. The Connection,
+// Standardization, and Metadata schemas are out of the partner threat model
+// entirely -- reached only from the operator's own local config, never from a
+// partner-supplied payload -- so their count fields are left as trusted input.
+// Every still-reachable RangeError was caught harmlessly in protocolSetup's
+// parse-error catch already (a RangeError has no `.issues`, so it renders via the
+// message fallback and the exchange aborts cleanly); the bounds turn that
+// ungraceful internal exception into a clean, bounded rejection. They are
+// defense-in-depth, not semantic limits.
 
 /**
  * Generous upper bound on a short partner-controlled string -- the identifier-
@@ -81,6 +100,80 @@ export const MAX_LINKAGE_ENTRIES = 256;
  * untrusted-input bounds note above.
  */
 export const MAX_PARAMS_ENTRIES = 256;
+
+/**
+ * Generous upper bound on the COUNT of values in a constraint `exclude`
+ * denylist. A denylist legitimately holds hundreds of values (a list of invalid
+ * SSN patterns, blocked test values, an email blocklist), so this is the most
+ * generous of the collection-count bounds; 4096 is far above any real denylist
+ * yet well below the ~130k count at which Zod's issue accumulation overflows the
+ * call stack (see the untrusted-input bounds note above). Enforced before
+ * per-element validation by {@link boundedArray}.
+ */
+export const MAX_EXCLUDE_ENTRIES = 4096;
+
+/**
+ * Generous upper bound on the COUNT of steps in a linkage-key element's
+ * `transform` pipeline. The bundled standardizing pipelines chain a handful of
+ * steps (parse_date, trim, uppercase); 256 is far above any real pipeline yet
+ * refuses an array padded to overflow Zod's call stack. Enforced before
+ * per-element validation by {@link boundedArray}.
+ */
+export const MAX_TRANSFORM_STEPS = 256;
+
+/**
+ * Generous upper bound on the COUNT of elements in a linkage key. A key combines
+ * a few field-derived elements (the default template's widest key has four);
+ * with at most {@link MAX_LINKAGE_ENTRIES} declared fields to reference, 256 is
+ * generous yet refuses an array padded to overflow Zod's call stack. The
+ * existing `.min(1)` floor is preserved. Enforced before per-element validation
+ * by {@link boundedArray}.
+ */
+export const MAX_KEY_ELEMENTS = 256;
+
+/**
+ * Wrap an array schema so a pathological ELEMENT COUNT is rejected with a single
+ * bounded issue BEFORE per-element validation runs.
+ *
+ * A plain `z.array(element).max(maxEntries)` does NOT suffice on the wire path:
+ * Zod v4 validates every element first (one issue per invalid element) and
+ * applies the length check only after, so a partner array of more than ~130k
+ * invalid elements overflows Zod's call stack spreading that issue array up
+ * through the surrounding array frames before `.max()` can fire (verified on Zod
+ * 4.4.3; the same ordering subtlety the `transform.params` bound handles, board
+ * item 202609308). The permissive `z.array(z.unknown())` first stage accepts the
+ * array without validating elements, the count refine rejects an over-count
+ * array with one issue, and `.pipe` re-validates the now count-capped array
+ * against the real `element` schema -- preserving every per-element check, and
+ * its issue path, for an in-range array. `min`, when given, is the preserved
+ * lower-bound floor applied on the validated stage.
+ */
+function boundedArray<T>(
+  element: z.ZodType<T>,
+  maxEntries: number,
+  message: string,
+  min?: number,
+): z.ZodType<T[]> {
+  const validated =
+    min === undefined ? z.array(element) : z.array(element).min(min);
+  return z
+    .array(z.unknown())
+    .refine((value) => value.length <= maxEntries, { message })
+    .pipe(validated);
+}
+
+/**
+ * A constraint `exclude` denylist: partner-controlled free-text values, each
+ * length-bounded like every other free-text string, with the entry COUNT bounded
+ * at {@link MAX_EXCLUDE_ENTRIES} before per-element validation (see
+ * {@link boundedArray}). Shared by all four constraint schemas so the bound is
+ * defined once.
+ */
+const ExcludeSchema = boundedArray(
+  z.string().max(MAX_TEXT_LENGTH),
+  MAX_EXCLUDE_ENTRIES,
+  `exclude must not exceed ${MAX_EXCLUDE_ENTRIES} entries`,
+);
 
 // --- Output ------------------------------------------------------------------
 
@@ -156,7 +249,7 @@ const NameConstraintsSchema: z.ZodType<NameConstraints> = z.object({
     )
     .optional(),
   affixesAllowed: z.boolean().optional(),
-  exclude: z.array(z.string().max(MAX_TEXT_LENGTH)).optional(),
+  exclude: ExcludeSchema.optional(),
 });
 
 /** Constraints on date-of-birth fields. */
@@ -169,7 +262,7 @@ interface DateConstraints {
 
 const DateConstraintsSchema: z.ZodType<DateConstraints> = z.object({
   validOnly: z.boolean().optional(),
-  exclude: z.array(z.string().max(MAX_TEXT_LENGTH)).optional(),
+  exclude: ExcludeSchema.optional(),
 });
 
 /** Constraints on SSN and SSN-last-4 fields. */
@@ -187,7 +280,7 @@ interface SSNConstraints {
 
 const SSNConstraintsSchema: z.ZodType<SSNConstraints> = z.object({
   validOnly: z.boolean().optional(),
-  exclude: z.array(z.string().max(MAX_TEXT_LENGTH)).optional(),
+  exclude: ExcludeSchema.optional(),
 });
 
 /** Constraints applicable to any semantic type. */
@@ -197,7 +290,7 @@ interface AnyConstraints {
 }
 
 const AnyConstraintsSchema: z.ZodType<AnyConstraints> = z.object({
-  exclude: z.array(z.string().max(MAX_TEXT_LENGTH)).optional(),
+  exclude: ExcludeSchema.optional(),
 });
 
 // Shared fields for all linkage field variants.
@@ -373,7 +466,13 @@ const LinkageKeyElementSchema: z.ZodType<LinkageKeyElement> = z.object({
   field: z.string().min(1).max(MAX_NAME_LENGTH),
   name: z.string().max(MAX_NAME_LENGTH).optional(),
   generateFuzzyComparisons: GenerateFuzzyComparisonsSchema.optional(),
-  transform: z.array(TransformStepSchema).optional(),
+  // The step COUNT is bounded at MAX_TRANSFORM_STEPS before per-element
+  // validation; see boundedArray and the untrusted-input bounds note.
+  transform: boundedArray(
+    TransformStepSchema,
+    MAX_TRANSFORM_STEPS,
+    `transform must not exceed ${MAX_TRANSFORM_STEPS} steps`,
+  ).optional(),
 });
 
 // --- Linkage keys ------------------------------------------------------------
@@ -400,7 +499,15 @@ export interface LinkageKey {
 
 const LinkageKeySchema: z.ZodType<LinkageKey> = z.object({
   name: z.string().min(1).max(MAX_NAME_LENGTH),
-  elements: z.array(LinkageKeyElementSchema).min(1),
+  // The element COUNT is bounded at MAX_KEY_ELEMENTS before per-element
+  // validation, with the existing .min(1) floor preserved; see boundedArray and
+  // the untrusted-input bounds note.
+  elements: boundedArray(
+    LinkageKeyElementSchema,
+    MAX_KEY_ELEMENTS,
+    `elements must not exceed ${MAX_KEY_ELEMENTS} entries`,
+    1,
+  ),
   swap: z
     .tuple([z.string().max(MAX_NAME_LENGTH), z.string().max(MAX_NAME_LENGTH)])
     .optional(),

--- a/packages/core/src/link.ts
+++ b/packages/core/src/link.ts
@@ -8,6 +8,16 @@ import {
 
 import { getLoggerForVerbosity } from "./utils/logger";
 
+// Parsed as the whole received message (the root array). With no enclosing
+// array/record/tuple frame above the root, a pathological count cannot drive the
+// ~130k STACK overflow the nested collections face (see participant.ts
+// associationTableMessage and config/linkageTerms.ts). A far larger count
+// (~millions of invalid elements, within the frame cap) can still make Zod throw
+// a `RangeError: Invalid string length` building the error: the receiveParsed
+// site (below) catches that as ConnectionError("protocol"), while the direct
+// `.parse()` site surfaces a bare RangeError. Low and pre-existing; bounding the
+// residual flat arrays uniformly is a follow-on. The legitimate count is bounded
+// by MAX_FRAME_SIZE_BYTES.
 const associationAndIterationArray = z.array(
   z.object({ theirIndex: z.number(), iteration: z.number() }),
 );

--- a/packages/core/src/participant.ts
+++ b/packages/core/src/participant.ts
@@ -5,6 +5,7 @@ import {
   receiveParsed,
   type MessageConnection,
 } from "./connection/messageConnection";
+import { singleIssueArray } from "./utils/singleIssueArray";
 
 import type { Client as PSIClient } from "@openmined/psi.js/implementation/client.d.ts";
 import type { PSILibrary } from "@openmined/psi.js/implementation/psi.d.ts";
@@ -16,10 +17,41 @@ const statusCompletedMessage = z.object({
   status: z.literal("completed"),
 });
 
+// A single flat array parsed as the whole received message (the root). With no
+// enclosing array/record/tuple frame above the root, it cannot drive the ~130k
+// STACK overflow {@link associationTableMessage} faces. It is not wholly
+// RangeError-free: a far larger count (~millions of invalid elements, within
+// MAX_FRAME_SIZE_BYTES) makes Zod throw building the error string
+// (`RangeError: Invalid string length`). Unlike the receiveParsed sites, this is
+// read by a direct `.parse()` (send-before-parse, below), so that residual
+// surfaces as a bare RangeError rather than a clean ConnectionError("protocol").
+// Low and pre-existing (this schema is unchanged); bounding the residual flat
+// arrays uniformly is a follow-on. The legitimate count is the partner's
+// original-index list, bounded by MAX_FRAME_SIZE_BYTES.
 const numberArrayMessage = z.array(z.number());
-const associationTableMessage = z.tuple([
-  z.array(z.number()),
-  z.array(z.number()),
+
+// CONFIRMED-EXPOSED to Zod's issue-accumulation stack overflow: a partner can
+// send a tuple whose inner index array holds hundreds of thousands of invalid
+// (non-number) elements, and Zod overflows its call stack spreading one issue
+// per element up through the inner-array and tuple frames (RangeError reproduced
+// at ~130k on Zod 4.4.3). receiveParsed already caught that harmlessly; the
+// single-issue validators below turn it into a clean, bounded rejection instead.
+// A count `.max()` is not an option: the association table is the PSI
+// intersection, legitimately in the millions (MAX_FRAME_SIZE_BYTES bounds it),
+// so any overflow-forestalling count bound would reject a real result. Each
+// validator mirrors `z.number()` exactly via Number.isFinite (which, like
+// z.number(), accepts every finite number and rejects NaN/Infinity and
+// non-numbers). See utils/singleIssueArray.ts.
+/** @internal exported for the pathological-count wire-message test. */
+export const associationTableMessage = z.tuple([
+  singleIssueArray<number>(
+    Number.isFinite,
+    "must be an array of finite numbers",
+  ),
+  singleIssueArray<number>(
+    Number.isFinite,
+    "must be an array of finite numbers",
+  ),
 ]);
 
 const DEFAULT_VERBOSITY = 1;

--- a/packages/core/src/payloadExchange.ts
+++ b/packages/core/src/payloadExchange.ts
@@ -5,6 +5,7 @@ import type { Metadata } from "./config/metadata.js";
 import type { CommittedPayload } from "./exchangeRecord.js";
 import type { MessageConnection } from "./connection/messageConnection.js";
 import { receiveParsed } from "./connection/messageConnection.js";
+import { singleIssueArray } from "./utils/singleIssueArray.js";
 
 /** The payload received from the exchange partner after PSI linkage. */
 export interface PartnerPayload {
@@ -24,14 +25,36 @@ export interface PartnerPayload {
   rows: Array<Array<string | null>>;
 }
 
+// One payload row: a single-issue array (utils/singleIssueArray.ts) rather than
+// `z.array(z.string().nullable())`. CONFIRMED-EXPOSED to Zod's
+// issue-accumulation stack overflow -- a partner row of hundreds of thousands of
+// invalid inner cells overflows Zod's call stack spreading one issue per cell up
+// through the inner-array and outer-`rows` frames (RangeError reproduced at ~300k
+// on Zod 4.4.3). The single-issue validator caps that at one clean issue. A count
+// `.max()` on the cells is unnecessary and a `.max()` on `rows` itself is
+// unsafe: a real exchange has one row per matched record, legitimately in the
+// millions (MAX_FRAME_SIZE_BYTES bounds it). The predicate mirrors
+// `z.string().nullable()` exactly.
+const payloadRow = singleIssueArray<string | null>(
+  (cell) => typeof cell === "string" || cell === null,
+  "each payload row must be an array of strings or nulls",
+);
+
 const payloadWireSchema = z.discriminatedUnion("hasData", [
   z.object({ hasData: z.literal(false) }),
   z
     .object({
       hasData: z.literal(true),
+      // `columns` and `rowIndices` are flat arrays one object-frame below this
+      // object, so a pathological count cannot drive the ~130k STACK overflow
+      // `rows` faces. A far larger count (~millions of invalid elements, within
+      // the frame cap) can still make Zod throw a `RangeError: Invalid string
+      // length` building the error, but receiveParsed catches that harmlessly as
+      // ConnectionError("protocol"). Left unbounded as a Low residual; the
+      // legitimate counts are bounded only by MAX_FRAME_SIZE_BYTES.
       columns: z.array(z.string()),
       rowIndices: z.array(z.number().int().nonnegative()),
-      rows: z.array(z.array(z.string().nullable())),
+      rows: z.array(payloadRow),
     })
     .refine(
       (v) => v.rowIndices.length === v.rows.length,

--- a/packages/core/src/utils/singleIssueArray.ts
+++ b/packages/core/src/utils/singleIssueArray.ts
@@ -1,0 +1,40 @@
+import * as z from "zod";
+
+/**
+ * An array schema whose elements are validated in a SINGLE pass that emits at
+ * most ONE issue, rather than Zod's default one-issue-per-invalid-element.
+ *
+ * Why this exists, not a plain `z.array(element)` or a count `.max()`: a
+ * partner-controlled post-handshake wire message can carry an array of hundreds
+ * of thousands of INVALID elements. Under `z.array(element)` Zod accumulates one
+ * issue per element and then overflows its own call stack spreading that issue
+ * array up through the surrounding array/tuple frames -- a `RangeError`,
+ * reproduced at ~130k elements on Zod 4.4.3 (the same mechanism the
+ * `transform.params` bound forestalls in config/linkageTerms.ts, board item
+ * 202609308). A count `.max()` cannot fix it here and is not even reached in
+ * time: Zod v4 validates every element BEFORE the array length check, so the
+ * overflow happens first; and these collections (PSI association-table indices,
+ * payload rows) are legitimately in the millions -- a single frame holds on the
+ * order of 6 million elements (docs/spec/CHANNEL_SECURITY.md) -- so any count
+ * bound low enough to forestall the overflow would reject a real exchange.
+ *
+ * Validating the element TYPE in one `every` pass caps issue accumulation at one
+ * regardless of count: an arbitrarily large VALID message still parses, while a
+ * hostile one fails as a clean, bounded rejection -- surfaced as a
+ * `ConnectionError("protocol")` by `receiveParsed` -- instead of an uncaught
+ * `RangeError`. The receive path already caught the `RangeError` harmlessly; this
+ * turns that ungraceful internal exception into a clean validation failure.
+ *
+ * `isElement` must mirror exactly the element schema it replaces, so the set of
+ * accepted messages is unchanged. The `T` type parameter is the element type and
+ * is not inferred from `isElement` -- pass it explicitly.
+ */
+export function singleIssueArray<T>(
+  isElement: (value: unknown) => boolean,
+  message: string,
+): z.ZodType<T[]> {
+  return z.custom<T[]>(
+    (value) => Array.isArray(value) && value.every(isElement),
+    { message },
+  );
+}

--- a/packages/core/test/linkageTerms.test.ts
+++ b/packages/core/test/linkageTerms.test.ts
@@ -9,6 +9,9 @@ import {
   MAX_TEXT_LENGTH,
   MAX_LINKAGE_ENTRIES,
   MAX_PARAMS_ENTRIES,
+  MAX_EXCLUDE_ENTRIES,
+  MAX_TRANSFORM_STEPS,
+  MAX_KEY_ELEMENTS,
 } from "../src/config/linkageTerms";
 import type { LinkageTerms } from "../src/config/linkageTerms";
 import {
@@ -1396,6 +1399,134 @@ test("an over-long transform params key within the count bound is still rejected
   expect(result.success).toBe(false);
   if (!result.success) {
     expect(result.error.issues[0].code).toBe("invalid_key");
+  }
+});
+
+// ─── Nested-collection count bounds ──────────────────────────────────────────
+// Each constraint `exclude` list, a key element's `transform` step list, and a
+// key's `elements` list is partner-controlled and nested beneath an outer array,
+// so an over-count payload could make Zod accumulate one issue per invalid
+// element and overflow its call stack spreading them (a RangeError, same class as
+// the transform.params bound). Each list is count-bounded BEFORE per-element
+// validation; pin the boundary, that a pathological count fails cleanly, and that
+// the per-element validation under the gate is preserved.
+
+const excludeTerms = (exclude: unknown[]) => ({
+  ...base,
+  linkageFields: [{ name: "ssn", type: "ssn", constraints: { exclude } }],
+});
+
+test("accepts a constraint exclude at exactly the maximum count", () => {
+  const exclude = Array.from(
+    { length: MAX_EXCLUDE_ENTRIES },
+    (_, i) => `v${i}`,
+  );
+  expect(() => parseLinkageTerms(excludeTerms(exclude))).not.toThrow();
+});
+
+test("rejects a constraint exclude over the maximum count", () => {
+  const exclude = Array.from(
+    { length: MAX_EXCLUDE_ENTRIES + 1 },
+    (_, i) => `v${i}`,
+  );
+  expect(() => parseLinkageTerms(excludeTerms(exclude))).toThrow(ZodError);
+});
+
+test("a pathological-count constraint exclude fails cleanly, not with a RangeError", () => {
+  // ~200k over-long values: on the unbounded schema Zod built one too_big issue
+  // per value and overflowed the call stack spreading them up through the
+  // exclude/linkageFields frames. The count gate, applied before per-element
+  // validation, must turn this into one clean, bounded issue. 200k clears the
+  // empirical overflow threshold (~130k).
+  const exclude = Array.from({ length: 200_000 }, () =>
+    "x".repeat(MAX_TEXT_LENGTH + 1),
+  );
+  let result: ReturnType<typeof safeParseLinkageTerms> | undefined;
+  expect(() => {
+    result = safeParseLinkageTerms(excludeTerms(exclude));
+  }).not.toThrow();
+  expect(result?.success).toBe(false);
+  if (result && !result.success) {
+    expect(
+      result.error.issues.some((i) =>
+        /exclude must not exceed/.test(i.message),
+      ),
+    ).toBe(true);
+  }
+});
+
+const transformTerms = (transform: unknown[]) => ({
+  ...base,
+  linkageKeys: [{ name: "SSN", elements: [{ field: "ssn", transform }] }],
+});
+
+test("accepts a transform step list at exactly the maximum count", () => {
+  const transform = Array.from({ length: MAX_TRANSFORM_STEPS }, () => ({
+    function: "trim",
+  }));
+  expect(() => parseLinkageTerms(transformTerms(transform))).not.toThrow();
+});
+
+test("rejects a transform step list over the maximum count", () => {
+  const transform = Array.from({ length: MAX_TRANSFORM_STEPS + 1 }, () => ({
+    function: "trim",
+  }));
+  expect(() => parseLinkageTerms(transformTerms(transform))).toThrow(ZodError);
+});
+
+test("a pathological-count transform step list fails cleanly, not with a RangeError", () => {
+  const transform = Array.from({ length: 200_000 }, () => 123);
+  let result: ReturnType<typeof safeParseLinkageTerms> | undefined;
+  expect(() => {
+    result = safeParseLinkageTerms(transformTerms(transform));
+  }).not.toThrow();
+  expect(result?.success).toBe(false);
+  if (result && !result.success) {
+    expect(
+      result.error.issues.some((i) =>
+        /transform must not exceed/.test(i.message),
+      ),
+    ).toBe(true);
+  }
+});
+
+const elementsTerms = (elements: unknown[]) => ({
+  ...base,
+  linkageFields: [{ name: "ssn", type: "ssn" }],
+  linkageKeys: [{ name: "SSN", elements }],
+});
+
+test("accepts a linkage key elements list at exactly the maximum count", () => {
+  // Distinct element names keep the within-key identifier-uniqueness refine
+  // satisfied; every element references the declared "ssn" field.
+  const elements = Array.from({ length: MAX_KEY_ELEMENTS }, (_, i) => ({
+    field: "ssn",
+    name: `e${i}`,
+  }));
+  expect(() => parseLinkageTerms(elementsTerms(elements))).not.toThrow();
+});
+
+test("rejects a linkage key elements list over the maximum count", () => {
+  const elements = Array.from({ length: MAX_KEY_ELEMENTS + 1 }, (_, i) => ({
+    field: "ssn",
+    name: `e${i}`,
+  }));
+  expect(() => parseLinkageTerms(elementsTerms(elements))).toThrow(ZodError);
+});
+
+test("a pathological-count linkage key elements list fails cleanly, not with a RangeError", () => {
+  const elements = Array.from({ length: 200_000 }, () => 123);
+  let result: ReturnType<typeof safeParseLinkageTerms> | undefined;
+  expect(() => {
+    result = safeParseLinkageTerms(elementsTerms(elements));
+  }).not.toThrow();
+  expect(result?.success).toBe(false);
+  if (result && !result.success) {
+    expect(
+      result.error.issues.some((i) =>
+        /elements must not exceed/.test(i.message),
+      ),
+    ).toBe(true);
   }
 });
 

--- a/packages/core/test/payloadExchange.test.ts
+++ b/packages/core/test/payloadExchange.test.ts
@@ -9,7 +9,10 @@ import {
 import type { Metadata } from "../src/config/metadata";
 import type { PartnerPayload } from "../src/payloadExchange";
 
-import { createMessagePipe } from "../src/connection/messageConnection";
+import {
+  createMessagePipe,
+  ConnectionError,
+} from "../src/connection/messageConnection";
 import type { MessageConnection } from "../src/connection/messageConnection";
 
 // --- Fixtures ----------------------------------------------------------------
@@ -236,6 +239,51 @@ test("exchangePayloads: send rejection rejects the responder", async () => {
   await expect(
     exchangePayloads(conn, "responder", { hasData: false }),
   ).rejects.toThrow("send failed");
+});
+
+test("exchangePayloads: a pathological-count partner row fails cleanly, not with a RangeError", async () => {
+  // A single row of ~300k invalid inner cells: the count that overflowed Zod's
+  // call stack on the unbounded `z.array(z.array(z.string().nullable()))` schema
+  // (RangeError). The single-issue row validator must turn it into a clean
+  // protocol rejection. receiveParsed wraps either outcome as a
+  // ConnectionError("protocol"); the improvement under test is that the cause is a
+  // bounded validation error, not the RangeError.
+  const [connA, connB] = createMessagePipe();
+  const initiatorPromise = exchangePayloads(connA, "initiator", {
+    hasData: false,
+  });
+  await connB.receive(); // consume the initiator's hasData:false frame
+  await connB.send({
+    hasData: true,
+    columns: ["c"],
+    rowIndices: [0],
+    rows: [Array.from({ length: 300_000 }, () => 1)],
+  });
+  const err = await initiatorPromise.catch((e: unknown) => e);
+  expect(err).toBeInstanceOf(ConnectionError);
+  expect((err as ConnectionError).kind).toBe("protocol");
+  expect((err as ConnectionError).cause).not.toBeInstanceOf(RangeError);
+});
+
+test("exchangePayloads: a legitimately large partner payload parses", async () => {
+  // rows is one entry per matched record, legitimately in the millions; a count
+  // `.max()` low enough to forestall the overflow would reject this, the
+  // single-issue validator does not. 200k clears the ~130k overflow threshold,
+  // so this also proves a VALID large message never trips the bound.
+  const n = 200_000;
+  const [connA, connB] = createMessagePipe();
+  const initiatorPromise = exchangePayloads(connA, "initiator", {
+    hasData: false,
+  });
+  await connB.receive();
+  await connB.send({
+    hasData: true,
+    columns: ["c"],
+    rowIndices: Array.from({ length: n }, (_, i) => i),
+    rows: Array.from({ length: n }, () => ["v"]),
+  });
+  const received = await initiatorPromise;
+  expect(received.rows).toHaveLength(n);
 });
 
 // --- buildOutputTable --------------------------------------------------------

--- a/packages/core/test/psiParticipant.test.ts
+++ b/packages/core/test/psiParticipant.test.ts
@@ -2,9 +2,13 @@ import { expect, test } from "vitest";
 
 import PSI from "@openmined/psi.js";
 
-import { PSIParticipant } from "../src/participant";
+import { PSIParticipant, associationTableMessage } from "../src/participant";
 
-import { createMessagePipe } from "../src/connection/messageConnection";
+import {
+  createMessagePipe,
+  receiveParsed,
+  ConnectionError,
+} from "../src/connection/messageConnection";
 import { sortAssociationTable } from "./utils/associationTable";
 
 const psiLibrary = await PSI();
@@ -68,4 +72,39 @@ test("order doesn't matter", () => {
   expect(serverResult[1]).toStrictEqual(clientResult[0]);
   expect(serverResult[0]).toStrictEqual([2, 4]);
   expect(serverResult[1]).toStrictEqual([0, 1]);
+});
+
+// ─── association-table wire message: pathological-count bound ─────────────────
+// The association table is partner-controlled (the PPRL threat model treats the
+// counterparty as adversarial) and rides the ~512 MiB exchange frame. An inner
+// index array of hundreds of thousands of invalid elements overflowed Zod's call
+// stack spreading one issue per element up through the array/tuple frames
+// (RangeError). receiveParsed always surfaces a parse failure as a clean
+// ConnectionError("protocol"); the single-issue validators make the cause a
+// bounded validation error rather than that RangeError.
+
+test("a pathological-count association table fails cleanly, not with a RangeError", async () => {
+  const [connA, connB] = createMessagePipe();
+  const parsed = receiveParsed(connA, associationTableMessage);
+  // ~300k invalid (non-number) inner elements, well past the ~130k overflow
+  // threshold the unbounded `z.array(z.number())` schema would hit.
+  await connB.send([Array.from({ length: 300_000 }, () => "x"), []]);
+  const err = await parsed.catch((e: unknown) => e);
+  expect(err).toBeInstanceOf(ConnectionError);
+  expect((err as ConnectionError).kind).toBe("protocol");
+  expect((err as ConnectionError).cause).not.toBeInstanceOf(RangeError);
+});
+
+test("a legitimately large association table parses", async () => {
+  // The intersection is legitimately in the millions; a count `.max()` would
+  // reject it, the single-issue validators do not. 200k clears the overflow
+  // threshold, so a VALID large table never trips the bound.
+  const n = 200_000;
+  const [connA, connB] = createMessagePipe();
+  const parsed = receiveParsed(connA, associationTableMessage);
+  const indices = Array.from({ length: n }, (_, i) => i);
+  await connB.send([indices, indices]);
+  const [first, second] = await parsed;
+  expect(first).toHaveLength(n);
+  expect(second).toHaveLength(n);
 });


### PR DESCRIPTION
## Summary

Bound the complete, verified set of partner-parsed unbounded-count collections so a pathological-count payload from the adversarial counterparty fails with a clean, bounded rejection instead of forcing Zod to overflow its call stack (`RangeError: Maximum call stack size exceeded`, ~130k invalid elements on Zod 4.4.3) while accumulating one issue per element. The overflow was already caught harmlessly (protocolSetup's parse-error catch, or `receiveParsed` wrapping the throw as `ConnectionError("protocol")`) and bounded upstream by the ~512 MiB frame cap, so this is a Low robustness / defense-in-depth hardening, not a live vulnerability. It is the follow-on to [202609308](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202609308), which bounded only `transform.params`.

Implements [202615892](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202615892).

## Changes

- `packages/core/src/config/linkageTerms.ts`: add a `boundedArray` helper that count-gates BEFORE per-element validation (`z.array(z.unknown()).refine(count).pipe(realArray)` -- a plain `.max()` does not work, Zod v4 validates every element first), and apply it to the `exclude` denylists (shared `ExcludeSchema`), `transform` step lists, and key `elements`; add `MAX_EXCLUDE_ENTRIES`/`MAX_TRANSFORM_STEPS`/`MAX_KEY_ELEMENTS`; reconcile the untrusted-input bounds note.
- `packages/core/src/utils/singleIssueArray.ts` (new): a single-pass `z.custom` validator that emits at most one issue regardless of element count, for the wire collections whose legitimate size is in the millions and so cannot be count-capped.
- `packages/core/src/payloadExchange.ts`: bound the `rows` inner array with `singleIssueArray`; record the left-unbounded decision for `columns`/`rowIndices`.
- `packages/core/src/participant.ts`: bound the `associationTableMessage` tuple's inner arrays with `singleIssueArray`, exported for the wire test; record the decision for `numberArrayMessage`.
- `packages/core/src/link.ts`: comment only -- record the left-unbounded decision for `associationAndIterationArray`.
- tests: pathological-count, boundary, and large-valid cases for every newly-bounded field (`linkageTerms`, `payloadExchange`, `psiParticipant`).

## Test plan

Ran: `npm run build -w packages/core`, `npm run typecheck`, `npm run lint`, `npm run format`, and `npm run test -w packages/core` (1453 passing). Focused: `npx vitest run packages/core/test/linkageTerms.test.ts packages/core/test/payloadExchange.test.ts packages/core/test/psiParticipant.test.ts`.
New tests cover: for each newly-bounded collection, a pathological-count payload (200k-300k invalid elements) fails as a clean bounded rejection rather than throwing a RangeError; the count boundary accepts the maximum and rejects one over it; and for the two wire messages, `receiveParsed` surfaces the over-count frame as `ConnectionError("protocol")` whose cause is a validation error rather than a RangeError, while a legitimately large valid message still parses.

## Background

Two strategies, chosen by the field's legitimate size. The small-count config collections take a count gate: a generous ceiling is both safe and below the ~130k overflow threshold, and the gate preserves full per-element validation, and its issue path, for an in-range array. The exchange-wire collections (the PSI association table and payload rows) are legitimately in the millions -- a single frame holds on the order of 6 million elements (`docs/spec/CHANNEL_SECURITY.md`) -- so any count bound low enough to forestall the overflow would reject a real result; `singleIssueArray` caps issue accumulation at one regardless of count instead. Each wire predicate mirrors the element schema it replaces exactly (`Number.isFinite` for `z.number()`, string-or-null for `z.string().nullable()`), so the set of accepted messages -- and therefore the canonical encoding, the terms hash, and the result -- is unchanged. The change is receive-side validation only; nothing new is sent on the wire.

## Out of scope / follow-on

- The same partner-parsed root/single-frame arrays left unbounded here throw a different RangeError (`Invalid string length`, raised while building the error from millions of issues) at ~2-4M invalid elements -- caught harmlessly at the `receiveParsed`/`protocolSetup` sites, a bare RangeError at two direct `.parse()` sites. Low, pre-existing, and frame-cap-bounded; surfaced by this PR's security review and tracked at [202630089](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202630089).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; the bounds are internal defense-in-depth ceilings (not semantic limits) and the accepted wire/config values are unchanged, consistent with the existing undocumented per-field bounds and sibling 202609308.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: Low defense-in-depth parse-hardening with no operator-visible behavior change (accepted inputs unchanged; the RangeError was already caught harmlessly); pre-release security entries are kept to headline changes per CONTRIBUTING, and sibling 202609308 was recorded the same way.
- [x] Security review -- security-relevant (receive-side hardening of partner-controlled wire/config input): ran three independent reviews (availability/DoS, disclosure/log-injection, integrity/parser-soundness) plus behavior-equivalence and completeness passes, all clear.