### PR TITLE
Fix consent breadth marker mis-ordering

### DIFF
--- a/apps/web/src/psi/invitationSummary.ts
+++ b/apps/web/src/psi/invitationSummary.ts
@@ -583,19 +583,36 @@ function parseDateDropsComponent(step: TransformStep): boolean {
  * undefined when the element matches exactly or only canonicalizes its value
  * (case, whitespace, accents, affixes, padding, and a `parse_date` that merely
  * reformats between equivalent layouts -- routine standardization, deliberately
- * not flagged so the recommended setup stays clean). It names any rule that
- * materially changes which records match: where the direction is determinable
- * from the terms it names the EFFECT ("partial" for a truncation, or for a
- * `parse_date` whose output layout drops a component its input carries and so
- * matches on only part of the date; "fuzzy" / "sound-alike" / "multiple" /
- * "fallback" for an expansion), and where an arbitrary partner-authored pattern
- * or value list makes the direction indeterminate it names the RULE directly
- * ("pattern replacement", "pattern extraction", "pattern filter", "excludes
- * values"). Informative, not a broaden-only warning: `filter_regex` and `null_if`
- * narrow matching but are still surfaced. "fuzzy" is reserved for the genuine
- * fuzzy-comparison expansion, distinct from `substring`'s "partial". None of the
- * regex/value rules appear on the default or guided path (only `substring` and
- * `swap` do), so an expert-authored rule is what trips those markers.
+ * not flagged so the recommended setup stays clean). `remove_affixes` is in that
+ * routine set by deliberate decision: stripping titles and suffixes (Dr., Jr.)
+ * is a BROADENING canonicalizer in the same family as accent and case folding --
+ * it makes superficially-different spellings match -- not a record-DROPPING
+ * narrower like the flagged `filter_regex` / `null_if`, so it earns no marker
+ * despite removing characters. It names any rule that materially changes which
+ * records match: where the direction is determinable from the terms it names the
+ * EFFECT ("partial" for a truncation, or for a `parse_date` whose output layout
+ * drops a component its input carries and so matches on only part of the date;
+ * "fuzzy" / "sound-alike" / "multiple" / "fallback" for an expansion), and where
+ * an arbitrary partner-authored pattern or value list makes the direction
+ * indeterminate it names the RULE directly ("pattern replacement", "pattern
+ * extraction", "pattern filter", "excludes values"). Informative, not a
+ * broaden-only warning: `filter_regex` and `null_if` narrow matching but are
+ * still surfaced. "fuzzy" is reserved for the genuine fuzzy-comparison expansion,
+ * distinct from `substring`'s "partial". None of the regex/value rules appear on
+ * the default or guided path (only `substring` and `swap` do), so an
+ * expert-authored rule is what trips those markers.
+ *
+ * "partial" marks a LITERAL character-truncation, so it fires for a `substring`
+ * only where the slice runs on the literal value. A `substring` after a
+ * value-recoding `phonetic` step (which replaces the name with a sound-alike
+ * code) slices that code, not the name, so it is not flagged "partial" -- the
+ * recoding's "sound-alike" is then the dominant, honest effect. This mirrors the
+ * detail row's position-aware literal ({@link substringEffect} /
+ * {@link summarizeKey}, which render "the first N characters" only for a
+ * substring on the unmodified value). A routine normalizer before the substring
+ * (case/accents/...) does not recode the value out of literal correspondence, so
+ * it keeps "partial"; a `phonetic` AFTER the substring does too, since the
+ * literal is truncated first.
  *
  * Returns a SINGLE, most-salient marker, not one per rule: the always-visible
  * header is deliberately terse, so an element carrying more than one rule shows
@@ -606,8 +623,16 @@ function parseDateDropsComponent(step: TransformStep): boolean {
 function elementBreadthMarker(element: LinkageKeyElement): string | undefined {
   const steps = element.transform ?? [];
   const functions = new Set(steps.map((s) => s.function));
-  // Effect named where the direction is determinable from the terms.
-  if (functions.has("substring")) return "partial";
+  // Effect named where the direction is determinable from the terms. "partial"
+  // is a literal truncation, so a substring counts only where it slices the
+  // literal value -- not after a value-recoding `phonetic` step, where it slices
+  // the sound-alike code and "sound-alike" (below) is the honest dominant effect.
+  const truncatesLiteral = steps.some(
+    (step, index) =>
+      step.function === "substring" &&
+      !steps.slice(0, index).some((prior) => prior.function === "phonetic"),
+  );
+  if (truncatesLiteral) return "partial";
   if (element.generateFuzzyComparisons !== undefined) return "fuzzy";
   if (functions.has("phonetic")) return "sound-alike";
   if (functions.has("split_on")) return "multiple";

--- a/apps/web/test/unit/acceptConsent.test.ts
+++ b/apps/web/test/unit/acceptConsent.test.ts
@@ -1268,6 +1268,59 @@ describe("summarizeInvitation", () => {
     ).toBe("last name (excludes values)");
   });
 
+  test("does not mark a phonetic-then-substring element as a literal truncation", () => {
+    const headerFor = (transform: LinkageKeyElement["transform"]) =>
+      summarizeInvitation(
+        makeToken({
+          linkageFields: [{ name: "ln", type: "last_name" }],
+          linkageKeys: [
+            {
+              name: "K",
+              elements: [{ field: "ln", ...(transform && { transform }) }],
+            },
+          ],
+        }),
+      ).linkageKeys[0].headerFields[0];
+
+    // The bug: a substring after a value-recoding phonetic step slices the
+    // sound-alike code, not the literal name, so "partial" (a literal truncation)
+    // would misdescribe the match -- "sound-alike" is the dominant honest effect.
+    expect(
+      headerFor([
+        { function: "phonetic" },
+        { function: "substring", params: { start: 1, length: 3 } },
+      ]),
+    ).toBe("last name (sound-alike)");
+    // Order matters, mirroring the detail row's position-aware literal: a
+    // substring FIRST does truncate the literal name (phonetic then codes that
+    // truncation), so "partial" is faithful and stays.
+    expect(
+      headerFor([
+        { function: "substring", params: { start: 1, length: 3 } },
+        { function: "phonetic" },
+      ]),
+    ).toBe("last name (partial)");
+    // A routine normalizer before the substring does not recode the value out of
+    // literal correspondence, so "partial" still fires.
+    expect(
+      headerFor([
+        { function: "to_lower_case" },
+        { function: "substring", params: { start: 1, length: 3 } },
+      ]),
+    ).toBe("last name (partial)");
+    // The single-transform baselines stay unchanged by the re-ordering.
+    expect(
+      headerFor([{ function: "substring", params: { start: 1, length: 3 } }]),
+    ).toBe("last name (partial)");
+    expect(headerFor([{ function: "phonetic" }])).toBe(
+      "last name (sound-alike)",
+    );
+    // remove_affixes earns no marker: it is a broadening canonicalizer (like
+    // accent/case folding), not a record-dropping narrower, so it is deliberately
+    // routine despite stripping characters (see elementBreadthMarker's doc).
+    expect(headerFor([{ function: "remove_affixes" }])).toBe("last name");
+  });
+
   test("classifies every core standardization function as marked or routine", () => {
     // The header marker is a hand-maintained classification; pin it against core's
     // full function set in both directions, so a new core function cannot ship


### PR DESCRIPTION
## Summary

The web accept-invitation consent screen's always-visible per-key field one-liner mislabeled how an element matches when its transform pipeline both reformats and truncates a value. `elementBreadthMarker` tested `substring` before `phonetic`, so a `[phonetic, substring]` element showed "(partial)" -- implying the literal name is character-truncated -- when the substring actually slices an already-rewritten sound-alike code. On the surface designed to be the honest anchor a partner-controlled key name cannot misrepresent, that misdescribed the matching (and, under `psi`, disclosure) semantics the acceptor consents to. This makes the marker position-aware so it reflects the dominant matching effect, and resolves the parallel `remove_affixes` glossary-vs-marker inconsistency by a documented decision.

Implements [203598761](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=203598761).

## Changes

- apps/web/src/psi/invitationSummary.ts: make the "partial" marker position-aware in `elementBreadthMarker` -- a `substring` earns "partial" only when no value-recoding `phonetic` step precedes it, so a `[phonetic, substring]` element shows "sound-alike" (the dominant honest effect) while substring-first and routine-normalizer-first pipelines keep "partial". Rewrite the doc comment to record this precedence and the deliberate decision that `remove_affixes` is a broadening canonicalizer (accent/case-fold family), not a record-dropping narrower, so it earns no marker.
- apps/web/test/unit/acceptConsent.test.ts: add a test covering phonetic-then-substring producing "sound-alike", substring-then-phonetic and normalizer-then-substring keeping "partial", the single-transform baselines, and the `remove_affixes` no-marker decision.

## Test plan

Ran: `npm run test:unit -w apps/web` (531 passed), `npx vitest run apps/web/test/unit/acceptConsent.test.ts` (51 passed), `npm run typecheck`, `npm run lint`, `npm run format` (no changes to these files).
New tests cover: the corrected `[phonetic, substring]` marker, order-sensitivity (`[substring, phonetic]` stays "partial"), a routine normalizer before a substring keeping "partial", the unchanged single-transform baselines (`substring` -> "partial", `phonetic` -> "sound-alike"), and the documented `remove_affixes` no-marker decision.

## Background

Surfaced in code review of already-merged web payload/consent work (PRs #285-#287). The fix mirrors the position-awareness already encoded for the expandable detail row (`substringEffect` / `summarizeKey` render "the first N characters" only for a substring on the unmodified value), so the header and detail views stay consistent. The recoding trigger is deliberately limited to `phonetic` -- a total recode into an opaque code with no literal correspondence -- whereas `replace_regex` / `extract_regex` / `split_on` / `coalesce` / `parse_date` before a substring keep "(partial)"; generalizing that is a separate design decision tracked in the follow-on below.

## Out of scope / follow-on

- Decide consent breadth markers for a value-deriving (non-phonetic) transform before a substring: [205012104](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=205012104).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/`; no page documents the consent breadth-marker selection (its rationale lives in the `elementBreadthMarker` JSDoc, the established pattern for this surface) -- n/a: no documented operational or spec behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: pre-release correctness fix to a consent surface still under `[Unreleased]` (its "Added" entry already covers the marker vocabulary); the mislabel never reached a released build, so no operator/reviewer acts on a separate entry.
- [x] Security review -- consent-disclosure surface (security-review scope under CONTRIBUTING, "what is disclosed: consent-surfaced fields"); three independent reviews this cycle (disclosure integrity, injection-safety, control-regression) all PASS.
