### PR TITLE
Guard camelizeKeys against deep-nesting overflow

### DIFF
--- a/packages/core/src/utils/camelizeKeys.ts
+++ b/packages/core/src/utils/camelizeKeys.ts
@@ -1,3 +1,40 @@
+import { UsageError } from "../errors.js";
+
+/**
+ * Maximum object/array nesting depth {@link transformKeysDeep} will descend
+ * through before rejecting the input. The walker recurses once per level with
+ * native recursion, so an untrusted payload nested past the call-stack limit
+ * (empirically a few thousand levels, and lower on a smaller stack) would
+ * otherwise overflow with a `RangeError` BEFORE any schema validation runs --
+ * `parseLinkageTerms` camelizes ahead of Zod, so a deeply-nested partner payload
+ * (a few tens of KB of JSON, trivially within the invitation and frame caps)
+ * reaches this walker first. 256 is far above any real config or exchange message
+ * -- the deepest schema path is under a dozen levels, and a `transform.params`
+ * value (the deepest partner-controlled spot, typed `z.unknown()`) holds shallow
+ * scalars -- yet well below the overflow threshold on any stack, so the guard
+ * fires as a clean bounded rejection long before native recursion would fault.
+ * Rejecting here, at the single shared camelize/snakeize chokepoint and ahead of
+ * Zod, also keeps a deep value from surviving validation (under `z.unknown()`)
+ * only to overflow a later recursive consumer such as `canonicalString`.
+ */
+export const MAX_NESTING_DEPTH = 256;
+
+/**
+ * Thrown by {@link transformKeysDeep} (and so by {@link camelizeKeys} /
+ * {@link snakeizeKeys}) when input nesting exceeds {@link MAX_NESTING_DEPTH}. A
+ * {@link UsageError} subclass, like the transport input-bound errors and
+ * `CanonicalEncodingError`: a payload too deep to walk is a bounded rejection of
+ * untrusted input, terminal and (at the CLI) exit 64, not an internal fault. Its
+ * message is fixed text carrying no input bytes, so the parse-error relay
+ * (`describeDecodeError`) can surface it verbatim.
+ */
+export class NestingDepthExceededError extends UsageError {
+  constructor() {
+    super(`input nesting exceeds the maximum depth of ${MAX_NESTING_DEPTH}`);
+    this.name = "NestingDepthExceededError";
+  }
+}
+
 /**
  * Field names whose value is an opaque map passed verbatim to an external
  * library, and whose keys must therefore NOT be case-transformed. Currently
@@ -54,19 +91,29 @@ function camelToSnake(s: string): string {
  * guarantee (asserted directly by a unit test driven from OPAQUE_VALUE_KEYS)
  * that keeps the write -> read round-trip byte-stable, rather than two
  * independent recursions held in agreement by prose.
+ *
+ * `depth` bounds the native recursion against an untrusted deeply-nested payload:
+ * the root value is at depth 0, so a value at depth {@link MAX_NESTING_DEPTH} or
+ * deeper -- past the documented {@link MAX_NESTING_DEPTH} levels -- is rejected
+ * with a clean {@link NestingDepthExceededError} before the recursion can
+ * overflow the call stack with a `RangeError`; values shallower than that are
+ * walked normally. The opaque-key skip does not recurse, so an opaque subtree's
+ * own depth never counts toward the bound.
  */
 function transformKeysDeep(
   value: unknown,
   transformKey: (key: string) => string,
+  depth: number,
 ): unknown {
+  if (depth >= MAX_NESTING_DEPTH) throw new NestingDepthExceededError();
   if (Array.isArray(value))
-    return value.map((v) => transformKeysDeep(v, transformKey));
+    return value.map((v) => transformKeysDeep(v, transformKey, depth + 1));
   if (value !== null && typeof value === "object")
     return Object.fromEntries(
       Object.entries(value).map(([k, v]) =>
         OPAQUE_VALUE_KEYS.has(snakeToCamel(k))
           ? [transformKey(k), v]
-          : [transformKey(k), transformKeysDeep(v, transformKey)],
+          : [transformKey(k), transformKeysDeep(v, transformKey, depth + 1)],
       ),
     );
   return value;
@@ -77,9 +124,17 @@ function transformKeysDeep(
  * that normalizes user-facing YAML/JSON (conventionally snake_case) into the
  * camelCase TypeScript sees before Zod parsing. Opaque-value maps
  * (`OPAQUE_VALUE_KEYS`) are left verbatim -- see {@link transformKeysDeep}.
+ *
+ * Runs ahead of the schema in the `parseX`/`safeParseX` config helpers, so on a
+ * pathologically deep input it throws BEFORE the schema -- meaning even a
+ * `safeParseX` wrapper that calls it can throw rather than return a failure
+ * result. No real config or exchange message reaches the bound.
+ *
+ * @throws {NestingDepthExceededError} if input nesting reaches
+ *   {@link MAX_NESTING_DEPTH} levels.
  */
 export function camelizeKeys(value: unknown): unknown {
-  return transformKeysDeep(value, snakeToCamel);
+  return transformKeysDeep(value, snakeToCamel, 0);
 }
 
 /**
@@ -95,9 +150,13 @@ export function camelizeKeys(value: unknown): unknown {
  * would snakeize to `u_r_l` -- but no such key occurs in the schema. Used by the
  * CLI config writer (`saveConfig`) to serialize a typed `ExchangeSpec` to
  * snake_case YAML; not a stable public API for consumers outside the workspace.
+ * Its input is the operator's own typed `ExchangeSpec`, never this deep, so the
+ * shared depth bound below is incidental here.
  *
+ * @throws {NestingDepthExceededError} if input nesting reaches
+ *   {@link MAX_NESTING_DEPTH} levels.
  * @internal
  */
 export function snakeizeKeys(value: unknown): unknown {
-  return transformKeysDeep(value, camelToSnake);
+  return transformKeysDeep(value, camelToSnake, 0);
 }

--- a/packages/core/test/camelizeKeys.test.ts
+++ b/packages/core/test/camelizeKeys.test.ts
@@ -4,6 +4,8 @@ import {
   camelizeKeys,
   OPAQUE_VALUE_KEYS,
   snakeizeKeys,
+  NestingDepthExceededError,
+  MAX_NESTING_DEPTH,
 } from "../src/utils/camelizeKeys";
 
 // snakeize a camelCase key the way the production walker's inverse transform
@@ -84,6 +86,66 @@ test("camelize and snakeize skip the identical set of opaque subtrees", () => {
   // ...and that set is exactly the opaque-keyed subtrees, not the control.
   expect(camelSkipped).toEqual([...expectedSkipped].sort());
   expect(camelSkipped).not.toContain("control");
+});
+
+// --- Nesting-depth guard -----------------------------------------------------
+// camelizeKeys runs BEFORE Zod on partner-controlled input (parseLinkageTerms),
+// and recurses once per nesting level, so a deeply-nested untrusted payload --
+// trivially within the invitation and frame caps -- would overflow the call
+// stack with a RangeError before any validation. The shared walker bounds the
+// depth so it fails as a clean, bounded rejection instead. snakeizeKeys shares
+// the walker and so the guard, though its input is operator-produced.
+
+// Build a chain of nested objects whose deepest value (an empty object) sits at
+// depth `depth` -- the index transformKeysDeep sees, with the root at depth 0 --
+// so the guard boundary can be asserted exactly.
+function nestedToDepth(depth: number): unknown {
+  let v: unknown = {};
+  for (let i = 0; i < depth; i++) v = { nested_key: v };
+  return v;
+}
+
+test("an ordinary nested payload is camelized at depth as before", () => {
+  expect(camelizeKeys({ outer_key: { inner_key: { leaf_key: 1 } } })).toEqual({
+    outerKey: { innerKey: { leafKey: 1 } },
+  });
+});
+
+test("the depth guard fires at exactly MAX_NESTING_DEPTH", () => {
+  // The deepest allowed value sits at depth MAX_NESTING_DEPTH - 1; one level
+  // deeper (depth MAX_NESTING_DEPTH) is rejected. Pinning the exact boundary --
+  // not just MAX +/- a margin -- keeps the guard from drifting by one. Both
+  // depths are far below the native stack overflow, so the accepted case proves
+  // the guard draws the line, not the stack. The bound is itself far above any
+  // real config (the deepest schema path is under a dozen levels).
+  expect(() =>
+    camelizeKeys(nestedToDepth(MAX_NESTING_DEPTH - 1)),
+  ).not.toThrow();
+  expect(() => camelizeKeys(nestedToDepth(MAX_NESTING_DEPTH))).toThrow(
+    NestingDepthExceededError,
+  );
+});
+
+test("a pathologically-deep payload fails cleanly, not with a RangeError", () => {
+  // ~5000 levels overflowed camelizeKeys's native recursion before the guard;
+  // it must now reject with the bounded UsageError. The guard fires at the bound,
+  // so the native stack overflow is never reached.
+  let err: unknown;
+  try {
+    camelizeKeys(nestedToDepth(5000));
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeInstanceOf(NestingDepthExceededError);
+  expect(err).not.toBeInstanceOf(RangeError);
+});
+
+test("snakeizeKeys shares the depth guard", () => {
+  // The walker is shared, so the write direction is bounded too -- harmless, its
+  // input is the operator's typed ExchangeSpec and never this deep.
+  expect(() => snakeizeKeys(nestedToDepth(5000))).toThrow(
+    NestingDepthExceededError,
+  );
 });
 
 // --- Round-trip and verbatim behavior ----------------------------------------

--- a/packages/core/test/linkageTerms.test.ts
+++ b/packages/core/test/linkageTerms.test.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_MAX_DISPLAY_LENGTH,
 } from "../src/utils/sanitizeForDisplay";
 import { describeDecodeError } from "../src/utils/describeDecodeError";
+import { NestingDepthExceededError } from "../src/utils/camelizeKeys";
 
 // Minimal valid set of terms used as a base for individual tests.
 const base = {
@@ -1512,6 +1513,39 @@ test("rejects a linkage key elements list over the maximum count", () => {
     name: `e${i}`,
   }));
   expect(() => parseLinkageTerms(elementsTerms(elements))).toThrow(ZodError);
+});
+
+test("a deeply-nested transform.params value fails cleanly, not with a RangeError", () => {
+  // DISTINCT from the count-overflow above: parseLinkageTerms camelizes BEFORE
+  // Zod, and camelizeKeys recurses once per nesting level, so a deeply-nested
+  // partner value (here under transform.params, typed z.unknown(), so it would
+  // otherwise survive into the parsed terms) overflows the call stack pre-Zod.
+  // ~5000 levels is a few tens of KB of JSON, well within the invitation and
+  // frame caps; the camelize depth guard must reject it as a clean bounded error.
+  let deepValue: unknown = { leaf: 1 };
+  for (let i = 0; i < 5000; i++) deepValue = { nested: deepValue };
+  const terms = {
+    ...base,
+    linkageKeys: [
+      {
+        name: "SSN",
+        elements: [
+          {
+            field: "ssn",
+            transform: [{ function: "trim", params: { deep: deepValue } }],
+          },
+        ],
+      },
+    ],
+  };
+  let err: unknown;
+  try {
+    parseLinkageTerms(terms);
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeInstanceOf(NestingDepthExceededError);
+  expect(err).not.toBeInstanceOf(RangeError);
 });
 
 test("a pathological-count linkage key elements list fails cleanly, not with a RangeError", () => {


### PR DESCRIPTION
## Summary

Bound the object/array nesting depth `camelizeKeys` will walk, so a deeply-nested payload from the adversarial counterparty fails with a clean, bounded rejection instead of overflowing the call stack with a `RangeError`. `parseLinkageTerms` runs `camelizeKeys` BEFORE Zod, and the walker recurses once per nesting level with no guard, so a payload nested a few thousand levels deep -- only tens of KB of JSON, trivially within both the 64 KiB invitation cap and the ~512 MiB frame cap -- faulted pre-validation. It was caught harmlessly (a `RangeError` renders via `describeDecodeError`'s message fallback; `receiveParsed` wraps it into a `ConnectionError`), so this is a Low robustness / defense-in-depth hardening, not a live vulnerability. It is distinct from the collection-count overflow class (202609308, 202615892): those bound collection counts to stop Zod's post-parse issue accumulation; this is a pre-Zod recursive-descent depth overflow reachable by deep nesting anywhere in the payload, which no per-field count bound touches.

Implements [202617716](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202617716).

## Changes

- `packages/core/src/utils/camelizeKeys.ts`: add a depth bound to the shared `transformKeysDeep` walker (the single chokepoint behind both `camelizeKeys` and `snakeizeKeys`), throwing a clean `NestingDepthExceededError` (a `UsageError` subclass, exit 64 at the CLI, fixed message with no input bytes) once nesting reaches `MAX_NESTING_DEPTH` (256, root at depth 0). Document the new throw with `@throws` on both entry points.
- `packages/core/test/camelizeKeys.test.ts`: exact-boundary, pathological-depth, ordinary-depth, and snakeize-shares-the-guard tests.
- `packages/core/test/linkageTerms.test.ts`: a deeply-nested `transform.params` value through `parseLinkageTerms` fails as a clean `NestingDepthExceededError`, not a `RangeError`.

## Test plan

Ran: `npm run build -w packages/core`, `npm run typecheck`, `npm run lint`, `npm run format`, and `npm run test -w packages/core` (1458 passing). Focused: `npx vitest run packages/core/test/camelizeKeys.test.ts packages/core/test/linkageTerms.test.ts`.
New tests cover: the guard fires at exactly `MAX_NESTING_DEPTH`; a pathologically deep payload (~5000 levels) fails as a clean `NestingDepthExceededError` rather than a `RangeError`, through `camelizeKeys` directly and through `parseLinkageTerms` with the deep value under `transform.params`; ordinary nested payloads parse unchanged; and `snakeizeKeys` shares the guard.

## Background

The fix guards the single shared walker rather than any one caller: every camelize-then-parse path funnels through `camelizeKeys`, so one bound protects them all, and each caller's existing error handling absorbs the throw (protocolSetup catches and renders it; the CLI maps `UsageError` to exit 64). Chosen over an iterative (non-recursive) rewrite of the walker for two reasons beyond simplicity. Rejecting at the camelize chokepoint stops a deep value before it can survive validation under `transform.params` (typed `z.unknown()`) and overflow a later recursive consumer such as `canonicalString`; an iterative camelize would merely relocate the overflow downstream. And an iterative walker would have to preserve the opaque-key skip, key order, collision semantics, and the byte-stable write/read round-trip the structural-invariant test pins, all of which the bound leaves untouched. The limit (256) is far above any real config -- the deepest schema path is under a dozen levels and a `params` value holds shallow scalars -- yet well below the overflow threshold on any realistic stack.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; the bound is an internal defense-in-depth ceiling and the set of accepted configs and exchange messages is unchanged, consistent with the existing undocumented per-field bounds and siblings 202609308 / 202615892.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: Low defense-in-depth parse-hardening with no operator-visible behavior change (accepted inputs unchanged; the overflow was already caught harmlessly); pre-release security entries are kept to headline changes per CONTRIBUTING, and sibling 202609308 was recorded the same way.
- [x] Security review -- security-relevant (receive-side hardening of partner-controlled input): ran three independent correctness reviews (completeness, caller-integration, test-efficacy/stack-safety) and three independent security reviews (availability/DoS including the opaque-skip-bypass case, disclosure/log-injection, integrity/guard-bypass), all clear.
