### PR TITLE
Address yaml bundle warning

### DIFF
--- a/packages/core/rollup.config.ts
+++ b/packages/core/rollup.config.ts
@@ -14,17 +14,19 @@ const pkg = require("./package.json");
 // @noble/curves is bundled in the UMD browser build only because it ships
 // ESM-only and has no UMD global name; the ESM/CJS builds keep it external.
 const ALWAYS_BUNDLED = new Set(["@openmined/psi.js"]);
-// canonicalize and re2js are bundled into the standalone UMD browser build
-// because they ship with no UMD global name; the ESM/CJS builds keep them
+// canonicalize, re2js, and yaml are bundled into the standalone UMD browser
+// build because they ship with no UMD global name; the ESM/CJS builds keep them
 // external (the consuming apps bundle them). re2js is the linear-time regex
 // engine that executes partner transform patterns; it is pure JS, so the same
 // build serves both the CLI (Node) and the web (browser) -- see
-// docs/spec/PROTOCOL.md "Transform regular-expression dialect".
+// docs/spec/PROTOCOL.md "Transform regular-expression dialect". yaml reaches the
+// browser via the sensitiveFile.ts config-import chokepoint.
 const UMD_BUNDLED = new Set([
   "@openmined/psi.js",
   "@noble/curves",
   "canonicalize",
   "re2js",
+  "yaml",
 ]);
 
 // Returns an `external` predicate that matches bare package names and their


### PR DESCRIPTION
No longer bundle YAML is that building core doesn't issue a warning.