### PR TITLE
Export standardization-function descriptor table

### DIFF
--- a/docs/EXCHANGE_REFERENCE.md
+++ b/docs/EXCHANGE_REFERENCE.md
@@ -941,7 +941,7 @@ Parameter names below are written in snake_case in YAML (e.g. `input_format`, `i
 | `pad_left` | Left-pad the value with a fill character up to a target length; pass-through if already at or above the length | `length` (positive integer, required), `char` (single character, default `"0"`) |
 | `phonetic` | Apply a phonetic encoding | `algorithm`: `soundex` (default); result is a 4-character string |
 | `replace_regex` | Replace all regex matches | `pattern` (required), `replacement` (default `""`) |
-| `extract_regex` | Keep only the first capture group; produce `null` if no match | `pattern` (required) |
+| `extract_regex` | Keep the first capture group, or the whole match if the pattern has none; produce `null` if there is no match or the result is empty | `pattern` (required) |
 
 #### Null-producing (filter) functions
 

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -622,10 +622,14 @@ export const STANDARDIZATION_FUNCTION_DESCRIPTORS: Record<
     label: "Substring",
     blurb: "Keep a fixed slice of the value by start position and length.",
     tier: "standard",
+    // The factory does no numeric validation -- it relies on String.slice, which
+    // tolerates fractional and negative bounds -- so the schema is deliberately
+    // stricter than the factory here, rejecting footgun shapes (a fractional
+    // position, a non-positive length, a 0 start) that slice would silently
+    // mangle. 0 is rejected because the factory treats it as a no-op returning an
+    // always-null fn; positions are 1-indexed, with a negative start counting
+    // from the end.
     params: z.object({
-      // 1-indexed; a negative start counts from the end. 0 is rejected -- the
-      // factory treats it as a no-op (always null), so it is never a useful
-      // editor value.
       start: z
         .number()
         .int()
@@ -672,7 +676,7 @@ export const STANDARDIZATION_FUNCTION_DESCRIPTORS: Record<
     name: "phonetic",
     label: "Phonetic encoding",
     blurb:
-      "Replace the value with a sound-alike phonetic code so names that sound alike can match.",
+      "Replace the value with a sound-alike phonetic code so names that sound alike can match; drops a value with no letters.",
     tier: "standard",
     // Only soundex is implemented; the factory throws on any other algorithm, so
     // the schema admits only what the factory accepts.
@@ -707,7 +711,7 @@ export const STANDARDIZATION_FUNCTION_DESCRIPTORS: Record<
     name: "extract_regex",
     label: "Extract (regex)",
     blurb:
-      "Keep the first regular-expression capture group, or the whole match if the pattern has none; drop the value on no match.",
+      "Keep the first regular-expression capture group, or the whole match if the pattern has none; drop the value on no match or an empty result.",
     tier: "regex",
     params: z.object({
       pattern: regexPatternSchema,

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -641,6 +641,11 @@ export const STANDARDIZATION_FUNCTION_DESCRIPTORS: Record<
     blurb:
       "Reformat a date between token layouts (YYYY, MM, DD) so different formats can match.",
     tier: "standard",
+    // Format strings are bounded to non-empty only, not their token content: a
+    // tokenless format is accepted, mirroring the factory, which builds a regex
+    // from any string and simply matches little (yielding null) rather than
+    // throwing. Requiring a YYYY/MM/DD token would reject a shape the factory
+    // accepts; surfacing tokenless formats is editor guidance, not validation.
     params: z.object({
       inputFormat: z.string().min(1).default("MM/DD/YYYY"),
       outputFormat: z.string().min(1).default("YYYYMMDD"),

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -384,10 +384,11 @@ function splitOnFactory(params: Params): StandardizingFn {
   };
 }
 
-// Each entry here must also be documented in
-// docs/EXCHANGE_REFERENCE.md § "Available functions" and given a descriptor in
-// STANDARDIZATION_FUNCTION_DESCRIPTORS below (its drift test fails CI on a
-// function added here without one, and vice versa).
+// Each entry here must also be given a descriptor in
+// STANDARDIZATION_FUNCTION_DESCRIPTORS below -- its drift test fails CI on a
+// function added here without a descriptor, and vice versa -- and be documented
+// in docs/EXCHANGE_REFERENCE.md § "Available functions", which is a prose
+// obligation no test enforces.
 //
 // NFC-comparison contract: any step that matches an authored value, pattern, or
 // delimiter against the intermediate value must NFC-normalize that value before

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -491,6 +491,13 @@ export interface StandardizationFunctionDescriptor {
    * params, which stay `z.unknown()` and are count-bounded in
    * `config/linkageTerms.ts`. The drift test pins each schema against its factory
    * so a descriptor cannot disagree with the function it describes.
+   *
+   * Typed `ZodObject<ZodRawShape>` rather than a per-function shape because the
+   * table is homogeneous (a `Record` over one descriptor type). An editor drives
+   * form fields by iterating `params.shape` at RUNTIME, where each entry is its
+   * concrete Zod type (`ZodNumber`, `ZodEnum`, ...); the interface widens the
+   * static shape to `ZodRawShape`, so a consumer that wants a param's static type
+   * narrows the concrete schema, not this field.
    */
   params: z.ZodObject<z.ZodRawShape>;
 }
@@ -501,7 +508,8 @@ const noParams = z.object({});
 /**
  * A user-authored regular-expression param. Required, and validated to compile,
  * mirroring each regex factory's `new RegExp(pattern)` (which throws on an
- * invalid pattern). The danger-tier gate against catastrophic backtracking is the
+ * invalid pattern; `replace_regex` adds the global flag, which does not affect
+ * validity). The danger-tier gate against catastrophic backtracking is the
  * editor's responsibility; this only rejects a syntactically invalid pattern.
  */
 const regexPatternSchema = z
@@ -694,7 +702,7 @@ export const STANDARDIZATION_FUNCTION_DESCRIPTORS: Record<
     name: "extract_regex",
     label: "Extract (regex)",
     blurb:
-      "Keep only the first regular-expression capture group; drop the value on no match.",
+      "Keep the first regular-expression capture group, or the whole match if the pattern has none; drop the value on no match.",
     tier: "regex",
     params: z.object({
       pattern: regexPatternSchema,

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { getLogger } from "./utils/logger.js";
 import { sanitizeForDisplay } from "./utils/sanitizeForDisplay.js";
 import type {
@@ -384,7 +385,9 @@ function splitOnFactory(params: Params): StandardizingFn {
 }
 
 // Each entry here must also be documented in
-// docs/EXCHANGE_REFERENCE.md § "Available functions".
+// docs/EXCHANGE_REFERENCE.md § "Available functions" and given a descriptor in
+// STANDARDIZATION_FUNCTION_DESCRIPTORS below (its drift test fails CI on a
+// function added here without one, and vice versa).
 //
 // NFC-comparison contract: any step that matches an authored value, pattern, or
 // delimiter against the intermediate value must NFC-normalize that value before
@@ -438,6 +441,296 @@ export const STANDARDIZATION_FUNCTION_NAMES: readonly string[] = [
   ...Object.keys(STANDARDIZING_FUNCTIONS),
   "coalesce",
 ];
+
+// --- Function descriptors ----------------------------------------------------
+
+/**
+ * The authoring-risk tier of a standardization function.
+ *
+ * - `standard` -- every function whose params are plain typed values.
+ * - `regex` -- the raw-pattern family (`replace_regex`, `extract_regex`,
+ *   `filter_regex`, `split_on`), whose param is an operator-authored regular
+ *   expression. This is the danger tier: an editor must gate raw-pattern
+ *   authoring behind a catastrophic-backtracking-aware affordance, because an
+ *   unbounded user pattern can hang on adversarial input. The descriptor marks
+ *   the tier; enforcing the gate is the editor's responsibility.
+ */
+export type StandardizationFunctionTier = "standard" | "regex";
+
+/**
+ * A single standardization function's editor-facing descriptor: enough for a web
+ * step editor to render a typed, plain-language input for it without re-encoding
+ * the function's parameter shape, label, or risk tier.
+ *
+ * The descriptor table {@link STANDARDIZATION_FUNCTION_DESCRIPTORS} is the single
+ * source of truth both expert editors (the linkage-terms transform editor and the
+ * metadata/standardization editor) drive their parameterized step UIs from, kept
+ * in lockstep with {@link STANDARDIZATION_FUNCTION_NAMES} -- and so with the
+ * {@link STANDARDIZING_FUNCTIONS} registry it derives from -- by a parity test in
+ * both directions.
+ */
+export interface StandardizationFunctionDescriptor {
+  /** The snake_case function name core dispatches on; equals the table key. */
+  name: string;
+  /** Human-readable label for an editor control (e.g. "Pad left"). */
+  label: string;
+  /** One-line plain-language description of what the function does. */
+  blurb: string;
+  /** The authoring-risk tier; see {@link StandardizationFunctionTier}. */
+  tier: StandardizationFunctionTier;
+  /**
+   * Typed Zod schema for the function's `params` object, so an editor can drive
+   * form fields off `params.shape` and validate authored params.
+   *
+   * KEYS are camelCase, matching the runtime params each factory reads AFTER
+   * {@link camelizeKeys} (e.g. `inputFormat`, `includeOriginal`), not the
+   * snake_case an operator writes in YAML. A defaulted param carries its default
+   * via Zod `.default(...)`, so a parse of omitted params yields the same value
+   * the factory falls back to. These schemas describe well-formed editor output
+   * (a value, or an omitted default); they are NOT the partner-supplied wire
+   * params, which stay `z.unknown()` and are count-bounded in
+   * `config/linkageTerms.ts`. The drift test pins each schema against its factory
+   * so a descriptor cannot disagree with the function it describes.
+   */
+  params: z.ZodObject<z.ZodRawShape>;
+}
+
+/** Functions that take no params: their `params` schema accepts an empty object. */
+const noParams = z.object({});
+
+/**
+ * A user-authored regular-expression param. Required, and validated to compile,
+ * mirroring each regex factory's `new RegExp(pattern)` (which throws on an
+ * invalid pattern). The danger-tier gate against catastrophic backtracking is the
+ * editor's responsibility; this only rejects a syntactically invalid pattern.
+ */
+const regexPatternSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (pattern) => {
+      try {
+        new RegExp(pattern);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: "must be a valid regular expression" },
+  );
+
+/**
+ * Editor-facing descriptor for every standardization function the library
+ * recognizes -- every member of {@link STANDARDIZING_FUNCTIONS} plus `coalesce`.
+ * Co-located with the registry so a new function is added beside its descriptor;
+ * the parity test enforces that neither can ship without the other.
+ *
+ * Param schemas are pinned to their factory behavior by the drift test: each
+ * accepts the well-formed param shapes its factory accepts and rejects malformed
+ * ones (e.g. `pad_left` rejects a non-positive `length` and a multi-character
+ * `char`, exactly as its factory throws).
+ */
+export const STANDARDIZATION_FUNCTION_DESCRIPTORS: Record<
+  string,
+  StandardizationFunctionDescriptor
+> = {
+  remove_non_ascii: {
+    name: "remove_non_ascii",
+    label: "Remove non-ASCII",
+    blurb:
+      "Drop every character outside the ASCII set (accented letters, emoji, symbols).",
+    tier: "standard",
+    params: noParams,
+  },
+  replace_separators_with_spaces: {
+    name: "replace_separators_with_spaces",
+    label: "Replace separators with spaces",
+    blurb:
+      "Turn hyphens, apostrophes, ampersands, slashes, and underscores into spaces.",
+    tier: "standard",
+    params: noParams,
+  },
+  squash_spaces: {
+    name: "squash_spaces",
+    label: "Squash spaces",
+    blurb: "Collapse runs of whitespace into a single space.",
+    tier: "standard",
+    params: noParams,
+  },
+  remove_punctuation: {
+    name: "remove_punctuation",
+    label: "Remove punctuation",
+    blurb:
+      "Remove ASCII punctuation and symbols, keeping letters, digits, and spaces.",
+    tier: "standard",
+    params: noParams,
+  },
+  remove_dashes: {
+    name: "remove_dashes",
+    label: "Remove dashes",
+    blurb: "Remove hyphens from the value.",
+    tier: "standard",
+    params: noParams,
+  },
+  trim_whitespace: {
+    name: "trim_whitespace",
+    label: "Trim whitespace",
+    blurb: "Remove leading and trailing whitespace.",
+    tier: "standard",
+    params: noParams,
+  },
+  to_upper_case: {
+    name: "to_upper_case",
+    label: "Uppercase",
+    blurb:
+      "Convert the value to uppercase so values differing only in case can match.",
+    tier: "standard",
+    params: noParams,
+  },
+  to_lower_case: {
+    name: "to_lower_case",
+    label: "Lowercase",
+    blurb:
+      "Convert the value to lowercase so values differing only in case can match.",
+    tier: "standard",
+    params: noParams,
+  },
+  remove_accents: {
+    name: "remove_accents",
+    label: "Remove accents",
+    blurb: "Strip accents and diacritics, keeping the base letters.",
+    tier: "standard",
+    params: noParams,
+  },
+  remove_affixes: {
+    name: "remove_affixes",
+    label: "Remove affixes",
+    blurb: "Remove name titles (Mr., Dr.) and suffixes (Jr., III).",
+    tier: "standard",
+    params: noParams,
+  },
+  substring: {
+    name: "substring",
+    label: "Substring",
+    blurb: "Keep a fixed slice of the value by start position and length.",
+    tier: "standard",
+    params: z.object({
+      // 1-indexed; a negative start counts from the end. 0 is rejected -- the
+      // factory treats it as a no-op (always null), so it is never a useful
+      // editor value.
+      start: z
+        .number()
+        .int()
+        .refine((n) => n !== 0, {
+          message: "start must not be 0 (positions are 1-indexed)",
+        }),
+      length: z.number().int().positive(),
+    }),
+  },
+  parse_date: {
+    name: "parse_date",
+    label: "Parse date",
+    blurb:
+      "Reformat a date between token layouts (YYYY, MM, DD) so different formats can match.",
+    tier: "standard",
+    params: z.object({
+      inputFormat: z.string().min(1).default("MM/DD/YYYY"),
+      outputFormat: z.string().min(1).default("YYYYMMDD"),
+    }),
+  },
+  pad_left: {
+    name: "pad_left",
+    label: "Pad left",
+    blurb: "Left-pad the value with a fill character up to a target length.",
+    tier: "standard",
+    params: z.object({
+      length: z.number().int().positive(),
+      // Exactly one character after NFC normalization, mirroring the factory's
+      // own check (a multi-unit fill corrupts padStart's cycling).
+      char: z
+        .string()
+        .refine((c) => c.normalize("NFC").length === 1, {
+          message: "char must be exactly one character",
+        })
+        .default("0"),
+    }),
+  },
+  phonetic: {
+    name: "phonetic",
+    label: "Phonetic encoding",
+    blurb:
+      "Replace the value with a sound-alike phonetic code so names that sound alike can match.",
+    tier: "standard",
+    // Only soundex is implemented; the factory throws on any other algorithm, so
+    // the schema admits only what the factory accepts.
+    params: z.object({
+      algorithm: z.enum(["soundex"]).default("soundex"),
+    }),
+  },
+  null_if: {
+    name: "null_if",
+    label: "Null if",
+    blurb: "Drop the value when it matches one of the listed values.",
+    tier: "standard",
+    // Either a single `value` or a list of `values`; the factory reads `values`
+    // first and falls back to `value`, treating neither as an empty exclusion
+    // list, so both are optional.
+    params: z.object({
+      value: z.string().optional(),
+      values: z.array(z.string()).optional(),
+    }),
+  },
+  replace_regex: {
+    name: "replace_regex",
+    label: "Replace (regex)",
+    blurb: "Replace every regular-expression match with a replacement string.",
+    tier: "regex",
+    params: z.object({
+      pattern: regexPatternSchema,
+      replacement: z.string().default(""),
+    }),
+  },
+  extract_regex: {
+    name: "extract_regex",
+    label: "Extract (regex)",
+    blurb:
+      "Keep only the first regular-expression capture group; drop the value on no match.",
+    tier: "regex",
+    params: z.object({
+      pattern: regexPatternSchema,
+    }),
+  },
+  filter_regex: {
+    name: "filter_regex",
+    label: "Filter (regex)",
+    blurb: "Drop the value unless it matches the regular expression.",
+    tier: "regex",
+    params: z.object({
+      pattern: regexPatternSchema,
+    }),
+  },
+  split_on: {
+    name: "split_on",
+    label: "Split on",
+    blurb:
+      "Split the value on a regular-expression delimiter into several match candidates.",
+    tier: "regex",
+    params: z.object({
+      delimiter: regexPatternSchema,
+      includeOriginal: z.boolean().default(false),
+    }),
+  },
+  coalesce: {
+    name: "coalesce",
+    label: "Coalesce",
+    blurb:
+      "Substitute a fallback value for an empty field, which can create matches that would not otherwise occur.",
+    tier: "standard",
+    params: z.object({
+      default: z.string().optional(),
+    }),
+  },
+};
 
 // --- Runtime-coercion contract -----------------------------------------------
 

--- a/packages/core/test/standardizationDescriptors.test.ts
+++ b/packages/core/test/standardizationDescriptors.test.ts
@@ -95,6 +95,15 @@ describe("param schemas", () => {
     expect(schemaFor("to_upper_case").safeParse({}).success).toBe(true);
   });
 
+  // The no-param functions share one `noParams` schema; the factory ignores
+  // params entirely, so the schema must strip unexpected keys rather than reject
+  // them -- otherwise it would disagree with a factory that accepts anything.
+  test("a no-param function strips unexpected keys (matching the factory)", () => {
+    const parsed = schemaFor("trim_whitespace").safeParse({ unexpected: 1 });
+    expect(parsed.success).toBe(true);
+    expect(parsed.data).toEqual({});
+  });
+
   describe("pad_left", () => {
     const schema = schemaFor("pad_left");
 
@@ -167,6 +176,31 @@ describe("param schemas", () => {
     test("rejects a missing length", () => {
       expect(schema.safeParse({ start: 1 }).success).toBe(false);
     });
+
+    // The factory does not throw on start=0; it returns an always-null function.
+    // The schema rejects exactly the value the factory renders useless, and the
+    // shapes it accepts produce the slice the factory computes (positive from the
+    // front, negative from the end).
+    test("agrees with the factory on the start it rejects and accepts", () => {
+      expect(schema.safeParse({ start: 0, length: 3 }).success).toBe(false);
+      expect(
+        runPipeline("ABCDE", [
+          { function: "substring", params: { start: 0, length: 3 } },
+        ]),
+      ).toBeNull();
+
+      expect(schema.safeParse({ start: 1, length: 3 }).success).toBe(true);
+      expect(
+        runPipeline("ABCDE", [
+          { function: "substring", params: { start: 1, length: 3 } },
+        ]),
+      ).toBe("ABC");
+      expect(
+        runPipeline("ABCDE", [
+          { function: "substring", params: { start: -2, length: 2 } },
+        ]),
+      ).toBe("DE");
+    });
   });
 
   describe("phonetic", () => {
@@ -207,6 +241,10 @@ describe("param schemas", () => {
 
     test("rejects a non-string value", () => {
       expect(schema.safeParse({ value: 5 }).success).toBe(false);
+    });
+
+    test("rejects a non-string element in values", () => {
+      expect(schema.safeParse({ values: ["a", 5] }).success).toBe(false);
     });
 
     // Neither field is required: the factory reads an absent value/values as an
@@ -274,16 +312,52 @@ describe("param schemas", () => {
       expect(schemaFor("filter_regex").safeParse({}).success).toBe(false);
     });
 
-    test("rejects a syntactically invalid pattern", () => {
+    test("accepts a valid pattern for extract_regex and filter_regex", () => {
+      expect(
+        schemaFor("extract_regex").safeParse({ pattern: "^(\\w+)-" }).success,
+      ).toBe(true);
+      expect(
+        schemaFor("filter_regex").safeParse({ pattern: "^[A-Z]+$" }).success,
+      ).toBe(true);
+    });
+
+    // The schema's compile-check rejects the same invalid pattern the factory's
+    // `new RegExp(pattern)` throws on at construction, so the descriptor cannot
+    // admit a pattern the function would reject.
+    test("rejects an invalid pattern, agreeing with the factory", () => {
       expect(
         schemaFor("extract_regex").safeParse({ pattern: "(" }).success,
       ).toBe(false);
+      expect(() =>
+        runPipeline("x", [
+          { function: "extract_regex", params: { pattern: "(" } },
+        ]),
+      ).toThrow();
     });
 
     test("split_on accepts a delimiter and defaults includeOriginal", () => {
       const parsed = schemaFor("split_on").safeParse({ delimiter: "-" });
       expect(parsed.success).toBe(true);
       expect(parsed.data).toEqual({ delimiter: "-", includeOriginal: false });
+    });
+  });
+
+  describe("coalesce", () => {
+    const schema = schemaFor("coalesce");
+
+    test("accepts a string default", () => {
+      expect(schema.safeParse({ default: "UNKNOWN" }).success).toBe(true);
+    });
+
+    // `default` is optional: the factory reads an absent default as "no
+    // substitution" (the field stays null), so the schema must accept an empty
+    // object to mirror that, not require a default.
+    test("accepts an empty object (no default substitution)", () => {
+      expect(schema.safeParse({}).success).toBe(true);
+    });
+
+    test("rejects a non-string default", () => {
+      expect(schema.safeParse({ default: 5 }).success).toBe(false);
     });
   });
 });

--- a/packages/core/test/standardizationDescriptors.test.ts
+++ b/packages/core/test/standardizationDescriptors.test.ts
@@ -208,6 +208,57 @@ describe("param schemas", () => {
     test("rejects a non-string value", () => {
       expect(schema.safeParse({ value: 5 }).success).toBe(false);
     });
+
+    // Neither field is required: the factory reads an absent value/values as an
+    // empty exclusion list and passes the value through, so the schema accepts
+    // an empty object to mirror that no-op rather than disagree with it.
+    test("accepts an empty object (the factory's no-op shape)", () => {
+      expect(schema.safeParse({}).success).toBe(true);
+    });
+  });
+
+  describe("parse_date", () => {
+    const schema = schemaFor("parse_date");
+
+    test("defaults both formats when omitted", () => {
+      const parsed = schema.safeParse({});
+      expect(parsed.success).toBe(true);
+      expect(parsed.data).toEqual({
+        inputFormat: "MM/DD/YYYY",
+        outputFormat: "YYYYMMDD",
+      });
+    });
+
+    test("accepts custom input and output formats", () => {
+      expect(
+        schema.safeParse({
+          inputFormat: "YYYY-MM-DD",
+          outputFormat: "DD/MM/YYYY",
+        }).success,
+      ).toBe(true);
+    });
+
+    test("rejects an empty format string", () => {
+      expect(schema.safeParse({ inputFormat: "" }).success).toBe(false);
+    });
+
+    test("rejects a non-string format", () => {
+      expect(schema.safeParse({ outputFormat: 5 }).success).toBe(false);
+    });
+
+    // The schema bounds the format strings to non-empty only, not their token
+    // content: a tokenless format like "garbage" is accepted, mirroring the
+    // factory, which accepts any string (it then matches little and yields null
+    // rather than throwing). Token presence is editor guidance, not a
+    // factory-agreement concern.
+    test("accepts a tokenless format string, agreeing with the factory", () => {
+      expect(schema.safeParse({ inputFormat: "garbage" }).success).toBe(true);
+      expect(() =>
+        runPipeline("01/15/1990", [
+          { function: "parse_date", params: { inputFormat: "garbage" } },
+        ]),
+      ).not.toThrow();
+    });
   });
 
   describe("regex family", () => {

--- a/packages/core/test/standardizationDescriptors.test.ts
+++ b/packages/core/test/standardizationDescriptors.test.ts
@@ -229,7 +229,7 @@ describe("param schemas", () => {
       ).toBe(false);
     });
 
-    test("split_on accepts a delimiter and defaults include_original", () => {
+    test("split_on accepts a delimiter and defaults includeOriginal", () => {
       const parsed = schemaFor("split_on").safeParse({ delimiter: "-" });
       expect(parsed.success).toBe(true);
       expect(parsed.data).toEqual({ delimiter: "-", includeOriginal: false });

--- a/packages/core/test/standardizationDescriptors.test.ts
+++ b/packages/core/test/standardizationDescriptors.test.ts
@@ -1,0 +1,238 @@
+import { expect, test, describe } from "vitest";
+
+import {
+  STANDARDIZATION_FUNCTION_DESCRIPTORS,
+  STANDARDIZATION_FUNCTION_NAMES,
+  runPipeline,
+} from "../src/standardization";
+
+// --- Descriptor / registry parity --------------------------------------------
+
+// STANDARDIZATION_FUNCTION_NAMES is derived from the STANDARDIZING_FUNCTIONS
+// registry (its keys, plus `coalesce`), so asserting descriptor/name parity is
+// equivalent to asserting descriptor/registry parity: a registry function added
+// without a descriptor surfaces as a name with no descriptor, and a descriptor
+// for a dropped function surfaces as a descriptor with no name. Either fails CI.
+describe("descriptor / registry parity", () => {
+  test("every recognized function name has a descriptor", () => {
+    const described = new Set(
+      Object.keys(STANDARDIZATION_FUNCTION_DESCRIPTORS),
+    );
+    const missing = STANDARDIZATION_FUNCTION_NAMES.filter(
+      (name) => !described.has(name),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  test("every descriptor names a recognized function", () => {
+    const recognized = new Set(STANDARDIZATION_FUNCTION_NAMES);
+    const extra = Object.keys(STANDARDIZATION_FUNCTION_DESCRIPTORS).filter(
+      (name) => !recognized.has(name),
+    );
+    expect(extra).toEqual([]);
+  });
+
+  test("the descriptor key set equals the recognized-name set exactly", () => {
+    expect(Object.keys(STANDARDIZATION_FUNCTION_DESCRIPTORS).sort()).toEqual(
+      [...STANDARDIZATION_FUNCTION_NAMES].sort(),
+    );
+  });
+});
+
+// --- Descriptor shape --------------------------------------------------------
+
+describe("descriptor fields", () => {
+  test("each descriptor's name matches its table key", () => {
+    for (const [key, descriptor] of Object.entries(
+      STANDARDIZATION_FUNCTION_DESCRIPTORS,
+    )) {
+      expect(descriptor.name).toBe(key);
+    }
+  });
+
+  test("each descriptor has a non-empty label and blurb", () => {
+    for (const descriptor of Object.values(
+      STANDARDIZATION_FUNCTION_DESCRIPTORS,
+    )) {
+      expect(descriptor.label.length).toBeGreaterThan(0);
+      expect(descriptor.blurb.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("the regex family is the danger tier and nothing else is", () => {
+    const regexTier = Object.values(STANDARDIZATION_FUNCTION_DESCRIPTORS)
+      .filter((d) => d.tier === "regex")
+      .map((d) => d.name)
+      .sort();
+    expect(regexTier).toEqual([
+      "extract_regex",
+      "filter_regex",
+      "replace_regex",
+      "split_on",
+    ]);
+  });
+
+  test("every tier is one of the known values", () => {
+    for (const descriptor of Object.values(
+      STANDARDIZATION_FUNCTION_DESCRIPTORS,
+    )) {
+      expect(["standard", "regex"]).toContain(descriptor.tier);
+    }
+  });
+});
+
+// --- Param-schema validation -------------------------------------------------
+
+// Each descriptor's param schema must accept the param shapes its factory
+// accepts and reject malformed ones, so a descriptor cannot disagree with the
+// function it describes. Representative coverage below; the pad_left and phonetic
+// cases also assert the agreement directly against runPipeline (the factory).
+describe("param schemas", () => {
+  const schemaFor = (name: string) =>
+    STANDARDIZATION_FUNCTION_DESCRIPTORS[name].params;
+
+  test("a no-param function accepts an empty params object", () => {
+    expect(schemaFor("to_upper_case").safeParse({}).success).toBe(true);
+  });
+
+  describe("pad_left", () => {
+    const schema = schemaFor("pad_left");
+
+    test("accepts a positive length and fills the char default", () => {
+      const parsed = schema.safeParse({ length: 9 });
+      expect(parsed.success).toBe(true);
+      expect(parsed.data).toEqual({ length: 9, char: "0" });
+    });
+
+    test("accepts an explicit single-character char", () => {
+      expect(schema.safeParse({ length: 4, char: "X" }).success).toBe(true);
+    });
+
+    test("rejects a missing length", () => {
+      expect(schema.safeParse({}).success).toBe(false);
+    });
+
+    test("rejects a non-positive length", () => {
+      expect(schema.safeParse({ length: 0 }).success).toBe(false);
+      expect(schema.safeParse({ length: -1 }).success).toBe(false);
+    });
+
+    test("rejects a non-integer length", () => {
+      expect(schema.safeParse({ length: 1.5 }).success).toBe(false);
+    });
+
+    test("rejects a multi-character char", () => {
+      expect(schema.safeParse({ length: 9, char: "AB" }).success).toBe(false);
+    });
+
+    // The schema and the factory agree on what is malformed: a value the schema
+    // rejects also makes the factory throw, and a value it accepts does not.
+    test("agrees with the factory on length validity", () => {
+      expect(schema.safeParse({ length: 0 }).success).toBe(false);
+      expect(() =>
+        runPipeline("1", [{ function: "pad_left", params: { length: 0 } }]),
+      ).toThrow('pad_left: "length" must be a positive integer');
+
+      expect(schema.safeParse({ length: 9 }).success).toBe(true);
+      expect(() =>
+        runPipeline("1", [{ function: "pad_left", params: { length: 9 } }]),
+      ).not.toThrow();
+    });
+
+    test("agrees with the factory on char validity", () => {
+      expect(schema.safeParse({ length: 4, char: "AB" }).success).toBe(false);
+      expect(() =>
+        runPipeline("1", [
+          { function: "pad_left", params: { length: 4, char: "AB" } },
+        ]),
+      ).toThrow('pad_left: "char" must be exactly one character');
+    });
+  });
+
+  describe("substring", () => {
+    const schema = schemaFor("substring");
+
+    test("accepts a positive start and length", () => {
+      expect(schema.safeParse({ start: 1, length: 3 }).success).toBe(true);
+    });
+
+    test("accepts a negative start (counts from the end)", () => {
+      expect(schema.safeParse({ start: -3, length: 3 }).success).toBe(true);
+    });
+
+    test("rejects a zero start", () => {
+      expect(schema.safeParse({ start: 0, length: 3 }).success).toBe(false);
+    });
+
+    test("rejects a missing length", () => {
+      expect(schema.safeParse({ start: 1 }).success).toBe(false);
+    });
+  });
+
+  describe("phonetic", () => {
+    const schema = schemaFor("phonetic");
+
+    test("defaults the algorithm to soundex when omitted", () => {
+      const parsed = schema.safeParse({});
+      expect(parsed.success).toBe(true);
+      expect(parsed.data).toEqual({ algorithm: "soundex" });
+    });
+
+    test("accepts the soundex algorithm", () => {
+      expect(schema.safeParse({ algorithm: "soundex" }).success).toBe(true);
+    });
+
+    // The schema rejects an unimplemented algorithm, exactly as the factory
+    // throws on one -- the descriptor admits only what the function supports.
+    test("rejects an unimplemented algorithm, agreeing with the factory", () => {
+      expect(schema.safeParse({ algorithm: "metaphone" }).success).toBe(false);
+      expect(() =>
+        runPipeline("x", [
+          { function: "phonetic", params: { algorithm: "metaphone" } },
+        ]),
+      ).toThrow('unsupported phonetic algorithm: "metaphone"');
+    });
+  });
+
+  describe("null_if", () => {
+    const schema = schemaFor("null_if");
+
+    test("accepts a single value", () => {
+      expect(schema.safeParse({ value: "000000000" }).success).toBe(true);
+    });
+
+    test("accepts a values array", () => {
+      expect(schema.safeParse({ values: ["a", "b"] }).success).toBe(true);
+    });
+
+    test("rejects a non-string value", () => {
+      expect(schema.safeParse({ value: 5 }).success).toBe(false);
+    });
+  });
+
+  describe("regex family", () => {
+    test("accepts a valid pattern and defaults the replacement", () => {
+      const parsed = schemaFor("replace_regex").safeParse({ pattern: "\\d" });
+      expect(parsed.success).toBe(true);
+      expect(parsed.data).toEqual({ pattern: "\\d", replacement: "" });
+    });
+
+    test("rejects a missing pattern", () => {
+      expect(schemaFor("replace_regex").safeParse({}).success).toBe(false);
+      expect(schemaFor("extract_regex").safeParse({}).success).toBe(false);
+      expect(schemaFor("filter_regex").safeParse({}).success).toBe(false);
+    });
+
+    test("rejects a syntactically invalid pattern", () => {
+      expect(
+        schemaFor("extract_regex").safeParse({ pattern: "(" }).success,
+      ).toBe(false);
+    });
+
+    test("split_on accepts a delimiter and defaults include_original", () => {
+      const parsed = schemaFor("split_on").safeParse({ delimiter: "-" });
+      expect(parsed.success).toBe(true);
+      expect(parsed.data).toEqual({ delimiter: "-", includeOriginal: false });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Export a single descriptor table from core so both web expert editors -- the linkage-terms transform editor and the metadata/standardization editor -- can render typed, plain-language, parameterized step UIs for cleaning-step functions from one source of truth. Today the function registry is module-private and a step's `params` is typed `unknown` with no per-function schema, so neither editor can drive intuitive inputs; this builds the artifact both authoring tiers are blocked on.

Implements [202533658](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202533658).

## Changes

- packages/core/src/standardization.ts: add `STANDARDIZATION_FUNCTION_DESCRIPTORS`, co-located with the registry -- one descriptor per recognized function (every `STANDARDIZING_FUNCTIONS` member plus `coalesce`) carrying name, a human-readable label, a typed Zod `params` schema, an authoring-risk `tier` (the regex family marked the danger tier), and a one-line blurb; export the `StandardizationFunctionDescriptor` interface and `StandardizationFunctionTier` type; expand the registry header comment to name the descriptor obligation and its enforcing test.
- packages/core/test/standardizationDescriptors.test.ts: new drift test -- descriptor/registry parity in both directions, the danger-tier marking, and per-function param-schema accept/reject with factory-agreement checks (pad_left, substring, phonetic, parse_date, null_if, coalesce, the regex family, and the no-param functions).
- docs/EXCHANGE_REFERENCE.md: correct the `extract_regex` row to match the factory (keeps the whole match when the pattern has no capture group, and drops on no match or an empty result).

## Test plan

Ran: `npx vitest run packages/core/test/standardizationDescriptors.test.ts` (43 tests) and the full core unit suite `npm test -w packages/core` (1501 tests); `npm run typecheck`, `npm run lint`, `npm run format`, and the doc-link check all pass.
New tests cover: descriptor/registry parity in both directions (adding a registry function without a descriptor, or a descriptor without a function, fails CI); the danger-tier marking; and that each representative param schema accepts the shapes its factory accepts and rejects malformed ones (pad_left and phonetic reject exactly what their factories throw on).

## Background

The descriptors are camelCase-keyed to match the post-`camelizeKeys` runtime params each factory reads, and carry factory defaults via Zod `.default()`, so a parse of omitted params yields the value the factory falls back to. They describe well-formed editor output and are NOT the partner-supplied wire params, which stay `z.unknown()` and count-bounded in `config/linkageTerms.ts`; the table has no runtime consumer yet.

## Out of scope / follow-on

- The editors that consume this table: [202520524](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202520524), [202533663](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202533663), and the expert raw-regex tier [202533670](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202533670).
- Hardening surfaced by review (pre-existing, partner-controlled-term execution): regex ReDoS interim [199539401](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=199539401), durable RE2 engine and pinned dialect [202724227](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202724227), and the pad_left length bound [202729557](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202729557).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/`; updated `docs/EXCHANGE_REFERENCE.md` (`extract_regex` description corrected to match the factory); no `docs/spec/` change -- no wire/protocol/constant behavior changed, and the descriptors are an internal core API with no operator-observable behavior.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: a `@psilink/core` API reshape (the apps are its only consumer) with no operator- or reviewer-visible behavior change, plus a doc-only correction; nothing an operator/deployer acts on.
- [x] Security review -- n/a: none of the listed surfaces are touched; a precautionary independent panel (reachability, security-review-scope/dependency/disclosure, and regression lenses) confirmed the descriptors are an inert, editor-facing artifact not on any partner-input path, with the wire path unchanged (`params` stays `z.unknown()`).