### PR TITLE
Style web 404 and error pages with Mantine

### DIFF
--- a/apps/web/src/components/DefaultCatchBoundary.tsx
+++ b/apps/web/src/components/DefaultCatchBoundary.tsx
@@ -1,3 +1,4 @@
+import { Button, Group, Stack } from "@mantine/core";
 import {
   ErrorComponent,
   Link,
@@ -5,6 +6,7 @@ import {
   useMatch,
   useRouter,
 } from "@tanstack/react-router";
+
 import type { ErrorComponentProps } from "@tanstack/react-router";
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
@@ -17,37 +19,43 @@ export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   console.error("DefaultCatchBoundary Error:", error);
 
   return (
-    <div className="min-w-0 flex-1 p-4 flex flex-col items-center justify-center gap-6">
+    <Stack align="center" gap="xl" p="md">
       <ErrorComponent error={error} />
-      <div className="flex gap-2 items-center flex-wrap">
-        <button
+      <Group gap="2xs">
+        <Button
+          color="gray"
+          size="compact-sm"
+          tt="uppercase"
+          fw={800}
           onClick={() => {
             router.invalidate();
           }}
-          className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold`}
         >
           Try Again
-        </button>
+        </Button>
         {isRoot ? (
-          <Link
+          <Button
+            component={Link}
             to="/"
-            className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold`}
+            color="gray"
+            size="compact-sm"
+            tt="uppercase"
+            fw={800}
           >
             Home
-          </Link>
+          </Button>
         ) : (
-          <Link
-            to="/"
-            className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold`}
-            onClick={(e) => {
-              e.preventDefault();
-              window.history.back();
-            }}
+          <Button
+            color="gray"
+            size="compact-sm"
+            tt="uppercase"
+            fw={800}
+            onClick={() => window.history.back()}
           >
             Go Back
-          </Link>
+          </Button>
         )}
-      </div>
-    </div>
+      </Group>
+    </Stack>
   );
 }


### PR DESCRIPTION
## Summary

The route error boundary (DefaultCatchBoundary) rendered unstyled because it was written against Tailwind utility classes that resolve to nothing -- apps/web has no Tailwind build (its PostCSS pipeline is postcss-preset-mantine, importing only Mantine CSS). This converts it to Mantine so it renders with intentional spacing and visible action buttons. The sibling 404 page (NotFound) was converted separately on staging in #222, which also raised the web palette to AA (primaryShade light 9), so this branch rebases onto that work and now carries only the error-boundary page.

Part of [202426101](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202426101); completes the error-boundary half (the 404 half landed in #222).

## Changes

- apps/web/src/components/DefaultCatchBoundary.tsx: convert the error boundary to Stack/Group/Button; map the inert Tailwind classes to theme spacing tokens and Button props; make the non-root Go Back a plain button (it was a Link with to="/" whose onClick preventDefault'd into history.back, so the href was dead and misleading); drop the inert flex-1/min-w-0/justify-center classes, which had no effect inside the non-flex Mantine Container the content renders in.

## Test plan

Ran: npm run typecheck, npm run lint, npm run format (no changes), npm run test:unit -w apps/web (199 passed).
New tests cover: n/a -- purely presentational conversion. No test imports DefaultCatchBoundary (appShell.test.ts references it only in a comment), and all behavior is preserved: router.invalidate, the Link to "/", and window.history.back.

## Background

Surfaced during the 202267321 accessibility branch and deferred here because the root cause is different: missing build tooling, not a wrong color value. Rebased onto #222, which converted NotFound and raised the palette to AA; the light-mode button-contrast concern formerly tracked for these pages (202641728) is addressed by that palette change.

## Out of scope / follow-on

- Route the error boundary's on-screen render and console.error through sanitizeErrorForDisplay, a pre-existing disclosure-hardening gap untouched by this PR: [202642215](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202642215).

## Checklist

- [x] Docs: enumerated docs/ and docs/spec/ and updated affected pages -- n/a: no documented behavior changed; this is a presentational fix to the error page with no operational, config, or wire change.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: cosmetic repair of dead styling confined to the error path; no operator- or reviewer-visible command, flag, config field, default, behavior, exit code, or wire/on-disk change.
- [x] Security review -- ran an independent three-lens panel (disclosure, injection, dependency/change-surface) on the pre-rebase diff; the rebased diff is a strict subset (only the error-boundary conversion remains). No security-relevant surface touched: no dependency added, and the error boundary's data-bearing lines (ErrorComponent and console.error) are byte-identical to staging. The one pre-existing disclosure surface there is untouched and tracked separately (see Out of scope).
