### PR TITLE
Add ignored as a column-metadata role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This changelog records, per release, the changes that affect how PSI-Link is run
 
 ### Changed
 
+- A `metadata` block with duplicate column names is now rejected at parse time; names must be unique (matched case-sensitively). See `docs/EXCHANGE_REFERENCE.md`.
 - BREAKING: the CLI authenticates recurring exchanges with the X25519 authenticated key exchange instead of SPAKE2, and the shared credential is renamed `pake_token` -> `shared_secret` in config. Old and new builds do not interoperate; pre-release, no migration shim. `exchange` now requires a `.psilink.key`. See `docs/spec/PROTOCOL.md`.
 - BREAKING: the `authentication` block moves from per-channel `connection` config to the top level of the exchange spec, and the WebRTC role moves to `connection.role`. Authentication, rotation, and expiry behavior are unchanged. See `docs/EXCHANGE_REFERENCE.md`.
 - BREAKING: the multi-word semantic-type and fuzzy-comparison enum values in config and invitations are now `snake_case` (`first_name`, `last_name`, `date_of_birth`, `phone_number`, `email_address`; `edit_distances`, `adjacent_years`), matching the convention for everything else users write; the old camelCase spellings are rejected. Single-word values (`ssn`, `ssn4`, `identifier`, `other`, `transpositions`) are unchanged. These ride the invitation token, so old and new builds do not interoperate; pre-release, no migration shim. See `docs/EXCHANGE_REFERENCE.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This changelog records, per release, the changes that affect how PSI-Link is run
 - `psilink invite` (offline) prints how to abandon a pending invitation before it expires: delete its key file. See `docs/CLI.md`.
 - Key file schema: a versioned JSON format for persisting the shared token and exchange metadata between sessions.
 - Metadata inference (column semantic types and date formats), custom linkage keys via configurable transformations, and data standardization that canonicalizes linkage values by semantic type. See `docs/EXCHANGE_REFERENCE.md`.
+- Metadata `role: ignored`: mark an input column present in your file but excluded from the exchange -- never linked, never an identifier, and never transmitted as payload (even if `is_payload: true`). Opt-in only; inference never assigns it. See `docs/EXCHANGE_REFERENCE.md`.
 
 ### Changed
 

--- a/docs/EXCHANGE_REFERENCE.md
+++ b/docs/EXCHANGE_REFERENCE.md
@@ -824,7 +824,7 @@ metadata:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | yes | Column name in the input CSV |
+| `name` | string | yes | Column name in the input CSV; must be unique within the metadata block (matched case-sensitively) |
 | `type` | string | no | Semantic type (see [Semantic Types](#semantic-types) above); inferred from name if omitted |
 | `role` | enum | no | `linkage`, `identifier`, `payload`, or `ignored`; inferred if omitted (inference never assigns `ignored` -- it is opt-in only) |
 | `is_payload` | boolean | no | Whether this column is transmitted as payload data after the intersection is identified; defaults to `true` when `role` is `payload`, `false` otherwise |

--- a/docs/EXCHANGE_REFERENCE.md
+++ b/docs/EXCHANGE_REFERENCE.md
@@ -816,7 +816,8 @@ metadata:
       role: payload
       description: "Date client enrolled in the program"
     - name: "COUNTY"
-      role: payload
+      role: ignored
+      description: "Present in the input but excluded from this exchange"
 ```
 
 ### Column fields
@@ -825,11 +826,13 @@ metadata:
 |-------|------|----------|-------------|
 | `name` | string | yes | Column name in the input CSV |
 | `type` | string | no | Semantic type (see [Semantic Types](#semantic-types) above); inferred from name if omitted |
-| `role` | enum | no | `linkage`, `identifier`, or `payload`; inferred if omitted |
+| `role` | enum | no | `linkage`, `identifier`, `payload`, or `ignored`; inferred if omitted (inference never assigns `ignored` -- it is opt-in only) |
 | `is_payload` | boolean | no | Whether this column is transmitted as payload data after the intersection is identified; defaults to `true` when `role` is `payload`, `false` otherwise |
 | `description` | string | no | Human-readable description; shared with partner for payload columns |
 
 `role` and `is_payload` are partially independent. A column used for linkage or as an identifier can also carry `is_payload: true`, meaning it participates in the PSI protocol *and* is transmitted as payload for matched members. For example, a phone-number column can have `role: linkage` and `is_payload: true` so that it both links records and is delivered to the partner for matched rows. Any column that is not used for linkage or identification must have `is_payload: true`; the application will treat such a column as `role: payload` if no role is specified.
+
+`role: ignored` is the explicit opposite of that default: a column present in the input but used for nothing. An ignored column is never used for linkage, never treated as an identifier, and never transmitted as payload -- the role wins over `is_payload`, so an ignored column is not sent even if it carries `is_payload: true`. Use it to keep a column in the input file (so the file need not be edited) while declaring that this exchange must not touch it. Inference never assigns `ignored`; it must be set explicitly.
 
 ---
 

--- a/packages/core/src/config/metadata.ts
+++ b/packages/core/src/config/metadata.ts
@@ -54,7 +54,21 @@ const ColumnMetadataSchema: z.ZodType<ColumnMetadata> = z.object({
 
 export type Metadata = Array<ColumnMetadata>;
 
-export const MetadataSchema = z.array(ColumnMetadataSchema);
+// Column names must be unique. Every consumer treats metadata as keyed by name
+// (`metadata.find((c) => c.name === ...)`), so a duplicate name makes "the
+// metadata for column X" position-dependent -- e.g. a `role: ignored` entry and a
+// `role: payload` entry for the same name would resolve differently depending on
+// which `find` reaches first, silently defeating the ignored exclusion. Reject it
+// at the schema, mirroring the linkage-field / linkage-key name-uniqueness refines.
+// The message is static and does not echo the user-controlled name, matching the
+// type-enum errors (a name can carry control/ANSI/bidi bytes; see the no-echo test).
+export const MetadataSchema = z.array(ColumnMetadataSchema).refine(
+  (cols) => {
+    const names = cols.map((c) => c.name);
+    return names.length === new Set(names).size;
+  },
+  { message: "metadata column names must be unique" },
+);
 
 /**
  * Non-throwing parse of a raw value as {@link Metadata}. Snake_case keys (the

--- a/packages/core/src/config/metadata.ts
+++ b/packages/core/src/config/metadata.ts
@@ -6,7 +6,29 @@ import { camelizeKeys } from "../utils/camelizeKeys.js";
 import type { SemanticType } from "../types";
 
 // ─── Metadata ────────────────────────────────────────────────────────────────
-export const ColumnRoleSchema = z.enum(["linkage", "identifier", "payload"]);
+/**
+ * The role a declared input column plays in an exchange:
+ *
+ * - `linkage` -- participates in the PSI protocol via its semantic type.
+ * - `identifier` -- indexes this party's matched records in the output.
+ * - `payload` -- transmitted to the partner for matched members (the default
+ *   for any column not used for linkage or identification).
+ * - `ignored` -- present in the input but used for nothing: never linked, never
+ *   an identifier, and never transmitted as payload (regardless of `isPayload`).
+ *   Opt-in only -- {@link inferMetadata} never assigns it.
+ *
+ * Nothing in the linkage/key-building path consults `role` (it branches on the
+ * column's semantic `type`), so an `ignored` column is not coerced out of
+ * linkage by a role default -- it would otherwise leak in via its `type`. Each
+ * type- or payload-driven consumer therefore excludes `ignored` explicitly
+ * (`preparePayload`, `resolveFieldColumns`'s type fallback, `getDefaultLinkageTerms`).
+ */
+export const ColumnRoleSchema = z.enum([
+  "linkage",
+  "identifier",
+  "payload",
+  "ignored",
+]);
 export type ColumnRole = z.infer<typeof ColumnRoleSchema>;
 
 /**

--- a/packages/core/src/config/metadata.ts
+++ b/packages/core/src/config/metadata.ts
@@ -20,8 +20,9 @@ import type { SemanticType } from "../types";
  * Nothing in the linkage/key-building path consults `role` (it branches on the
  * column's semantic `type`), so an `ignored` column is not coerced out of
  * linkage by a role default -- it would otherwise leak in via its `type`. Each
- * type- or payload-driven consumer therefore excludes `ignored` explicitly
- * (`preparePayload`, `resolveFieldColumns`'s type fallback, `getDefaultLinkageTerms`).
+ * type- or payload-driven consumer therefore excludes `ignored` explicitly:
+ * `preparePayload`, `resolveFieldColumns` (both binding rules), `getDefaultLinkageTerms`,
+ * and the date-format inference in `prepareForExchange`.
  */
 export const ColumnRoleSchema = z.enum([
   "linkage",

--- a/packages/core/src/defaults/linkageTerms.ts
+++ b/packages/core/src/defaults/linkageTerms.ts
@@ -208,7 +208,13 @@ export function getDefaultLinkageTerms(
 ): LinkageTerms {
   let linkageKeys: LinkageKey[];
   if (metadata !== undefined && metadata.length > 0) {
-    const availableTypes = new Set(metadata.map((m) => m.type));
+    // Exclude `role: ignored` columns: a key kept solely because an ignored
+    // column supplies the only instance of its type would then bind that ignored
+    // column at exchange time (resolveFieldColumns skips it, so the field would
+    // resolve to nothing) -- drop the key here instead of building an unusable one.
+    const availableTypes = new Set(
+      metadata.filter((m) => m.role !== "ignored").map((m) => m.type),
+    );
     linkageKeys = DEFAULT_LINKAGE_KEYS.filter((key) =>
       key.elements.every((el) => availableTypes.has(el.field as SemanticType)),
     );

--- a/packages/core/src/exchange.ts
+++ b/packages/core/src/exchange.ts
@@ -125,7 +125,12 @@ export function prepareForExchange(
 
   let dateInputFormat: string | undefined;
   if (exchangeDataSpec.standardization === undefined) {
-    const dobCol = metadata.find((c) => c.type === "date_of_birth");
+    // Skip `role: ignored` columns: an ignored date_of_birth column does not
+    // participate in linkage, so it must not drive the inferred date format
+    // either (and resolveFieldColumns would not bind it as the dob field).
+    const dobCol = metadata.find(
+      (c) => c.type === "date_of_birth" && c.role !== "ignored",
+    );
     if (dobCol !== undefined) {
       dateInputFormat = inferDateFormat(
         rawRows.map((row) => row[dobCol.name] ?? ""),

--- a/packages/core/src/payloadExchange.ts
+++ b/packages/core/src/payloadExchange.ts
@@ -77,15 +77,20 @@ export type PayloadWireMessage = z.infer<typeof payloadWireSchema>;
  * Prepares the payload message to send after PSI linkage.
  *
  * Gathers all `isPayload` columns from the matched rows (indexed by
- * `associationTable[0]`) and packages them for transmission. Returns a
- * no-data message when the dataset has no payload columns or no matched rows.
+ * `associationTable[0]`) and packages them for transmission. A `role: ignored`
+ * column is never transmitted, regardless of its `isPayload` value -- the role
+ * is the explicit "use this column for nothing" opt-out, so it wins over any
+ * `isPayload: true` left on the column. Returns a no-data message when the
+ * dataset has no transmittable payload columns or no matched rows.
  */
 export function preparePayload(
   rawRows: Array<Record<string, string>>,
   metadata: Metadata,
   associationTable: AssociationTable,
 ): PayloadWireMessage {
-  const payloadCols = metadata.filter((col) => col.isPayload);
+  const payloadCols = metadata.filter(
+    (col) => col.isPayload && col.role !== "ignored",
+  );
   if (payloadCols.length === 0 || associationTable[0].length === 0) {
     return { hasData: false };
   }

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -743,9 +743,11 @@ export interface FieldColumnResolution {
  *    present in the data. (When two transformations name the same output the
  *    last wins, matching the builder's field map and the checker's old mapping.)
  * 2. Type fallback: otherwise the field binds to the FIRST `metadata` column of
- *    its semantic type (`metadata.find(c => c.type === field.type)`), or to
+ *    its semantic type that is not `role: ignored`
+ *    (`metadata.find(c => c.type === field.type && c.role !== "ignored")`), or to
  *    nothing when no such column exists. First-match -- not "any same-typed
- *    column" -- because the exchange reads exactly that column.
+ *    column" -- because the exchange reads exactly that column. An ignored column
+ *    is skipped even when it is the only one of its type, so it never links.
  *
  * Binding is independent of whether the bound column is present in the input:
  * the builder reads rows from the column and a presence-only consumer layers the
@@ -778,7 +780,14 @@ export function resolveFieldColumns(
       resolution.set(field.name, { column: transform.input, transform });
       continue;
     }
-    const col = metadata.find((c) => c.type === field.type);
+    // Skip `role: ignored` columns: the linkage path keys on `type`, not
+    // `role`, so an ignored column of the field's type would otherwise bind here
+    // and participate in linkage. This is the one chokepoint the builder, the
+    // satisfiability checker, and the default-standardization derivation share,
+    // so excluding it once keeps an ignored column out of all three.
+    const col = metadata.find(
+      (c) => c.type === field.type && c.role !== "ignored",
+    );
     resolution.set(field.name, { column: col?.name, transform: undefined });
   }
   return resolution;
@@ -789,7 +798,7 @@ export function resolveFieldColumns(
  * each field to an input column via {@link resolveFieldColumns}: an explicit
  * standardization transformation when one names the field (its steps run on the
  * bound column), otherwise the identity transformation over the first metadata
- * column of the field's semantic type.
+ * column of the field's semantic type that is not `role: ignored`.
  *
  * Linkage fields that resolve to no column are absent from the dataset; records
  * referencing those fields are excluded from the corresponding linkage keys.
@@ -1048,9 +1057,9 @@ export function validateStandardizationAgainstTerms(
  * Because the binding is shared, the resolution rules apply unchanged: an
  * explicit standardization preempts the type fallback (a field whose explicit
  * source column is absent is unsatisfiable even when a same-typed column exists),
- * and the type fallback binds to the FIRST metadata column of the field's type.
- * An empty result means every configured field can be produced; a non-empty
- * result names the fields that cannot.
+ * and the type fallback binds to the FIRST non-`ignored` metadata column of the
+ * field's type. An empty result means every configured field can be produced; a
+ * non-empty result names the fields that cannot.
  *
  * Pass `metadata` to match an exchange that runs from an explicit metadata block
  * (`prepareForExchange` resolves the type fallback against

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -740,8 +740,11 @@ export interface FieldColumnResolution {
  * 1. Explicit standardization preempts the type fallback: if `standardization`
  *    carries a transformation whose `output` is the field name, the field binds
  *    to that transformation's `input` column -- whether or not the column is
- *    present in the data. (When two transformations name the same output the
- *    last wins, matching the builder's field map and the checker's old mapping.)
+ *    present in the data -- UNLESS that column is `role: ignored`, in which case
+ *    the field binds to nothing: `ignored` ("never participates in linkage")
+ *    wins over a contradictory explicit transform. (When two transformations name
+ *    the same output the last wins, matching the builder's field map and the
+ *    checker's old mapping.)
  * 2. Type fallback: otherwise the field binds to the FIRST `metadata` column of
  *    its semantic type that is not `role: ignored`
  *    (`metadata.find(c => c.type === field.type && c.role !== "ignored")`), or to
@@ -777,7 +780,18 @@ export function resolveFieldColumns(
   for (const field of terms.linkageFields) {
     const transform = explicit.get(field.name);
     if (transform !== undefined) {
-      resolution.set(field.name, { column: transform.input, transform });
+      // An explicit standardization naming a `role: ignored` column must not
+      // bind it into linkage: `ignored` means "never participates in linkage",
+      // and that wins over a contradictory explicit transform. The field then
+      // resolves to no column (surfacing as unsatisfiable through the shared
+      // checker) rather than silently linking a column the operator excluded.
+      const inputIgnored =
+        metadata.find((c) => c.name === transform.input)?.role === "ignored";
+      if (inputIgnored) {
+        resolution.set(field.name, { column: undefined, transform: undefined });
+      } else {
+        resolution.set(field.name, { column: transform.input, transform });
+      }
       continue;
     }
     // Skip `role: ignored` columns: the linkage path keys on `type`, not

--- a/packages/core/test/metadata.test.ts
+++ b/packages/core/test/metadata.test.ts
@@ -231,6 +231,56 @@ test.each([
   expect(result.success).toBe(false);
 });
 
+// ─── role: ignored ────────────────────────────────────────────────────────────
+
+test("safeParseMetadata accepts role: ignored", () => {
+  const result = safeParseMetadata([
+    { name: "COUNTY", type: "other", role: "ignored", is_payload: false },
+  ]);
+  expect(result.success).toBe(true);
+  if (!result.success) return;
+  expect(result.data[0].role).toBe("ignored");
+});
+
+test("safeParseMetadata accepts role: ignored with is_payload: true (accept-but-ignore)", () => {
+  // The is_payload + ignored open question is resolved as accept-but-ignore: the
+  // schema accepts any is_payload on an ignored column; transmission is suppressed
+  // at the preparePayload chokepoint (see payloadExchange.test.ts), not at parse.
+  const result = safeParseMetadata([
+    { name: "COUNTY", type: "other", role: "ignored", is_payload: true },
+  ]);
+  expect(result.success).toBe(true);
+  if (!result.success) return;
+  expect(result.data[0]).toEqual({
+    name: "COUNTY",
+    type: "other",
+    role: "ignored",
+    isPayload: true,
+  });
+});
+
+test("safeParseMetadata rejects an unknown role", () => {
+  const result = safeParseMetadata([
+    { name: "c", type: "other", role: "excluded", is_payload: false },
+  ]);
+  expect(result.success).toBe(false);
+});
+
+test("inferMetadata never assigns role: ignored", () => {
+  // ignored is opt-in (user intent, not inferable): inference only ever emits
+  // linkage, identifier, or payload. Exercise linkage, canonical-identifier,
+  // _id-suffix, promoted-single-id, and unknown columns together.
+  const result = inferMetadata([
+    "ssn",
+    "first_name",
+    "identifier",
+    "client_id",
+    "member_id",
+    "program_start_date",
+  ]);
+  expect(result.every((c) => c.role !== "ignored")).toBe(true);
+});
+
 test("a rejected metadata type is not echoed in the parse error", () => {
   // The metadata `type` is a z.enum(SEMANTIC_TYPES) reached by the operator-config
   // path (loadConfigLinkageSource), which relays the Zod issue message verbatim.

--- a/packages/core/test/metadata.test.ts
+++ b/packages/core/test/metadata.test.ts
@@ -231,6 +231,42 @@ test.each([
   expect(result.success).toBe(false);
 });
 
+// ─── column-name uniqueness ───────────────────────────────────────────────────
+
+test("safeParseMetadata rejects duplicate column names", () => {
+  const result = safeParseMetadata([
+    { name: "X", type: "other", role: "ignored", is_payload: false },
+    { name: "X", type: "other", role: "payload", is_payload: true },
+  ]);
+  expect(result.success).toBe(false);
+});
+
+test("safeParseMetadata does not echo a duplicated name in the error", () => {
+  // The name is operator-authored and may carry control/ANSI/bidi bytes; the
+  // uniqueness refine reports a static message, never the offending name.
+  const evil = "\x1b[31mDUP\x1b[0m‮";
+  const result = safeParseMetadata([
+    { name: evil, type: "other", role: "payload", is_payload: true },
+    { name: evil, type: "other", role: "payload", is_payload: true },
+  ]);
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.message).not.toContain("DUP");
+    expect(result.error.message).not.toContain("\x1b");
+    expect(result.error.message).not.toContain("‮");
+  }
+});
+
+test("safeParseMetadata accepts names differing only in case (matching is exact)", () => {
+  // Column identity is case-sensitive everywhere a column is read by name, so
+  // "X" and "x" are distinct columns, not a duplicate.
+  const result = safeParseMetadata([
+    { name: "X", type: "other", role: "payload", is_payload: true },
+    { name: "x", type: "other", role: "payload", is_payload: true },
+  ]);
+  expect(result.success).toBe(true);
+});
+
 // ─── role: ignored ────────────────────────────────────────────────────────────
 
 test("safeParseMetadata accepts role: ignored", () => {

--- a/packages/core/test/payloadExchange.test.ts
+++ b/packages/core/test/payloadExchange.test.ts
@@ -91,6 +91,57 @@ test("preparePayload: missing column value becomes null", () => {
   expect(result.rows[0]).toEqual(["P0", null]);
 });
 
+test("preparePayload: ignored column is never transmitted, even with isPayload:true", () => {
+  // The role: ignored opt-out wins over isPayload (accept-but-ignore resolution
+  // of the is_payload + ignored open question). diagnosis is a normal payload
+  // column; county is ignored despite isPayload:true and must not be sent.
+  const metaWithIgnored: Metadata = [
+    { name: "ssn", type: "ssn", role: "linkage", isPayload: false },
+    { name: "diagnosis", type: "other", role: "payload", isPayload: true },
+    { name: "county", type: "other", role: "ignored", isPayload: true },
+  ];
+  const withCounty = rawRows.map((r) => ({ ...r, county: "DC" }));
+  const result = preparePayload(withCounty, metaWithIgnored, [[0], [0]]);
+  if (!result.hasData) throw new Error("expected hasData:true");
+  expect(result.columns).toEqual(["diagnosis"]);
+  expect(result.columns).not.toContain("county");
+});
+
+test("preparePayload: a dataset whose only isPayload column is ignored has no data", () => {
+  const metaOnlyIgnored: Metadata = [
+    { name: "ssn", type: "ssn", role: "linkage", isPayload: false },
+    { name: "county", type: "other", role: "ignored", isPayload: true },
+  ];
+  const result = preparePayload(rawRows, metaOnlyIgnored, [[0], [0]]);
+  expect(result).toEqual({ hasData: false });
+});
+
+test("buildOutputTable: an ignored column is not treated as the identifier", () => {
+  // patient_id is present but marked ignored, so it is not the output identifier;
+  // the header falls back to row_id just as it does with no identifier column.
+  const metaIgnoredId: Metadata = [
+    { name: "ssn", type: "ssn", role: "linkage", isPayload: false },
+    {
+      name: "patient_id",
+      type: "identifier",
+      role: "ignored",
+      isPayload: false,
+    },
+  ];
+  const partnerPayload: PartnerPayload = {
+    columns: ["partner_id"],
+    rowIndices: [0],
+    rows: [["Q0"]],
+  };
+  const { headers } = buildOutputTable(
+    [[0], [0]],
+    rawRows,
+    metaIgnoredId,
+    partnerPayload,
+  );
+  expect(headers[0]).toBe("row_id");
+});
+
 // --- exchangePayloads --------------------------------------------------------
 
 async function runExchangePayloads(

--- a/packages/core/test/standardization.test.ts
+++ b/packages/core/test/standardization.test.ts
@@ -1356,6 +1356,34 @@ describe("resolveFieldColumns", () => {
     expect(resolution.get("ssn")?.column).toBeUndefined();
   });
 
+  const roledCol = (
+    name: string,
+    type: ColumnMetadata["type"],
+    role: ColumnMetadata["role"],
+  ): ColumnMetadata => ({ name, type, role, isPayload: false });
+
+  test("an ignored column never binds a linkage field, even as the only one of its type", () => {
+    // The linkage path keys on `type`, not `role`, so an ignored ssn column would
+    // otherwise type-fall-back into the ssn field. It must resolve to no column.
+    const resolution = resolveFieldColumns(terms, undefined, [
+      roledCol("ssn", "ssn", "ignored"),
+      roledCol("last_name", "last_name", "linkage"),
+    ]);
+    expect(resolution.get("ssn")?.column).toBeUndefined();
+    expect(resolution.get("lastName")?.column).toBe("last_name");
+  });
+
+  test("the type fallback skips an ignored column to bind a later non-ignored one", () => {
+    // First-match would pick the ignored column; the ignored exclusion makes the
+    // fallback bind the non-ignored same-typed column listed after it.
+    const resolution = resolveFieldColumns(terms, undefined, [
+      roledCol("ignored_ssn", "ssn", "ignored"),
+      roledCol("real_ssn", "ssn", "linkage"),
+      roledCol("last_name", "last_name", "linkage"),
+    ]);
+    expect(resolution.get("ssn")?.column).toBe("real_ssn");
+  });
+
   test("a duplicate explicit output binds to the last one", () => {
     // Not reachable through the schema (it forbids duplicate outputs) but pinned
     // so the builder's field map and the checker stay in agreement on the rule.
@@ -1368,6 +1396,55 @@ describe("resolveFieldColumns", () => {
       inferMetadata(["first_src", "second_src"]),
     );
     expect(resolution.get("ssn")?.column).toBe("second_src");
+  });
+});
+
+// --- getDefaultLinkageTerms: role: ignored -----------------------------------
+
+describe("getDefaultLinkageTerms — ignored columns", () => {
+  const linkageCol = (
+    name: string,
+    type: ColumnMetadata["type"],
+  ): ColumnMetadata => ({ name, type, role: "linkage", isPayload: false });
+
+  test("a type supplied only by an ignored column is excluded from the keys", () => {
+    // ssn is present in the input but marked ignored; every other linkage type is
+    // a normal linkage column. No surviving key may reference ssn/ssn4, and ssn
+    // must not appear among the derived linkage fields.
+    const metadata: ColumnMetadata[] = [
+      { name: "SSN", type: "ssn", role: "ignored", isPayload: false },
+      linkageCol("FN", "first_name"),
+      linkageCol("LN", "last_name"),
+      linkageCol("DOB", "date_of_birth"),
+    ];
+    const terms = getDefaultLinkageTerms("Agency A", metadata);
+
+    const referencesSsn = terms.linkageKeys.some((k) =>
+      k.elements.some((el) => el.field === "ssn" || el.field === "ssn4"),
+    );
+    expect(referencesSsn).toBe(false);
+    expect(terms.linkageFields.some((f) => f.name === "ssn")).toBe(false);
+    // The pure-name key (LN + FN + DOB) needs no ssn, so it still survives.
+    expect(terms.linkageKeys.length).toBeGreaterThan(0);
+  });
+
+  test("marking a type ignored drops the keys an equivalent linkage column would keep", () => {
+    const base: ColumnMetadata[] = [
+      linkageCol("FN", "first_name"),
+      linkageCol("LN", "last_name"),
+      linkageCol("DOB", "date_of_birth"),
+    ];
+    const withSsnLinkage = getDefaultLinkageTerms("Agency A", [
+      linkageCol("SSN", "ssn"),
+      ...base,
+    ]);
+    const withSsnIgnored = getDefaultLinkageTerms("Agency A", [
+      { name: "SSN", type: "ssn", role: "ignored", isPayload: false },
+      ...base,
+    ]);
+    expect(withSsnIgnored.linkageKeys.length).toBeLessThan(
+      withSsnLinkage.linkageKeys.length,
+    );
   });
 });
 

--- a/packages/core/test/standardization.test.ts
+++ b/packages/core/test/standardization.test.ts
@@ -1373,6 +1373,23 @@ describe("resolveFieldColumns", () => {
     expect(resolution.get("lastName")?.column).toBe("last_name");
   });
 
+  test("an explicit standardization naming an ignored column does not bind it into linkage", () => {
+    // role: ignored wins over a contradictory explicit transform -- the field
+    // resolves to no column (surfacing as unsatisfiable) rather than silently
+    // linking a column the operator marked excluded. Without this, the explicit
+    // binding (rule 1) would bypass the type-fallback ignored guard.
+    const resolution = resolveFieldColumns(
+      terms,
+      [{ output: "ssn", input: "secret_ssn" }],
+      [
+        roledCol("secret_ssn", "ssn", "ignored"),
+        roledCol("last_name", "last_name", "linkage"),
+      ],
+    );
+    expect(resolution.get("ssn")?.column).toBeUndefined();
+    expect(resolution.get("ssn")?.transform).toBeUndefined();
+  });
+
   test("the type fallback skips an ignored column to bind a later non-ignored one", () => {
     // First-match would pick the ignored column; the ignored exclusion makes the
     // fallback bind the non-ignored same-typed column listed after it.


### PR DESCRIPTION
## Summary

Add `ignored` as a column-metadata role so an operator can keep a column in their input file while declaring that this exchange must not use it. An `ignored` column never participates in linkage, is never treated as the output identifier, and is never transmitted as payload -- regardless of its semantic `type` or its `is_payload` value. This closes the gap that previously forced an unused column to be mislabeled `payload`, and restores the `docs/EXCHANGE_REFERENCE.md` `COUNTY` example to `role: ignored`.

Implements [192973880](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=192973880).

## Changes

- `packages/core/src/config/metadata.ts`: add `ignored` to `ColumnRoleSchema` (and document the role and its consumers); reject duplicate column names in a metadata block with a static, name-free message, mirroring the linkage-field / linkage-key uniqueness refines.
- `packages/core/src/standardization.ts`: exclude `ignored` columns at both `resolveFieldColumns` binding rules -- the semantic-type fallback and the explicit-standardization input -- so the one shared chokepoint keeps an ignored column out of the dataset builder, the satisfiability checker, and the default-standardization derivation at once.
- `packages/core/src/payloadExchange.ts`: `preparePayload` filters out `ignored` columns, so an ignored column is never transmitted even with `is_payload: true` (the role wins; accept-but-ignore).
- `packages/core/src/defaults/linkageTerms.ts`: `getDefaultLinkageTerms` builds `availableTypes` from non-ignored columns, so a default key kept only because an ignored column supplied its type is dropped rather than built unusable.
- `packages/core/src/exchange.ts`: the `date_of_birth` date-format inference in `prepareForExchange` skips ignored columns.
- `docs/EXCHANGE_REFERENCE.md`: restore the `COUNTY` example to `role: ignored`, list `ignored` in the role table (noted opt-in, never inferred), document the `is_payload` interaction, and note column-name uniqueness.
- `CHANGELOG.md`: Added (the `ignored` role) and Changed (metadata column-name uniqueness).
- Tests (`metadata.test.ts`, `standardization.test.ts`, `payloadExchange.test.ts`): cover parse, inference, every exclusion route, the explicit-standardization edge, and name uniqueness.

## Test plan

Ran: `npm test -w packages/core` (1473 passed), `npm run test:unit -w apps/cli` (859), `npm run test:unit -w apps/web` (199), plus `npm run typecheck`, `npm run lint`, `npm run format` -- all clean. Integration suites run in CI.

New tests cover: `role: ignored` parses (including with `is_payload: true`); inference never emits `ignored`; an ignored column is excluded from linkage via both binding rules (type fallback and explicit standardization), from the default key set, from payload transmission, and from identifier selection; and a metadata block with duplicate column names is rejected without echoing the offending name.

## Background

Nothing in the linkage/key-building path consults `role` -- it binds input columns to linkage fields by their semantic `type` (and by explicit-standardization input name). An `ignored` column therefore is not coerced out of linkage by a role default; it would leak in via its `type` unless each type- and payload-driven consumer excludes it explicitly. The exclusion is added at each such consumer, with the resolution primitive `resolveFieldColumns` as the shared chokepoint for the three linkage-binding consumers. The duplicate-name rejection backs this up: every consumer treats metadata as keyed by name, so a duplicate name made the ignored exclusion silently position-dependent.

## Out of scope / follow-on

- Cross-validate `linkage_terms.payload.send`/`receive` declarations against the metadata `is_payload`/`role` transmission gate (a consent/record-accuracy consistency gap, disclosure-safe direction, pre-existing): [202710475](https://github.com/orgs/georgetown-mdi/projects/9/?itemId=202710475).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages -- `docs/EXCHANGE_REFERENCE.md` (Input metadata: role table, `COUNTY` example, `is_payload` interaction, name uniqueness); no `docs/spec/` page covers metadata roles, so none changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- Added: the `ignored` role; Changed: metadata column-name uniqueness.
- [x] Security review -- applies (changes payload-transmission gating and linkage participation -- "what is disclosed"). The branch was independently reviewed across the disclosure and linkage surfaces (every value-bearing channel -- wire payload, PSI linkage key, output CSV, exchange record -- traced gated against `ignored`, independent of `type`/`is_payload`).