### PR TITLE
Surface schema payload error masked by direction conflict

### DIFF
--- a/apps/web/src/components/LinkageTermsEditor.tsx
+++ b/apps/web/src/components/LinkageTermsEditor.tsx
@@ -539,7 +539,16 @@ export function LinkageTermsEditor({
                 </Text>
               )}
               {errors.payload && (
-                <Text size="xs" c="red" role="alert">
+                // The payload control can carry two distinct problems at once (a
+                // schema/column error and the send-direction conflict), joined with
+                // a newline by validateAdvancedInvite; pre-line renders them as
+                // separate lines rather than one run-on paragraph.
+                <Text
+                  size="xs"
+                  c="red"
+                  role="alert"
+                  style={{ whiteSpace: "pre-line" }}
+                >
                   {errors.payload}
                 </Text>
               )}

--- a/apps/web/src/psi/advancedInvite.ts
+++ b/apps/web/src/psi/advancedInvite.ts
@@ -622,9 +622,9 @@ export function validateAdvancedInvite(
     // over the generic schema mapping, and stacking several messages on one input
     // is noise. The payload control is the one exception -- a schema payload error
     // (e.g. an over-long sent column name) is a second, distinct obstacle from the
-    // direction-conflict message that may already occupy it, so the two are
-    // composed rather than letting the direction conflict mask the schema problem
-    // and leave the operator unaware of an obstacle that still blocks generation.
+    // direction-conflict message that may already occupy it, so both are surfaced
+    // rather than letting the direction conflict mask the schema problem and leave
+    // the operator unaware of an obstacle that still blocks generation.
     const schemaFields = new Set(
       parsed.error.issues.map((issue) => fieldForIssuePath(issue.path)),
     );
@@ -633,7 +633,12 @@ export function validateAdvancedInvite(
       if (existing === undefined) {
         errors[field] = messageForField(field);
       } else if (field === "payload") {
-        errors.payload = `${existing} ${messageForField("payload")}`;
+        // Lead with the schema/column error and trail the direction conflict: the
+        // schema error is the obstacle that persists after the operator reverses
+        // the one-click direction choice, so it earns first position. Joined with a
+        // newline (not a space) so the editor renders the two problems as separate
+        // lines rather than one run-on paragraph.
+        errors.payload = `${messageForField("payload")}\n${existing}`;
       }
     }
   }

--- a/apps/web/src/psi/advancedInvite.ts
+++ b/apps/web/src/psi/advancedInvite.ts
@@ -615,11 +615,26 @@ export function validateAdvancedInvite(
 
   const parsed = safeParseLinkageTerms(terms);
   if (!parsed.success) {
-    for (const issue of parsed.error.issues) {
-      const field = fieldForIssuePath(issue.path);
-      // Keep the first message per control; the schema reports the most specific
-      // issue first, and stacking several on one input is noise.
-      if (errors[field] === undefined) errors[field] = messageForField(field);
+    // Each control touched by a schema issue gets its control-specific message
+    // (the message is keyed on the control, not the individual issue, so the set of
+    // affected controls is all that matters). Keep the first message per control:
+    // the keys control deliberately sets its accurate message up front so it wins
+    // over the generic schema mapping, and stacking several messages on one input
+    // is noise. The payload control is the one exception -- a schema payload error
+    // (e.g. an over-long sent column name) is a second, distinct obstacle from the
+    // direction-conflict message that may already occupy it, so the two are
+    // composed rather than letting the direction conflict mask the schema problem
+    // and leave the operator unaware of an obstacle that still blocks generation.
+    const schemaFields = new Set(
+      parsed.error.issues.map((issue) => fieldForIssuePath(issue.path)),
+    );
+    for (const field of schemaFields) {
+      const existing = errors[field];
+      if (existing === undefined) {
+        errors[field] = messageForField(field);
+      } else if (field === "payload") {
+        errors.payload = `${existing} ${messageForField("payload")}`;
+      }
     }
   }
 

--- a/apps/web/test/unit/advancedInvite.test.ts
+++ b/apps/web/test/unit/advancedInvite.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import {
   MAX_INVITATION_LIFETIME_SECONDS,
+  MAX_NAME_LENGTH,
   assertPayloadSendDisclosed,
   assessLinkageSatisfiability,
   canonicalString,
@@ -525,6 +526,57 @@ describe("payload authoring", () => {
       validateAdvancedInvite({ ...draft, outputDirection: "both" }, seed).errors
         .payload,
     ).toBeUndefined();
+  });
+
+  test("a schema payload error is surfaced even behind the direction conflict, not masked", () => {
+    // A disclosed (sent) column whose name exceeds the schema's MAX_NAME_LENGTH is a
+    // payload-path schema failure; choosing inviter-only output while disclosing
+    // columns is the direction conflict. Both attach to the payload control, where a
+    // first-message-wins guard would otherwise drop the schema error behind the (more
+    // common) direction conflict -- hiding a second obstacle that still blocks Generate.
+    const overLong = "x".repeat(MAX_NAME_LENGTH + 1);
+    // The over-long header infers as an `other` column, disclosed (sent) by default.
+    const { draft, seed } = seedAdvancedInvite("Org", [
+      ...ALL_COLUMNS,
+      overLong,
+    ]);
+    expect(disclosedColumnNames(draft.metadata)).toContain(overLong);
+
+    // Single-problem baselines, so the both-problems assertion compares against the
+    // actual messages rather than hard-coding the copy.
+    // (1) Schema-payload-error only: output shared, so no direction conflict.
+    const schemaOnly = validateAdvancedInvite(
+      { ...draft, outputDirection: "both" },
+      seed,
+    );
+    const schemaMessage = schemaOnly.errors.payload ?? "";
+    expect(schemaMessage.length).toBeGreaterThan(0);
+    expect(schemaOnly.canGenerate).toBe(false);
+
+    // (2) Direction-conflict only: a normally-named disclosed column, inviter-only.
+    const conflict = seedAdvancedInvite("Org", [...ALL_COLUMNS, "notes"]);
+    const conflictOnly = validateAdvancedInvite(
+      { ...conflict.draft, outputDirection: "inviter" },
+      conflict.seed,
+    );
+    const directionMessage = conflictOnly.errors.payload ?? "";
+    expect(directionMessage.length).toBeGreaterThan(0);
+    expect(conflictOnly.canGenerate).toBe(false);
+
+    // The single-problem cases stay clean: neither carries the other's message.
+    expect(schemaMessage).not.toContain(directionMessage);
+    expect(directionMessage).not.toContain(schemaMessage);
+
+    // (3) Both problems at once: the payload message surfaces BOTH, so the schema
+    // error is no longer masked by the direction conflict.
+    const both = validateAdvancedInvite(
+      { ...draft, outputDirection: "inviter" },
+      seed,
+    );
+    const bothMessage = both.errors.payload ?? "";
+    expect(bothMessage).toContain(schemaMessage);
+    expect(bothMessage).toContain(directionMessage);
+    expect(both.canGenerate).toBe(false);
   });
 
   test("a disclosed-payload invitation round-trips through the acceptor mirror", () => {

--- a/apps/web/test/unit/advancedInvite.test.ts
+++ b/apps/web/test/unit/advancedInvite.test.ts
@@ -568,14 +568,16 @@ describe("payload authoring", () => {
     expect(directionMessage).not.toContain(schemaMessage);
 
     // (3) Both problems at once: the payload message surfaces BOTH, so the schema
-    // error is no longer masked by the direction conflict.
+    // error is no longer masked by the direction conflict. They are newline-separated
+    // (the editor renders them as a stacked list) with the more-persistent schema
+    // error leading -- it is the obstacle that remains after the one-click direction
+    // choice is reversed.
     const both = validateAdvancedInvite(
       { ...draft, outputDirection: "inviter" },
       seed,
     );
     const bothMessage = both.errors.payload ?? "";
-    expect(bothMessage).toContain(schemaMessage);
-    expect(bothMessage).toContain(directionMessage);
+    expect(bothMessage.split("\n")).toEqual([schemaMessage, directionMessage]);
     expect(both.canGenerate).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

The web Advanced-options editor could silently drop a schema-level payload error (for example an over-long sent-column name) when a payload direction conflict was also present, so the operator saw only the direction conflict and never learned of a second obstacle that still blocked Generate. This surfaces both problems on the payload control -- the more-persistent schema error leading -- so the operator can clear every blocker in one pass. Generation was already correctly blocked in this state; only the surfaced message changes.

Implements [203598888](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=203598888).

## Changes

- apps/web/src/psi/advancedInvite.ts: in validateAdvancedInvite, dedupe schema issues by control and compose the payload control's two competing messages (schema error first, newline-separated) rather than letting the first-set direction-conflict message win; the keys-control first-message-wins precedence is preserved.
- apps/web/src/components/LinkageTermsEditor.tsx: render the payload error with white-space pre-line so two problems show on separate lines; the single-message cases render exactly as before.
- apps/web/test/unit/advancedInvite.test.ts: add a both-problems case asserting the schema error is not masked and pinning the schema-first order and newline separation, alongside the two single-problem cases remaining unchanged.

## Test plan

Ran: `npx vitest run apps/web/test/unit/advancedInvite.test.ts` (48 passed); `npm run test:browser -w apps/web -- linkageTermsEditor` (14 passed); `npm run typecheck && npm run lint` (clean); `npm run format` (clean).
New tests cover: a draft carrying both the direction conflict and a schema payload error (schema error surfaced not masked, schema-first and newline-separated), plus the direction-conflict-only and schema-payload-only cases remaining unchanged.

## Background

validateAdvancedInvite set the direction-conflict message on the payload control before running the core schema parse, and the schema-error loop wrote a control's message only when that control had none yet (`errors[field] === undefined`). With both problems present the direction conflict occupied the payload control first and the schema error was suppressed. That write-guard is deliberate elsewhere -- the keys control relies on its hand-set message winning over the generic schema mapping -- so the fix is scoped to the payload control's two messages and leaves that precedence intact.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: COMMUNICATION.md describes the editor's validation gate conceptually but not its message text or precedence; what is blocked is unchanged, only an error message's completeness improved.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: fixes a message-precedence bug in unreleased web-editor code (the payload-authoring and direction-conflict feature is itself under `[Unreleased]`); no behavior visible to a reader relative to the last release changed.
- [x] Security review -- done: the change touches the displayed surface, so it was given an independent multi-lens review (disclosure, injection/rendering, fail-closed gate); PASS -- the message composes only fixed string constants so no partner-controlled or untrusted value reaches the UI or any log, white-space pre-line is CSS-only with React text-node escaping intact, and `canGenerate`/gate behavior is unchanged.