### PR TITLE
Distinguish a tokenless parse_date breadth marker

### DIFF
--- a/apps/web/src/psi/invitationSummary.ts
+++ b/apps/web/src/psi/invitationSummary.ts
@@ -567,16 +567,31 @@ function dateComponentsOf(format: string): Set<DateFormatToken> {
 }
 
 /**
- * Whether a `parse_date` step's output layout omits a date component its input
- * carries -- the case that collapses distinct dates (an `outputFormat` of "YYYY"
- * makes every date in a year match; a tokenless output collapses every date to a
- * constant) rather than merely reformatting between equivalent layouts, which is
- * routine canonicalization. The params are partner-controlled and typed
- * `unknown`, so each format is narrowed to a string, falling back to core's
- * default layout (which carries every component) when absent.
+ * The breadth marker a `parse_date` step's output layout earns, or undefined when
+ * it merely reformats between equivalent full layouts (routine canonicalization,
+ * deliberately unflagged). Distinguishes two magnitudes of date collapse:
+ *
+ * - "constant": the output layout carries NO date token at all, so every date
+ *   collapses to one constant value and the element matches every record's date
+ *   as that single value -- the maximal match breadth (e.g. an `outputFormat` of
+ *   "registered").
+ * - "partial": the output keeps at least one date token but omits a component its
+ *   input carries, so distinct dates collapse onto a coarser bucket and the
+ *   element matches on only part of the date (e.g. a year-only output matches
+ *   every date within a year).
+ *
+ * Keyed on the OUTPUT's token set: a tokenless output is "constant" whatever the
+ * input, since no input layout can un-collapse a constant output; the proper drop
+ * is then a component the input carries that a non-empty output omits. The params
+ * are partner-controlled and typed `unknown`, so each format is narrowed to a
+ * string, falling back to core's default layout (which carries every component)
+ * when absent. The returned word is one of these two fixed literals, never
+ * partner text, so the marker is injection-safe by construction.
  */
-function parseDateDropsComponent(step: TransformStep): boolean {
-  if (step.function !== "parse_date") return false;
+function parseDateBreadth(
+  step: TransformStep,
+): "constant" | "partial" | undefined {
+  if (step.function !== "parse_date") return undefined;
   const rawInput = step.params?.inputFormat;
   const rawOutput = step.params?.outputFormat;
   const input =
@@ -584,9 +599,11 @@ function parseDateDropsComponent(step: TransformStep): boolean {
   const output =
     typeof rawOutput === "string" ? rawOutput : DEFAULT_PARSE_DATE_OUTPUT;
   const outputComponents = dateComponentsOf(output);
-  return [...dateComponentsOf(input)].some(
+  if (outputComponents.size === 0) return "constant";
+  const dropsComponent = [...dateComponentsOf(input)].some(
     (component) => !outputComponents.has(component),
   );
+  return dropsComponent ? "partial" : undefined;
 }
 
 /**
@@ -602,7 +619,9 @@ function parseDateDropsComponent(step: TransformStep): boolean {
  * despite removing characters. It names any rule that materially changes which
  * records match: where the direction is determinable from the terms it names the
  * EFFECT ("partial" for a truncation, or for a `parse_date` whose output layout
- * drops a component its input carries and so matches on only part of the date;
+ * drops a date component its input carries and so matches on only part of the
+ * date; "constant" for a `parse_date` whose output carries no date token at all,
+ * collapsing every date to one value -- a stronger breadth than the partial drop;
  * "fuzzy" / "sound-alike" / "multiple" / "fallback" for an expansion), and where
  * an arbitrary partner-authored pattern or value list makes the direction
  * indeterminate it names the RULE directly ("pattern replacement", "pattern
@@ -648,10 +667,15 @@ function elementBreadthMarker(element: LinkageKeyElement): string | undefined {
   if (functions.has("phonetic")) return "sound-alike";
   if (functions.has("split_on")) return "multiple";
   if (functions.has("coalesce")) return "fallback";
-  // parse_date is routine date canonicalization UNLESS its output layout drops a
-  // component its input carries, which collapses distinct dates -- then it
-  // matches on only part of the date.
-  if (steps.some(parseDateDropsComponent)) return "partial";
+  // parse_date is routine date canonicalization UNLESS its output layout narrows
+  // matching. A tokenless output collapses every date to one constant value (the
+  // maximal breadth, "constant"); an output that keeps a token but drops a
+  // component its input carries matches on only part of the date ("partial"). The
+  // stronger word across the element's steps wins, so a constant-collapsing step
+  // is never understated as a partial drop.
+  const parseDateBreadths = steps.map(parseDateBreadth);
+  if (parseDateBreadths.includes("constant")) return "constant";
+  if (parseDateBreadths.includes("partial")) return "partial";
   // Rule named directly where a partner-authored pattern or value list makes the
   // matching direction indeterminate from the terms alone.
   if (functions.has("replace_regex")) return "pattern replacement";

--- a/apps/web/src/psi/invitationSummary.ts
+++ b/apps/web/src/psi/invitationSummary.ts
@@ -646,13 +646,23 @@ function parseDateBreadth(
  *
  * Returns a SINGLE, most-salient marker, not one per rule: the always-visible
  * header is deliberately terse, so an element carrying more than one rule shows
- * just the first -- effect-named rules take precedence over the directly-named
- * ones -- while its complete rule set sits one expand down in
- * {@link MatchKeyDetails}. The element stays flagged either way.
+ * just the first -- the maximal-breadth "constant" date collapse ranks first,
+ * then the other effect-named rules, then the directly-named ones -- while its
+ * complete rule set sits one expand down in {@link MatchKeyDetails}. The element
+ * stays flagged either way.
  */
 function elementBreadthMarker(element: LinkageKeyElement): string | undefined {
   const steps = element.transform ?? [];
   const functions = new Set(steps.map((s) => s.function));
+  // A tokenless `parse_date` output collapses every date to one constant value --
+  // the maximal match breadth -- so it is checked first and outranks every other
+  // rule the element might also carry: once every value collapses to one, a
+  // further substring/fuzzy/expansion loosening is moot, so "constant" is the
+  // honest dominant effect and is never understated as a milder word. (A
+  // `parse_date` that drops only some components, not all, is the milder "partial"
+  // handled below at the parse_date position.)
+  const parseDateBreadths = steps.map(parseDateBreadth);
+  if (parseDateBreadths.includes("constant")) return "constant";
   // Effect named where the direction is determinable from the terms. "partial"
   // is a literal truncation, so a substring counts only where it slices the
   // literal value -- not after a value-recoding `phonetic` step, where it slices
@@ -668,13 +678,9 @@ function elementBreadthMarker(element: LinkageKeyElement): string | undefined {
   if (functions.has("split_on")) return "multiple";
   if (functions.has("coalesce")) return "fallback";
   // parse_date is routine date canonicalization UNLESS its output layout narrows
-  // matching. A tokenless output collapses every date to one constant value (the
-  // maximal breadth, "constant"); an output that keeps a token but drops a
-  // component its input carries matches on only part of the date ("partial"). The
-  // stronger word across the element's steps wins, so a constant-collapsing step
-  // is never understated as a partial drop.
-  const parseDateBreadths = steps.map(parseDateBreadth);
-  if (parseDateBreadths.includes("constant")) return "constant";
+  // matching: an output that keeps a date token but drops a component its input
+  // carries matches on only part of the date ("partial"). The tokenless
+  // every-date-to-one case is the stronger "constant", handled at the top.
   if (parseDateBreadths.includes("partial")) return "partial";
   // Rule named directly where a partner-authored pattern or value list makes the
   // matching direction indeterminate from the terms alone.

--- a/apps/web/src/psi/invitationSummary.ts
+++ b/apps/web/src/psi/invitationSummary.ts
@@ -1,4 +1,8 @@
-import { describeTransformCoercions, sanitizeForDisplay } from "@psilink/core";
+import {
+  describeTransformCoercions,
+  parseDateInputDropsEveryRecord,
+  sanitizeForDisplay,
+} from "@psilink/core";
 
 import { APPLIED_SETTINGS } from "@psi/appliedSettings";
 
@@ -569,9 +573,11 @@ function dateComponentsOf(format: string): Set<DateFormatToken> {
 /**
  * The breadth marker a `parse_date` step's output layout earns, or undefined when
  * it merely reformats between equivalent full layouts (routine canonicalization,
- * deliberately unflagged). Distinguishes two magnitudes of date collapse:
+ * deliberately unflagged) -- or when its INPUT format cannot supply a full date,
+ * which is not a broadening at all (see below). Distinguishes two magnitudes of
+ * date collapse:
  *
- * - "constant": the output layout carries NO date token at all, so every date
+ * - "any date": the output layout carries NO date token at all, so every date
  *   collapses to one constant value and the element matches every record's date
  *   as that single value -- the maximal match breadth (e.g. an `outputFormat` of
  *   "registered").
@@ -580,18 +586,31 @@ function dateComponentsOf(format: string): Set<DateFormatToken> {
  *   element matches on only part of the date (e.g. a year-only output matches
  *   every date within a year).
  *
- * Keyed on the OUTPUT's token set: a tokenless output is "constant" whatever the
- * input, since no input layout can un-collapse a constant output; the proper drop
- * is then a component the input carries that a non-empty output omits. The params
- * are partner-controlled and typed `unknown`, so each format is narrowed to a
- * string, falling back to core's default layout (which carries every component)
- * when absent. The returned word is one of these two fixed literals, never
- * partner text, so the marker is injection-safe by construction.
+ * A `parse_date` whose input format omits a component core requires drops EVERY
+ * record (it returns null for every value), so the element matches NOTHING, not
+ * more -- the opposite of a broadening -- and earns no breadth marker here: that
+ * self-defeating key is a narrowing surfaced by the separate dead-key advisory,
+ * and the output is classified only once a full date is actually parsed. This
+ * defers to core's own runtime-faithful `parseDateInputDropsEveryRecord` (which
+ * also covers a non-string input format) rather than re-deriving the
+ * required-component rule here, so the marker cannot drift from the runtime.
+ *
+ * The output classification is keyed on the OUTPUT's token set: a tokenless output
+ * is "any date" whatever the (now full) input, since no input layout can
+ * un-collapse a constant output; the proper drop is then a component the input
+ * carries that a non-empty output omits. The params are partner-controlled and
+ * typed `unknown`, so each format is narrowed to a string, falling back to core's
+ * default layout (which carries every component) when absent. The returned word is
+ * one of these two fixed literals, never partner text, so the marker is
+ * injection-safe by construction.
  */
 function parseDateBreadth(
   step: TransformStep,
-): "constant" | "partial" | undefined {
+): "any date" | "partial" | undefined {
   if (step.function !== "parse_date") return undefined;
+  // An input format core cannot assemble a full date from drops every record, so
+  // the element matches nothing rather than broadening -- no breadth marker.
+  if (parseDateInputDropsEveryRecord(step.params)) return undefined;
   const rawInput = step.params?.inputFormat;
   const rawOutput = step.params?.outputFormat;
   const input =
@@ -599,7 +618,7 @@ function parseDateBreadth(
   const output =
     typeof rawOutput === "string" ? rawOutput : DEFAULT_PARSE_DATE_OUTPUT;
   const outputComponents = dateComponentsOf(output);
-  if (outputComponents.size === 0) return "constant";
+  if (outputComponents.size === 0) return "any date";
   const dropsComponent = [...dateComponentsOf(input)].some(
     (component) => !outputComponents.has(component),
   );
@@ -620,7 +639,7 @@ function parseDateBreadth(
  * records match: where the direction is determinable from the terms it names the
  * EFFECT ("partial" for a truncation, or for a `parse_date` whose output layout
  * drops a date component its input carries and so matches on only part of the
- * date; "constant" for a `parse_date` whose output carries no date token at all,
+ * date; "any date" for a `parse_date` whose output carries no date token at all,
  * collapsing every date to one value -- a stronger breadth than the partial drop;
  * "fuzzy" / "sound-alike" / "multiple" / "fallback" for an expansion), and where
  * an arbitrary partner-authored pattern or value list makes the direction
@@ -646,8 +665,8 @@ function parseDateBreadth(
  *
  * Returns a SINGLE, most-salient marker, not one per rule: the always-visible
  * header is deliberately terse, so an element carrying more than one rule shows
- * just the first -- the maximal-breadth "constant" date collapse ranks first,
- * then the other effect-named rules, then the directly-named ones -- while its
+ * just the first -- the maximal-breadth "any date" collapse ranks first, then the
+ * other effect-named rules, then the directly-named ones -- while its
  * complete rule set sits one expand down in {@link MatchKeyDetails}. The element
  * stays flagged either way.
  */
@@ -657,12 +676,12 @@ function elementBreadthMarker(element: LinkageKeyElement): string | undefined {
   // A tokenless `parse_date` output collapses every date to one constant value --
   // the maximal match breadth -- so it is checked first and outranks every other
   // rule the element might also carry: once every value collapses to one, a
-  // further substring/fuzzy/expansion loosening is moot, so "constant" is the
+  // further substring/fuzzy/expansion loosening is moot, so "any date" is the
   // honest dominant effect and is never understated as a milder word. (A
   // `parse_date` that drops only some components, not all, is the milder "partial"
   // handled below at the parse_date position.)
   const parseDateBreadths = steps.map(parseDateBreadth);
-  if (parseDateBreadths.includes("constant")) return "constant";
+  if (parseDateBreadths.includes("any date")) return "any date";
   // Effect named where the direction is determinable from the terms. "partial"
   // is a literal truncation, so a substring counts only where it slices the
   // literal value -- not after a value-recoding `phonetic` step, where it slices
@@ -680,7 +699,7 @@ function elementBreadthMarker(element: LinkageKeyElement): string | undefined {
   // parse_date is routine date canonicalization UNLESS its output layout narrows
   // matching: an output that keeps a date token but drops a component its input
   // carries matches on only part of the date ("partial"). The tokenless
-  // every-date-to-one case is the stronger "constant", handled at the top.
+  // every-date-to-one case is the stronger "any date", handled at the top.
   if (parseDateBreadths.includes("partial")) return "partial";
   // Rule named directly where a partner-authored pattern or value list makes the
   // matching direction indeterminate from the terms alone.

--- a/apps/web/src/psi/invitationSummary.ts
+++ b/apps/web/src/psi/invitationSummary.ts
@@ -1,6 +1,7 @@
 import {
   describeTransformCoercions,
   parseDateInputDropsEveryRecord,
+  pipelineAlwaysDrops,
   sanitizeForDisplay,
 } from "@psilink/core";
 
@@ -608,8 +609,13 @@ function parseDateBreadth(
   step: TransformStep,
 ): "any date" | "partial" | undefined {
   if (step.function !== "parse_date") return undefined;
-  // An input format core cannot assemble a full date from drops every record, so
-  // the element matches nothing rather than broadening -- no breadth marker.
+  // A parse_date whose input format cannot assemble a full date produces no value
+  // to classify (core drops every such record), so emit no date marker. Defer to
+  // core's check (which also covers a non-string input format). The element-level
+  // pipelineAlwaysDrops guard in elementBreadthMarker suppresses ALL markers when
+  // this kills the whole element; this step-level guard additionally stops a dead
+  // parse_date that a later `coalesce` RESCUES to a constant from mislabelling the
+  // element a date collapse (the honest marker there is the coalesce's "fallback").
   if (parseDateInputDropsEveryRecord(step.params)) return undefined;
   const rawInput = step.params?.inputFormat;
   const rawOutput = step.params?.outputFormat;
@@ -630,7 +636,11 @@ function parseDateBreadth(
  * undefined when the element matches exactly or only canonicalizes its value
  * (case, whitespace, accents, affixes, padding, and a `parse_date` that merely
  * reformats between equivalent layouts -- routine standardization, deliberately
- * not flagged so the recommended setup stays clean). `remove_affixes` is in that
+ * not flagged so the recommended setup stays clean). It is also undefined when the
+ * element's pipeline matches NOTHING -- a `parse_date` whose input format drops
+ * every record, unless a later `coalesce` rescues it to a constant -- since that is
+ * a narrowing-to-empty, not a broadening, and is surfaced separately by the
+ * dead-key advisory. `remove_affixes` is in that
  * routine set by deliberate decision: stripping titles and suffixes (Dr., Jr.)
  * is a BROADENING canonicalizer in the same family as accent and case folding --
  * it makes superficially-different spellings match -- not a record-DROPPING
@@ -673,6 +683,14 @@ function parseDateBreadth(
 function elementBreadthMarker(element: LinkageKeyElement): string | undefined {
   const steps = element.transform ?? [];
   const functions = new Set(steps.map((s) => s.function));
+  // An element whose pipeline produces no value for ANY record matches nothing,
+  // not more -- the opposite of a broadening, and a narrowing-to-empty the separate
+  // dead-key advisory surfaces -- so it earns no marker, whatever rule a later step
+  // would otherwise name: a substring/phonetic/... after a dead `parse_date`
+  // null-propagates, so the record is dropped regardless. Defer to core's
+  // pipelineAlwaysDrops, which also accounts for a rescuing `coalesce`, so the
+  // marker cannot drift from the runtime.
+  if (pipelineAlwaysDrops(element.transform)) return undefined;
   // A tokenless `parse_date` output collapses every date to one constant value --
   // the maximal match breadth -- so it is checked first and outranks every other
   // rule the element might also carry: once every value collapses to one, a

--- a/apps/web/test/unit/acceptConsent.test.ts
+++ b/apps/web/test/unit/acceptConsent.test.ts
@@ -1183,9 +1183,11 @@ describe("summarizeInvitation", () => {
     ).toBe("last name (excludes values)");
 
     // parse_date is routine canonicalization when it reformats between full
-    // layouts, but matches on only part of the date when its output drops a
-    // component its input carries (a year-only output collapses every date in a
-    // year; a tokenless output collapses every date to a constant).
+    // layouts, but narrows matching when its output drops a date component. A
+    // year-only output keeps a token yet collapses every date within a year, so
+    // it matches on only part of the date ("partial"); a tokenless output carries
+    // no date token at all and collapses every date to one constant value -- the
+    // maximal breadth, marked distinctly ("constant").
     expect(
       headerFor([
         {
@@ -1198,10 +1200,10 @@ describe("summarizeInvitation", () => {
       headerFor([
         {
           function: "parse_date",
-          params: { inputFormat: "MM/DD/YYYY", outputFormat: "SAME" },
+          params: { inputFormat: "MM/DD/YYYY", outputFormat: "registered" },
         },
       ]),
-    ).toBe("last name (partial)");
+    ).toBe("last name (constant)");
     expect(
       headerFor([
         {
@@ -1218,6 +1220,80 @@ describe("summarizeInvitation", () => {
     // A bare parse_date defaults to the full layout on both sides -- no drop.
     expect(headerFor([{ function: "parse_date" }])).toBe("last name");
     expect(headerFor(undefined)).toBe("last name");
+  });
+
+  test("marks a tokenless parse_date output as a stronger breadth than a partial drop", () => {
+    const headerFor = (transform: LinkageKeyElement["transform"]) =>
+      summarizeInvitation(
+        makeToken({
+          linkageFields: [{ name: "ln", type: "last_name" }],
+          linkageKeys: [
+            {
+              name: "K",
+              elements: [{ field: "ln", ...(transform && { transform }) }],
+            },
+          ],
+        }),
+      ).linkageKeys[0].headerFields[0];
+
+    // An output that keeps a date token but drops a component its input carries
+    // collapses dates onto a coarser bucket -- it matches on only part of the
+    // date, so it wears the same "(partial)" marker a substring truncation does.
+    expect(
+      headerFor([
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD/YYYY", outputFormat: "YYYY" },
+        },
+      ]),
+    ).toBe("last name (partial)");
+    // An output carrying NO date token collapses every date to one constant value
+    // -- the maximal match breadth -- so it earns a distinct, stronger marker
+    // rather than reading as the same magnitude as a one-component drop.
+    expect(
+      headerFor([
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD/YYYY", outputFormat: "registered" },
+        },
+      ]),
+    ).toBe("last name (constant)");
+    // A tokenless output with a tokenless input is still a constant collapse: the
+    // input cannot un-collapse a constant output, and the most degenerate case is
+    // not left unmarked.
+    expect(
+      headerFor([
+        {
+          function: "parse_date",
+          params: { inputFormat: "none", outputFormat: "none" },
+        },
+      ]),
+    ).toBe("last name (constant)");
+    // Across an element's steps the stronger word wins, so a constant collapse is
+    // never understated as a partial drop by an accompanying partial step.
+    expect(
+      headerFor([
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD/YYYY", outputFormat: "YYYY" },
+        },
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD/YYYY", outputFormat: "registered" },
+        },
+      ]),
+    ).toBe("last name (constant)");
+    // The constant collapse is an effect, so it wins over a directly-named rule
+    // the same way the partial drop does.
+    expect(
+      headerFor([
+        { function: "null_if", params: { values: ["x"] } },
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD/YYYY", outputFormat: "registered" },
+        },
+      ]),
+    ).toBe("last name (constant)");
   });
 
   test("shows a single most-salient marker, effect-named before directly-named", () => {

--- a/apps/web/test/unit/acceptConsent.test.ts
+++ b/apps/web/test/unit/acceptConsent.test.ts
@@ -1294,6 +1294,28 @@ describe("summarizeInvitation", () => {
         },
       ]),
     ).toBe("last name (constant)");
+    // Being the maximal breadth, it outranks even a literal-truncating substring
+    // (the otherwise-highest-precedence marker), in either order: once every date
+    // is one value, slicing that value leaves it constant, so "(partial)" would
+    // understate the collapse.
+    expect(
+      headerFor([
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD/YYYY", outputFormat: "registered" },
+        },
+        { function: "substring", params: { start: 1, length: 3 } },
+      ]),
+    ).toBe("last name (constant)");
+    expect(
+      headerFor([
+        { function: "substring", params: { start: 1, length: 3 } },
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD/YYYY", outputFormat: "registered" },
+        },
+      ]),
+    ).toBe("last name (constant)");
   });
 
   test("shows a single most-salient marker, effect-named before directly-named", () => {

--- a/apps/web/test/unit/acceptConsent.test.ts
+++ b/apps/web/test/unit/acceptConsent.test.ts
@@ -1187,7 +1187,7 @@ describe("summarizeInvitation", () => {
     // year-only output keeps a token yet collapses every date within a year, so
     // it matches on only part of the date ("partial"); a tokenless output carries
     // no date token at all and collapses every date to one constant value -- the
-    // maximal breadth, marked distinctly ("constant").
+    // maximal breadth, marked distinctly ("any date").
     expect(
       headerFor([
         {
@@ -1203,7 +1203,7 @@ describe("summarizeInvitation", () => {
           params: { inputFormat: "MM/DD/YYYY", outputFormat: "registered" },
         },
       ]),
-    ).toBe("last name (constant)");
+    ).toBe("last name (any date)");
     expect(
       headerFor([
         {
@@ -1257,10 +1257,12 @@ describe("summarizeInvitation", () => {
           params: { inputFormat: "MM/DD/YYYY", outputFormat: "registered" },
         },
       ]),
-    ).toBe("last name (constant)");
-    // A tokenless output with a tokenless input is still a constant collapse: the
-    // input cannot un-collapse a constant output, and the most degenerate case is
-    // not left unmarked.
+    ).toBe("last name (any date)");
+    // The "(any date)" collapse presupposes the date is actually parsed: a
+    // tokenless OUTPUT whose INPUT also carries no date token drops every record at
+    // the input stage -- the element matches NOTHING, not everything -- so it earns
+    // no broadening marker (the dead-key advisory, a narrowing concern, surfaces it
+    // instead). See the dedicated input-drop test below.
     expect(
       headerFor([
         {
@@ -1268,9 +1270,9 @@ describe("summarizeInvitation", () => {
           params: { inputFormat: "none", outputFormat: "none" },
         },
       ]),
-    ).toBe("last name (constant)");
-    // Across an element's steps the stronger word wins, so a constant collapse is
-    // never understated as a partial drop by an accompanying partial step.
+    ).toBe("last name");
+    // Across an element's steps the stronger word wins, so an "(any date)" collapse
+    // is never understated as a partial drop by an accompanying partial step.
     expect(
       headerFor([
         {
@@ -1282,9 +1284,9 @@ describe("summarizeInvitation", () => {
           params: { inputFormat: "MM/DD/YYYY", outputFormat: "registered" },
         },
       ]),
-    ).toBe("last name (constant)");
-    // The constant collapse is an effect, so it wins over a directly-named rule
-    // the same way the partial drop does.
+    ).toBe("last name (any date)");
+    // The "(any date)" collapse is an effect, so it wins over a directly-named
+    // rule the same way the partial drop does.
     expect(
       headerFor([
         { function: "null_if", params: { values: ["x"] } },
@@ -1293,7 +1295,7 @@ describe("summarizeInvitation", () => {
           params: { inputFormat: "MM/DD/YYYY", outputFormat: "registered" },
         },
       ]),
-    ).toBe("last name (constant)");
+    ).toBe("last name (any date)");
     // Being the maximal breadth, it outranks even a literal-truncating substring
     // (the otherwise-highest-precedence marker), in either order: once every date
     // is one value, slicing that value leaves it constant, so "(partial)" would
@@ -1306,7 +1308,7 @@ describe("summarizeInvitation", () => {
         },
         { function: "substring", params: { start: 1, length: 3 } },
       ]),
-    ).toBe("last name (constant)");
+    ).toBe("last name (any date)");
     expect(
       headerFor([
         { function: "substring", params: { start: 1, length: 3 } },
@@ -1315,7 +1317,55 @@ describe("summarizeInvitation", () => {
           params: { inputFormat: "MM/DD/YYYY", outputFormat: "registered" },
         },
       ]),
-    ).toBe("last name (constant)");
+    ).toBe("last name (any date)");
+  });
+
+  test("shows no breadth marker for a parse_date whose input drops every record", () => {
+    const headerFor = (transform: LinkageKeyElement["transform"]) =>
+      summarizeInvitation(
+        makeToken({
+          linkageFields: [{ name: "ln", type: "last_name" }],
+          linkageKeys: [
+            {
+              name: "K",
+              elements: [{ field: "ln", ...(transform && { transform }) }],
+            },
+          ],
+        }),
+      ).linkageKeys[0].headerFields[0];
+
+    // A parse_date whose input format omits a component core requires (here no
+    // year) returns null for EVERY record -- the key matches nothing, a narrowing
+    // the separate dead-key advisory surfaces -- so the breadth marker, which
+    // signals BROADENING, stays silent rather than misreporting the drop as a
+    // widening (it showed "(partial)"/"(any date)" before this was fixed).
+    expect(
+      headerFor([
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD", outputFormat: "YYYYMMDD" },
+        },
+      ]),
+    ).toBe("last name");
+    // The input drop dominates the output classification: the value never reaches
+    // the output stage, so neither a tokenless output ("any date") ...
+    expect(
+      headerFor([
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD", outputFormat: "registered" },
+        },
+      ]),
+    ).toBe("last name");
+    // ... nor an output that itself drops a component ("partial") fires.
+    expect(
+      headerFor([
+        {
+          function: "parse_date",
+          params: { inputFormat: "DD", outputFormat: "YYYY" },
+        },
+      ]),
+    ).toBe("last name");
   });
 
   test("shows a single most-salient marker, effect-named before directly-named", () => {

--- a/apps/web/test/unit/acceptConsent.test.ts
+++ b/apps/web/test/unit/acceptConsent.test.ts
@@ -1366,6 +1366,84 @@ describe("summarizeInvitation", () => {
         },
       ]),
     ).toBe("last name");
+    // A non-string input format (params are partner-controlled `unknown`) also
+    // drops every record at runtime; core's check reports it dead without parsing
+    // it, so the web shows no marker rather than narrowing it to the default.
+    expect(
+      headerFor([
+        {
+          function: "parse_date",
+          params: { inputFormat: 42, outputFormat: "registered" },
+        },
+      ]),
+    ).toBe("last name");
+  });
+
+  test("shows no breadth marker when a dead parse_date kills the element via a later rule", () => {
+    const headerFor = (transform: LinkageKeyElement["transform"]) =>
+      summarizeInvitation(
+        makeToken({
+          linkageFields: [{ name: "ln", type: "last_name" }],
+          linkageKeys: [
+            {
+              name: "K",
+              elements: [{ field: "ln", ...(transform && { transform }) }],
+            },
+          ],
+        }),
+      ).linkageKeys[0].headerFields[0];
+
+    // A parse_date whose input format omits a component drops every record, and a
+    // later step null-propagates it, so the element matches NOTHING. The breadth
+    // marker (a broadening signal) must stay silent even though the later rule,
+    // judged alone, would name an effect -- before the element-level guard this
+    // showed the later rule's marker (a wrong-direction "(partial)" / "(sound-
+    // alike)" / ... on an empty key).
+    const dead = {
+      function: "parse_date",
+      params: { inputFormat: "MM/DD", outputFormat: "YYYYMMDD" },
+    };
+    expect(
+      headerFor([
+        dead,
+        { function: "substring", params: { start: 1, length: 3 } },
+      ]),
+    ).toBe("last name");
+    expect(headerFor([dead, { function: "phonetic" }])).toBe("last name");
+    expect(
+      headerFor([dead, { function: "null_if", params: { values: ["x"] } }]),
+    ).toBe("last name");
+
+    // A later `coalesce` with a string default RESCUES every dropped value to that
+    // constant, so the element is NOT dead -- it matches every record as the
+    // fallback constant. That is a real broadening, honestly marked "(fallback)".
+    expect(
+      headerFor([dead, { function: "coalesce", params: { default: "X" } }]),
+    ).toBe("last name (fallback)");
+    // A coalesce with no string default does not rescue, so the element stays dead.
+    expect(headerFor([dead, { function: "coalesce", params: {} }])).toBe(
+      "last name",
+    );
+
+    // A fuzzy expansion declared on a dead element is likewise moot -- no marker.
+    const fuzzyDead = summarizeInvitation(
+      makeToken({
+        linkageFields: [{ name: "ln", type: "last_name" }],
+        linkageKeys: [
+          {
+            name: "K",
+            elements: [
+              {
+                field: "ln",
+                transform: [dead],
+                generateFuzzyComparisons: "adjacent_years",
+              },
+            ],
+          },
+        ],
+      }),
+    ).linkageKeys[0].headerFields[0];
+    expect(fuzzyDead).toBe("last name");
   });
 
   test("shows a single most-salient marker, effect-named before directly-named", () => {

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -1604,8 +1604,8 @@ export function parseDateInputDropsEveryRecord(
  * legitimate pipeline. Only a value-independent certainty is reported, so this can
  * never claim a producible pipeline is dead.
  */
-function pipelineAlwaysDrops(
-  steps: ReadonlyArray<{ function: string; params?: Params }> | undefined,
+export function pipelineAlwaysDrops(
+  steps: ReadonlyArray<TransformStep> | undefined,
 ): boolean {
   if (steps === undefined) return false;
   let dropped = false;

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -1574,7 +1574,9 @@ const PARSE_DATE_REQUIRED_COMPONENTS: readonly DateFormatToken[] = [
  * re-implemented scan -- the encode-the-runtime-invariant-as-a-check rule, here
  * over a "this never produces a value" claim.
  */
-function parseDateInputDropsEveryRecord(params: Params | undefined): boolean {
+export function parseDateInputDropsEveryRecord(
+  params: Params | undefined,
+): boolean {
   const raw = params?.inputFormat;
   if (raw === null || raw === undefined) return false;
   if (typeof raw !== "string") return true;


### PR DESCRIPTION
## Summary

The web consent screen's always-visible breadth markers now reflect the true match breadth of a `parse_date` element in two cases they previously misrepresented. A tokenless output format collapses every record's date to one value -- the maximal match breadth -- yet wore the same terse `(partial)` marker as a one-component drop; it is now marked `(any date)` and ranked above every other rule. And an element whose pipeline matches no record at all advertised a later rule's broadening -- a widening of a key that actually matches nothing; it now carries no marker, the narrowing-to-empty left to the dead-key advisory. The marker stays a fixed, injection-safe literal from the schema-validated date-token vocabulary.

Implements [203530935](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=203530935).

## Changes

- `apps/web/src/psi/invitationSummary.ts`: classify a `parse_date` breadth as `any date` (tokenless output) / `partial` (a component drop) / none; rank `any date` first, since once every value collapses to one a further loosening is moot; and suppress all markers for an element whose pipeline matches nothing, reusing core's `pipelineAlwaysDrops` (which keeps a rescuing `coalesce` honestly marked `fallback`).
- `packages/core/src/standardization.ts`: export `parseDateInputDropsEveryRecord` and `pipelineAlwaysDrops` (the latter retyped on the public `TransformStep`) so the web reuses core's runtime-faithful drop determination instead of re-deriving it, so the displayed breadth cannot drift from what the exchange matches.
- `apps/web/test/unit/acceptConsent.test.ts`: cover the `(any date)` marker and its precedence, a deficient or non-string input format producing no marker, and a dead element killed via a later rule (no marker) versus rescued by a string `coalesce` (`fallback`).

## Test plan

Ran: `npm run test` (core 1916, cli 897, web 537 -- all pass), `npm run typecheck`, `npm run lint`, `npm run format`; `npx vitest run apps/web/test/unit/acceptConsent.test.ts` (54 pass); the web consent-gate browser project (`acceptConsentGate`, `acceptInvitationTerms`, `invitationTerms`).
New tests cover: the `(any date)` marker for a tokenless `parse_date` output and its precedence over substring / partial / directly-named rules; a deficient input format (`MM/DD`, `DD`) and a non-string input format producing no marker; a dead `parse_date` killing an element through a substring / phonetic / null_if / fuzzy step (no marker); and a rescuing `coalesce` (string default) yielding `(fallback)` versus a non-rescuing one (no marker).

## Background

Refined through independent review across phases: a faithfulness review confirmed the detection mirrors core's `parse_date` runtime; a wording review steered the marker from `constant` to `any date` (a non-expert can misread "constant" as restrictive rather than maximal breadth); and a correctness review caught that suppressing only the `parse_date`'s own marker left a dead element still advertising a later rule's broadening, closed by the element-level `pipelineAlwaysDrops` gate.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: `docs/COMMUNICATION.md` already describes the consent-marker mechanism conceptually and illustratively ("a looseness word such as 'partial'"), not an exhaustive vocabulary; the new word and precedence are code-level detail consistent with that description, and no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: refines the still-unreleased web consent-marker feature (whose `[Unreleased]` entry already describes the marker mechanism); no released behavior changes, and the core change is a `@psilink/core` API reshape (apps are its only consumer).
- [x] Security review -- done: this PR changes a consent-surfaced disclosure display, so it is in scope. Three independent reviewers (consent disclosure-integrity, injection / output-sanitization, and DoS / crash-safety + core API surface) reviewed the branch and found no issues at any severity; the change only tightens the disclosure surface and the marker stays a fixed injection-safe literal.