### PR TITLE
Gate inviter Generate on the single-identifier rule (parity with acceptor)

### DIFF
--- a/apps/web/src/components/LinkageTermsEditor.tsx
+++ b/apps/web/src/components/LinkageTermsEditor.tsx
@@ -41,6 +41,7 @@ import {
   validateAdvancedInvite,
 } from "@psi/advancedInvite";
 import { APPLIED_SETTINGS } from "@psi/appliedSettings";
+import { hasMultipleIdentifiers } from "@psi/metadataEditing";
 
 import { ExpertKeyEditor } from "@components/ExpertKeyEditor";
 import { InvitationTerms } from "@components/InvitationTerms";
@@ -192,6 +193,19 @@ export function LinkageTermsEditor({
   );
   const previewTerms = useMemo(() => buildAdvancedTerms(draft), [draft]);
 
+  // The single-identifier gate, mirroring the acceptor (PrepareData's
+  // `multipleIdentifiers`): `inferMetadata` can SEED two row-identifier columns
+  // (an `id` and an `identifier` both infer to `role: identifier`), which the
+  // grid surfaces as its red "Only one column can be the row identifier" error.
+  // Fold it into a single `canGenerate` used uniformly by the footer status, the
+  // Generate button, and `handleGenerate`, so the three stay consistent and an
+  // invitation cannot be minted while the metadata is in that known-invalid state.
+  // `validateAdvancedInvite` is metadata-disclosure-agnostic by design, so this
+  // stays a component gate over the same predicate the acceptor uses rather than a
+  // new validation rule.
+  const canGenerate =
+    validation.canGenerate && !hasMultipleIdentifiers(draft.metadata);
+
   // Per-key satisfiability badge, derived from the draft's CURRENT metadata so it
   // tracks column-type edits. A field is producible when the edited metadata has a
   // non-ignored column of its type; the offerable terms for that metadata declare
@@ -324,7 +338,7 @@ export function LinkageTermsEditor({
   };
 
   const handleGenerate = () => {
-    if (!validation.canGenerate || validation.terms === undefined) return;
+    if (!canGenerate || validation.terms === undefined) return;
     onGenerate(validation.terms, draft.lifetimeSeconds, draft.metadata);
   };
 
@@ -674,7 +688,7 @@ export function LinkageTermsEditor({
       >
         <Group justify="space-between">
           <Group gap="xs">
-            {validation.canGenerate ? (
+            {canGenerate ? (
               <Text size="sm" c="dimmed">
                 Ready to generate.
               </Text>
@@ -695,7 +709,7 @@ export function LinkageTermsEditor({
             </Button>
             <Button
               onClick={handleGenerate}
-              disabled={!validation.canGenerate || generating}
+              disabled={!canGenerate || generating}
               loading={generating}
             >
               Generate invitation

--- a/apps/web/src/components/LinkageTermsEditor.tsx
+++ b/apps/web/src/components/LinkageTermsEditor.tsx
@@ -687,7 +687,15 @@ export function LinkageTermsEditor({
         }}
       >
         <Group justify="space-between">
-          <Group gap="xs">
+          {/* The validation status lives in ONE stable, polite, atomic live
+              region -- the same idiom as the acceptor's PrepareData verdict. The
+              wrapper persists across renders while the inner text swaps, so a
+              screen reader hears the Ready <-> Resolve transition (including the
+              inviter newly blocking on the two-identifier state), not only the
+              sighted footer change; a bare swap of two separately-mounted nodes
+              would not reliably announce it. Polite, not assertive, so it does
+              not fight the heading focus on mount. */}
+          <div role="status" aria-live="polite" aria-atomic="true">
             {canGenerate ? (
               <Text size="sm" c="dimmed">
                 Ready to generate.
@@ -702,7 +710,7 @@ export function LinkageTermsEditor({
                 Resolve the highlighted items to continue.
               </Text>
             )}
-          </Group>
+          </div>
           <Group gap="sm">
             <Button variant="default" onClick={handleReset}>
               Reset to recommended

--- a/apps/web/test/browser/linkageTermsEditor.test.ts
+++ b/apps/web/test/browser/linkageTermsEditor.test.ts
@@ -170,6 +170,15 @@ describe("LinkageTermsEditor", () => {
       .element(page.getByText("Resolve the highlighted items to continue."))
       .toBeInTheDocument();
 
+    // The block is announced, not a silent visual-only footer swap: the footer
+    // status sits in a polite live region (the acceptor verdict idiom), so a
+    // screen reader hears the gate engage and later release.
+    const footerStatus = page
+      .getByText("Resolve the highlighted items to continue.")
+      .element()
+      .closest('[role="status"]');
+    expect(footerStatus?.getAttribute("aria-live")).toBe("polite");
+
     // Demote one identifier to Ignored, leaving a single row identifier: the grid
     // error clears and Generate re-enables. The disclosure dropdown opens
     // highlighting the current "Row identifier - not sent" choice; two steps down

--- a/apps/web/test/browser/linkageTermsEditor.test.ts
+++ b/apps/web/test/browser/linkageTermsEditor.test.ts
@@ -29,8 +29,11 @@ let root: Root | undefined;
 const onGenerate =
   vi.fn<(terms: LinkageTerms, lifetimeSeconds: number) => void>();
 
-function mount(initialIdentity = "County Health Dept"): AdvancedInviteSeed {
-  const { seed } = seedAdvancedInvite(initialIdentity, ALL_COLUMNS);
+function mount(
+  initialIdentity = "County Health Dept",
+  columns: Array<string> = ALL_COLUMNS,
+): AdvancedInviteSeed {
+  const { seed } = seedAdvancedInvite(initialIdentity, columns);
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -139,6 +142,50 @@ describe("LinkageTermsEditor", () => {
     await expect
       .element(page.getByText("Enter a name to identify yourself."))
       .toBeInTheDocument();
+  });
+
+  test("two identifier columns gate Generate until one is resolved", async () => {
+    // Mirrors the acceptor's two-identifier gate (acceptConsentGate.test.ts): `id`
+    // and `identifier` both infer to role:identifier, so the seed carries two. The
+    // name + dob columns make the LN+FN+DOB key satisfiable (validation otherwise
+    // passes), but the grid flags the ambiguous identifier and Generate stays
+    // disabled -- with the footer status consistent with the button -- until the
+    // operator picks a single one.
+    mount("County Health Dept", [
+      "id",
+      "identifier",
+      "first_name",
+      "last_name",
+      "dob",
+    ]);
+    await expect
+      .element(
+        page.getByText(
+          "Only one column can be the row identifier. Choose a single identifier.",
+        ),
+      )
+      .toBeInTheDocument();
+    await expect.element(generateButton()).toBeDisabled();
+    await expect
+      .element(page.getByText("Resolve the highlighted items to continue."))
+      .toBeInTheDocument();
+
+    // Demote one identifier to Ignored, leaving a single row identifier: the grid
+    // error clears and Generate re-enables. The disclosure dropdown opens
+    // highlighting the current "Row identifier" choice; two steps down reach
+    // "Ignored" (Row identifier -> Sent to your partner -> Ignored).
+    await userEvent.click(
+      page.getByRole("combobox", { name: "How column id is used" }),
+    );
+    await userEvent.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+    await expect
+      .element(
+        page.getByText(
+          "Only one column can be the row identifier. Choose a single identifier.",
+        ),
+      )
+      .not.toBeInTheDocument();
+    await expect.element(generateButton()).toBeEnabled();
   });
 
   test("Reset to recommended restores the seeded name after an edit", async () => {

--- a/apps/web/test/browser/linkageTermsEditor.test.ts
+++ b/apps/web/test/browser/linkageTermsEditor.test.ts
@@ -172,8 +172,9 @@ describe("LinkageTermsEditor", () => {
 
     // Demote one identifier to Ignored, leaving a single row identifier: the grid
     // error clears and Generate re-enables. The disclosure dropdown opens
-    // highlighting the current "Row identifier" choice; two steps down reach
-    // "Ignored" (Row identifier -> Sent to your partner -> Ignored).
+    // highlighting the current "Row identifier - not sent" choice; two steps down
+    // reach "Ignored" ("Row identifier - not sent" -> "Sent to your partner" ->
+    // "Ignored").
     await userEvent.click(
       page.getByRole("combobox", { name: "How column id is used" }),
     );


### PR DESCRIPTION
## Summary

Close a parity gap in the web inviter's Advanced "Prepare your data" editor: like the acceptor, it must now resolve the single-identifier conflict before "Generate invitation" proceeds. When a file infers two row-identifier columns (an `id` and an `identifier` column both mapping to `role:identifier`), the shared metadata grid already showed the red "Only one column can be the row identifier" error, yet Generate still proceeded under a "Ready to generate" footer. Generation is now blocked while the conflict stands, the footer and button stay consistent, and the blocked state is announced to assistive technology.

Implements [202958927](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202958927).

## Changes

- apps/web/src/components/LinkageTermsEditor.tsx: compute one `canGenerate = validation.canGenerate && !hasMultipleIdentifiers(draft.metadata)` -- the same predicate the acceptor's PrepareData uses -- and read it uniformly from the footer status, the Generate button `disabled`, and the `handleGenerate` guard, so the three cannot disagree. Wrap the footer status in a stable polite atomic live region (the acceptor verdict idiom) so the Ready/Resolve transition is announced, not only shown visually.
- apps/web/test/browser/linkageTermsEditor.test.ts: add a browser test mirroring the acceptor's two-identifier-gate test -- a CSV with both `id` and `identifier` leaves Generate disabled (with a consistent footer) until one identifier is resolved, then re-enables it -- and guard that the footer status sits in a polite live region.

## Test plan

Ran: `npx vitest run --project browser linkageTermsEditor acceptConsentGate` (24 tests pass) and `npm run typecheck && npm run lint && npm run format` (green).
New tests cover: the inviter Generate gate engaging on a two-identifier seed while keys are otherwise satisfiable, re-enabling once the conflict is resolved, footer/button consistency, and the footer live-region wiring.

## Background

Severity framing (carried from the issue, re-confirmed by an independent security panel): this is a UX-consistency fix, not a disclosure fix. An identifier-role column is never sent (`isPayload: false`, set by `normalizeForEditor`/`applyDisclosure`), and the invitation token embeds no per-party column metadata, so an invitation minted in the two-identifier state could not have disclosed data; the harm was a confusing footer/button state only. The guarantee rests on the editor never producing an identifier column with `isPayload: true`, currently ensured structurally by `applyDisclosure` being the sole writer of that role.

## Out of scope / follow-on

- Convert the shared metadata grid's identifier-conflict message from a conditionally-mounted assertive `role="alert"` to a stable polite live region, designed and tested for both editors -- [203326596](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=203326596).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: COMMUNICATION.md already states the inviter editor blocks generating until the terms are valid and at least one key is satisfiable; the single-identifier rule is a per-party metadata-validity sub-detail not spelled out for either editor (so the doc stays consistent across both), and no wire/protocol/spec-tier detail changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: parity fix within an unreleased web feature already described under [Unreleased] Added, whose entry ("validation that blocks generating an invalid or unlinkable invitation") already covers the two-identifier state; no new operator- or reviewer-visible behavior beyond what is documented.
- [x] Security review -- done: independent panel across three lenses (disclosure-surface, bypass/fail-open, injection/display-safety), all APPROVE, no findings. The PR touches the "what is disclosed" surface (the invitation-generation path) but is confirmed UX-only -- identifier-role columns are never sent and the token carries no per-party metadata.