### PR TITLE
Scope constraint sweep to referenced fields and extract chokepoint

### DIFF
--- a/apps/cli/test/unit/exchange.test.ts
+++ b/apps/cli/test/unit/exchange.test.ts
@@ -41,11 +41,13 @@ vi.mock("@psilink/core", async (importActual) => {
     // real so it consumes the input stream (a mock would leave a dangling
     // createReadStream whose async open races the afterEach cleanup). Only the
     // handler tests exercise this path; loadConfig never calls it. The shape
-    // carries the empty fields the value-constraint sweep (warnOnValueConstraints)
-    // reads, so the sweep is a no-op here rather than tripping on a partial stub.
+    // carries the empty linkageFields and linkageKeys the value-constraint sweep
+    // (warnOnValueConstraints) reads -- it scopes to key-referenced fields, so it
+    // walks both -- so the sweep is a no-op here rather than tripping on a partial
+    // stub.
     prepareForExchange: vi.fn().mockReturnValue({
       warnings: [],
-      linkageTerms: { linkageFields: [] },
+      linkageTerms: { linkageFields: [], linkageKeys: [] },
       dataset: { getField: () => undefined },
       rowCount: 0,
     }),

--- a/apps/web/src/psi/advancedInvite.ts
+++ b/apps/web/src/psi/advancedInvite.ts
@@ -9,6 +9,7 @@ import {
   getDefaultStandardization,
   inferDateFormat,
   inferMetadata,
+  referencedLinkageFieldNames,
   safeParseLinkageTerms,
 } from "@psilink/core";
 
@@ -417,9 +418,7 @@ export function buildAdvancedTerms(draft: AdvancedInviteDraft): LinkageTerms {
     .map((entry) =>
       APPLIED_SETTINGS.fuzzyComparisons ? entry.key : stripFuzzy(entry.key),
     );
-  const referenced = new Set(
-    enabledKeys.flatMap((key) => key.elements.map((el) => el.field)),
-  );
+  const referenced = referencedLinkageFieldNames(enabledKeys);
   // Derive the linkage fields from the authored standardization, not the
   // one-field-per-type default: a transformation per type declares its own field
   // (named by its output, bound to its input column), so two transformations of one

--- a/packages/core/src/config/linkageTerms.ts
+++ b/packages/core/src/config/linkageTerms.ts
@@ -712,6 +712,47 @@ const LinkageKeySchema: z.ZodType<LinkageKey> = z.object({
     .optional(),
 });
 
+/**
+ * The set of linkage-field names referenced by at least one element of
+ * `linkageKeys` -- the union of every element's `field`. The exchange standardizes
+ * and consumes exactly these fields, so a caller filters its declared linkage
+ * fields down to this set (a declared field no key references is read by nothing in
+ * the exchange): the constraint sweep, the default-terms field derivation, and the
+ * advanced-invite field derivation all apply the same
+ * `field => referenced.has(field.name)` filter, and share this one definition of
+ * "referenced" rather than re-deriving it.
+ *
+ * DISCLOSURE-RELEVANT: two of those callers -- the default-terms and
+ * advanced-invite field derivations -- use the result to choose which
+ * `linkageFields` enter the constructed terms, and so the cross-party terms hash
+ * (the canonical encoding both parties agree on); only the constraint sweep is
+ * warn-only and off the wire. A change to which names this set includes or excludes
+ * therefore silently moves that hash and breaks interop, so it is in the
+ * security-review scope: preserve the exact membership. A change here that altered a
+ * constructed-terms field set would fail the field-set regression tests for the
+ * default and advanced-invite paths (which derive one side without this function),
+ * rather than silently moving the hash.
+ *
+ * `swap` does not widen the result: it only permutes `field` among a key's existing
+ * elements at receive time, so the union over the authored (un-swapped) elements
+ * already names every field any swapped order could reference. Callers pass keys as
+ * authored, without resolving swap.
+ *
+ * This is the UNION, distinct from the per-key satisfiability predicate
+ * (`key.elements.every(...)`) the satisfiability checker and {@link LinkageTermsSchema}'s
+ * referential-integrity refine compute. The returned set may include a name that is
+ * not a declared linkage field for a terms object not built through that schema
+ * (whose refine forbids a dangling element `field`); used as a membership filter,
+ * such a stray name matches no declared field and is harmless.
+ */
+export function referencedLinkageFieldNames(
+  linkageKeys: readonly LinkageKey[],
+): Set<string> {
+  return new Set(
+    linkageKeys.flatMap((key) => key.elements.map((e) => e.field)),
+  );
+}
+
 // --- Payload -----------------------------------------------------------------
 
 interface PayloadColumn {

--- a/packages/core/src/defaults/linkageTerms.ts
+++ b/packages/core/src/defaults/linkageTerms.ts
@@ -1,3 +1,4 @@
+import { referencedLinkageFieldNames } from "../config/linkageTerms";
 import type {
   LinkageTerms,
   LinkageField,
@@ -226,9 +227,7 @@ export function getDefaultLinkageTerms(
     linkageKeys = [...DEFAULT_LINKAGE_KEYS];
   }
 
-  const referencedFields = new Set(
-    linkageKeys.flatMap((key) => key.elements.map((el) => el.field)),
-  );
+  const referencedFields = referencedLinkageFieldNames(linkageKeys);
   const linkageFields = DEFAULT_LINKAGE_FIELDS.filter((f) =>
     referencedFields.has(f.name),
   );

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -22,6 +22,7 @@ import type {
 import {
   MAX_DATE_FORMAT_LENGTH,
   MAX_TRANSFORM_PATTERN_LENGTH,
+  referencedLinkageFieldNames,
 } from "./config/linkageTerms.js";
 import { inferMetadata } from "./config/metadata.js";
 import type { ColumnMetadata } from "./config/metadata.js";
@@ -1913,12 +1914,9 @@ export function summarizeDatasetConstraintViolations(
   dataset: StandardizedDataset,
   rowCount: number,
 ): ConstraintViolationSummary[] {
-  // The fields at least one linkage key references -- the only fields the exchange
-  // standardizes and consumes. `swap` only permutes `field` among existing
-  // elements, so the un-swapped elements already name every referenced field.
-  const referencedFields = new Set(
-    terms.linkageKeys.flatMap((key) => key.elements.map((e) => e.field)),
-  );
+  // Scope to the fields a linkage key references -- the only fields the exchange
+  // standardizes and consumes; see referencedLinkageFieldNames.
+  const referencedFields = referencedLinkageFieldNames(terms.linkageKeys);
   const summaries: ConstraintViolationSummary[] = [];
   for (const field of terms.linkageFields) {
     if (field.constraints === undefined) continue;

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -1885,29 +1885,44 @@ export interface ConstraintViolationSummary {
 }
 
 /**
- * Sweep a whole {@link StandardizedDataset} and aggregate the value-level
- * constraint violations its produced values trip, per (field, kind). Runs the same
- * per-value {@link checkValueConstraints} the web workbench renders badges from --
- * one implementation for both surfaces -- over every produced value of every
- * declared field, so the CLI warns on exactly the violations the web shows.
+ * Sweep a {@link StandardizedDataset} and aggregate the value-level constraint
+ * violations its produced values trip, per (field, kind), for the linkage fields a
+ * linkage key actually references. Runs the same per-value
+ * {@link checkValueConstraints} the web workbench renders badges from -- one
+ * implementation, so the two surfaces never disagree on whether a given value
+ * violates a constraint (they differ in WHICH fields they cover: the web badges
+ * the field being edited, this sweep scopes to key-referenced fields, below).
  * Warn-not-enforce: it only counts; it never throws or rejects a value, and the
  * caller decides how to surface the result (the CLI logs a warning per entry and
  * proceeds). An empty result means every produced value conforms.
  *
- * A field declared in `terms` but absent from the dataset (it resolved to no
- * column) contributes nothing. Each row's produced value set is checked
- * element-wise, so a fan-out value (e.g. from `split_on`) is judged per candidate.
- * The dataset caches each row's values, so this pre-pass warms the same cache the
- * key-building exchange reuses rather than computing them twice.
+ * The sweep is scoped to key-referenced fields because the exchange standardizes
+ * and consumes only those (via {@link StandardizedKeyIterable}): a constraint
+ * violation on a declared field that no linkage key references cannot affect
+ * matching, so warning about it would be noise and running its standardization
+ * pipeline would be wasted work. A constrained field that no linkage key
+ * references therefore contributes nothing and is never standardized by the sweep;
+ * so does a referenced field that resolved to no column and is absent from the
+ * dataset. Each row's produced value set is checked element-wise, so a fan-out
+ * value (e.g. from `split_on`) is judged per candidate. The dataset caches each
+ * row's values, so this pre-pass warms the same cache the key-building exchange
+ * reuses rather than computing them twice.
  */
 export function summarizeDatasetConstraintViolations(
   terms: LinkageTerms,
   dataset: StandardizedDataset,
   rowCount: number,
 ): ConstraintViolationSummary[] {
+  // The fields at least one linkage key references -- the only fields the exchange
+  // standardizes and consumes. `swap` only permutes `field` among existing
+  // elements, so the un-swapped elements already name every referenced field.
+  const referencedFields = new Set(
+    terms.linkageKeys.flatMap((key) => key.elements.map((e) => e.field)),
+  );
   const summaries: ConstraintViolationSummary[] = [];
   for (const field of terms.linkageFields) {
     if (field.constraints === undefined) continue;
+    if (!referencedFields.has(field.name)) continue;
     const standardized = dataset.getField(field.name);
     if (standardized === undefined) continue;
     // Tally this field's violations keyed only by the closed `kind` enum, so no

--- a/packages/core/test/linkageTerms.test.ts
+++ b/packages/core/test/linkageTerms.test.ts
@@ -1,9 +1,10 @@
 import { ZodError } from "zod";
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import {
   deriveAcceptedLinkageTerms,
   parseLinkageTerms,
+  referencedLinkageFieldNames,
   safeParseLinkageTerms,
   validateCompatibility,
   MAX_NAME_LENGTH,
@@ -18,6 +19,7 @@ import {
   MAX_KEY_ELEMENTS,
   MAX_PAYLOAD_ENTRIES,
 } from "../src/config/linkageTerms";
+import type { LinkageKey } from "../src/config/linkageTerms";
 import type { LinkageTerms } from "../src/config/linkageTerms";
 import {
   DISPLAY_TRUNCATION_MARKER,
@@ -2450,4 +2452,32 @@ test("deriveAcceptedLinkageTerms accepts a coherent deduplicate config (no false
   expect(() =>
     deriveAcceptedLinkageTerms(inviterTerms, "Accepting Org"),
   ).not.toThrow();
+});
+
+describe("referencedLinkageFieldNames", () => {
+  test("returns the union of element fields across keys, deduplicated", () => {
+    const keys: LinkageKey[] = [
+      { name: "k1", elements: [{ field: "a" }, { field: "b" }] },
+      { name: "k2", elements: [{ field: "b" }, { field: "c" }] },
+    ];
+    expect(referencedLinkageFieldNames(keys)).toEqual(new Set(["a", "b", "c"]));
+  });
+
+  test("is unaffected by a key's swap directive", () => {
+    // swap only permutes which slot holds which field at receive time, so the
+    // union of referenced fields is identical with or without it -- the property
+    // that lets every caller pass keys as authored, without resolving swap.
+    const swapped: LinkageKey[] = [
+      {
+        name: "k",
+        elements: [{ field: "a" }, { field: "b" }],
+        swap: ["a", "b"],
+      },
+    ];
+    expect(referencedLinkageFieldNames(swapped)).toEqual(new Set(["a", "b"]));
+  });
+
+  test("returns an empty set for no keys", () => {
+    expect(referencedLinkageFieldNames([])).toEqual(new Set<string>());
+  });
 });

--- a/packages/core/test/standardization.test.ts
+++ b/packages/core/test/standardization.test.ts
@@ -2718,4 +2718,109 @@ describe("summarizeDatasetConstraintViolations", () => {
       },
     ]);
   });
+
+  test("skips a constrained field no linkage key references, still reports a referenced one", () => {
+    // Both fields are declared, constrained, resolve to a column, and carry a
+    // value that violates their constraints. Only `last_name` is referenced by a
+    // linkage key; `first_name` is declared-but-unreferenced, so the exchange
+    // never standardizes or consumes it and the sweep must not warn on it.
+    const terms: LinkageTerms = {
+      ...sweepTerms,
+      linkageFields: [
+        {
+          name: "last_name",
+          type: "last_name",
+          constraints: { allowedCharacters: "A-Z" },
+        },
+        {
+          name: "first_name",
+          type: "first_name",
+          constraints: { allowedCharacters: "A-Z" },
+        },
+      ],
+      linkageKeys: [{ name: "LN", elements: [{ field: "last_name" }] }],
+    };
+    const rows = [{ LN: "smith", FN: "jane" }]; // both lowercase -> both violate A-Z
+    const dataset = buildStandardizedDataset(
+      undefined,
+      rows,
+      [
+        { name: "LN", type: "last_name", role: "linkage", isPayload: false },
+        { name: "FN", type: "first_name", role: "linkage", isPayload: false },
+      ],
+      terms,
+    );
+    // The unreferenced first_name DOES resolve to a column (it is present in the
+    // dataset), so its exclusion is the referenced-scoping at work, not the
+    // resolved-to-no-column path the prior test covers.
+    expect(dataset.getField("first_name")).toBeDefined();
+    expect(
+      summarizeDatasetConstraintViolations(terms, dataset, rows.length),
+    ).toEqual([
+      {
+        field: "last_name",
+        kind: "disallowedCharacters",
+        label: "disallowed characters",
+        count: 1,
+      },
+    ]);
+  });
+
+  test("sweeps every field a swap key references, unaffected by the swap", () => {
+    // Encodes the referenced-set comment's swap-invariance claim as a check: the
+    // sweep reads the un-swapped `element.field`, and `swap` only permutes which
+    // slot holds which field, so the set of fields it sweeps is identical with or
+    // without the swap. Both swapped fields are constrained and violate, so both
+    // must be reported -- a field reachable only through the swap is not missed.
+    const terms: LinkageTerms = {
+      ...sweepTerms,
+      linkageFields: [
+        {
+          name: "first_name",
+          type: "first_name",
+          constraints: { allowedCharacters: "A-Z" },
+        },
+        {
+          name: "last_name",
+          type: "last_name",
+          constraints: { allowedCharacters: "A-Z" },
+        },
+      ],
+      linkageKeys: [
+        {
+          name: "swap(FN,LN)",
+          elements: [{ field: "first_name" }, { field: "last_name" }],
+          swap: ["first_name", "last_name"],
+        },
+      ],
+    };
+    const rows = [{ FN: "jane", LN: "smith" }]; // both lowercase -> both violate A-Z
+    const dataset = buildStandardizedDataset(
+      undefined,
+      rows,
+      [
+        { name: "FN", type: "first_name", role: "linkage", isPayload: false },
+        { name: "LN", type: "last_name", role: "linkage", isPayload: false },
+      ],
+      terms,
+    );
+    expect(
+      summarizeDatasetConstraintViolations(terms, dataset, rows.length),
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          field: "first_name",
+          kind: "disallowedCharacters",
+          label: "disallowed characters",
+          count: 1,
+        },
+        {
+          field: "last_name",
+          kind: "disallowedCharacters",
+          label: "disallowed characters",
+          count: 1,
+        },
+      ]),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

The dataset constraint sweep (`summarizeDatasetConstraintViolations`) now warns only on linkage fields a linkage key references, aligning the CLI prepare-path warning with what the exchange actually standardizes and matches on: a constraint violation on a declared-but-unreferenced field cannot affect the exchange, so warning about it was noise. The "fields a key references" computation is then consolidated into one shared core primitive, `referencedLinkageFieldNames`, used by the sweep and the two other sites that derived the same set inline.

Implements [203439466](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=203439466).

## Changes

Two commits, separable for review:

Commit 1 -- scope the sweep:

- packages/core/src/standardization.ts: `summarizeDatasetConstraintViolations` skips any linkage field no linkage key references.
- packages/core/test/standardization.test.ts: cover referenced-vs-unreferenced (an unreferenced constrained field, present in the dataset, yields no summary while a referenced one still does) and swap-invariance.

Commit 2 -- extract the chokepoint:

- packages/core/src/config/linkageTerms.ts: add `referencedLinkageFieldNames(linkageKeys)`, with a disclosure-relevant JSDoc (two consumers feed the cross-party terms hash).
- packages/core/src/standardization.ts, packages/core/src/defaults/linkageTerms.ts, apps/web/src/psi/advancedInvite.ts: route the three previously-inline copies of the union idiom through it (the web app consumes it via @psilink/core).
- packages/core/test/linkageTerms.test.ts: direct unit tests for the primitive (union, dedup, swap-invariance, empty).

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format`, `npm test -w packages/core` (1807 passed), `npm run test:unit -w apps/web` (497 passed).
New tests cover: the sweep's referenced-vs-unreferenced scoping and swap-invariance; the primitive's union/dedup/swap-invariance/empty contract.
Not run locally: the Playwright browser suite (heavy; runs in CI). The extraction is byte-identical, so the produced terms and their cross-party hash are unchanged.

## Background

The chokepoint extraction grew out of review: the union expression `new Set(linkageKeys.flatMap(k => k.elements.map(e => e.field)))` was duplicated byte-identically across the three sites above. Deliberately left out of the consolidation: `exchangeRecord.ts`'s `matchingBasis` (a different ordered, type-resolved, deterministically sorted computation with a cross-party determinism contract on a disclosure surface) and the per-key `key.elements.every(...)` satisfiability predicates (a boolean, not the union). Two of the three consolidated consumers shape the invitation terms and their cross-party hash, so the refactor is behavior-preserving by construction; membership is regression-pinned by the default-vs-authored field-set tests.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed. The constraint contract in `docs/EXCHANGE_REFERENCE.md` ("the application will warn if a constraint is violated") stays accurate; the referenced-scoping detail is implementation-tier and lives in the primitive's JSDoc.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: refines an unreleased feature (the constraint-warning entry stays accurate) and consolidates a @psilink/core primitive whose only consumers are the apps.
- [x] Security review -- in scope (disclosure: the logged warning set narrows, and the terms-construction / cross-party-hash path is refactored). Independent multi-role adversarial review conducted (disclosure/wire-integrity, untrusted-input, threat-model): verdict SHIP, terms hash verified byte-identical, input bounds enforced upstream of the primitive, no fail-open or injection. Maintainer security review still required pre-merge.
