### PR TITLE
Anchor Details disclosure aria-controls to a stable wrapper

### DIFF
--- a/apps/web/src/components/InvitationTerms.tsx
+++ b/apps/web/src/components/InvitationTerms.tsx
@@ -312,12 +312,15 @@ export function InvitationTerms({
       {/* A real disclosure: the toggle carries aria-expanded and aria-controls,
           and Mantine's Collapse sets aria-hidden + inert (and display:none) on the
           panel while closed, so the dense detail is hidden from assistive tech and
-          the tab order until opened. This holds because the app theme leaves
-          respectReducedMotion off, so Collapse animates and keeps the panel
-          mounted-but-hidden. Turning respectReducedMotion on would make Collapse
-          unmount the closed panel for a reduced-motion user, dangling this
-          aria-controls -- revisit (e.g. a stable wrapper holding the id) before
-          enabling it. */}
+          the tab order until opened. aria-controls points at the stable wrapper
+          below, not the Collapse panel: with respectReducedMotion on, Collapse
+          unmounts the closed panel for a reduced-motion user, which would dangle an
+          id held on the panel itself; the always-mounted wrapper keeps the
+          reference resolvable in every state and under either motion preference
+          (collapsed content is hidden from AT when the panel is mounted-but-hidden,
+          and absent when it is unmounted). A render test pins this against the
+          accessibility tree, so the wrapper is not safe to inline back onto the
+          panel. */}
       <UnstyledButton
         onClick={() => setDetailsOpen((open) => !open)}
         aria-expanded={detailsOpen}
@@ -338,107 +341,109 @@ export function InvitationTerms({
         </Group>
       </UnstyledButton>
 
-      <Collapse id={detailsId} expanded={detailsOpen}>
-        <Stack gap="sm">
-          <Term label="Matching rules">
-            {/* A Stack of key blocks, not a Mantine List: each key renders flow
+      <div id={detailsId}>
+        <Collapse expanded={detailsOpen}>
+          <Stack gap="sm">
+            <Term label="Matching rules">
+              {/* A Stack of key blocks, not a Mantine List: each key renders flow
                 content (see MatchKeyDetails), which a List.Item would nest
                 invalidly. Keyed by index -- the list is static and key names are
                 not unique once sanitized. */}
-            <Stack gap="sm">
-              {summary.linkageKeys.map((key, index) => (
-                <MatchKeyDetails key={index} summary={key} />
-              ))}
-            </Stack>
-          </Term>
+              <Stack gap="sm">
+                {summary.linkageKeys.map((key, index) => (
+                  <MatchKeyDetails key={index} summary={key} />
+                ))}
+              </Stack>
+            </Term>
 
-          <Term label="Personal data used">
-            <Stack gap="xs">
-              {summary.linkageFields.map((field, index) =>
-                field.constraints.length > 0 ? (
-                  <Stack key={index} gap={2}>
-                    <Text size="sm">{field.label}</Text>
-                    {/* Each constraint as its own item rather than a joined
+            <Term label="Personal data used">
+              <Stack gap="xs">
+                {summary.linkageFields.map((field, index) =>
+                  field.constraints.length > 0 ? (
+                    <Stack key={index} gap={2}>
+                      <Text size="sm">{field.label}</Text>
+                      {/* Each constraint as its own item rather than a joined
                         string: a partner-controlled allowedCharacters class may
                         contain the separator, which joined text would render as
                         spurious extra clauses. Keyed by index -- order is fixed
                         for a field. */}
-                    <List size="xs" withPadding listStyleType="circle">
-                      {field.constraints.map((constraint, ci) => (
-                        <List.Item key={ci}>
-                          <Text span size="xs" c="dimmed">
-                            {constraint}
-                          </Text>
-                        </List.Item>
-                      ))}
-                    </List>
-                  </Stack>
-                ) : (
-                  <Text key={index} size="sm">
-                    {field.label}
-                  </Text>
-                ),
-              )}
-            </Stack>
-          </Term>
+                      <List size="xs" withPadding listStyleType="circle">
+                        {field.constraints.map((constraint, ci) => (
+                          <List.Item key={ci}>
+                            <Text span size="xs" c="dimmed">
+                              {constraint}
+                            </Text>
+                          </List.Item>
+                        ))}
+                      </List>
+                    </Stack>
+                  ) : (
+                    <Text key={index} size="sm">
+                      {field.label}
+                    </Text>
+                  ),
+                )}
+              </Stack>
+            </Term>
 
-          {summary.payload !== undefined && (
-            <Term label="Additional data for matched records">
-              {summary.payload.send.length > 0 && (
-                <Stack gap={2}>
-                  <Text size="sm">Your partner will send:</Text>
-                  {/* One column per item rather than a joined string: a
+            {summary.payload !== undefined && (
+              <Term label="Additional data for matched records">
+                {summary.payload.send.length > 0 && (
+                  <Stack gap={2}>
+                    <Text size="sm">Your partner will send:</Text>
+                    {/* One column per item rather than a joined string: a
                       partner-controlled column name may contain the separator,
                       which joined text would render as spurious extra columns.
                       Keyed by index -- column order is fixed and a sanitized
                       name is not unique. */}
-                  <List size="sm" withPadding listStyleType="circle">
-                    {summary.payload.send.map((column, index) => (
-                      <List.Item key={index}>{column}</List.Item>
-                    ))}
-                  </List>
-                </Stack>
-              )}
-              {summary.payload.receive.length > 0 && (
-                <Stack gap={2}>
-                  <Text size="sm">Your partner requests from you:</Text>
-                  <List size="sm" withPadding listStyleType="circle">
-                    {summary.payload.receive.map((column, index) => (
-                      <List.Item key={index}>{column}</List.Item>
-                    ))}
-                  </List>
-                </Stack>
-              )}
-            </Term>
-          )}
-
-          {summary.legalAgreement !== undefined && (
-            <Term label="Legal agreement">
-              <Text size="sm">{summary.legalAgreement.reference}</Text>
-              <Text size="sm">{summary.legalAgreement.purpose}</Text>
-              <Text size="xs" c="dimmed">
-                Valid through {summary.legalAgreement.expirationDate}
-              </Text>
-            </Term>
-          )}
-
-          <Term label="Duplicate matches">
-            <Text size="sm">
-              {summary.deduplicate
-                ? "A record may match more than one of the partner's records."
-                : "Each record matches at most one of the partner's records."}
-            </Text>
-            {/* A proposed looser setting the run does not yet honor: flag it
-                rather than let the line above read as the behavior in force. */}
-            {summary.deduplicate && !summary.deduplicateApplied && (
-              <Text size="xs" c="dimmed">
-                Your partner proposes this, but this version of the exchange
-                does not yet apply it; each record still matches at most one.
-              </Text>
+                    <List size="sm" withPadding listStyleType="circle">
+                      {summary.payload.send.map((column, index) => (
+                        <List.Item key={index}>{column}</List.Item>
+                      ))}
+                    </List>
+                  </Stack>
+                )}
+                {summary.payload.receive.length > 0 && (
+                  <Stack gap={2}>
+                    <Text size="sm">Your partner requests from you:</Text>
+                    <List size="sm" withPadding listStyleType="circle">
+                      {summary.payload.receive.map((column, index) => (
+                        <List.Item key={index}>{column}</List.Item>
+                      ))}
+                    </List>
+                  </Stack>
+                )}
+              </Term>
             )}
-          </Term>
-        </Stack>
-      </Collapse>
+
+            {summary.legalAgreement !== undefined && (
+              <Term label="Legal agreement">
+                <Text size="sm">{summary.legalAgreement.reference}</Text>
+                <Text size="sm">{summary.legalAgreement.purpose}</Text>
+                <Text size="xs" c="dimmed">
+                  Valid through {summary.legalAgreement.expirationDate}
+                </Text>
+              </Term>
+            )}
+
+            <Term label="Duplicate matches">
+              <Text size="sm">
+                {summary.deduplicate
+                  ? "A record may match more than one of the partner's records."
+                  : "Each record matches at most one of the partner's records."}
+              </Text>
+              {/* A proposed looser setting the run does not yet honor: flag it
+                rather than let the line above read as the behavior in force. */}
+              {summary.deduplicate && !summary.deduplicateApplied && (
+                <Text size="xs" c="dimmed">
+                  Your partner proposes this, but this version of the exchange
+                  does not yet apply it; each record still matches at most one.
+                </Text>
+              )}
+            </Term>
+          </Stack>
+        </Collapse>
+      </div>
 
       {summary.expires !== undefined && (
         <Text size="xs" c="dimmed">

--- a/apps/web/test/browser/invitationTerms.test.ts
+++ b/apps/web/test/browser/invitationTerms.test.ts
@@ -82,13 +82,27 @@ function renderTerms() {
   );
 }
 
-// The disclosure panel, resolved from the toggle's aria-controls so the test
-// follows the same wiring assistive tech does.
+// The stable wrapper the toggle's aria-controls points at, resolved the same way
+// assistive tech follows the reference. The id lives on this always-mounted
+// wrapper (not the Collapse panel) so it never dangles when Mantine unmounts the
+// closed panel under a reduced-motion preference.
 function detailsPanel(): HTMLElement {
   const toggle = container!.querySelector("[aria-controls]");
   const id = toggle?.getAttribute("aria-controls");
   const panel = id ? document.getElementById(id) : null;
   if (!panel) throw new Error("details panel not found");
+  return panel;
+}
+
+// The Mantine Collapse panel itself: the wrapper's only child, carrying the
+// aria-hidden + inert (and display:none) that hide the collapsed detail from
+// assistive tech. Separate from the wrapper because aria-controls resolves to the
+// always-mounted wrapper, while these hidden-state attributes sit on the panel
+// Mantine mounts inside it.
+function collapsePanel(): HTMLElement {
+  const panel = detailsPanel().firstElementChild;
+  if (!(panel instanceof HTMLElement))
+    throw new Error("collapse panel not found");
   return panel;
 }
 
@@ -102,10 +116,12 @@ describe("InvitationTerms: always-visible core vs Details disclosure", () => {
     expect(toggle.element().getAttribute("aria-expanded")).toBe("false");
 
     const panel = detailsPanel();
-    // Collapsed: Mantine marks the panel aria-hidden + inert, so the dense detail
-    // is out of the accessibility tree and the tab order until opened.
-    expect(panel.getAttribute("aria-hidden")).toBe("true");
-    expect(panel.hasAttribute("inert")).toBe(true);
+    // Collapsed: Mantine marks the Collapse panel inside the wrapper aria-hidden +
+    // inert, so the dense detail is out of the accessibility tree and the tab order
+    // until opened. The wrapper that holds aria-controls stays mounted regardless.
+    const collapse = collapsePanel();
+    expect(collapse.getAttribute("aria-hidden")).toBe("true");
+    expect(collapse.hasAttribute("inert")).toBe(true);
 
     // The always-visible core stays OUTSIDE the disclosure: the non-standard
     // badge -- which must never be hidden in collapsed content -- the matching
@@ -140,9 +156,67 @@ describe("InvitationTerms: always-visible core vs Details disclosure", () => {
     await userEvent.click(toggle);
 
     expect(toggle.element().getAttribute("aria-expanded")).toBe("true");
-    const panel = detailsPanel();
-    expect(panel.getAttribute("aria-hidden")).toBe("false");
-    expect(panel.hasAttribute("inert")).toBe(false);
+    const collapse = collapsePanel();
+    expect(collapse.getAttribute("aria-hidden")).toBe("false");
+    expect(collapse.hasAttribute("inert")).toBe(false);
+  });
+});
+
+describe("InvitationTerms: the disclosure's aria-controls survives a reduced-motion preference", () => {
+  // With respectReducedMotion on, Mantine's Collapse unmounts the closed panel for
+  // a reduced-motion user -- the configuration that would dangle an aria-controls
+  // pointing at the panel itself. Force both halves of it: the OS reduced-motion
+  // signal (matchMedia) and the theme switch that honors it.
+  let originalMatchMedia: typeof window.matchMedia;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+    window.matchMedia = (query: string) => ({
+      matches: query.includes("prefers-reduced-motion"),
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    });
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  test("aria-controls resolves to a present element while collapsed under reduced motion", async () => {
+    root!.render(
+      createElement(
+        MantineProvider,
+        { theme: { respectReducedMotion: true } },
+        createElement(InvitationTerms, { linkageTerms: terms }),
+      ),
+    );
+
+    const toggle = page.getByRole("button", { name: "Details" });
+    await expect.element(toggle).toBeInTheDocument();
+    expect(toggle.element().getAttribute("aria-expanded")).toBe("false");
+
+    const id = toggle.element().getAttribute("aria-controls");
+    expect(id).toBeTruthy();
+
+    // The reduced-motion media effect resolves after mount and unmounts the closed
+    // Collapse panel, emptying the wrapper -- the state in which an id held on the
+    // panel itself would dangle. Wait for that unmount so the assertion exercises
+    // it rather than the pre-effect mounted-but-hidden panel.
+    await expect
+      .poll(() => document.getElementById(id!)?.children.length)
+      .toBe(0);
+
+    // The stable wrapper holding aria-controls stays mounted, so the reference
+    // still resolves to a present element; the unmounted panel keeps the collapsed
+    // detail out of the accessibility tree.
+    const panel = document.getElementById(id!);
+    expect(panel).not.toBeNull();
+    expect(panel!.textContent).toBe("");
   });
 });
 


### PR DESCRIPTION
## Summary

Make the linkage-terms "Details" disclosure keep a valid aria-controls target even if the web theme later honors a reduced-motion preference. The disclosure is correct today only because the theme leaves respectReducedMotion off; with it on, Mantine's Collapse unmounts the closed panel for reduced-motion users and the toggle's aria-controls would dangle while collapsed. Anchoring the id to an always-mounted wrapper closes that latent ARIA-correctness gap before the theme changes, with no change to what is displayed.

Implements [202556827](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=202556827).

## Changes

- apps/web/src/components/InvitationTerms.tsx: move the disclosure's aria-controls id off the Collapse panel onto a new always-mounted `<div>` wrapper around it, so the reference resolves in every state and under either motion preference; rewrite the inline comment to describe the resolved wiring instead of flagging a pending revisit.
- apps/web/test/browser/invitationTerms.test.ts: add a render test that forces the reduced-motion configuration (matchMedia plus respectReducedMotion) and asserts, against the rendered accessibility tree, that aria-controls still resolves to a present element while the panel is collapsed and unmounted; update the existing collapsed and expanded assertions to read the hidden-state attributes off the Collapse panel inside the wrapper.

## Test plan

Ran: `npm run test:browser -w apps/web -- invitationTerms` (6 passed), `npm run test:unit -w apps/web -- acceptConsent` (51 passed), plus `npm run typecheck`, `npm run lint`, and `npm run format`.
New tests cover: the disclosure's aria-controls resolving to a present, mounted element while collapsed under a reduced-motion preference -- the configuration that exposes the dangling reference today -- and the collapsed detail being absent from the accessibility tree in that state.

## Background

With respectReducedMotion off (Mantine's default, today's config), Collapse keeps the closed panel mounted-but-hidden (aria-hidden + inert + display:none), so a panel-held id always resolved. With it on, Collapse unmounts the closed panel for a reduced-motion user, which would dangle an id held on the panel itself. The always-mounted wrapper holds the id regardless, so the reference never dangles; collapsed content stays hidden from assistive tech either way (hidden when the panel is mounted, absent when it is unmounted). The always-visible vs collapsed partition is unchanged -- security-relevant terms (the non-standard-matching badge, matching method, key names, result sharing) remain outside the disclosure.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed; latent UI accessibility fix, unreachable under the current theme configuration.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: not visible to an operator/deployer or security reviewer under the current config (respectReducedMotion off); no command, flag, default, behavior, exit code, or wire/on-disk format change.
- [x] Security review -- consent-surface file (InvitationTerms) independently reviewed for disclosure integrity and DOM/untrusted-input attack surface: DOM-structure-only change, no consent-surfaced field disclosed, hidden, or relocated; aria-controls id derives from useId() (no partner input); the summarizeInvitation sanitization boundary is untouched -- no threat-model impact (a maintainer may confirm, since the file is a consent surface).
