### PR TITLE
Raise web interactive and status colors to AA

### DIFF
--- a/apps/web/src/components/AcceptInvitationPanel.tsx
+++ b/apps/web/src/components/AcceptInvitationPanel.tsx
@@ -9,6 +9,8 @@ import {
   TextInput,
 } from "@mantine/core";
 
+import { IconAlertCircle } from "@tabler/icons-react";
+
 import { commitAcceptance } from "@psi/acceptConsent";
 
 import FileAcquire from "@components/FileAcquire";
@@ -88,6 +90,9 @@ export function AcceptInvitationPanel({
         // to an error, rather than leaving a screen-reader user on the spinner.
         <Alert
           color="red"
+          // Severity icon so the error is not signalled by color alone (WCAG
+          // 1.4.1); aria-hidden since the title text already names it.
+          icon={<IconAlertCircle aria-hidden />}
           title="Cannot accept this invitation"
           mt="md"
           ref={errorRef}
@@ -152,6 +157,7 @@ export function AcceptInvitationPanel({
             // zero-coverage block message carries none.
             <Alert
               color="red"
+              icon={<IconAlertCircle aria-hidden />}
               title={error.title}
               style={{ whiteSpace: "pre-line" }}
             >

--- a/apps/web/src/components/ExchangeView.tsx
+++ b/apps/web/src/components/ExchangeView.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState } from "react";
 
 import { Alert, Button, Group, Stack } from "@mantine/core";
 
+import { IconAlertCircle, IconAlertTriangle } from "@tabler/icons-react";
+
 // @ts-ignore this is really there
 import PSI from "@openmined/psi.js/psi_wasm_web";
 
@@ -505,6 +507,9 @@ export function ExchangeView(config: ExchangeConfig) {
         // rather than run together. tabIndex + ref so a blocking error takes focus.
         <Alert
           color="red"
+          // A severity icon so error is not signalled by color alone (WCAG
+          // 1.4.1); aria-hidden because the title text already names the error.
+          icon={<IconAlertCircle aria-hidden />}
           title={errorAlert.title}
           style={{ whiteSpace: "pre-line" }}
           ref={errorAlertRef}
@@ -537,7 +542,14 @@ export function ExchangeView(config: ExchangeConfig) {
         headingRef={config.role === "acceptor" ? leadingHeadingRef : undefined}
       />
       {warningAlert && (
-        <Alert color="yellow" title={warningAlert.title}>
+        <Alert
+          color="yellow"
+          // A severity icon so warning is not signalled by color alone (WCAG
+          // 1.4.1), and is distinguishable from the red error icon; aria-hidden
+          // because the title text already names the warning.
+          icon={<IconAlertTriangle aria-hidden />}
+          title={warningAlert.title}
+        >
           {warningAlert.message}
         </Alert>
       )}

--- a/apps/web/src/components/InvitePanel.tsx
+++ b/apps/web/src/components/InvitePanel.tsx
@@ -9,6 +9,7 @@ import {
   TextInput,
   Title,
 } from "@mantine/core";
+import { IconAlertCircle } from "@tabler/icons-react";
 import { useForm } from "@tanstack/react-form";
 
 import { sanitizeErrorForDisplay, sanitizeForDisplay } from "@psilink/core";
@@ -242,6 +243,9 @@ export function InvitePanel() {
           {error && (
             <Alert
               color="red"
+              // Severity icon so the error is not signalled by color alone (WCAG
+              // 1.4.1); aria-hidden since the title text already names it.
+              icon={<IconAlertCircle aria-hidden />}
               title={error.title}
               // pre-line so the read-failure message's per-cause newlines (from
               // sanitizeErrorForDisplay) render one cause per line; the other

--- a/apps/web/src/components/NotFound.tsx
+++ b/apps/web/src/components/NotFound.tsx
@@ -1,25 +1,23 @@
 import { Link } from "@tanstack/react-router";
 
-export function NotFound({ children }: { children?: any }) {
+import { Button, Group, Stack, Text } from "@mantine/core";
+
+import type { ReactNode } from "react";
+
+export function NotFound({ children }: { children?: ReactNode }) {
   return (
-    <div className="space-y-2 p-2">
-      <div className="text-gray-600 dark:text-gray-400">
-        {children || <p>The page you are looking for does not exist.</p>}
-      </div>
-      <p className="flex items-center gap-2 flex-wrap">
-        <button
-          onClick={() => window.history.back()}
-          className="bg-emerald-500 text-white px-2 py-1 rounded uppercase font-black text-sm"
-        >
+    <Stack gap="sm" p="sm">
+      {children ?? (
+        <Text c="dimmed">The page you are looking for does not exist.</Text>
+      )}
+      <Group gap="sm">
+        <Button variant="default" onClick={() => window.history.back()}>
           Go back
-        </button>
-        <Link
-          to="/"
-          className="bg-cyan-600 text-white px-2 py-1 rounded uppercase font-black text-sm"
-        >
-          Start Over
-        </Link>
-      </p>
-    </div>
+        </Button>
+        <Button component={Link} to="/">
+          Start over
+        </Button>
+      </Group>
+    </Stack>
   );
 }

--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -162,8 +162,11 @@ const MUTED_TEXT = {
  * - warning #92400e on yellow-1 = 6.36:1.
  * - error #a51111 on red-1 = 6.45:1.
  *
- * Only the light scheme is overridden; the dark `light-color` (shade 0 on a dark
- * tint) already passes. Enforced by test/unit/themeContrast.test.ts.
+ * Only the light scheme is overridden -- it is where these failures are. The
+ * dark scheme is left at Mantine's defaults, where the same tokens are a
+ * near-white shade-0 on a dark tint (the inverse arrangement), not the dark-on-
+ * light one that fails here. The light-scheme ratios above are enforced by
+ * test/unit/themeContrast.test.ts.
  */
 const STATUS_TEXT = {
   warning: "#92400e",

--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -174,11 +174,25 @@ const STATUS_TEXT = {
 } as const;
 
 /**
+ * Accessible color for Mantine's `error` token in the light scheme -- the input
+ * validation message text, the `withAsterisk` required marker, and the
+ * error-state input border. Mantine's light default is red-6 (#fa5252) = 3.28:1
+ * on the white page/input, which fails WCAG 2.1 AA 1.4.3 for the normal-weight
+ * validation text. red-9 (#c92a2a) = 5.46:1 on white (5.18:1 on the gray-0 card)
+ * clears it with margin. This differs from {@link STATUS_TEXT}.error: that sits
+ * on the red-1 Alert tint, where #c92a2a is only 4.51:1, so the two error reds
+ * are tuned to their different backgrounds. Enforced by
+ * test/unit/themeContrast.test.ts.
+ */
+const ERROR_TEXT = "#c92a2a";
+
+/**
  * Raises the `dimmed` and input `placeholder` tokens to {@link MUTED_TEXT} in
  * both color schemes, and the yellow/red `light`-variant text tokens to
- * {@link STATUS_TEXT} in the light scheme. Mantine deep-merges this over the
- * default resolver, so only the overridden variables need be returned. Passed to
- * `MantineProvider` in the root route.
+ * {@link STATUS_TEXT} plus the `error` token to {@link ERROR_TEXT} in the light
+ * scheme. Mantine deep-merges this over the default resolver, so only the
+ * overridden variables need be returned. Passed to `MantineProvider` in the root
+ * route.
  */
 export const cssVariablesResolver: CSSVariablesResolver = () => ({
   variables: {},
@@ -187,6 +201,7 @@ export const cssVariablesResolver: CSSVariablesResolver = () => ({
     "--mantine-color-placeholder": MUTED_TEXT.light,
     "--mantine-color-yellow-light-color": STATUS_TEXT.warning,
     "--mantine-color-red-light-color": STATUS_TEXT.error,
+    "--mantine-color-error": ERROR_TEXT,
   },
   dark: {
     "--mantine-color-dimmed": MUTED_TEXT.dark,

--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -52,6 +52,20 @@ export const mantineTheme: MantineThemeOverride = createTheme({
     "3xl": rem("32px"),
   },
   primaryColor: "cyan",
+  // Light-scheme primary shade raised 6 -> 9 for WCAG 2.1 AA contrast. The
+  // default cyan-6 (#15aabf) fails wherever the primary is used: white-on-cyan-6
+  // filled buttons (and the filled copy ActionIcon glyph and the consent Checkbox
+  // checkmark) = 2.79:1; the cyan-6 anchor/link and the cyan-6 focus-visible
+  // outline / input focus border on the white page = 2.79:1. autoContrast does
+  // not solve this -- it only recolours text sitting on a filled surface, so it
+  // cannot lift the anchor, focus ring, or input border (cyan-on-white, not
+  // text-on-fill). cyan-8 is also short (white text 4.35:1, under the 4.5 floor);
+  // cyan-9 (#0b7285) is the first shade that clears it, fixing all of those at
+  // once: white-on-cyan-9 = 5.59:1 and cyan-9-on-white = 5.59:1. The filled hover
+  // step resolves to cyan-8 (4.35:1) -- transient, and AA is judged on the resting
+  // state. dark stays at its 8 default (stated so it cannot drift); the dark
+  // scheme is unchanged. The ratios are enforced by test/unit/themeContrast.test.ts.
+  primaryShade: { light: 9, dark: 8 },
   components: {
     /** Put your mantine component override here */
     Container: Container.extend({
@@ -130,16 +144,46 @@ const MUTED_TEXT = {
 } as const;
 
 /**
+ * Accessible text color for the yellow "warning" and red "error" Mantine `light`
+ * variant surfaces in the light scheme -- the Alert title and icon, and the
+ * yellow "Non-standard matching" Badge label. Mantine's default
+ * `--mantine-color-{c}-light-color` is the color's shade 9 on its shade-1 tint,
+ * which fails WCAG 2.1 AA 1.4.3 for normal-weight text:
+ * - yellow-9 (#e67700) on yellow-1 (#fff3bf) = 2.69:1 -- and no yellow/orange
+ *   shade clears even the 3:1 non-text floor on that tint, so the text has to
+ *   leave the yellow ramp entirely.
+ * - red-9 (#c92a2a) on red-1 (#ffe3e3) = 4.51:1 -- a hairline pass, fragile to a
+ *   future palette nudge.
+ *
+ * Darkened in-hue rather than to plain black so each title still reads as
+ * amber/caution and red/error; warning-vs-error no longer rests on the title
+ * color alone, because the Alerts now also carry a severity icon (WCAG 1.4.1).
+ * Ratios against the real shade-1 tints:
+ * - warning #92400e on yellow-1 = 6.36:1.
+ * - error #a51111 on red-1 = 6.45:1.
+ *
+ * Only the light scheme is overridden; the dark `light-color` (shade 0 on a dark
+ * tint) already passes. Enforced by test/unit/themeContrast.test.ts.
+ */
+const STATUS_TEXT = {
+  warning: "#92400e",
+  error: "#a51111",
+} as const;
+
+/**
  * Raises the `dimmed` and input `placeholder` tokens to {@link MUTED_TEXT} in
- * both color schemes. Mantine deep-merges this over the default resolver, so
- * only the overridden variables need be returned. Passed to `MantineProvider`
- * in the root route.
+ * both color schemes, and the yellow/red `light`-variant text tokens to
+ * {@link STATUS_TEXT} in the light scheme. Mantine deep-merges this over the
+ * default resolver, so only the overridden variables need be returned. Passed to
+ * `MantineProvider` in the root route.
  */
 export const cssVariablesResolver: CSSVariablesResolver = () => ({
   variables: {},
   light: {
     "--mantine-color-dimmed": MUTED_TEXT.light,
     "--mantine-color-placeholder": MUTED_TEXT.light,
+    "--mantine-color-yellow-light-color": STATUS_TEXT.warning,
+    "--mantine-color-red-light-color": STATUS_TEXT.error,
   },
   dark: {
     "--mantine-color-dimmed": MUTED_TEXT.dark,

--- a/apps/web/test/browser/notFound.test.ts
+++ b/apps/web/test/browser/notFound.test.ts
@@ -1,0 +1,96 @@
+/// <reference types="@vitest/browser-playwright/context" />
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { page, userEvent } from "vitest/browser";
+
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+
+import { MantineProvider } from "@mantine/core";
+
+import { NotFound } from "@components/NotFound";
+import { mantineTheme } from "@theme";
+
+import type { ReactNode } from "react";
+import type { Root } from "react-dom/client";
+
+// NotFound reaches the home route through Mantine's polymorphic `component` prop
+// (`<Button component={Link} to="/">`). Stub the router module to render Link as a
+// plain <a href={to}>, the same pattern appShell.test.ts uses, since a real
+// RouterProvider trips a duplicate-React dispatcher error under the browser
+// runner. With Link surfacing `to` as the href, this still exercises the
+// load-bearing MANTINE side: that the polymorphic `component` is honoured (so
+// "Start over" renders as an <a>, not Mantine's default <button>) and that `to`
+// is forwarded through. TanStack's own to->href resolution is its concern, not
+// this component's, so stubbing it loses no coverage of our code.
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    className,
+    children,
+  }: {
+    to?: string;
+    className?: string;
+    children?: ReactNode;
+  }) =>
+    createElement(
+      "a",
+      { href: typeof to === "string" ? to : "#", className },
+      children,
+    ),
+}));
+
+let container: HTMLElement | undefined;
+let root: Root | undefined;
+
+// Mount under the real app theme, the way the running app composes it.
+function mount(node: ReactNode) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  root.render(createElement(MantineProvider, { theme: mantineTheme }, node));
+}
+
+afterEach(() => {
+  root?.unmount();
+  container?.remove();
+  root = undefined;
+  container = undefined;
+  vi.restoreAllMocks();
+});
+
+describe("NotFound", () => {
+  test("'Start over' renders as a link to the home route", async () => {
+    mount(createElement(NotFound));
+
+    // role=link (not button) confirms Mantine honoured `component={Link}` rather
+    // than falling back to its default <button>; the href confirms `to` was
+    // forwarded. A Mantine change that broke component-forwarding would surface
+    // here as a missing link / a stray <button>.
+    const startOver = page.getByRole("link", { name: "Start over" });
+    await expect.element(startOver).toBeInTheDocument();
+    await expect.element(startOver).toHaveAttribute("href", "/");
+  });
+
+  test("'Go back' is a button that calls history.back()", async () => {
+    const back = vi
+      .spyOn(window.history, "back")
+      .mockImplementation(() => undefined);
+    mount(createElement(NotFound));
+
+    const goBack = page.getByRole("button", { name: "Go back" });
+    await expect.element(goBack).toBeInTheDocument();
+    await userEvent.click(goBack);
+
+    expect(back).toHaveBeenCalledOnce();
+  });
+
+  test("shows a default message when given no children", async () => {
+    mount(createElement(NotFound));
+
+    await expect
+      .element(page.getByText("The page you are looking for does not exist."))
+      .toBeInTheDocument();
+  });
+});

--- a/apps/web/test/unit/themeContrast.test.ts
+++ b/apps/web/test/unit/themeContrast.test.ts
@@ -62,6 +62,7 @@ const dark6 = theme.colors.dark[6];
 
 const warningText = vars.light["--mantine-color-yellow-light-color"];
 const errorText = vars.light["--mantine-color-red-light-color"];
+const errorToken = vars.light["--mantine-color-error"];
 const dimmedLight = vars.light["--mantine-color-dimmed"];
 const placeholderLight = vars.light["--mantine-color-placeholder"];
 const dimmedDark = vars.dark["--mantine-color-dimmed"];
@@ -112,6 +113,12 @@ describe("theme colour contrast (WCAG 2.1 AA)", () => {
         name: "error Alert title: deep red on red-1",
         fg: errorText,
         bg: red1,
+        floor: 4.5,
+      },
+      {
+        name: "error token (validation text + asterisk): on white input",
+        fg: errorToken,
+        bg: white,
         floor: 4.5,
       },
       // Locks the prior dimmed/placeholder fix in both schemes.

--- a/apps/web/test/unit/themeContrast.test.ts
+++ b/apps/web/test/unit/themeContrast.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "vitest";
+
+import { DEFAULT_THEME, mergeMantineTheme } from "@mantine/core";
+
+import { cssVariablesResolver, mantineTheme } from "@theme";
+
+// Enforces the WCAG 2.1 AA contrast invariants the theme is tuned to: 4.5:1 for
+// normal-weight text (1.4.3) and 3:1 for non-text UI / focus indicators (1.4.11).
+// The JSDoc in theme.ts records the chosen colors and their ratios; this is the
+// executable form of those claims, so a future palette nudge or Mantine bump that
+// silently drops a surface under its floor fails here instead of shipping.
+//
+// Colours are read from the MERGED theme (createTheme is the identity function,
+// so mantineTheme alone has no `colors`) and from the cssVariablesResolver output
+// rather than hardcoded hex, so changing primaryShade or an override re-runs the
+// arithmetic against the new value -- a real check, not a restatement.
+
+/** WCAG 2.1 relative luminance of an `#rgb` or `#rrggbb` colour. */
+function relativeLuminance(hex: string): number {
+  const linearize = (v: number) =>
+    v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  let n = hex.replace("#", "");
+  // Expand the 3-digit shorthand (Mantine's white is "#fff") to 6 digits.
+  if (n.length === 3) {
+    n = n
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  const [r, g, b] = [0, 2, 4].map((i) => parseInt(n.slice(i, i + 2), 16) / 255);
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+/** WCAG contrast ratio between two `#rrggbb` colours (1..21). */
+function contrast(a: string, b: string): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+const theme = mergeMantineTheme(DEFAULT_THEME, mantineTheme);
+const vars = cssVariablesResolver(theme);
+
+const lightShade =
+  typeof theme.primaryShade === "number"
+    ? theme.primaryShade
+    : theme.primaryShade.light;
+const primary = theme.colors[theme.primaryColor][lightShade];
+const white = theme.white;
+const gray0 = theme.colors.gray[0];
+const cyan1 = theme.colors.cyan[1];
+const yellow1 = theme.colors.yellow[1];
+const red1 = theme.colors.red[1];
+const dark7 = theme.colors.dark[7];
+const dark6 = theme.colors.dark[6];
+
+const warningText = vars.light["--mantine-color-yellow-light-color"];
+const errorText = vars.light["--mantine-color-red-light-color"];
+const dimmedLight = vars.light["--mantine-color-dimmed"];
+const dimmedDark = vars.dark["--mantine-color-dimmed"];
+const placeholderDark = vars.dark["--mantine-color-placeholder"];
+
+describe("theme colour contrast (WCAG 2.1 AA)", () => {
+  const cases: Array<{ name: string; fg: string; bg: string; floor: number }> =
+    [
+      // Primary (raised to cyan-9): one shade covers every surface it touches.
+      {
+        name: "filled button text: white on primary",
+        fg: white,
+        bg: primary,
+        floor: 4.5,
+      },
+      {
+        name: "anchor/link text: primary on white page",
+        fg: primary,
+        bg: white,
+        floor: 4.5,
+      },
+      {
+        name: "anchor/link text: primary on gray-0 surface",
+        fg: primary,
+        bg: gray0,
+        floor: 4.5,
+      },
+      {
+        name: "focus ring + input border: primary on page (non-text)",
+        fg: primary,
+        bg: white,
+        floor: 3,
+      },
+      {
+        name: "copied-state copy icon: primary on cyan-1 (non-text)",
+        fg: primary,
+        bg: cyan1,
+        floor: 3,
+      },
+      // Status light-variant text (overridden tokens) on their shade-1 tints.
+      {
+        name: "warning Alert title + Badge: amber on yellow-1",
+        fg: warningText,
+        bg: yellow1,
+        floor: 4.5,
+      },
+      {
+        name: "error Alert title: deep red on red-1",
+        fg: errorText,
+        bg: red1,
+        floor: 4.5,
+      },
+      // Locks the prior dimmed/placeholder fix in both schemes.
+      {
+        name: "dimmed text (light): on white body",
+        fg: dimmedLight,
+        bg: white,
+        floor: 4.5,
+      },
+      {
+        name: "dimmed text (light): on gray-0 surface",
+        fg: dimmedLight,
+        bg: gray0,
+        floor: 4.5,
+      },
+      {
+        name: "dimmed text (dark): on dark-7 body",
+        fg: dimmedDark,
+        bg: dark7,
+        floor: 4.5,
+      },
+      {
+        name: "placeholder text (dark): on dark-6 input",
+        fg: placeholderDark,
+        bg: dark6,
+        floor: 4.5,
+      },
+    ];
+
+  test.each(cases)("$name >= $floor:1", ({ fg, bg, floor }) => {
+    expect(contrast(fg, bg)).toBeGreaterThanOrEqual(floor);
+  });
+
+  test("primary uses the AA-tuned light shade, not the failing default", () => {
+    // cyan-6 (Mantine's default light primary shade) reintroduces the 2.79:1
+    // button/anchor/focus failures, and cyan-8 is short at 4.35:1; cyan-9 is the
+    // first shade clearing the 4.5 text floor with white text. Guards the choice
+    // itself, since the cases above would still pass at a wrongly-low shade only
+    // if every other surface happened to compensate.
+    expect(lightShade).toBeGreaterThanOrEqual(9);
+    expect(contrast(white, primary)).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/apps/web/test/unit/themeContrast.test.ts
+++ b/apps/web/test/unit/themeContrast.test.ts
@@ -17,6 +17,11 @@ import { cssVariablesResolver, mantineTheme } from "@theme";
 
 /** WCAG 2.1 relative luminance of an `#rgb` or `#rrggbb` colour. */
 function relativeLuminance(hex: string): number {
+  // 0.03928 is the threshold in WCAG 2.1's published relative-luminance formula
+  // (and in Mantine's own luminance(), which drives its autoContrast picks). The
+  // mathematically-exact sRGB break is 0.04045; the two differ only for a channel
+  // landing in that narrow gap, which none of the tested colours do. Matching the
+  // spec text and Mantine is deliberate -- do not "correct" it to 0.04045.
   const linearize = (v: number) =>
     v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
   let n = hex.replace("#", "");
@@ -58,6 +63,7 @@ const dark6 = theme.colors.dark[6];
 const warningText = vars.light["--mantine-color-yellow-light-color"];
 const errorText = vars.light["--mantine-color-red-light-color"];
 const dimmedLight = vars.light["--mantine-color-dimmed"];
+const placeholderLight = vars.light["--mantine-color-placeholder"];
 const dimmedDark = vars.dark["--mantine-color-dimmed"];
 const placeholderDark = vars.dark["--mantine-color-placeholder"];
 
@@ -119,6 +125,12 @@ describe("theme colour contrast (WCAG 2.1 AA)", () => {
         name: "dimmed text (light): on gray-0 surface",
         fg: dimmedLight,
         bg: gray0,
+        floor: 4.5,
+      },
+      {
+        name: "placeholder text (light): on white input",
+        fg: placeholderLight,
+        bg: white,
         floor: 4.5,
       },
       {


### PR DESCRIPTION
## Summary

Raise the web app's interactive and status colors to the WCAG 2.1 AA contrast bar (1.4.3 text, 1.4.11 non-text) in the light scheme, the app's default and effectively only scheme. Filled buttons, links, focus indicators, status Alert/Badge text, and form validation errors now clear their contrast floors with margin, and the result is enforced by a theme-derived contrast test so it cannot silently regress.

Implements [202426038](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202426038).

## Changes

- apps/web/src/theme.ts: raise the primary light shade cyan-6 -> cyan-9 (white-on-cyan-9 = 5.59:1), fixing filled buttons, the anchor, the focus ring, the input border, and the filled copy icon / consent checkmark in one knob; override the yellow/red light-variant status-text tokens to a dark amber (6.36:1) and deep red (6.45:1), and the form-error token to red-9 (5.46:1). Each value is recorded with its measured ratio.
- Alerts (ExchangeView, AcceptInvitationPanel, InvitePanel): add a severity icon (warning triangle / error circle, aria-hidden) so warning vs error is not conveyed by color alone (1.4.1).
- apps/web/src/components/NotFound.tsx: rewrite the 404 page from raw themeless, sub-AA Tailwind utility classes to Mantine controls that track the theme.
- tests: add a theme-derived WCAG contrast unit test (asserts each surface clears its floor, reading shades and overrides from the merged theme, and locks the prior dimmed/placeholder fix) and a NotFound browser test (guards the Button component={Link} anchor forwarding and the Go back action).

## Test plan

Ran: `npm run test:unit -w apps/web` (199 pass, including 14 contrast assertions), `npm run test:browser -w apps/web` (82 pass, including 3 NotFound), plus `npm run typecheck`, `npm run lint`, and `npm run format`, all clean.
New tests cover: each adjusted surface clears its WCAG floor, computed from the merged theme so a palette or Mantine change re-checks rather than regressing; NotFound renders "Start over" as an anchor to "/" and "Go back" as a button calling history.back().

## Background

autoContrast was rejected as the button fix: it only recolors text on a filled surface, so it cannot lift the anchor, focus ring, or input border (cyan-on-white, not text-on-fill), and cyan-8 falls short at 4.35:1. Raising the primary shade to cyan-9 fixes the whole cyan cluster at once and keeps white button text. It deepens the brand from bright cyan to deep teal in the light scheme, the intended and signed-off visual change. The dark scheme is pinned to its current shade and is unchanged.

## Out of scope / follow-on

- Dark-scheme button and focus contrast: the dark scheme has its own AA gaps needing a different mechanism (autoContrast plus a lighter dark shade). [202634810](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202634810).
- Dropzone drag-state icon contrast (1.4.11) on the transient drag-over tints. [202639318](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202639318).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages -- n/a: no documented behavior changed; `docs/COMPLIANCE.md` and `docs/ROADMAP.md` still accurately state the web app awaits a formal WCAG evaluation, and this is incremental remediation, consistent with the prior contrast fix (#191) which updated no docs.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: a presentational web accessibility/contrast change with no operator-, deployer-, or reviewer-actionable surface (no command, flag, config, default, wire or on-disk format, or security change); matches the prior contrast fix (#191), which added no entry.
- [x] Security review -- n/a: no security-review-scope surface touched (web theme, markup, and contrast only); independently confirmed by two security reviews (web application security, and disclosure/scope/dependency), both clear.
