### PR TITLE
Align web error boundary to the NotFound Mantine idiom

### DIFF
--- a/apps/web/src/components/DefaultCatchBoundary.tsx
+++ b/apps/web/src/components/DefaultCatchBoundary.tsx
@@ -19,40 +19,23 @@ export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   console.error("DefaultCatchBoundary Error:", error);
 
   return (
-    <Stack align="center" gap="xl" p="md">
+    <Stack gap="sm" p="sm">
       <ErrorComponent error={error} />
-      <Group gap="2xs">
+      <Group gap="sm">
         <Button
-          color="gray"
-          size="compact-sm"
-          tt="uppercase"
-          fw={800}
           onClick={() => {
             router.invalidate();
           }}
         >
-          Try Again
+          Try again
         </Button>
         {isRoot ? (
-          <Button
-            component={Link}
-            to="/"
-            color="gray"
-            size="compact-sm"
-            tt="uppercase"
-            fw={800}
-          >
+          <Button component={Link} to="/" variant="default">
             Home
           </Button>
         ) : (
-          <Button
-            color="gray"
-            size="compact-sm"
-            tt="uppercase"
-            fw={800}
-            onClick={() => window.history.back()}
-          >
-            Go Back
+          <Button variant="default" onClick={() => window.history.back()}>
+            Go back
           </Button>
         )}
       </Group>

--- a/apps/web/test/browser/defaultCatchBoundary.test.ts
+++ b/apps/web/test/browser/defaultCatchBoundary.test.ts
@@ -1,0 +1,153 @@
+/// <reference types="@vitest/browser-playwright/context" />
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { page, userEvent } from "vitest/browser";
+
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+
+import { MantineProvider } from "@mantine/core";
+
+import { DefaultCatchBoundary } from "@components/DefaultCatchBoundary";
+import { mantineTheme } from "@theme";
+
+import type { ReactNode } from "react";
+import type { Root } from "react-dom/client";
+
+// Stub the router seams DefaultCatchBoundary touches, the same pattern
+// notFound.test.ts / appShell.test.ts use, since a real RouterProvider trips a
+// duplicate-React dispatcher error under the browser runner. The mock surfaces:
+//   - Link as a plain <a href={to}>, so the polymorphic `component={Link}` Home
+//     button is exercised on the Mantine side (the `to` is forwarded as href);
+//   - useRouter().invalidate as a spy, so the retry action's call is observable;
+//   - rootRouteId plus a useMatch that runs the component's real `select` over a
+//     test-controlled route id, so toggling `routerMock.matchedRouteId` drives
+//     the isRoot branch (Home when root, Go back otherwise) through the same
+//     comparison the component makes;
+//   - ErrorComponent as a marker, since rendering the real one is out of scope.
+// Hoisted so the vi.mock factory (lifted above all top-level declarations) can
+// read it. `rootId` is shared between the mocked rootRouteId and the test bodies
+// that flip `matchedRouteId` to it to take the root branch.
+const routerMock = vi.hoisted(() => ({
+  invalidate: vi.fn(),
+  rootId: "__root__",
+  // Default to a non-root match; root-branch tests set this to rootId.
+  matchedRouteId: "/some-route",
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  rootRouteId: routerMock.rootId,
+  useRouter: () => ({ invalidate: routerMock.invalidate }),
+  useMatch: ({ select }: { select: (state: { id: string }) => unknown }) =>
+    select({ id: routerMock.matchedRouteId }),
+  ErrorComponent: ({ error }: { error: unknown }) =>
+    createElement(
+      "div",
+      { "data-testid": "error-component" },
+      error instanceof Error ? error.message : String(error),
+    ),
+  Link: ({
+    to,
+    className,
+    children,
+  }: {
+    to?: string;
+    className?: string;
+    children?: ReactNode;
+  }) =>
+    createElement(
+      "a",
+      { href: typeof to === "string" ? to : "#", className },
+      children,
+    ),
+}));
+
+let container: HTMLElement | undefined;
+let root: Root | undefined;
+
+// Mount under the real app theme, the way the running app composes it.
+function mount(node: ReactNode) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  root.render(createElement(MantineProvider, { theme: mantineTheme }, node));
+}
+
+// DefaultCatchBoundary takes ErrorComponentProps; it reads only `error`, but the
+// type requires `reset`, so a no-op stands in for it.
+function mountBoundary(error: Error = new Error("boom")) {
+  mount(createElement(DefaultCatchBoundary, { error, reset: () => undefined }));
+}
+
+// DefaultCatchBoundary logs every caught error via console.error by design (out
+// of scope here); silence that expected noise so the suite output stays clean.
+// Restored by vi.restoreAllMocks() in afterEach.
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  root?.unmount();
+  container?.remove();
+  root = undefined;
+  container = undefined;
+  routerMock.matchedRouteId = "/some-route";
+  vi.restoreAllMocks();
+  routerMock.invalidate.mockReset();
+});
+
+describe("DefaultCatchBoundary", () => {
+  test("renders the error component and the retry action", async () => {
+    mountBoundary(new Error("boom"));
+
+    await expect
+      .element(page.getByTestId("error-component"))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByRole("button", { name: "Try again" }))
+      .toBeInTheDocument();
+  });
+
+  test("'Try again' invalidates the router", async () => {
+    mountBoundary();
+
+    const tryAgain = page.getByRole("button", { name: "Try again" });
+    await expect.element(tryAgain).toBeInTheDocument();
+    await userEvent.click(tryAgain);
+
+    expect(routerMock.invalidate).toHaveBeenCalledOnce();
+  });
+
+  describe("root branch", () => {
+    test("shows 'Home' as a link to the home route, not 'Go back'", async () => {
+      routerMock.matchedRouteId = routerMock.rootId;
+      mountBoundary();
+
+      // role=link (not button) confirms Mantine honoured `component={Link}`; the
+      // href confirms `to` was forwarded. The back action is absent on root.
+      const home = page.getByRole("link", { name: "Home" });
+      await expect.element(home).toBeInTheDocument();
+      await expect.element(home).toHaveAttribute("href", "/");
+
+      expect(page.getByRole("button", { name: "Go back" }).query()).toBeNull();
+    });
+  });
+
+  describe("non-root branch", () => {
+    test("shows 'Go back' which calls history.back(), not 'Home'", async () => {
+      const back = vi
+        .spyOn(window.history, "back")
+        .mockImplementation(() => undefined);
+      routerMock.matchedRouteId = "/some-route";
+      mountBoundary();
+
+      const goBack = page.getByRole("button", { name: "Go back" });
+      await expect.element(goBack).toBeInTheDocument();
+      await userEvent.click(goBack);
+
+      expect(back).toHaveBeenCalledOnce();
+      expect(page.getByRole("link", { name: "Home" }).query()).toBeNull();
+    });
+  });
+});

--- a/apps/web/test/browser/defaultCatchBoundary.test.ts
+++ b/apps/web/test/browser/defaultCatchBoundary.test.ts
@@ -101,9 +101,12 @@ describe("DefaultCatchBoundary", () => {
   test("renders the error component and the retry action", async () => {
     mountBoundary(new Error("boom"));
 
+    // The boundary forwards `error` into <ErrorComponent error={error} />; the
+    // mock surfaces error.message, so asserting the text (not just the marker's
+    // presence) proves the prop is wired through and would catch a dropped error.
     await expect
       .element(page.getByTestId("error-component"))
-      .toBeInTheDocument();
+      .toHaveTextContent("boom");
     await expect
       .element(page.getByRole("button", { name: "Try again" }))
       .toBeInTheDocument();

--- a/apps/web/test/browser/defaultCatchBoundary.test.ts
+++ b/apps/web/test/browser/defaultCatchBoundary.test.ts
@@ -130,7 +130,9 @@ describe("DefaultCatchBoundary", () => {
       await expect.element(home).toBeInTheDocument();
       await expect.element(home).toHaveAttribute("href", "/");
 
-      expect(page.getByRole("button", { name: "Go back" }).query()).toBeNull();
+      await expect
+        .element(page.getByRole("button", { name: "Go back" }))
+        .not.toBeInTheDocument();
     });
   });
 
@@ -139,7 +141,8 @@ describe("DefaultCatchBoundary", () => {
       const back = vi
         .spyOn(window.history, "back")
         .mockImplementation(() => undefined);
-      routerMock.matchedRouteId = "/some-route";
+      // matchedRouteId defaults to the non-root "/some-route" (set in the hoisted
+      // holder and restored by afterEach), so the non-root branch needs no setup.
       mountBoundary();
 
       const goBack = page.getByRole("button", { name: "Go back" });
@@ -147,7 +150,9 @@ describe("DefaultCatchBoundary", () => {
       await userEvent.click(goBack);
 
       expect(back).toHaveBeenCalledOnce();
-      expect(page.getByRole("link", { name: "Home" }).query()).toBeNull();
+      await expect
+        .element(page.getByRole("link", { name: "Home" }))
+        .not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary

Brings the web route error boundary's action buttons in line with the sibling 404 page so the two error/404 surfaces match, and adds the browser test the boundary previously lacked. This is consistency polish: the merged boundary was already functional, so the change is presentational plus test coverage.

Implements [202701708](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202701708).

## Changes

- apps/web/src/components/DefaultCatchBoundary.tsx: restyle the three action buttons to the NotFound Mantine idiom. Retry ("Try again") is the primary; Home and Go back are `variant="default"` neutrals; labels drop to sentence case; the uppercase, extra-bold, compact-sm, and gray-fill treatments are removed; layout follows NotFound's `Stack`/`Group` with `gap="sm"` and `p="sm"`. Behavior, roles, and the root-vs-non-root branch are unchanged.
- apps/web/test/browser/defaultCatchBoundary.test.ts: new browser test modeled on `notFound.test.ts`, covering both branches and asserting each action renders and behaves.

## Test plan

Ran: `npm run test:browser -w apps/web -- test/browser/defaultCatchBoundary.test.ts` (4 passed), plus `npm run typecheck`, `npm run lint`, and `npm run format` (all clean).
New tests cover: the boundary forwards `error` into `ErrorComponent`; "Try again" calls `router.invalidate()`; the root branch renders Home as a link to "/" (no Go back); the non-root branch renders Go back invoking `window.history.back()` (no Home).

## Background

Spun off from PR #223 (the Tailwind-to-Mantine conversion), which merged the boundary in a faithful-to-original style; the sibling NotFound page had separately moved to the contrast-aware Mantine idiom in #222.

## Out of scope / follow-on

- Routing the displayed error through `sanitizeErrorForDisplay` -- tracked separately as [202642215](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202642215).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: cosmetic restyle plus a test, no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: UI consistency polish plus a test, nothing an operator/deployer or security reviewer acts on.
- [x] Security review -- client-side and information-disclosure reviews run; the displayed and logged error lines are byte-identical to staging (no disclosure change), and the pre-existing sanitizer gap is tracked separately (202642215).
