### PR TITLE
Raise web dark-scheme button and focus contrast to WCAG AA

### DIFF
--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -1,5 +1,8 @@
 import {
+  ActionIcon,
+  Button,
   Card,
+  Checkbox,
   Container,
   Paper,
   Select,
@@ -8,6 +11,40 @@ import {
 } from "@mantine/core";
 
 import type { CSSVariablesResolver, MantineThemeOverride } from "@mantine/core";
+
+/**
+ * True for a filled surface rendered in the primary color -- the default
+ * (`filled`, no explicit `color`) Button / ActionIcon / Checkbox. Used to scope the
+ * per-scheme contrast-text overrides below so they touch only the primary-filled
+ * surfaces, leaving `default`/`subtle`/`light` variants and any future non-primary
+ * filled surface on their own text color. See {@link FILLED_PRIMARY_CONTRAST}.
+ */
+const isFilledPrimary = (
+  variant: string | undefined,
+  color: string | undefined,
+) => (variant === undefined || variant === "filled") && color === undefined;
+
+/**
+ * Route a filled-primary surface's text/icon color through Mantine's per-scheme
+ * `--mantine-primary-color-contrast` variable instead of the static white its own
+ * varsResolver emits.
+ *
+ * Mantine resolves a filled theme-color surface's text color color-scheme-blind:
+ * the Button/ActionIcon/Checkbox `varsResolver`s call the variant resolver with no
+ * color scheme, so `autoContrast` parses the primary against its LIGHT shade
+ * (cyan-9, luminance 0.14 -> not light) and picks white for BOTH schemes. That
+ * leaves the dark filled-primary text white on the brighter cyan-6 dark fill =
+ * 2.79:1, below the 1.4.3 floor. `--mantine-primary-color-contrast` is the one
+ * contrast value Mantine computes per scheme (white on the light cyan-9 fill, black
+ * on the dark cyan-6 fill -- the latter is why `autoContrast` must stay enabled, as
+ * it drives that pick), so pointing the filled-primary text at it yields black-on-
+ * cyan-6 = 7.53:1 in dark while staying white in light (byte-identical to the static
+ * default). Each component names this color through a different CSS variable, hence
+ * three near-identical overrides. The resolved ratios are enforced by
+ * test/unit/themeContrast.test.ts and the rendered colors by
+ * test/browser/themeContrast.test.ts.
+ */
+const FILLED_PRIMARY_CONTRAST = "var(--mantine-primary-color-contrast)";
 
 const CONTAINER_SIZES = {
   xxs: rem("200px"),
@@ -52,22 +89,62 @@ export const mantineTheme: MantineThemeOverride = createTheme({
     "3xl": rem("32px"),
   },
   primaryColor: "cyan",
-  // Light-scheme primary shade raised 6 -> 9 for WCAG 2.1 AA contrast. The
-  // default cyan-6 (#15aabf) fails wherever the primary is used: white-on-cyan-6
-  // filled buttons (and the filled copy ActionIcon glyph and the consent Checkbox
-  // checkmark) = 2.79:1; the cyan-6 anchor/link and the cyan-6 focus-visible
-  // outline / input focus border on the white page = 2.79:1. autoContrast does
-  // not solve this -- it only recolours text sitting on a filled surface, so it
-  // cannot lift the anchor, focus ring, or input border (cyan-on-white, not
-  // text-on-fill). cyan-8 is also short (white text 4.35:1, under the 4.5 floor);
-  // cyan-9 (#0b7285) is the first shade that clears it, fixing all of those at
-  // once: white-on-cyan-9 = 5.59:1 and cyan-9-on-white = 5.59:1. The filled hover
-  // step resolves to cyan-8 (4.35:1) -- transient, and AA is judged on the resting
-  // state. dark stays at its 8 default (stated so it cannot drift); the dark
-  // scheme is unchanged. The ratios are enforced by test/unit/themeContrast.test.ts.
-  primaryShade: { light: 9, dark: 8 },
+  // Enabled so Mantine computes `--mantine-primary-color-contrast` per scheme (white
+  // on the light cyan-9 fill, black on the dark cyan-6 fill), the variable the
+  // filled-primary overrides below route their text/icon color to; without it that
+  // variable is white in both schemes and the dark text fix would not hold.
+  // autoContrast does NOT by itself recolor filled theme-color text per scheme -- see
+  // FILLED_PRIMARY_CONTRAST above for why the overrides, not autoContrast, are the fix.
+  autoContrast: true,
+  // Per-scheme primary shade, each tuned to WCAG 2.1 AA (1.4.3 text 4.5:1, 1.4.11
+  // non-text 3:1) against its own surfaces; enforced by
+  // test/unit/themeContrast.test.ts.
+  //
+  // Light raised 6 -> 9. The default cyan-6 (#15aabf) fails wherever the primary is
+  // used: white-on-cyan-6 filled buttons (and the copy ActionIcon glyph and the
+  // consent Checkbox checkmark) = 2.79:1; the cyan-6 anchor/link and the cyan-6
+  // focus-visible outline / input focus border on the white page = 2.79:1. cyan-8
+  // is also short (white text 4.35:1); cyan-9 (#0b7285) is the first shade clearing
+  // it, fixing all of those at once: white-on-cyan-9 = 5.59:1 and cyan-9-on-white =
+  // 5.59:1. The filled hover step resolves to cyan-8 (4.35:1) -- transient, and AA
+  // is judged on the resting state.
+  //
+  // Dark moved 8 -> 6. No single cyan shade satisfies both dark bars with WHITE
+  // filled text: cyan-8 (the old default) left the filled button text at
+  // white-on-cyan-8 = 4.35:1 (under 4.5), and darkening to cyan-9 fixes the button
+  // but drops the focus ring / input border on the dark body to 2.78:1 / 2.43:1
+  // (under 3). cyan-6 is bright enough that the focus ring on the dark-7 body reaches
+  // 5.57:1 and the input focus border on the dark-6 input 4.87:1, and the
+  // filled-primary text -- routed through --mantine-primary-color-contrast (black on
+  // cyan-6) by the component overrides below -- reaches 7.53:1. All three clear with
+  // margin.
+  primaryShade: { light: 9, dark: 6 },
   components: {
     /** Put your mantine component override here */
+    // Filled-primary text/icon -> per-scheme contrast color (see
+    // FILLED_PRIMARY_CONTRAST). Each names the color through its own CSS variable;
+    // the merge keeps the rest of each component's vars (background, sizing).
+    Button: Button.extend({
+      vars: (_, { variant, color }) => ({
+        root: isFilledPrimary(variant, color)
+          ? { "--button-color": FILLED_PRIMARY_CONTRAST }
+          : {},
+      }),
+    }),
+    ActionIcon: ActionIcon.extend({
+      vars: (_, { variant, color }) => ({
+        root: isFilledPrimary(variant, color)
+          ? { "--ai-color": FILLED_PRIMARY_CONTRAST }
+          : {},
+      }),
+    }),
+    Checkbox: Checkbox.extend({
+      vars: (_, { variant, color }) => ({
+        root: isFilledPrimary(variant, color)
+          ? { "--checkbox-icon-color": FILLED_PRIMARY_CONTRAST }
+          : {},
+      }),
+    }),
     Container: Container.extend({
       vars: (_, { size, fluid }) => ({
         root: {

--- a/apps/web/test/browser/themeContrast.test.ts
+++ b/apps/web/test/browser/themeContrast.test.ts
@@ -1,0 +1,151 @@
+/// <reference types="@vitest/browser-playwright/context" />
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+
+import "@mantine/core/styles.css";
+import { ActionIcon, Button, Checkbox, MantineProvider } from "@mantine/core";
+
+import { mantineTheme } from "@theme";
+
+import type { ComponentType, ReactNode } from "react";
+import type { Root } from "react-dom/client";
+
+// Button and Checkbox are polymorphic factory components; this is a `.ts` file (the
+// browser project globs `.ts`, not `.tsx`, so no JSX), and createElement cannot
+// resolve their overloaded type directly -- cast each to the plain component shape
+// this test renders.
+const FilledButton = Button as unknown as ComponentType<{
+  children?: ReactNode;
+}>;
+const PrimaryCheckbox = Checkbox as unknown as ComponentType<{
+  defaultChecked?: boolean;
+  "aria-label"?: string;
+}>;
+const FilledActionIcon = ActionIcon as unknown as ComponentType<{
+  children?: ReactNode;
+  "aria-label"?: string;
+}>;
+
+// Render-level counterpart to test/unit/themeContrast.test.ts. The unit test
+// asserts the palette arithmetic and that the theme ROUTES filled-primary text
+// through --mantine-primary-color-contrast; it cannot prove the browser actually
+// paints that color, because Mantine resolves a filled surface's text color
+// color-scheme-blind in JS. That blind spot already shipped one regression (a dark
+// button rendered white-on-cyan-6 = 2.79:1 while a unit test that modeled an
+// idealized autoContrast stayed green), so this measures the REAL computed colors
+// of all three contrast-routed filled-primary surfaces -- the Button label, the
+// (consent-gate) Checkbox checkmark, and the copy ActionIcon glyph -- in both schemes
+// and checks them against the WCAG 2.1 AA 1.4.3 text floor. The focus ring / input
+// border use the per-scheme --mantine-primary-color-filled directly (a plain shade
+// lookup, not the autoContrast path), so the unit test covers them.
+
+let container: HTMLElement | undefined;
+let root: Root | undefined;
+
+function mount(scheme: "light" | "dark", node: ReactNode) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  root.render(
+    createElement(
+      MantineProvider,
+      { theme: mantineTheme, forceColorScheme: scheme },
+      node,
+    ),
+  );
+}
+
+afterEach(() => {
+  root?.unmount();
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+/** Wait for a mounted element (createRoot.render is not synchronous), then return
+ * it. */
+async function waitForEl(selector: string): Promise<HTMLElement> {
+  await expect.poll(() => container!.querySelector(selector)).not.toBeNull();
+  return container!.querySelector(selector) as HTMLElement;
+}
+
+/** sRGB channels of a computed `rgb(r, g, b)` / `rgba(...)` color string. */
+function channels(color: string): [number, number, number] {
+  const m = color.match(/-?\d+(\.\d+)?/g);
+  if (!m || m.length < 3) throw new Error(`unparseable color: ${color}`);
+  return [Number(m[0]), Number(m[1]), Number(m[2])];
+}
+
+/** WCAG 2.1 relative luminance of a computed color string. */
+function relativeLuminance(color: string): number {
+  const linear = (v: number) =>
+    v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  const [r, g, b] = channels(color).map((c) => c / 255);
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+}
+
+/** WCAG contrast ratio between two computed color strings (1..21). */
+function contrast(a: string, b: string): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+describe("rendered theme colour contrast (WCAG 2.1 AA)", () => {
+  // Black resolves brighter on cyan-6 (7.53) than white does on cyan-9 (5.59), so a
+  // single >= 4.5 floor covers both schemes; the per-scheme text assertions below
+  // pin WHICH colour renders, which is the half that regressed before.
+  for (const { scheme, expectedText } of [
+    { scheme: "light" as const, expectedText: "rgb(255, 255, 255)" },
+    { scheme: "dark" as const, expectedText: "rgb(0, 0, 0)" },
+  ]) {
+    test(`filled-primary button label is AA-legible (${scheme})`, async () => {
+      mount(scheme, createElement(FilledButton, null, "Continue"));
+      const btn = await waitForEl(".mantine-Button-root");
+      await expect.poll(() => getComputedStyle(btn).color).toBe(expectedText);
+      const { color, backgroundColor } = getComputedStyle(btn);
+      expect(contrast(color, backgroundColor)).toBeGreaterThanOrEqual(4.5);
+    });
+
+    test(`consent checkbox checkmark is AA-legible (${scheme})`, async () => {
+      mount(
+        scheme,
+        createElement(PrimaryCheckbox, {
+          defaultChecked: true,
+          "aria-label": "consent",
+        }),
+      );
+      // The checkmark (CheckIcon, currentColor) sits in .mantine-Checkbox-icon; its
+      // fill is --checkbox-icon-color and its background is the filled box (the input).
+      const input = await waitForEl(".mantine-Checkbox-input");
+      const icon = await waitForEl(".mantine-Checkbox-icon");
+      await expect.poll(() => getComputedStyle(icon).color).toBe(expectedText);
+      const fill = getComputedStyle(input).backgroundColor;
+      expect(
+        contrast(getComputedStyle(icon).color, fill),
+      ).toBeGreaterThanOrEqual(4.5);
+    });
+
+    test(`filled-primary action icon glyph is AA-legible (${scheme})`, async () => {
+      // The copy ActionIcon (ShareBlock) in its filled state; glyph colour is
+      // --ai-color, routed to the contrast variable. No variant prop -> the default
+      // filled, matching how the override is scoped.
+      mount(
+        scheme,
+        createElement(
+          FilledActionIcon,
+          { "aria-label": "copy" },
+          createElement("span", null, "i"),
+        ),
+      );
+      const ai = await waitForEl(".mantine-ActionIcon-root");
+      await expect.poll(() => getComputedStyle(ai).color).toBe(expectedText);
+      const { color, backgroundColor } = getComputedStyle(ai);
+      expect(contrast(color, backgroundColor)).toBeGreaterThanOrEqual(4.5);
+    });
+  }
+});

--- a/apps/web/test/unit/themeContrast.test.ts
+++ b/apps/web/test/unit/themeContrast.test.ts
@@ -70,6 +70,11 @@ const lightShade =
     ? theme.primaryShade
     : theme.primaryShade.light;
 const primary = theme.colors[theme.primaryColor][lightShade];
+const darkShade =
+  typeof theme.primaryShade === "number"
+    ? theme.primaryShade
+    : theme.primaryShade.dark;
+const darkPrimary = theme.colors[theme.primaryColor][darkShade];
 const white = theme.white;
 const gray0 = theme.colors.gray[0];
 const cyan1 = theme.colors.cyan[1];
@@ -103,13 +108,36 @@ const placeholderLight = vars.light["--mantine-color-placeholder"];
 const dimmedDark = vars.dark["--mantine-color-dimmed"];
 const placeholderDark = vars.dark["--mantine-color-placeholder"];
 
+// Resolves Mantine's `--mantine-primary-color-contrast` for a given primary fill,
+// mirroring getPrimaryContrastColor -> getContrastColor: with autoContrast on, the
+// contrast color is black when the fill is "light" (luminance strictly above the
+// theme's luminanceThreshold, the same comparison as Mantine's isLightColor) else
+// white; with autoContrast off it is always white. The filled-primary Button /
+// ActionIcon / Checkbox text is routed to this variable by the theme (Mantine
+// resolves a filled surface's own text color color-scheme-blind, so it would
+// otherwise be white in both schemes); the "filled-primary text is routed..." test
+// below pins that wiring. Reading the value from the theme rather than hardcoding it
+// means flipping autoContrast off or picking a darker dark shade re-runs the
+// arithmetic here -- a real check, not a restated constant.
+function primaryContrast(fill: string): string {
+  return theme.autoContrast &&
+    relativeLuminance(fill) > theme.luminanceThreshold
+    ? theme.black
+    : theme.white;
+}
+const darkButtonText = primaryContrast(darkPrimary);
+
 describe("theme colour contrast (WCAG 2.1 AA)", () => {
   const cases: Array<{ name: string; fg: string; bg: string; floor: number }> =
     [
       // Primary (raised to cyan-9): one shade covers every surface it touches.
+      // The text colour is read through primaryContrast (the per-scheme contrast
+      // variable the filled-primary text is routed to) so this tracks what actually
+      // renders; the light guard test below locks it to white (byte-identical to the
+      // pre-autoContrast static default).
       {
-        name: "filled button text: white on primary",
-        fg: white,
+        name: "filled button text: contrast text on primary",
+        fg: primaryContrast(primary),
         bg: primary,
         floor: 4.5,
       },
@@ -135,6 +163,33 @@ describe("theme colour contrast (WCAG 2.1 AA)", () => {
         name: "copied-state copy icon: primary on cyan-1 (non-text)",
         fg: primary,
         bg: cyan1,
+        floor: 3,
+      },
+      // Dark scheme primary (shade 6): the counterpart to the light primary fix. A
+      // lighter dark shade lifts the focus indicators on the dark surfaces, and the
+      // filled-primary text -- routed to --mantine-primary-color-contrast (black on
+      // cyan-6) -- clears the text floor. Modeled like the light primary cases above:
+      // button text on the fill, focus ring on the dark-7 body, input focus border on
+      // the dark-6 input. cyan-8 (the old default) left the button text at 4.35:1
+      // (under 4.5); darkening to cyan-9 instead would drop the focus ring / input
+      // border to 2.78:1 / 2.43:1 (under 3), which is why the shade went lighter, not
+      // darker (and why the text fix is the contrast-var route, not a shade move).
+      {
+        name: "filled button text (dark): contrast var on dark primary",
+        fg: darkButtonText,
+        bg: darkPrimary,
+        floor: 4.5,
+      },
+      {
+        name: "focus ring (dark): dark primary on dark-7 body (non-text)",
+        fg: darkPrimary,
+        bg: dark7,
+        floor: 3,
+      },
+      {
+        name: "input focus border (dark): dark primary on dark-6 input (non-text)",
+        fg: darkPrimary,
+        bg: dark6,
         floor: 3,
       },
       // Status light-variant text (overridden tokens) on their shade-1 tints.
@@ -232,5 +287,54 @@ describe("theme colour contrast (WCAG 2.1 AA)", () => {
     // if every other surface happened to compensate.
     expect(lightShade).toBeGreaterThanOrEqual(9);
     expect(contrast(white, primary)).toBeGreaterThanOrEqual(4.5);
+    // Enabling autoContrast (for the dark fix) must leave the light scheme
+    // byte-identical: the light primary cyan-9 sits below the luminanceThreshold, so
+    // --mantine-primary-color-contrast stays white -- the same colour the static
+    // default produced. A future shade light enough to flip it to black would fail
+    // here.
+    expect(primaryContrast(primary)).toBe(white);
+  });
+
+  test("dark primary clears AA via the per-scheme contrast variable", () => {
+    // autoContrast must be on so --mantine-primary-color-contrast computes per scheme,
+    // and the dark shade must be light enough (luminance above the threshold) that it
+    // resolves to black -- white-on-cyan-6 is only 2.79:1, so without the flip the
+    // dark filled-primary text fails. Guards both halves so dropping autoContrast or
+    // choosing a darker dark shade fails here, not only through whichever case above
+    // happened to still pass.
+    expect(theme.autoContrast).toBe(true);
+    expect(relativeLuminance(darkPrimary)).toBeGreaterThan(
+      theme.luminanceThreshold,
+    );
+    expect(darkButtonText).toBe(theme.black);
+    expect(contrast(darkButtonText, darkPrimary)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  test("filled-primary text is routed through the per-scheme contrast variable", () => {
+    // The dark contrast cases above model --mantine-primary-color-contrast, which the
+    // filled-primary Button / ActionIcon / Checkbox text must actually be pointed at
+    // (Mantine resolves a filled surface's own text colour color-scheme-blind, so it
+    // would otherwise be white in both schemes -- the failure this whole change
+    // corrects). Pin that wiring: each component's vars override must emit the
+    // contrast variable for the filled primary (default variant, no colour) and must
+    // NOT touch a default/subtle/light or explicitly-coloured instance, which keep
+    // their own text colour. The rendered colours themselves are checked in
+    // test/browser/themeContrast.test.ts.
+    const contrastVar = "var(--mantine-primary-color-contrast)";
+    const wiring: Array<[string, string]> = [
+      ["Button", "--button-color"],
+      ["ActionIcon", "--ai-color"],
+      ["Checkbox", "--checkbox-icon-color"],
+    ];
+    for (const [name, cssVar] of wiring) {
+      const resolve = theme.components[name].vars;
+      expect(resolve, `${name} vars override`).toBeDefined();
+      const at = (props: Record<string, unknown>) =>
+        resolve!(theme, props, {}).root[cssVar];
+      expect(at({ variant: "filled" })).toBe(contrastVar);
+      expect(at({})).toBe(contrastVar); // default variant is filled
+      expect(at({ variant: "default" })).toBeUndefined();
+      expect(at({ variant: "filled", color: "red" })).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Raise the web app's dark color-scheme filled-primary button text and focus indicators to WCAG 2.1 AA (1.4.3 text 4.5:1, 1.4.11 non-text 3:1), the dark counterpart to the light-scheme fix already shipped. The dark scheme is effectively unused (light is the default and only reachable scheme), so this is a low-severity, defensive conformance fix; the light scheme is left byte-identical.

Implements [202634810](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202634810).

## Changes

- apps/web/src/theme.ts: enable `autoContrast`, move the dark primary shade cyan-8 -> cyan-6 (lifting the dark focus ring to 5.57:1 and input border to 4.87:1), and route the filled-primary Button/ActionIcon/Checkbox text through Mantine's per-scheme `--mantine-primary-color-contrast` variable (black on the dark cyan-6 fill = 7.53:1, white in light), scoped to the filled primary so other variants and explicit colors are untouched.
- apps/web/test/unit/themeContrast.test.ts: add dark-scheme contrast cases and a wiring assertion that the filled-primary text is routed to the contrast variable.
- apps/web/test/browser/themeContrast.test.ts: new render test measuring the actual computed colors of all three contrast-routed surfaces (button label, consent checkbox checkmark, copy action icon) in both schemes.

## Test plan

Ran: `npm run test:unit -w apps/web` (435 pass), full `npm run test:browser -w apps/web` (190 pass, including the 6 new cases), and `npm run typecheck` / `npm run lint` / `npm run format`.
New tests cover: the dark-scheme button-text, focus-ring, and input-border contrast ratios; that filled-primary text is wired to `--mantine-primary-color-contrast`; and the literally-rendered button/checkbox/action-icon colors in light and dark. A negative control (removing the override) was confirmed to turn the dark render cases red, so the suite catches the regression it is meant to.

## Background

Mantine v9.1.1 resolves a filled theme-color surface's text color color-scheme-blind, against the light primary shade, so theme `autoContrast` alone yields white text in both schemes -- on the brighter cyan-6 dark fill that is 2.79:1, below the floor. Pointing the filled-primary text at `--mantine-primary-color-contrast` (the one contrast value Mantine computes per scheme) is what produces black text in dark; `autoContrast` stays enabled because that variable depends on it.

## Out of scope / follow-on

- Render-pinning the remaining contrast surfaces -- the focus ring and input focus border are still verified by palette arithmetic, not by the rendered color: [203282650](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=203282650).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; ROADMAP and COMPLIANCE state the accessibility goal conceptually and name no shades or ratios, and the per-shade rationale lives in theme.ts JSDoc and the tests.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: defensive a11y fix to the default-off dark scheme with the light scheme byte-identical, so no operator- or reviewer-visible change (the two counterpart a11y commits added none either).
- [x] Security review -- n/a: none of the listed areas touched -- the change is CSS color-token resolution only, with no change to data sent/logged/displayed/written and no dependency change. Independent security reviews during development confirmed no security impact.
