### PR TITLE
Fix invalid Dependabot cooldown keys for docker and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,10 +70,9 @@ updates:
       day: monday
     open-pull-requests-limit: 5
     cooldown:
+      # Only default-days is valid for the docker and github-actions
+      # ecosystems; the semver-*-days keys are supported for npm only.
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 5
 
   # GitHub Actions used by the workflows in .github/workflows. Every action is
   # tag-pinned (e.g. actions/checkout@v6), so this tracks those tags for new
@@ -86,7 +85,6 @@ updates:
       day: monday
     open-pull-requests-limit: 5
     cooldown:
+      # Only default-days is valid for the docker and github-actions
+      # ecosystems; the semver-*-days keys are supported for npm only.
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 5


### PR DESCRIPTION
The `semver-major-days`/`semver-minor-days`/`semver-patch-days` cooldown keys added in #308 are only valid for the npm ecosystem. Dependabot rejected the config for the `docker` and `github-actions` ecosystems (where only `default-days` is supported), which stops it from parsing the file at all. This drops the unsupported keys from those two blocks; npm keeps the full per-bump cooldown.

Caught by Dependabot's own config-validation check after #308 merged.