### PR TITLE
Make safeParseX non-throwing for camelize bounds

### DIFF
--- a/apps/cli/test/unit/config.test.ts
+++ b/apps/cli/test/unit/config.test.ts
@@ -6,6 +6,7 @@ import YAML from "yaml";
 import {
   getDefaultLinkageTerms,
   MAX_NAME_LENGTH,
+  MAX_NESTING_DEPTH,
   NestingDepthExceededError,
   parseExchangeSpec,
   UsageError,
@@ -1316,6 +1317,60 @@ test("loadConfigLinkageSource rejects invalid linkage_terms", () => {
     expect(() => loadConfigLinkageSource(configPath)).toThrow(UsageError);
     expect(() => loadConfigLinkageSource(configPath)).toThrow(
       "invalid linkage_terms",
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// A local config whose linkage_terms trips a camelizeKeys structural bound (here
+// the depth bound, the cheapest to reach) must still surface the file-named
+// "config file X has invalid linkage_terms: ..." wrap, not the raw bound-error
+// text -- safeParseLinkageTerms is now genuinely non-throwing for the bound, so
+// the if(!result.success) branch produces the helpful message rather than the
+// throw skipping straight past it. Still a UsageError (CLI exit 64), as before.
+test("loadConfigLinkageSource file-names a linkage_terms camelize-bound trip", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
+  try {
+    const configPath = path.join(dir, "psilink.yaml");
+    // Nest one level past the depth bound so camelizeKeys rejects before Zod.
+    let deepTerms: unknown = { identity: "Agency A" };
+    for (let i = 0; i < MAX_NESTING_DEPTH; i++)
+      deepTerms = { nested: deepTerms };
+    fs.writeFileSync(configPath, YAML.stringify({ linkage_terms: deepTerms }));
+    expect(() => loadConfigLinkageSource(configPath)).toThrow(UsageError);
+    // The file-named wrap, carrying the bound's fixed message (no input bytes),
+    // not the raw NestingDepthExceededError text that the pre-fix throw produced.
+    expect(() => loadConfigLinkageSource(configPath)).toThrow(
+      `config file ${configPath} has invalid linkage_terms: input nesting ` +
+        `exceeds the maximum depth of ${MAX_NESTING_DEPTH}`,
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// The same for the metadata branch: a valid linkage_terms reaches it, then a
+// camelize-bound-tripping metadata block surfaces the file-named "invalid
+// metadata" wrap rather than throwing the raw bound error.
+test("loadConfigLinkageSource file-names a metadata camelize-bound trip", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-config-"));
+  try {
+    const configPath = path.join(dir, "psilink.yaml");
+    let deepMetadata: unknown = { name: "X" };
+    for (let i = 0; i < MAX_NESTING_DEPTH; i++)
+      deepMetadata = { nested: deepMetadata };
+    fs.writeFileSync(
+      configPath,
+      YAML.stringify({
+        linkage_terms: getDefaultLinkageTerms("Agency A"),
+        metadata: deepMetadata,
+      }),
+    );
+    expect(() => loadConfigLinkageSource(configPath)).toThrow(UsageError);
+    expect(() => loadConfigLinkageSource(configPath)).toThrow(
+      `config file ${configPath} has invalid metadata: input nesting ` +
+        `exceeds the maximum depth of ${MAX_NESTING_DEPTH}`,
     );
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });

--- a/packages/core/src/config/connection.ts
+++ b/packages/core/src/config/connection.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { camelizeKeys } from "../utils/camelizeKeys.js";
+import { safeParseCamelized } from "./safeParseCamelized.js";
 import { randomBytes, toBase64Url } from "../utils/crypto.js";
 import { pathsResolveToSameDir } from "../utils/pathCompare.js";
 
@@ -1057,9 +1058,13 @@ export function parseConnectionConfig(raw: unknown): ConnectionConfig {
   return ConnectionConfigSchema.parse(camelizeKeys(raw));
 }
 
-/** Non-throwing version of {@link parseConnectionConfig}. */
+/**
+ * Non-throwing version of {@link parseConnectionConfig}. Honors the "safe"
+ * contract for the {@link camelizeKeys} bounds too -- see
+ * {@link safeParseCamelized}.
+ */
 export function safeParseConnectionConfig(raw: unknown) {
-  return ConnectionConfigSchema.safeParse(camelizeKeys(raw));
+  return safeParseCamelized(ConnectionConfigSchema, raw);
 }
 
 /**
@@ -1074,7 +1079,11 @@ export function parseFileSyncOptions(raw: unknown): FileSyncOptions {
   return FileSyncOptionsSchema.parse(camelizeKeys(raw));
 }
 
-/** Non-throwing version of {@link parseFileSyncOptions}. */
+/**
+ * Non-throwing version of {@link parseFileSyncOptions}. Honors the "safe"
+ * contract for the {@link camelizeKeys} bounds too -- see
+ * {@link safeParseCamelized}.
+ */
 export function safeParseFileSyncOptions(raw: unknown) {
-  return FileSyncOptionsSchema.safeParse(camelizeKeys(raw));
+  return safeParseCamelized(FileSyncOptionsSchema, raw);
 }

--- a/packages/core/src/config/exchangeSpec.ts
+++ b/packages/core/src/config/exchangeSpec.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { camelizeKeys } from "../utils/camelizeKeys.js";
+import { safeParseCamelized } from "./safeParseCamelized.js";
 import { LinkageTermsSchema } from "./linkageTerms.js";
 import { AuthenticationSchema, ConnectionConfigSchema } from "./connection.js";
 import { StandardizationSchema } from "./standardization.js";
@@ -63,7 +64,10 @@ export function parseExchangeSpec(raw: unknown): ExchangeSpec {
   return ExchangeSpecSchema.parse(camelizeKeys(raw));
 }
 
-/** Non-throwing version of {@link parseExchangeSpec}. */
+/**
+ * Non-throwing version of {@link parseExchangeSpec}. Honors the "safe" contract
+ * for the {@link camelizeKeys} bounds too -- see {@link safeParseCamelized}.
+ */
 export function safeParseExchangeSpec(raw: unknown) {
-  return ExchangeSpecSchema.safeParse(camelizeKeys(raw));
+  return safeParseCamelized(ExchangeSpecSchema, raw);
 }

--- a/packages/core/src/config/linkageTerms.ts
+++ b/packages/core/src/config/linkageTerms.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { AlgorithmSchema } from "../types.js";
 import type { Algorithm } from "../types.js";
 import { camelizeKeys } from "../utils/camelizeKeys.js";
+import { safeParseCamelized } from "./safeParseCamelized.js";
 import { canonicalString, CanonicalEncodingError } from "../utils/canonical.js";
 import { sanitizeForDisplay } from "../utils/sanitizeForDisplay.js";
 import { boundedArray } from "../utils/boundedArray.js";
@@ -1003,10 +1004,12 @@ export function parseLinkageTerms(raw: unknown): LinkageTerms {
 /**
  * Non-throwing version of {@link parseLinkageTerms}.
  * Returns a Zod `SafeParseReturnType` with `success` and either `data` or
- * `error`.
+ * `error`. Honors the "safe" contract for the {@link camelizeKeys} bounds too:
+ * a depth- or node-count-tripping input yields a `{ success: false }` result
+ * rather than throwing (see {@link safeParseCamelized}).
  */
 export function safeParseLinkageTerms(raw: unknown) {
-  return LinkageTermsSchema.safeParse(camelizeKeys(raw, PARAMS_WIDTH_BOUND));
+  return safeParseCamelized(LinkageTermsSchema, raw, PARAMS_WIDTH_BOUND);
 }
 
 // --- Compatibility -----------------------------------------------------------

--- a/packages/core/src/config/metadata.ts
+++ b/packages/core/src/config/metadata.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { SEMANTIC_TYPES } from "../types";
-import { camelizeKeys } from "../utils/camelizeKeys.js";
+import { safeParseCamelized } from "./safeParseCamelized.js";
 
 import type { SemanticType } from "../types";
 
@@ -75,10 +75,13 @@ export const MetadataSchema = z.array(ColumnMetadataSchema).refine(
  * on-disk form, e.g. `is_payload`) are converted to camelCase before validation,
  * so a `metadata` block read straight from a YAML/JSON config can be passed
  * directly -- mirroring {@link safeParseLinkageTerms} and
- * {@link safeParseExchangeSpec}. Returns a Zod `SafeParseReturnType`.
+ * {@link safeParseExchangeSpec}. Returns a Zod `SafeParseReturnType`. Honors the
+ * "safe" contract for the camelize bounds too -- a depth- or node-count-tripping
+ * input yields a `{ success: false }` result rather than throwing (see
+ * {@link safeParseCamelized}).
  */
 export function safeParseMetadata(raw: unknown) {
-  return MetadataSchema.safeParse(camelizeKeys(raw));
+  return safeParseCamelized(MetadataSchema, raw);
 }
 
 // ─── Metadata Inference ──────────────────────────────────────────────────────

--- a/packages/core/src/config/safeParseCamelized.ts
+++ b/packages/core/src/config/safeParseCamelized.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+import {
+  camelizeKeys,
+  NestingDepthExceededError,
+  NodeCountExceededError,
+} from "../utils/camelizeKeys.js";
+
+/**
+ * Shared camelize-then-`safeParse` behind every `safeParseX` config helper,
+ * made genuinely non-throwing for the {@link camelizeKeys} structural bounds.
+ *
+ * `camelizeKeys` runs BEFORE Zod's `safeParse`, and on a pathologically deep or
+ * wide input it throws a bounded-rejection error ({@link NestingDepthExceededError}
+ * for the depth bound, {@link NodeCountExceededError} for the node-count/width
+ * budget) -- a throw that would otherwise escape the "safe" contract a
+ * `safeParseX` name promises (a `{ success: false }` result, not an exception)
+ * for every caller, not just the ones wrapped in try/catch today. This converts
+ * either bound into a synthesized `safeParse` failure with the shape Zod itself
+ * produces: a {@link z.ZodError} carrying one `custom` issue whose message is the
+ * bound's fixed text (no attacker- or operator-supplied bytes) at the root path
+ * (`[]`). A caller that reads `result.error.issues` -- e.g. the CLI's
+ * `loadConfigLinkageSource` file-naming formatter -- then handles a tripped
+ * camelize bound identically to any other invalid input.
+ *
+ * Only the `safe` helpers route through here. The throwing `parseX` siblings
+ * (`parseLinkageTerms` and the rest) deliberately call `camelizeKeys` directly
+ * and keep throwing the bound error: their partner-wire call sites
+ * (`protocolSetup.ts`) catch it and surface the same sanitized rejection.
+ *
+ * Any throw that is not one of the two camelize bounds is a genuine fault and
+ * propagates unchanged.
+ */
+export function safeParseCamelized<T>(
+  schema: z.ZodType<T>,
+  raw: unknown,
+  widthBoundedKeys?: ReadonlyMap<string, number>,
+): z.ZodSafeParseResult<T> {
+  let camelized: unknown;
+  try {
+    camelized = camelizeKeys(raw, widthBoundedKeys);
+  } catch (err) {
+    if (
+      err instanceof NestingDepthExceededError ||
+      err instanceof NodeCountExceededError
+    )
+      // The ZodError runtime constructor is not generic (it yields
+      // ZodError<unknown>); cast to ZodError<T> to match the failure result
+      // shape. Safe because a synthesized failure carries no `data`, so the
+      // phantom output type the cast asserts is never read.
+      return {
+        success: false,
+        error: new z.ZodError([
+          { code: "custom", path: [], message: err.message },
+        ]) as z.ZodError<T>,
+      };
+    throw err;
+  }
+  return schema.safeParse(camelized);
+}

--- a/packages/core/src/config/safeParseCamelized.ts
+++ b/packages/core/src/config/safeParseCamelized.ts
@@ -30,6 +30,11 @@ import {
  *
  * Any throw that is not one of the two camelize bounds is a genuine fault and
  * propagates unchanged.
+ *
+ * Internal to `@psilink/core`: a shared helper for the config `safeParseX`
+ * siblings, not re-exported from the package index and not a stable public API.
+ *
+ * @internal
  */
 export function safeParseCamelized<T>(
   schema: z.ZodType<T>,

--- a/packages/core/src/config/signing.ts
+++ b/packages/core/src/config/signing.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { camelizeKeys } from "../utils/camelizeKeys.js";
+import { safeParseCamelized } from "./safeParseCamelized.js";
 
 // Signing configuration for exchange receipts. Lives as an optional `signing`
 // block on the ExchangeSpec (psilink.yaml); see EXCHANGE_REFERENCE.md. It carries
@@ -125,7 +126,10 @@ export function parseSigningConfig(raw: unknown): SigningConfig {
   return SigningConfigSchema.parse(camelizeKeys(raw));
 }
 
-/** Non-throwing version of {@link parseSigningConfig}. */
+/**
+ * Non-throwing version of {@link parseSigningConfig}. Honors the "safe" contract
+ * for the {@link camelizeKeys} bounds too -- see {@link safeParseCamelized}.
+ */
 export function safeParseSigningConfig(raw: unknown) {
-  return SigningConfigSchema.safeParse(camelizeKeys(raw));
+  return safeParseCamelized(SigningConfigSchema, raw);
 }

--- a/packages/core/src/utils/camelizeKeys.ts
+++ b/packages/core/src/utils/camelizeKeys.ts
@@ -261,9 +261,11 @@ function transformKeysDeep(
  * (`OPAQUE_VALUE_KEYS`) are left verbatim -- see {@link transformKeysDeep}.
  *
  * Runs ahead of the schema in the `parseX`/`safeParseX` config helpers, so on a
- * pathologically deep or wide input it throws BEFORE the schema -- meaning even a
- * `safeParseX` wrapper that calls it can throw rather than return a failure
- * result. No real config or exchange message reaches either bound.
+ * pathologically deep or wide input it throws BEFORE the schema. The throwing
+ * `parseX` helpers propagate that throw (their partner-wire call sites catch it);
+ * the `safeParseX` helpers route through `safeParseCamelized`, which converts the
+ * bound into a `{ success: false }` result so their "safe" contract holds. No
+ * real config or exchange message reaches either bound.
  *
  * `widthBoundedKeys` (see {@link transformKeysDeep}) lets a caller name keys
  * whose object value is left verbatim once it exceeds a given key count, so a

--- a/packages/core/test/linkageTerms.test.ts
+++ b/packages/core/test/linkageTerms.test.ts
@@ -23,8 +23,8 @@ import {
 } from "../src/utils/sanitizeForDisplay";
 import { describeDecodeError } from "../src/utils/describeDecodeError";
 import {
+  MAX_NODE_COUNT,
   NestingDepthExceededError,
-  NodeCountExceededError,
 } from "../src/utils/camelizeKeys";
 
 // Minimal valid set of terms used as a base for individual tests.
@@ -1902,18 +1902,20 @@ test("rejects a payload send list over the maximum count", () => {
 test("a pathological-count payload send list is rejected by the node budget, not with a RangeError", () => {
   // ~4M entries, past both the camelize node budget (MAX_NODE_COUNT) and the
   // ~3.5M `Invalid string length` threshold the unbounded schema hit. The
-  // camelize pre-pass now fronts the boundedArray count gate: an over-budget
-  // partner collection is rejected with a clean, bounded NodeCountExceededError
-  // before the O(n) walk -- and so before Zod (path b) -- never a RangeError.
+  // camelize pre-pass fronts the boundedArray count gate: an over-budget partner
+  // collection is rejected by that budget before the O(n) walk -- and so before
+  // Zod (path b) -- never a RangeError. safeParseLinkageTerms now ABSORBS that
+  // bound into a { success: false } result (the "safe" contract) instead of
+  // throwing, so the rejection surfaces as the node-count issue, not an exception.
   const send = Array.from({ length: 4_000_000 }, () => 123);
-  let err: unknown;
-  try {
-    safeParseLinkageTerms(sendTerms(send));
-  } catch (e) {
-    err = e;
-  }
-  expect(err).toBeInstanceOf(NodeCountExceededError);
-  expect(err).not.toBeInstanceOf(RangeError);
+  let result: ReturnType<typeof safeParseLinkageTerms> | undefined;
+  expect(() => {
+    result = safeParseLinkageTerms(sendTerms(send));
+  }).not.toThrow();
+  expect(result?.success).toBe(false);
+  expect(result?.success === false && result.error.issues[0]?.message).toBe(
+    `input node count exceeds the maximum of ${MAX_NODE_COUNT}`,
+  );
 });
 
 test("accepts a payload receive list at exactly the maximum count", () => {
@@ -1932,14 +1934,14 @@ test("rejects a payload receive list over the maximum count", () => {
 
 test("a pathological-count payload receive list is rejected by the node budget, not with a RangeError", () => {
   const receive = Array.from({ length: 4_000_000 }, () => 123);
-  let err: unknown;
-  try {
-    safeParseLinkageTerms(receiveTerms(receive));
-  } catch (e) {
-    err = e;
-  }
-  expect(err).toBeInstanceOf(NodeCountExceededError);
-  expect(err).not.toBeInstanceOf(RangeError);
+  let result: ReturnType<typeof safeParseLinkageTerms> | undefined;
+  expect(() => {
+    result = safeParseLinkageTerms(receiveTerms(receive));
+  }).not.toThrow();
+  expect(result?.success).toBe(false);
+  expect(result?.success === false && result.error.issues[0]?.message).toBe(
+    `input node count exceeds the maximum of ${MAX_NODE_COUNT}`,
+  );
 });
 
 // ─── Top-level linkageFields / linkageKeys count bounds ──────────────────────
@@ -1982,18 +1984,19 @@ test("rejects linkageFields over the maximum count", () => {
 test("a pathological-count linkageFields is rejected by the node budget, not with a RangeError", () => {
   // ~4M entries, past both the camelize node budget (MAX_NODE_COUNT) and the
   // ~3.5M `Invalid string length` threshold the `.max()`-only schema hit. The
-  // camelize node budget now fronts the boundedArray count gate, rejecting the
-  // over-budget array with a clean, bounded NodeCountExceededError before the
-  // walk -- and so before Zod (path b) -- never a RangeError.
+  // camelize node budget fronts the boundedArray count gate, rejecting the
+  // over-budget array by that budget before the walk -- and so before Zod (path
+  // b) -- never a RangeError. safeParseLinkageTerms absorbs the bound into a
+  // { success: false } result rather than throwing (the "safe" contract).
   const fields = Array.from({ length: 4_000_000 }, () => 123);
-  let err: unknown;
-  try {
-    safeParseLinkageTerms(linkageFieldsTerms(fields));
-  } catch (e) {
-    err = e;
-  }
-  expect(err).toBeInstanceOf(NodeCountExceededError);
-  expect(err).not.toBeInstanceOf(RangeError);
+  let result: ReturnType<typeof safeParseLinkageTerms> | undefined;
+  expect(() => {
+    result = safeParseLinkageTerms(linkageFieldsTerms(fields));
+  }).not.toThrow();
+  expect(result?.success).toBe(false);
+  expect(result?.success === false && result.error.issues[0]?.message).toBe(
+    `input node count exceeds the maximum of ${MAX_NODE_COUNT}`,
+  );
 });
 
 test("accepts linkageKeys at exactly the maximum count", () => {
@@ -2014,22 +2017,23 @@ test("rejects linkageKeys over the maximum count", () => {
 
 test("a pathological-count linkageKeys is rejected by the node budget, not with a RangeError or a TypeError", () => {
   // ~4M entries, past the camelize node budget (MAX_NODE_COUNT). The node budget
-  // fronts the boundedArray count gate, rejecting the over-budget array with a
-  // clean, bounded NodeCountExceededError before the walk -- and so before Zod
-  // (path b) -- never a RangeError, and never the TypeError a raw non-object key
-  // would drive at the terms-level refine (the over-budget array never reaches
-  // it). The boundedArray `abort` that guards that refine for a sub-budget
-  // over-count is pinned by the next test.
+  // fronts the boundedArray count gate, rejecting the over-budget array by that
+  // budget before the walk -- and so before Zod (path b) -- never a RangeError,
+  // and never the TypeError a raw non-object key would drive at the terms-level
+  // refine (the over-budget array never reaches it). safeParseLinkageTerms
+  // absorbs the bound into a { success: false } result rather than throwing (the
+  // "safe" contract); the not-throwing assertion stands in for the prior
+  // not-a-RangeError / not-a-TypeError checks. The boundedArray `abort` that
+  // guards that refine for a sub-budget over-count is pinned by the next test.
   const keys = Array.from({ length: 4_000_000 }, () => 123);
-  let err: unknown;
-  try {
-    safeParseLinkageTerms(linkageKeysTerms(keys));
-  } catch (e) {
-    err = e;
-  }
-  expect(err).toBeInstanceOf(NodeCountExceededError);
-  expect(err).not.toBeInstanceOf(RangeError);
-  expect(err).not.toBeInstanceOf(TypeError);
+  let result: ReturnType<typeof safeParseLinkageTerms> | undefined;
+  expect(() => {
+    result = safeParseLinkageTerms(linkageKeysTerms(keys));
+  }).not.toThrow();
+  expect(result?.success).toBe(false);
+  expect(result?.success === false && result.error.issues[0]?.message).toBe(
+    `input node count exceeds the maximum of ${MAX_NODE_COUNT}`,
+  );
 });
 
 test("an over-count linkageKeys of raw non-object entries aborts to a clean count issue", () => {

--- a/packages/core/test/safeParseCamelized.test.ts
+++ b/packages/core/test/safeParseCamelized.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "vitest";
+import type { z } from "zod";
+
+import {
+  MAX_NODE_COUNT,
+  MAX_NESTING_DEPTH,
+  NodeCountExceededError,
+  NestingDepthExceededError,
+} from "../src/utils/camelizeKeys";
+import {
+  parseLinkageTerms,
+  safeParseLinkageTerms,
+} from "../src/config/linkageTerms";
+import { safeParseExchangeSpec } from "../src/config/exchangeSpec";
+import {
+  safeParseConnectionConfig,
+  safeParseFileSyncOptions,
+} from "../src/config/connection";
+import { safeParseSigningConfig } from "../src/config/signing";
+import { safeParseMetadata } from "../src/config/metadata";
+
+// Every safeParseX config helper runs camelizeKeys BEFORE Zod's safeParse, so a
+// camelize structural bound (the depth bound or the node-count/width budget)
+// must surface as a { success: false } result, not a throw -- the contract the
+// `safe` name promises for EVERY caller, not just the ones a try/catch wraps
+// today. One bound-tripping input exercises all six: camelize runs on the raw
+// value ahead of any schema, so the rejection is independent of which helper
+// (and which schema) is called.
+
+// A flat array one past the node-count budget -- the cheapest node-count trip
+// (the O(1) array-length check rejects before .map allocates). Mirrors
+// camelizeKeys.test.ts.
+function overWideInput(): unknown {
+  return Array.from({ length: MAX_NODE_COUNT + 1 }, (_, i) => i);
+}
+
+// A chain nested one level past the depth bound (root at depth 0, so a value at
+// depth MAX_NESTING_DEPTH is rejected).
+function overDeepInput(): unknown {
+  let v: unknown = {};
+  for (let i = 0; i < MAX_NESTING_DEPTH; i++) v = { nested_key: v };
+  return v;
+}
+
+type SafeHelper = (raw: unknown) => z.ZodSafeParseResult<unknown>;
+
+const safeHelpers: ReadonlyArray<{ name: string; fn: SafeHelper }> = [
+  { name: "safeParseLinkageTerms", fn: safeParseLinkageTerms },
+  { name: "safeParseExchangeSpec", fn: safeParseExchangeSpec },
+  { name: "safeParseConnectionConfig", fn: safeParseConnectionConfig },
+  { name: "safeParseFileSyncOptions", fn: safeParseFileSyncOptions },
+  { name: "safeParseSigningConfig", fn: safeParseSigningConfig },
+  { name: "safeParseMetadata", fn: safeParseMetadata },
+];
+
+for (const { name, fn } of safeHelpers) {
+  test(`${name} returns success:false on a node-count-tripping input, not a throw`, () => {
+    let result: z.ZodSafeParseResult<unknown> | undefined;
+    expect(() => {
+      result = fn(overWideInput());
+    }).not.toThrow();
+    expect(result?.success).toBe(false);
+    // The synthesized failure has the shape a Zod safeParse failure has -- one
+    // issue at the root path -- so a caller reading result.error.issues handles
+    // it identically to any other invalid input. The message is the bound's
+    // fixed text: it carries no input bytes, satisfying the no-echo contract.
+    expect(result?.success === false && result.error.issues).toEqual([
+      {
+        code: "custom",
+        path: [],
+        message: `input node count exceeds the maximum of ${MAX_NODE_COUNT}`,
+      },
+    ]);
+  });
+
+  test(`${name} returns success:false on a depth-tripping input, not a throw`, () => {
+    let result: z.ZodSafeParseResult<unknown> | undefined;
+    expect(() => {
+      result = fn(overDeepInput());
+    }).not.toThrow();
+    expect(result?.success).toBe(false);
+    expect(result?.success === false && result.error.issues).toEqual([
+      {
+        code: "custom",
+        path: [],
+        message: `input nesting exceeds the maximum depth of ${MAX_NESTING_DEPTH}`,
+      },
+    ]);
+  });
+}
+
+// A legitimate config is unaffected: it parses to success as before.
+const minimalLinkageTerms = {
+  version: "1.0.0",
+  identity: "Test Party",
+  date: "2025-01-01",
+  algorithm: "psi",
+  output: { expectsOutput: true, shareWithPartner: false },
+  deduplicate: false,
+  linkageFields: [{ name: "ssn", type: "ssn" }],
+  linkageKeys: [{ name: "SSN", elements: [{ field: "ssn" }] }],
+};
+
+test("a legitimate config still parses through the safe helper", () => {
+  const result = safeParseLinkageTerms(minimalLinkageTerms);
+  expect(result.success).toBe(true);
+});
+
+// The throwing parseX siblings are deliberately left throwing -- their
+// partner-wire call sites (protocolSetup.ts) catch the bound and surface the
+// same sanitized rejection. Only the `safe` helpers absorb it.
+test("the throwing parseLinkageTerms still throws the camelize bound", () => {
+  expect(() => parseLinkageTerms(overWideInput())).toThrow(
+    NodeCountExceededError,
+  );
+  expect(() => parseLinkageTerms(overDeepInput())).toThrow(
+    NestingDepthExceededError,
+  );
+});


### PR DESCRIPTION
## Summary

The six `@psilink/core` `safeParseX` config helpers now honor their non-throwing contract for the `camelizeKeys` structural bounds. They ran `camelizeKeys` ahead of Zod's `safeParse`, so a pathologically deep or wide input made them THROW a bounded-rejection (`NestingDepthExceededError` / `NodeCountExceededError`) despite the `{ success: false }` their "safe" name promises -- the node-count budget made this more reachable than the depth bound alone was. The visible payoff is the CLI's `loadConfigLinkageSource`: a pathological local config that trips a bound now surfaces the file-named "config file X has invalid linkage_terms/metadata: ..." message instead of the raw bound text, while still exiting 64.

Implements [202805373](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202805373).

## Changes

- `packages/core/src/config/safeParseCamelized.ts` (new): shared helper that runs `camelizeKeys`, catches the two bound errors, and returns a synthesized `{ success: false }` ZodError carrying one `custom` issue with the bound's fixed message at the root path; any other throw propagates.
- `packages/core/src/config/{linkageTerms,exchangeSpec,connection,signing,metadata}.ts`: route all six `safeParseX` helpers through `safeParseCamelized`; the throwing `parseX` siblings are left calling `camelizeKeys` directly and still throw.
- `packages/core/src/utils/camelizeKeys.ts`: correct the now-stale JSDoc that claimed a `safeParseX` wrapper can throw.
- `packages/core/test/safeParseCamelized.test.ts` (new) and `linkageTerms.test.ts`, `apps/cli/test/unit/config.test.ts`: cover the new contract and update four node-budget tests that asserted the old throwing behavior.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format`, plus `npx vitest run packages/core/test/safeParseCamelized.test.ts packages/core/test/linkageTerms.test.ts packages/core/test/camelizeKeys.test.ts apps/cli/test/unit/config.test.ts` (259 passed), and the full `packages/core` (1656) and `apps/cli` unit (863) suites.
New tests cover: each of the six `safeParseX` helpers returns `{ success: false }` (not a throw) on depth- and node-count-tripping input with the fixed bound message; a legitimate config still parses; the throwing `parseLinkageTerms` partner-wire path still throws both bounds; and `loadConfigLinkageSource` surfaces the file-named wrap (still exit 64) on a bound-tripping local config.

## Background

Same parsed-input-bounds family as the node budget (202740573) that motivated it. The fix is operator-config-only: partner-controlled input flows through the throwing `parseLinkageTerms` (wrapped in try/catch at `protocolSetup.ts`), which is untouched. Three independent adversarial security reviews (fail-closed/control-integrity, input-bounds/DoS/reachability, disclosure/leak) found no fail-open, no weakened bound, and no new disclosure. One latent, verified-non-exploitable observation: in the web advanced-invite flow, `canonicalString(terms)` runs even when the parse returns `{ success: false }`, but `terms` there is built from the inviter's own local draft and cannot reach either bound.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed. `docs/spec/CHANNEL_SECURITY.md` describes the structural bounds and the throwing `parseLinkageTerms` parse-error path, both unchanged; the `safeParseX` result-shape conversion is implementation detail below the spec tier.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: `@psilink/core` contract cleanup whose only operator-visible delta is a friendlier error message on a pathological local config no real operator writes (exit code and crash-free behavior unchanged), below the "observable change a reader acts on" bar.
- [x] Security review -- done: three independent adversarial reviews (fail-closed/control-integrity, input-bounds/DoS/reachability, disclosure/leak) of the displayed-error change in the parsed-input-bounds family; all confirmed operator-config-only scope, partner-wire throwing path unchanged, bounds unchanged, and no new disclosure.