### PR TITLE
Infer date format for acceptor's prepared data

### DIFF
--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -10,6 +10,7 @@ import {
   inferMetadata,
   getDefaultLinkageTerms,
   getDefaultStandardization,
+  columnValues,
   inferDateFormat,
   MAX_ENDPOINT_HOST_LENGTH,
   MAX_ENDPOINT_PATH_LENGTH,
@@ -844,7 +845,7 @@ export function buildDataSpec(args: {
   const dobCol = metadata.find((c) => c.type === "date_of_birth");
   const dateInputFormat =
     dobCol !== undefined
-      ? inferDateFormat(rows.rawRows.map((r) => r[dobCol.name] ?? ""))
+      ? inferDateFormat(columnValues(rows.rawRows, dobCol.name))
       : undefined;
 
   try {

--- a/apps/web/src/components/PrepareData.tsx
+++ b/apps/web/src/components/PrepareData.tsx
@@ -24,11 +24,7 @@ import {
 } from "@tabler/icons-react";
 import { useDisclosure } from "@mantine/hooks";
 
-import {
-  assessLinkageSatisfiability,
-  getDefaultStandardization,
-  inferMetadata,
-} from "@psilink/core";
+import { assessLinkageSatisfiability, inferMetadata } from "@psilink/core";
 
 import {
   SEMANTIC_TYPE_LABELS,
@@ -43,6 +39,8 @@ import {
   applyStepOverrides,
   isStepValid,
 } from "@psi/standardizationAuthoring";
+
+import { defaultStandardizationForRows } from "@psi/advancedInvite";
 
 import { isSilentEmpty } from "@psi/nonEmptyAggregate";
 
@@ -74,10 +72,11 @@ import type { FieldStepOverride } from "@psi/standardizationAuthoring";
  *
  * The verdict and the run consume the SAME `{ metadata, standardization }`: the
  * standardization is derived from the current metadata via
- * {@link getDefaultStandardization} (so the recommended per-type cleaning is
- * always applied to the current column bindings, matching the acceptor's prior
- * inferred behavior), and that exact pair is handed to {@link onLaunch}. So the
- * gate the operator sees and the exchange that runs cannot disagree.
+ * {@link defaultStandardizationForRows} (so the recommended per-type cleaning is
+ * always applied to the current column bindings, with the date-of-birth input
+ * format inferred from the operator's own rows), and that exact pair is handed to
+ * {@link onLaunch}. So the gate the operator sees and the exchange that runs
+ * cannot disagree.
  *
  * Metadata/standardization are LOCAL and per-party: they are never embedded in the
  * token or cross-checked, so editing them changes only this party's match rate and
@@ -155,10 +154,15 @@ export function PrepareData({
   );
 
   // The recommended per-type cleaning for the default type-fallback binding,
-  // re-derived from the current metadata so it tracks a remap.
+  // re-derived from the current metadata so it tracks a remap. The date-of-birth
+  // input format is inferred from the operator's own rows rather than assumed
+  // MM/DD/YYYY: this editor always supplies an explicit standardization to the
+  // exchange, which then skips its own inference, so an ISO-dated file would
+  // otherwise be parsed as US-format and under-match every dob key. Mirrors the
+  // inviter advanced path (see defaultStandardizationForRows).
   const baseStandardization = useMemo(
-    () => getDefaultStandardization(metadata, linkageTerms),
-    [metadata, linkageTerms],
+    () => defaultStandardizationForRows(metadata, linkageTerms, rawRows),
+    [metadata, linkageTerms, rawRows],
   );
 
   // Field name -> its declared linkage field, for the per-field card label, the

--- a/apps/web/src/psi/advancedInvite.ts
+++ b/apps/web/src/psi/advancedInvite.ts
@@ -206,12 +206,13 @@ export interface AdvancedValidation {
  * pipeline's input format inferred from the operator's own rows, rather than the
  * fixed `MM/DD/YYYY` {@link getDefaultStandardization} assumes. The quick path
  * auto-detects the layout because it supplies no explicit standardization (the
- * exchange infers when none is given); the advanced path always supplies one, so
- * it must infer here or it would silently parse a non-US date file with the wrong
- * format and under-match every date-of-birth key. Mirrors the exchange's own
- * inference: the first present `role: linkage` date_of_birth column's values drive
- * {@link inferDateFormat}, falling back to the `MM/DD/YYYY` default when there is no
- * such column or the format cannot be inferred (e.g. seeded with no rows).
+ * exchange infers when none is given); the advanced path and the acceptor's
+ * Prepare-data editor always supply one, so they must infer here or they would
+ * silently parse a non-US date file with the wrong format and under-match every
+ * date-of-birth key. Mirrors the exchange's own inference: the first present
+ * `role: linkage` date_of_birth column's values drive {@link inferDateFormat},
+ * falling back to the `MM/DD/YYYY` default when there is no such column or the
+ * format cannot be inferred (e.g. seeded with no rows).
  *
  * The inferred format lives only in the local cleaning steps; the cross-party terms
  * carry the field, not its cleaning ({@link authoredLinkageFields} ignores steps),

--- a/apps/web/src/psi/advancedInvite.ts
+++ b/apps/web/src/psi/advancedInvite.ts
@@ -5,6 +5,7 @@ import {
   assessLinkageSatisfiability,
   authoredLinkageFields,
   canonicalString,
+  columnValues,
   disclosedColumnNames,
   getDefaultLinkageTerms,
   getDefaultStandardization,
@@ -228,7 +229,7 @@ export function defaultStandardizationForRows(
   );
   const dateInputFormat =
     dobColumn !== undefined
-      ? inferDateFormat(rawRows.map((row) => row[dobColumn.name] ?? ""))
+      ? inferDateFormat(columnValues(rawRows, dobColumn.name))
       : undefined;
   return getDefaultStandardization(metadata, terms, { dateInputFormat });
 }

--- a/apps/web/test/browser/nonEmptyCoverage.test.ts
+++ b/apps/web/test/browser/nonEmptyCoverage.test.ts
@@ -189,15 +189,16 @@ const dobTerms: LinkageTerms = {
 describe("PrepareData surfaces a silent-empty collapse before launch", () => {
   test("a shape-satisfiable file whose dates the transform drops shows the alarm and announces it", async () => {
     // The column infers to date_of_birth, so the verdict (SHAPE) is satisfiable --
-    // yet the default parse_date expects MM/DD/YYYY and these ISO dates all drop to
-    // null. This is the exact hazard the aggregate guards: shape passes, value
-    // collapses. Two rows keep the sweep inline (below the worker threshold), so no
-    // worker is spawned and the result is deterministic.
+    // yet these values parse as a date in no candidate format, so format inference
+    // finds no signal, the dob pipeline falls back to MM/DD/YYYY, and every value
+    // drops to null. This is the exact hazard the aggregate guards: shape passes,
+    // value collapses. Two rows keep the sweep inline (below the worker threshold),
+    // so no worker is spawned and the result is deterministic.
     render(
       createElement(PrepareData, {
         linkageTerms: dobTerms,
         columns: ["dob"],
-        rawRows: [{ dob: "1990-01-01" }, { dob: "1985-12-31" }],
+        rawRows: [{ dob: "unknown" }, { dob: "unknown" }],
         onLaunch: vi.fn(),
         onBack: vi.fn(),
       }),
@@ -226,6 +227,31 @@ describe("PrepareData surfaces a silent-empty collapse before launch", () => {
         ),
       )
       .toBe(true);
+  });
+
+  test("an ISO-dated file produces full coverage: the acceptor infers the date format from its own rows", async () => {
+    // The acceptor editor always supplies an explicit standardization, so the
+    // exchange skips its own inference -- the editor must infer the date layout
+    // itself or an ISO file would be parsed as MM/DD/YYYY and drop every dob value.
+    // A day past 12 makes YYYY-MM-DD the only candidate, so the inference is
+    // unambiguous; with it the dob pipeline parses all rows and coverage is full
+    // (no silent-empty alarm). Two rows keep the sweep inline and deterministic.
+    render(
+      createElement(PrepareData, {
+        linkageTerms: dobTerms,
+        columns: ["dob"],
+        rawRows: [{ dob: "1990-01-31" }, { dob: "1985-12-25" }],
+        onLaunch: vi.fn(),
+        onBack: vi.fn(),
+      }),
+    );
+
+    await expect
+      .element(page.getByTestId("coverage-rate"))
+      .toHaveTextContent("2 of 2 rows produce a value (100%)");
+    expect(page.getByTestId("coverage-silent-empty").elements()).toHaveLength(
+      0,
+    );
   });
 
   test('"Reset to recommended" turns the expert tier back off', async () => {

--- a/packages/core/src/exchange.ts
+++ b/packages/core/src/exchange.ts
@@ -7,7 +7,7 @@ import {
   validateStandardizationAgainstTerms,
   StandardizedKeyIterable,
 } from "./standardization.js";
-import { inferDateFormat } from "./utils/date.js";
+import { columnValues, inferDateFormat } from "./utils/date.js";
 import { sanitizeForDisplay } from "./utils/sanitizeForDisplay.js";
 import { PSIParticipant } from "./participant.js";
 import {
@@ -166,9 +166,7 @@ export function prepareForExchange(
       (c) => c.type === "date_of_birth" && c.role === "linkage",
     );
     if (dobCol !== undefined) {
-      dateInputFormat = inferDateFormat(
-        rawRows.map((row) => row[dobCol.name] ?? ""),
-      );
+      dateInputFormat = inferDateFormat(columnValues(rawRows, dobCol.name));
       if (dateInputFormat !== undefined)
         log.info(`inferred date of birth format: ${dateInputFormat}`);
     }

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -62,7 +62,7 @@ export * from "./signingIdentity";
 export * from "./standardization";
 export { loadCSVFile, loadCSVColumns } from "./file";
 
-export { inferDateFormat } from "./utils/date.js";
+export { inferDateFormat, columnValues } from "./utils/date.js";
 export {
   computeHostKeyFingerprint,
   verifyHostKeyFingerprint,

--- a/packages/core/src/utils/date.ts
+++ b/packages/core/src/utils/date.ts
@@ -21,10 +21,10 @@ export const CANDIDATE_DATE_FORMATS = [
 type CandidateDateFormat = (typeof CANDIDATE_DATE_FORMATS)[number];
 
 /**
- * Maximum number of non-empty rows scanned by {@link inferDateFormat}.
+ * Maximum number of non-empty values scanned by {@link inferDateFormat}.
  *
- * The cap counts every non-empty value iterated, including rows that no
- * candidate can parse (noise). A column with many leading noise rows may
+ * The cap counts every non-empty value iterated, including values that no
+ * candidate can parse (noise). A column with many leading noise values may
  * exhaust the cap before any format is inferred.
  */
 export const INFER_DATE_SCAN_CAP = 1000;
@@ -56,27 +56,29 @@ function buildDateParser(format: CandidateDateFormat): (s: string) => boolean {
 }
 
 /**
- * Infers the date format used in a column of string values by scanning rows
+ * Infers the date format used in a column of string values by scanning them
  * and eliminating candidates that fail to parse.
  *
  * Starts with all {@link CANDIDATE_DATE_FORMATS} as candidates. For each
- * non-empty row, if at least one candidate parses the value, any candidate
- * that fails is eliminated. Rows that no candidate can parse are skipped
- * (treated as noise). Scanning stops as soon as only one candidate remains
- * or {@link INFER_DATE_SCAN_CAP} rows have been examined.
+ * non-empty value, if at least one candidate parses it, any candidate that
+ * fails is eliminated. Values that no candidate can parse are skipped (treated
+ * as noise). Scanning stops as soon as only one candidate remains or
+ * {@link INFER_DATE_SCAN_CAP} non-empty values have been examined.
  *
- * Returns `undefined` when the column is empty or when scanning exhausts all
- * candidates.
+ * The `values` iterable is consumed lazily in a single pass: empty values are
+ * skipped without consuming the scan budget, and iteration stops at the cap, so
+ * a large or unbounded source (e.g. {@link columnValues} over a whole file) is
+ * read only up to that bound rather than materialized in full.
+ *
+ * Returns `undefined` when the source yields no non-empty value or when
+ * scanning exhausts all candidates.
  *
  * **Tie-breaking**: when more than one candidate survives (e.g. all days ≤ 12
  * so MM/DD and DD/MM are never disproved), the candidate that appears earliest
  * in {@link CANDIDATE_DATE_FORMATS} is returned — but only because it is
  * consistent with the data, not as a blind default.
  */
-export function inferDateFormat(values: string[]): string | undefined {
-  const nonEmpty = values.filter((v) => v !== undefined && v.trim() !== "");
-  if (nonEmpty.length === 0) return undefined;
-
+export function inferDateFormat(values: Iterable<string>): string | undefined {
   const remaining = new Map<string, (s: string) => boolean>(
     CANDIDATE_DATE_FORMATS.map((fmt) => [fmt, buildDateParser(fmt)]),
   );
@@ -84,7 +86,13 @@ export function inferDateFormat(values: string[]): string | undefined {
   let rowsScanned = 0;
   let anyElimination = false;
 
-  for (const value of nonEmpty) {
+  for (const value of values) {
+    // Empty values carry no format signal and do not count toward the cap, so
+    // skip them without spending the scan budget (was a non-empty pre-filter).
+    if (value === undefined || value.trim() === "") continue;
+    // Stop once a single candidate remains or the cap is reached; checked before
+    // pulling further so the source is consumed only up to INFER_DATE_SCAN_CAP
+    // non-empty values.
     if (remaining.size <= 1 || rowsScanned >= INFER_DATE_SCAN_CAP) break;
 
     const survivors: string[] = [];
@@ -104,9 +112,22 @@ export function inferDateFormat(values: string[]): string | undefined {
   }
 
   // Return the top-ranked survivor only if scanning produced useful signal
-  // (at least one format was eliminated). If every row was noise, we have no
-  // evidence for any candidate.
+  // (at least one format was eliminated). If every value was noise or the
+  // source was empty, we have no evidence for any candidate.
   return anyElimination && remaining.size >= 1
     ? remaining.keys().next().value
     : undefined;
+}
+
+/**
+ * Lazily yields one column's value per row (the empty string when the column is
+ * absent from a row), so {@link inferDateFormat} can scan a bounded prefix of a
+ * large file without first materializing the whole column. Pair the two:
+ * `inferDateFormat(columnValues(rows, dobColumn))`.
+ */
+export function* columnValues(
+  rows: Iterable<Record<string, string>>,
+  column: string,
+): Generator<string> {
+  for (const row of rows) yield row[column] ?? "";
 }

--- a/packages/core/test/defaultStandardization.test.ts
+++ b/packages/core/test/defaultStandardization.test.ts
@@ -3,6 +3,7 @@ import { expect, test, describe } from "vitest";
 import { getDefaultStandardization } from "../src/defaults/standardization";
 import {
   inferDateFormat,
+  columnValues,
   CANDIDATE_DATE_FORMATS,
   INFER_DATE_SCAN_CAP,
 } from "../src/utils/date";
@@ -751,6 +752,66 @@ describe("inferDateFormat — scanning", () => {
     for (const fmt of CANDIDATE_DATE_FORMATS) {
       expect(inferDateFormat(samples[fmt]), `format: ${fmt}`).toBe(fmt);
     }
+  });
+
+  test("interleaved empties do not consume the scan budget", () => {
+    // Empties are skipped lazily and must not spend the cap: a run of empty
+    // values longer than INFER_DATE_SCAN_CAP, followed by real dates, must still
+    // infer. If empties counted toward the cap the budget would be exhausted
+    // before any date was reached and the result would be undefined.
+    const values = [
+      ...Array.from({ length: INFER_DATE_SCAN_CAP * 2 }, () => ""),
+      "01/15/1990",
+      "12/31/2000",
+      "06/28/1975",
+    ];
+    expect(inferDateFormat(values)).toBe("MM/DD/YYYY");
+  });
+
+  test("consumes the source lazily, stopping at the scan cap", () => {
+    // All days and months <= 12 keep both MM/DD/YYYY and DD/MM/YYYY alive, so the
+    // candidate set never narrows to one and the cap alone governs how far we
+    // scan. The generator can yield far past the cap; inferDateFormat must stop
+    // pulling at INFER_DATE_SCAN_CAP rather than draining the whole source -- the
+    // property that lets a large file be scanned without materializing its column.
+    let yielded = 0;
+    function* ambiguousDates(): Generator<string> {
+      for (let i = 0; i < INFER_DATE_SCAN_CAP * 3; i++) {
+        yielded++;
+        yield "01/05/1990";
+      }
+    }
+    expect(inferDateFormat(ambiguousDates())).toBe("MM/DD/YYYY");
+    expect(yielded).toBeLessThanOrEqual(INFER_DATE_SCAN_CAP + 1);
+  });
+});
+
+describe("columnValues", () => {
+  test("yields each row's value for the named column", () => {
+    expect([...columnValues([{ dob: "a" }, { dob: "b" }], "dob")]).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  test("yields the empty string for a row missing the column", () => {
+    expect([
+      ...columnValues([{ dob: "a" }, { other: "x" }, { dob: "c" }], "dob"),
+    ]).toEqual(["a", "", "c"]);
+  });
+
+  test("is lazy: pulls a row only as the consumer advances", () => {
+    let yielded = 0;
+    function* rows(): Generator<Record<string, string>> {
+      for (let i = 0; i < 100; i++) {
+        yielded++;
+        yield { dob: "01/15/1990" };
+      }
+    }
+    const gen = columnValues(rows(), "dob");
+    gen.next();
+    gen.next();
+    expect(yielded).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Summary

The web acceptor's "Prepare your data" editor now auto-detects the date layout (e.g. YYYY-MM-DD) from its own rows, so an operator with a non-US date file no longer has to set the date_of_birth format by hand for keys to match. Previously the editor assumed MM/DD/YYYY and silently dropped every dob value on an ISO file, under-matching every date key -- the inviter already inferred the format, so only the acceptor was affected.

## Changes

- apps/web/src/components/PrepareData.tsx: derive the seed standardization through `defaultStandardizationForRows` (which infers the dob input format from `rawRows`) instead of the bare MM/DD/YYYY `getDefaultStandardization`; add `rawRows` to the memo deps.
- packages/core/src/utils/date.ts: `inferDateFormat` consumes an `Iterable<string>` in a single lazy pass -- empties are skipped without spending the cap, iteration stops at `INFER_DATE_SCAN_CAP`; add a `columnValues` generator that lazily yields one column's value per row.
- packages/core/src/main.ts: export `columnValues`.
- packages/core/src/exchange.ts, apps/web/src/psi/advancedInvite.ts, apps/cli/src/commands/bootstrap.ts: feed `inferDateFormat` via `columnValues(rows, col)` instead of a whole-column array, so a large file is read only up to the cap.
- packages/core/test/defaultStandardization.test.ts: add laziness, budget-conservation, and `columnValues` tests.
- apps/web/test/browser/nonEmptyCoverage.test.ts: add an ISO-file full-coverage test; rework the silent-empty test to use values no candidate format parses (the old ISO dates now infer correctly).

## Test plan

Ran: `npm test -w packages/core` (1864 pass), `npm run test:unit -w apps/cli` (866 pass), `npm run test:unit -w apps/web` (530 pass), `npm run test:browser -w apps/web` (nonEmptyCoverage, 11 pass); `npm run typecheck`, `npm run lint`, `npm run format` all clean.
New tests cover: an acceptor ISO-dated file reaches full coverage with no silent-empty alarm; `inferDateFormat` stops pulling at the scan cap and interleaved empties do not consume the budget; `columnValues` yields each value, "" for a missing column, and pulls lazily.

## Background

The acceptor editor always hands the exchange an explicit standardization, and the exchange runs its own date-format inference only when none is supplied (exchange.ts, gated on `standardization === undefined`). So the editor's bare default won and an ISO file parsed as MM/DD/YYYY. The inviter's advanced path already worked around this via `defaultStandardizationForRows`; this applies the same helper on the acceptor side. The inferred format is per-party and local -- carried only in cleaning steps, excluded from the agreed-terms hash -- so it never changes the cross-party agreement.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: COMMUNICATION.md describes the acceptor workbench's "recommended per-type cleaning" generically with no date-default claim to correct; the inference algorithm and its scan bound run over the operator's own local file (implementation detail, not channel input), and parse_date's documented default and semantics (EXCHANGE_REFERENCE.md, spec/PROTOCOL.md, spec/CHANNEL_SECURITY.md) are unchanged.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: fix to the still-`[Unreleased]` "Prepare your data" editor (no released behavior changes; it folds into that feature's existing Added entry), and the `inferDateFormat` change is a `@psilink/core` reshape with identical behavior.
- [x] Security review -- independent security/privacy review performed: partner-controlled `linkageTerms` cannot redirect the dob-column or format inference (driven by acceptor-derived metadata over the acceptor's own file); the inferred format stays in local cleaning steps, is never sent on the wire, logged, or persisted, and the cross-party agreement-byte hash is unchanged; the inference scan is bounded by `INFER_DATE_SCAN_CAP` (1000) and now reads only up to that bound.