### PR TITLE
Add element-transform compile-count guards

### DIFF
--- a/packages/core/test/standardization.test.ts
+++ b/packages/core/test/standardization.test.ts
@@ -1062,6 +1062,44 @@ describe("buildKeyStrings: element-transform compilation reused across rows", ()
     // independent of row count. Pre-memoization this was 4 * 50.
     expect(spy).toHaveBeenCalledTimes(4);
   });
+
+  test("a multi-step element transform compiles every step once, not per row", () => {
+    // The other compile-count tests use single-step transforms, so they pin "one
+    // transform array -> one compile" but not "every STEP of the array compiles
+    // once". The WeakMap caches the whole compiled step array under the array's
+    // identity, so each regex-bearing step must compile once and be reused across
+    // rows. Without this case, a regression that re-ran compileSteps per row only
+    // for multi-step arrays (e.g. a `steps.length > 1` carve-out) would pass every
+    // single-step test while recompiling up to MAX_TRANSFORM_STEPS (256) patterns
+    // per row -- the same fail-open per-row compile cost the control bounds. The
+    // real bound is distinct-transforms * regex-steps-per-transform, flat in rows.
+    const key = {
+      name: "MULTI_STEP",
+      elements: [
+        {
+          field: "ssn",
+          transform: [
+            { function: "filter_regex", params: { pattern: "\\d" } },
+            { function: "extract_regex", params: { pattern: "(\\d{2})$" } },
+          ],
+        },
+      ],
+    };
+    const rowCount = 50;
+    const rows = Array.from({ length: rowCount }, (_, i) => ({
+      SSN: `${100000000 + i}`,
+    }));
+    const dataset = new StandardizedDataset([
+      new StandardizedField("ssn", "SSN", [], rows),
+    ]);
+
+    const spy = vi.spyOn(linearRegex, "compileLinearRegex");
+    for (let i = 0; i < rowCount; i++) buildKeyStrings(key, dataset, i);
+    // Two regex steps in one transform array -> two compiles total (the array is
+    // compiled once and reused), flat in the 50 rows. A per-row recompile of a
+    // multi-step transform would be 2 * 50.
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("regex factories fail closed (no fallback to new RegExp)", () => {

--- a/packages/core/test/standardization.test.ts
+++ b/packages/core/test/standardization.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe, vi } from "vitest";
+import { expect, test, describe, afterEach, vi } from "vitest";
 
 import {
   runPipeline,
@@ -857,6 +857,14 @@ describe("buildKeyStrings: NFC normalization of the assembled key", () => {
 });
 
 describe("buildKeyStrings: element-transform compilation reused across rows", () => {
+  // Restore the compileLinearRegex spy after every test, even one that throws
+  // mid-body: a per-test `spy.mockRestore()` is skipped when an assertion throws,
+  // and a vi.spyOn on the still-installed spy returns the same object carrying the
+  // failed test's stale call count -- inflating the next test's count (a real
+  // regression would then cascade as 50/100/160 instead of clean independent
+  // failures). afterEach restores regardless, so each count stands alone.
+  afterEach(() => vi.restoreAllMocks());
+
   // The element transform compiles once and is memoized by the step array's
   // identity, then reused for every row. A memoization bug would cross-contaminate
   // rows or stale a result, so build several rows through one regex element
@@ -924,7 +932,6 @@ describe("buildKeyStrings: element-transform compilation reused across rows", ()
     // One regex step in one element transform -> one compile, independent of the
     // 50 rows. Pre-memoization this was 50 (one recompile per row).
     expect(spy).toHaveBeenCalledTimes(1);
-    spy.mockRestore();
   });
 
   test("a parse_date element transform compiles once across many rows, not per row", () => {
@@ -955,7 +962,6 @@ describe("buildKeyStrings: element-transform compilation reused across rows", ()
     // parse_date builds its input-format regex once at closure-build time; memoized,
     // that build is shared across all 50 rows.
     expect(spy).toHaveBeenCalledTimes(1);
-    spy.mockRestore();
   });
 
   test("the swap path preserves the per-element compile cache (compiles per element, not per row)", () => {
@@ -997,7 +1003,64 @@ describe("buildKeyStrings: element-transform compilation reused across rows", ()
     for (let i = 0; i < rowCount; i++) buildKeyStrings(key, dataset, i, true);
     // Two distinct element-transform arrays -> two compiles across all 30 rows.
     expect(spy).toHaveBeenCalledTimes(2);
-    spy.mockRestore();
+  });
+
+  test("compile count tracks distinct element transforms, not row count", () => {
+    // The single-transform tests above pin the bound for one transform across
+    // rows; this pins the invariant the security comment actually rests on --
+    // total compiles equal the number of DISTINCT element transforms, flat in the
+    // row count -- by building several at once. The schema bounds that distinct
+    // count (MAX_LINKAGE_ENTRIES * MAX_KEY_ELEMENTS), far below the rows a real
+    // dataset carries, which is why per-element rather than per-row compilation is
+    // the bound that matters. Mixes regex and parse_date transforms.
+    const key = {
+      name: "MULTI",
+      elements: [
+        {
+          field: "f1",
+          transform: [
+            { function: "extract_regex", params: { pattern: "(\\d{2})$" } },
+          ],
+        },
+        {
+          field: "f2",
+          transform: [
+            { function: "extract_regex", params: { pattern: "^(\\d{2})" } },
+          ],
+        },
+        {
+          field: "f3",
+          transform: [
+            { function: "extract_regex", params: { pattern: "(\\d{3})" } },
+          ],
+        },
+        {
+          field: "f4",
+          transform: [
+            { function: "parse_date", params: { inputFormat: "MM/DD/YYYY" } },
+          ],
+        },
+      ],
+    };
+    const rowCount = 50;
+    const rows = Array.from({ length: rowCount }, (_, i) => ({
+      F1: `${1000 + i}`,
+      F2: `${2000 + i}`,
+      F3: `${3000 + i}`,
+      F4: `01/${String((i % 28) + 1).padStart(2, "0")}/2020`,
+    }));
+    const dataset = new StandardizedDataset([
+      new StandardizedField("f1", "F1", [], rows),
+      new StandardizedField("f2", "F2", [], rows),
+      new StandardizedField("f3", "F3", [], rows),
+      new StandardizedField("f4", "F4", [], rows),
+    ]);
+
+    const spy = vi.spyOn(linearRegex, "compileLinearRegex");
+    for (let i = 0; i < rowCount; i++) buildKeyStrings(key, dataset, i);
+    // Four distinct element transforms -> four compiles across all 50 rows,
+    // independent of row count. Pre-memoization this was 4 * 50.
+    expect(spy).toHaveBeenCalledTimes(4);
   });
 });
 

--- a/packages/core/test/standardization.test.ts
+++ b/packages/core/test/standardization.test.ts
@@ -892,6 +892,13 @@ describe("buildKeyStrings: element-transform compilation reused across rows", ()
   // so the invariant is a check instead. compileLinearRegex is the entry point
   // every regex/parse_date factory calls exactly once at closure-build time, so
   // its call count over a build IS the element-transform compile count.
+  //
+  // The spy reaches standardization.ts's static `compileLinearRegex` import
+  // through Vitest's module transform; under a future native-ESM pool (e.g.
+  // `vmForks`) the namespace spy could stop intercepting that binding. The
+  // failure mode is safe either way: the first row always compiles exactly once,
+  // so a working spy sees >= 1 and a broken one sees 0 -- a 0 count fails these
+  // assertions loudly, it never lets a per-row regression pass as green.
   test("a regex element transform compiles once across many rows, not per row", () => {
     const key = {
       name: "SSN4",

--- a/packages/core/test/standardization.test.ts
+++ b/packages/core/test/standardization.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe } from "vitest";
+import { expect, test, describe, vi } from "vitest";
 
 import {
   runPipeline,
@@ -12,6 +12,7 @@ import {
   StandardizedField,
   StandardizedDataset,
 } from "../src/standardization";
+import * as linearRegex from "../src/utils/linearRegex";
 import { inferMetadata } from "../src/config/metadata";
 import { getDefaultLinkageTerms } from "../src/defaults/linkageTerms";
 import type { LinkageTerms } from "../src/config/linkageTerms";
@@ -880,6 +881,116 @@ describe("buildKeyStrings: element-transform compilation reused across rows", ()
     expect(buildKeyStrings(key, dataset, 1)).toEqual(new Set(["6666"]));
     // No 4-digit tail -> the element produces no value -> the key collapses.
     expect(buildKeyStrings(key, dataset, 2)).toBeNull();
+  });
+
+  // The per-element compile-once is a security control, not just a perf win: a
+  // hostile-but-schema-valid terms set can carry more distinct patterns than the
+  // linear-time engine's own compile cache holds, so per-row recompilation would
+  // thrash that cache into an unbounded per-row CPU cost over a large dataset.
+  // "Compilation does not happen per row" is therefore a runtime invariant, and a
+  // comment asserting it would rot silently; these spy on the compile entry point
+  // so the invariant is a check instead. compileLinearRegex is the entry point
+  // every regex/parse_date factory calls exactly once at closure-build time, so
+  // its call count over a build IS the element-transform compile count.
+  test("a regex element transform compiles once across many rows, not per row", () => {
+    const key = {
+      name: "SSN4",
+      elements: [
+        {
+          field: "ssn",
+          transform: [
+            { function: "extract_regex", params: { pattern: "(\\d{4})$" } },
+          ],
+        },
+      ],
+    };
+    const rowCount = 50;
+    const rows = Array.from({ length: rowCount }, (_, i) => ({
+      SSN: `${100000000 + i}`,
+    }));
+    const dataset = new StandardizedDataset([
+      new StandardizedField("ssn", "SSN", [], rows),
+    ]);
+
+    const spy = vi.spyOn(linearRegex, "compileLinearRegex");
+    for (let i = 0; i < rowCount; i++) buildKeyStrings(key, dataset, i);
+    // One regex step in one element transform -> one compile, independent of the
+    // 50 rows. Pre-memoization this was 50 (one recompile per row).
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  test("a parse_date element transform compiles once across many rows, not per row", () => {
+    const key = {
+      name: "DOB",
+      elements: [
+        {
+          field: "dob",
+          transform: [
+            {
+              function: "parse_date",
+              params: { inputFormat: "MM/DD/YYYY", outputFormat: "YYYYMMDD" },
+            },
+          ],
+        },
+      ],
+    };
+    const rowCount = 50;
+    const rows = Array.from({ length: rowCount }, (_, i) => ({
+      DOB: `01/${String((i % 28) + 1).padStart(2, "0")}/2020`,
+    }));
+    const dataset = new StandardizedDataset([
+      new StandardizedField("dob", "DOB", [], rows),
+    ]);
+
+    const spy = vi.spyOn(linearRegex, "compileLinearRegex");
+    for (let i = 0; i < rowCount; i++) buildKeyStrings(key, dataset, i);
+    // parse_date builds its input-format regex once at closure-build time; memoized,
+    // that build is shared across all 50 rows.
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  test("the swap path preserves the per-element compile cache (compiles per element, not per row)", () => {
+    // swapElements rebuilds the element wrapper objects on every receiver row but
+    // preserves each element's own `transform` array reference, so the WeakMap keyed
+    // on that array still hits across rows under swap. A swap that copied the steps
+    // would silently reintroduce per-row recompilation; pin that it does not.
+    const key = {
+      name: "SWAP",
+      swap: ["a", "b"] as [string, string],
+      elements: [
+        {
+          name: "a",
+          field: "first",
+          transform: [
+            { function: "extract_regex", params: { pattern: "(\\d{2})$" } },
+          ],
+        },
+        {
+          name: "b",
+          field: "second",
+          transform: [
+            { function: "extract_regex", params: { pattern: "^(\\d{2})" } },
+          ],
+        },
+      ],
+    };
+    const rowCount = 30;
+    const rows = Array.from({ length: rowCount }, (_, i) => ({
+      FIRST: `${1000 + i}`,
+      SECOND: `${2000 + i}`,
+    }));
+    const dataset = new StandardizedDataset([
+      new StandardizedField("first", "FIRST", [], rows),
+      new StandardizedField("second", "SECOND", [], rows),
+    ]);
+
+    const spy = vi.spyOn(linearRegex, "compileLinearRegex");
+    for (let i = 0; i < rowCount; i++) buildKeyStrings(key, dataset, i, true);
+    // Two distinct element-transform arrays -> two compiles across all 30 rows.
+    expect(spy).toHaveBeenCalledTimes(2);
+    spy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

Pin the per-element transform compile-once behavior with a regression net. The memoization that bounds attacker-controlled compile work on the key-building hot path landed in #248 without a test asserting it; this adds that coverage so a future refactor cannot silently reintroduce per-row recompilation. Test-only -- no runtime change.

Part of [202822992](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202822992).

## Changes

- packages/core/test/standardization.test.ts: add five compile-count guards to the "element-transform compilation reused across rows" describe block -- a single regex transform, a single parse_date transform, several distinct transforms in one build, the swap path, and a multi-step transform -- each asserting the compileLinearRegex call count is bounded by the distinct element-transform (and per-array step) count, flat in the row count. Restore the spy in afterEach so a failing guard reports a clean independent count instead of inflating later ones.

## Test plan

Ran: `npx vitest run packages/core/test/standardization.test.ts` (166 pass), plus `npm run typecheck`, `npm run lint`, `npm run format` (all clean).
New tests cover: that buildKeyStrings compiles each element transform's steps once and reuses them across rows -- bounded by distinct-transform count and by per-array step count, not row count -- including the swap path's array-identity preservation. Each guard was verified to fail under a forced per-row recompile (regex 50/1, parse_date 50/1, swap 60/2, N-distinct 200/4, multi-step 100/2).

## Background

The compile-once memoization (the compiledElementTransforms WeakMap in packages/core/src/standardization.ts) is a security control: a hostile-but-schema-valid linkage-terms set can carry more distinct regex/parse_date patterns than the linear-time engine's bounded compile cache (1024 entries) holds, so per-row recompilation would thrash that cache into an unbounded per-row CPU cost over a large dataset -- a fail-open denial of service, the volume sibling of the catastrophic-backtracking vector the linear-time engine closes. The optimization itself merged in #248 (board item 202724227); item 202822992 specified this regression test as an acceptance criterion that did not land with it. Independent security review across DoS, PSI-determinism, and adversarial test-efficacy lenses shaped the coverage: the adversarial pass found the single-step guards missed a multi-step per-row recompile, which the multi-step test now closes (verified by mutation).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier -- n/a: test-only, no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-only addition, no operator- or reviewer-visible behavior change.
- [x] Security review -- n/a: test-only; modifies no cryptographic/AEAD/credential/auth/disclosure surface or security-relevant dependency. The guarded compile-once control and this regression net were nonetheless put through an independent security panel (DoS, PSI-determinism, adversarial test-efficacy); see Background.
