### PR TITLE
Make default SSN/SSN4 blank-drop explicit

### DIFF
--- a/packages/core/src/defaults/standardization.ts
+++ b/packages/core/src/defaults/standardization.ts
@@ -16,6 +16,14 @@ const SSN_STEPS: StandardizationStep[] = [
   { function: "remove_dashes" },
   // Remove any remaining non-digit characters (spaces, dots, parens).
   { function: "replace_regex", params: { pattern: "[^0-9]", replacement: "" } },
+  // Drop a value that cleaned to empty (a blank or all-non-digit cell) here,
+  // before pad_left can mask it: an empty string would otherwise pad to
+  // "000000000" and be dropped only as a side effect of the placeholder null_if
+  // below happening to list that value. Since item 203074741 the linkage layer
+  // no longer drops "" together with the no-key sentinel, so the blank-cell
+  // footgun is prevented explicitly here -- and stays prevented even if an
+  // operator removes "000000000" from the placeholder list for their own data.
+  { function: "null_if", params: { value: "" } },
   // Zero-pad to 9 digits for SSNs stored without a leading zero.
   { function: "pad_left", params: { length: 9 } },
   // Reject anything that isn't exactly 9 digits.
@@ -33,6 +41,9 @@ const SSN4_STEPS: StandardizationStep[] = [
   { function: "remove_non_ascii" },
   { function: "remove_dashes" },
   { function: "replace_regex", params: { pattern: "[^0-9]", replacement: "" } },
+  // Drop a value that cleaned to empty before pad_left masks it as "0000"; see
+  // SSN_STEPS for why this explicit blank-drop is needed since item 203074741.
+  { function: "null_if", params: { value: "" } },
   // Zero-pad to 4 digits for SSN4 values stored without a leading zero.
   { function: "pad_left", params: { length: 4 } },
   { function: "extract_regex", params: { pattern: "(\\d{4})$" } },

--- a/packages/core/test/defaultStandardization.test.ts
+++ b/packages/core/test/defaultStandardization.test.ts
@@ -244,19 +244,21 @@ describe("default SSN / SSN4 pipelines: explicit blank-drop before pad_left", ()
       expect(padIdx).toBeGreaterThan(emptyDropIdx);
     });
 
-    test(`${type}: a blank still drops with the placeholder null_if removed`, () => {
+    test(`${type}: a blank or cleaned-empty value still drops with the placeholder null_if removed`, () => {
       // Prove the explicit empty-drop is load-bearing, not redundant with the
       // terminal placeholder null_if: strip the placeholder step (the null_if
-      // listing all-zeros/sequential placeholders via `values`) and a blank must
-      // still map to null. Without the explicit `null_if ""`, the blank would pad
-      // to an all-zeros value and survive as a matchable key.
+      // listing all-zeros/sequential placeholders via `values`) and a value that
+      // is blank ("", "   ") OR cleans to empty through the chain ("abc", "----"
+      // lose every non-digit) must still map to null. Without the explicit
+      // `null_if ""`, such a value would pad to an all-zeros value and survive as
+      // a matchable key.
       const withoutPlaceholder = stepsFor(type, column).filter(
         (s) => !(s.function === "null_if" && s.params?.values !== undefined),
       );
-      for (const blank of ["", "   ", "abc", "----"]) {
+      for (const input of ["", "   ", "abc", "----"]) {
         expect(
-          runPipeline(blank, withoutPlaceholder),
-          `input ${JSON.stringify(blank)}`,
+          runPipeline(input, withoutPlaceholder),
+          `input ${JSON.stringify(input)}`,
         ).toBeNull();
       }
     });

--- a/packages/core/test/defaultStandardization.test.ts
+++ b/packages/core/test/defaultStandardization.test.ts
@@ -188,6 +188,79 @@ describe('default chains: a blank input yields null, never ""', () => {
       }
     });
   }
+
+  // A non-blank "junk" cell that CLEANS to empty (separators or punctuation a
+  // type strips entirely) is the other half of "blank/'' cleaned value" in item
+  // 203074970: it never arrives as whitespace but reduces to "" partway through.
+  // Every default type drops these characters, so each maps to null for the same
+  // reason a literal blank does; pin it so a chain that let a cleaned-empty value
+  // survive trips this test.
+  const cleansToEmpty = ["---", "...", "!!!", "@@@"];
+  for (const t of transformations) {
+    test(`${t.output}: a non-blank value that cleans to empty maps to null`, () => {
+      for (const junk of cleansToEmpty) {
+        expect(
+          runPipeline(junk, t.steps!),
+          `input ${JSON.stringify(junk)}`,
+        ).toBeNull();
+      }
+    });
+  }
+});
+
+// --- SSN / SSN4 explicit blank-drop ------------------------------------------
+
+describe("default SSN / SSN4 pipelines: explicit blank-drop before pad_left", () => {
+  // Item 203074970: SSN/SSN4 pad a cleaned value to a fixed width, so a value
+  // that cleaned to empty would pad into an all-zeros placeholder ("000000000" /
+  // "0000") before reaching any null-mapping step -- dropped only as a side
+  // effect of the terminal placeholder null_if happening to list that value. An
+  // explicit `null_if ""` placed BEFORE pad_left drops the empty value as empty,
+  // so the blank-cell footgun (live since item 203074741 stopped dropping "" at
+  // the linkage layer) is prevented here and stays prevented even if an operator
+  // edits the placeholder list. Pin the step's presence, its position, and the
+  // fact that it -- not the placeholder null_if -- carries the blank-drop.
+  const cases: Array<{ type: "ssn" | "ssn4"; column: string }> = [
+    { type: "ssn", column: "SSN" },
+    { type: "ssn4", column: "SSN4" },
+  ];
+
+  function stepsFor(type: "ssn" | "ssn4", column: string) {
+    const [t] = getDefaultStandardization(
+      [{ name: column, type, role: "linkage", isPayload: false }],
+      { ...minimalTerms, linkageFields: [{ name: type, type }] },
+    );
+    return t.steps ?? [];
+  }
+
+  for (const { type, column } of cases) {
+    test(`${type}: an explicit null_if "" precedes pad_left`, () => {
+      const steps = stepsFor(type, column);
+      const emptyDropIdx = steps.findIndex(
+        (s) => s.function === "null_if" && s.params?.value === "",
+      );
+      const padIdx = steps.findIndex((s) => s.function === "pad_left");
+      expect(emptyDropIdx).toBeGreaterThanOrEqual(0);
+      expect(padIdx).toBeGreaterThan(emptyDropIdx);
+    });
+
+    test(`${type}: a blank still drops with the placeholder null_if removed`, () => {
+      // Prove the explicit empty-drop is load-bearing, not redundant with the
+      // terminal placeholder null_if: strip the placeholder step (the null_if
+      // listing all-zeros/sequential placeholders via `values`) and a blank must
+      // still map to null. Without the explicit `null_if ""`, the blank would pad
+      // to an all-zeros value and survive as a matchable key.
+      const withoutPlaceholder = stepsFor(type, column).filter(
+        (s) => !(s.function === "null_if" && s.params?.values !== undefined),
+      );
+      for (const blank of ["", "   ", "abc", "----"]) {
+        expect(
+          runPipeline(blank, withoutPlaceholder),
+          `input ${JSON.stringify(blank)}`,
+        ).toBeNull();
+      }
+    });
+  }
 });
 
 // --- SSN pipeline ------------------------------------------------------------


### PR DESCRIPTION
## Summary

Make the default SSN and SSN4 standardization chains drop a blank or cleaned-empty cell to null explicitly, instead of relying on `pad_left` plus the terminal placeholder `null_if` to mask it. Since item 203074741 (#260) made the empty string a first-class, matchable linkage key, the standardization layer is the sole guard against the blank-cell footgun (two blank cells spuriously matching) for default exchanges; this makes that guard explicit and independent of the placeholder list. End-to-end behavior for default exchanges is unchanged.

Implements [203074970](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=203074970).

## Changes

- packages/core/src/defaults/standardization.ts: insert an explicit `null_if {value: ""}` into the SSN and SSN4 default chains, after the non-digit-stripping `replace_regex` and before `pad_left`, so a cleaned-empty value is dropped as empty rather than padded into an all-zeros placeholder that the terminal `null_if` happens to list.
- packages/core/test/defaultStandardization.test.ts: add tests for a non-blank value that cleans to empty mapping to null for every default field type, for the SSN/SSN4 explicit `null_if ""` preceding `pad_left`, and for a blank still dropping once the terminal placeholder `null_if` is removed.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm test -w packages/core` (47 files, 1748 pass), `npm run test:unit -w apps/web` (403 pass), `npm run test:unit -w apps/cli` (865 pass), and `npx vitest run packages/core/test/defaultStandardization.test.ts`.
New tests cover: each default field type maps a non-blank value that cleans to empty to null; the SSN/SSN4 explicit empty-drop precedes `pad_left`; and the blank-drop survives removal of the terminal placeholder `null_if`, proving the new step (not the placeholder) carries it. Verified empirically that the new SSN/SSN4 chains are byte-identical to the pre-change chains across an adversarial input set, and that the four untouched default chains can never emit `""`.

## Background

Only SSN and SSN4 needed the explicit step: they pad to a fixed width before validating, so a blank padded to `"000000000"`/`"0000"` and was dropped only because that value is in the terminal placeholder `null_if`. The other four default chains already map a cleaned-empty value to null through a terminal validating step (name via `filter_regex "[A-Z]"`, date via `parse_date`, phone and email via their format `filter_regex`), so they are unchanged. Custom/operator-authored chains that emit `""` remain the operator's responsibility, out of scope here per the board item.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; PROTOCOL.md's existing statement that the default per-type cleaning chains map an empty value to NULL (added by #260) remains accurate and is now more literally true.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: behavior-preserving hardening of default-chain internals with no operator- or reviewer-visible change; the #260 "Changed" entry already records that default chains map empty values to null.
- [x] Security review -- done: change is within the "what is disclosed" scope (consent-surfaced default chains, the blank-cell footgun guard); three independent reviewers each reviewed the disclosure/matching-semantics, guarantee-integrity, and encoding/cross-party-determinism surfaces and returned safe-to-merge with no findings.
