### PR TITLE
Bound init's CSV read to header and DOB sample

### DIFF
--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -6,6 +6,8 @@ import logLibrary from "loglevel";
 import {
   getLogger,
   loadCSVFile,
+  loadCSVColumnSample,
+  INFER_DATE_SCAN_CAP,
   prepareForExchange,
   inferMetadata,
   getDefaultLinkageTerms,
@@ -811,6 +813,49 @@ export async function loadInputRows(
     rawRows: csvResult.data as Array<Record<string, string>>,
     columns: csvResult.meta.fields ?? [],
   };
+}
+
+/**
+ * Load only what `init`'s inference needs from a CSV -- the column header names
+ * and a bounded sample of the date-of-birth column -- instead of the full row set
+ * {@link loadInputRows} reads. `init` infers column metadata and linkage fields
+ * from the header alone and the date-input format from the DOB column, and never
+ * consumes any other row data, so this caps `init`'s peak memory at one parse
+ * chunk rather than letting it scale with the input file (board item 206482800).
+ *
+ * The result is shaped exactly as {@link loadInputRows}'s -- `{ rawRows, columns
+ * }` -- so it drops straight into {@link buildDataSpec} unchanged, keeping `init`
+ * on the same inference path as `invite`/`accept` (matching their inferred terms
+ * is a design goal). The trick is that `buildDataSpec` reads `rawRows` for one
+ * purpose only: the DOB column's values, fed to {@link inferDateFormat}. So
+ * `rawRows` here holds just that column's bounded sample, projected to one-field
+ * records keyed by the DOB column name. The bound is exact, not heuristic: the
+ * sample caps at {@link INFER_DATE_SCAN_CAP} non-empty values, the same cap
+ * `inferDateFormat` stops its own scan at, so the date format inferred from the
+ * sample is identical to one inferred from a full read.
+ *
+ * The DOB column is resolved by running {@link inferMetadata} over the header --
+ * the same resolution `buildDataSpec` repeats internally, so the column the sample
+ * is keyed on always matches the one `buildDataSpec` reads. When no DOB column is
+ * inferred, the sample is empty and `rawRows` is empty (only the header was read).
+ */
+export async function loadInputRowsForInference(
+  input: string,
+  { allowStdin = false }: { allowStdin?: boolean } = {},
+): Promise<{ rawRows: Array<Record<string, string>>; columns: string[] }> {
+  const dobColumnOf = (columns: string[]): string | undefined =>
+    inferMetadata(columns).find((c) => c.type === "date_of_birth")?.name;
+  const { columns, sample } = await loadCSVColumnSample(
+    openInputSource(input, { allowStdin }),
+    dobColumnOf,
+    INFER_DATE_SCAN_CAP,
+  );
+  const dobColumn = dobColumnOf(columns);
+  const rawRows =
+    dobColumn !== undefined
+      ? sample.map((value) => ({ [dobColumn]: value }))
+      : [];
+  return { rawRows, columns };
 }
 
 // --- Linkage strategy selection ----------------------------------------------

--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -836,24 +836,22 @@ export async function loadInputRows(
  *
  * The DOB column is resolved by running {@link inferMetadata} over the header --
  * the same resolution `buildDataSpec` repeats internally, so the column the sample
- * is keyed on always matches the one `buildDataSpec` reads. When no DOB column is
- * inferred, the sample is empty and `rawRows` is empty (only the header was read).
+ * is keyed on always matches the one `buildDataSpec` reads. The loader reports the
+ * column it sampled, so that resolution runs once. When no DOB column is inferred,
+ * the sample is empty and `rawRows` is empty (only the header was read).
  */
 export async function loadInputRowsForInference(
   input: string,
   { allowStdin = false }: { allowStdin?: boolean } = {},
 ): Promise<{ rawRows: Array<Record<string, string>>; columns: string[] }> {
-  const dobColumnOf = (columns: string[]): string | undefined =>
-    inferMetadata(columns).find((c) => c.type === "date_of_birth")?.name;
-  const { columns, sample } = await loadCSVColumnSample(
+  const { columns, sampledColumn, sample } = await loadCSVColumnSample(
     openInputSource(input, { allowStdin }),
-    dobColumnOf,
+    (cols) => inferMetadata(cols).find((c) => c.type === "date_of_birth")?.name,
     INFER_DATE_SCAN_CAP,
   );
-  const dobColumn = dobColumnOf(columns);
   const rawRows =
-    dobColumn !== undefined
-      ? sample.map((value) => ({ [dobColumn]: value }))
+    sampledColumn !== undefined
+      ? sample.map((value) => ({ [sampledColumn]: value }))
       : [];
   return { rawRows, columns };
 }

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -18,7 +18,11 @@ import {
   promptConfirm,
   singleValue,
 } from "../util/cli";
-import { buildDataSpec, loadInputRows, runOrExit } from "./bootstrap";
+import {
+  buildDataSpec,
+  loadInputRowsForInference,
+  runOrExit,
+} from "./bootstrap";
 
 // The identity written into a fresh template when --identity is not given. A
 // placeholder, like the connection's host/username -- init produces a scaffold to
@@ -180,7 +184,9 @@ export function resolveInitInput(
  * linkage fields, and standardization when an input CSV is given, or just the
  * default linkage terms when it is not. Reuses `buildDataSpec` -- the same
  * inference `invite`/`accept`/zero-setup run -- so the template's terms match
- * what those commands would author from the same file.
+ * what those commands would author from the same file. Reads the input through
+ * `loadInputRowsForInference` (header plus a bounded DOB sample), not the full
+ * row set the exchange commands load, since init's inference needs no more.
  *
  * @internal exported for testing
  */
@@ -194,7 +200,7 @@ export async function buildTemplateData(
 
   let rows;
   try {
-    rows = await loadInputRows(input, { allowStdin: true });
+    rows = await loadInputRowsForInference(input, { allowStdin: true });
   } catch (err) {
     // openInputSource's stdin-specific rejections (`-` disallowed, `-` at a bare
     // TTY) are already UsageErrors with actionable wording -- keep them. A missing

--- a/apps/cli/test/unit/bootstrap.test.ts
+++ b/apps/cli/test/unit/bootstrap.test.ts
@@ -2212,6 +2212,32 @@ test("loadInputRowsForInference: a file with no dob column reads only the header
   }
 });
 
+test("loadInputRowsForInference: a header larger than the read buffer is read whole, matching the full read", async () => {
+  // A header longer than fs.createReadStream's 64 KiB read buffer spans multiple
+  // stream reads, so the bounded loader must not commit to the first (empty-field)
+  // chunk -- otherwise init reads an empty header and silently infers nothing
+  // while the full read infers correctly. Compare the header both paths recover.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-bighdr-"));
+  try {
+    const cols = Array.from({ length: 8000 }, (_v, i) =>
+      i === 4000 ? "dob" : `column_${i}`,
+    );
+    expect(Buffer.byteLength(cols.join(","))).toBeGreaterThan(64 * 1024);
+    const row = cols.map((c) => (c === "dob" ? "1990-01-02" : "x")).join(",");
+    const file = path.join(dir, "in.csv");
+    fs.writeFileSync(file, `${cols.join(",")}\n${row}\n`);
+
+    const full = await loadInputRows(file);
+    const light = await loadInputRowsForInference(file);
+    expect(light.columns).toEqual(full.columns);
+    expect(light.columns).toHaveLength(8000);
+    // The DOB sample was still taken from the (now correctly read) header.
+    expect(light.rawRows).toEqual([{ dob: "1990-01-02" }]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("loadInputRowsForInference: a `-` CSV from stdin infers the same terms as the file", async () => {
   // init reads its input with allowStdin enabled; the bounded read must work over
   // a non-rewindable stdin stream in a single pass, matching the file path.

--- a/apps/cli/test/unit/bootstrap.test.ts
+++ b/apps/cli/test/unit/bootstrap.test.ts
@@ -8,6 +8,7 @@ import YAML from "yaml";
 import {
   getDefaultLinkageTerms,
   getLogger,
+  INFER_DATE_SCAN_CAP,
   MAX_RECONNECT_ATTEMPTS,
   safeParseConnectionConfig,
   SHARED_SECRET_REGEX,
@@ -29,6 +30,7 @@ import {
   endpointFromConnection,
   generateSharedSecret,
   loadInputRows,
+  loadInputRowsForInference,
   logOnlineBootstrapOutcome,
   looksLikeUrl,
   parseCommonBootstrapArgs,
@@ -2104,6 +2106,129 @@ test("loadInputRows: `-` at an interactive terminal is rejected (invite path inh
       /pipe/,
     );
   });
+});
+
+// --- loadInputRowsForInference (init's bounded read) -------------------------
+
+// A column set where date_of_birth joins a satisfiable default linkage key (a
+// name + DOB combination), so the inferred terms include a date_of_birth field
+// and its parse_date pipeline -- the path whose date format the bounded sample
+// must reproduce. The dob column is a fixed YYYY-MM-DD date.
+const INFER_COLUMNS = ["first_name", "last_name", "dob", "member_id"];
+
+/** Build a CSV with `rows` data rows over {@link INFER_COLUMNS}. */
+function csvWithRows(rows: number): string {
+  const body = Array.from(
+    { length: rows },
+    (_v, i) =>
+      `First${i},Last${i},1990-01-${String((i % 28) + 1).padStart(2, "0")},${i}`,
+  ).join("\n");
+  return `${INFER_COLUMNS.join(",")}\n${body}\n`;
+}
+
+/** The parse_date input format a standardization inferred for the dob column. */
+function dobInputFormat(
+  dataSpec: ReturnType<typeof buildDataSpec>["dataSpec"],
+): unknown {
+  const step = (dataSpec.standardization ?? [])
+    .flatMap((s) => s.steps ?? [])
+    .find((s) => s.function === "parse_date");
+  return (step?.params as { inputFormat?: unknown } | undefined)?.inputFormat;
+}
+
+test("loadInputRowsForInference: infers the same metadata, fields, standardization, and dob format as a full read", async () => {
+  // The divergence guard the issue makes load-bearing: init's lighter read must
+  // author terms byte-identical to what invite/accept derive from a full read of
+  // the same file. Pin all four inferred outputs by comparing the two dataSpecs.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-infer-"));
+  try {
+    const file = path.join(dir, "in.csv");
+    fs.writeFileSync(file, csvWithRows(40));
+    const full = buildDataSpec({
+      identity: "Org",
+      rows: await loadInputRows(file),
+    });
+    const light = buildDataSpec({
+      identity: "Org",
+      rows: await loadInputRowsForInference(file),
+    });
+    expect(light.dataSpec.metadata).toEqual(full.dataSpec.metadata);
+    expect(light.dataSpec.linkageTerms).toEqual(full.dataSpec.linkageTerms);
+    expect(light.dataSpec.standardization).toEqual(
+      full.dataSpec.standardization,
+    );
+    expect(dobInputFormat(light.dataSpec)).toBe("YYYY-MM-DD");
+    expect(dobInputFormat(light.dataSpec)).toBe(dobInputFormat(full.dataSpec));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadInputRowsForInference: does not read the full row set -- the dob sample is bounded to the scan cap", async () => {
+  // A file with more dob rows than the inference cap: the full read returns every
+  // row, the inference read returns the header plus a sample capped at
+  // INFER_DATE_SCAN_CAP, so init's memory does not scale with the file.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-bounded-"));
+  try {
+    const file = path.join(dir, "in.csv");
+    const rowCount = INFER_DATE_SCAN_CAP + 500;
+    fs.writeFileSync(file, csvWithRows(rowCount));
+    const full = await loadInputRows(file);
+    expect(full.rawRows).toHaveLength(rowCount);
+
+    const light = await loadInputRowsForInference(file);
+    // The header is read whole...
+    expect(light.columns).toEqual(INFER_COLUMNS);
+    // ...but the rows handed to inference are capped at the scan limit, and hold
+    // only the projected dob column rather than the full record.
+    expect(light.rawRows).toHaveLength(INFER_DATE_SCAN_CAP);
+    expect(Object.keys(light.rawRows[0])).toEqual(["dob"]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadInputRowsForInference: a file with no dob column reads only the header", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-nodob-"));
+  try {
+    const file = path.join(dir, "in.csv");
+    fs.writeFileSync(file, "first_name,last_name,member_id\nAlice,Smith,1\n");
+    const { columns, rawRows } = await loadInputRowsForInference(file);
+    expect(columns).toEqual(["first_name", "last_name", "member_id"]);
+    // No DOB column to sample, so no row data is retained at all.
+    expect(rawRows).toEqual([]);
+    // Inference over it still matches a full read (no date format to infer).
+    const full = buildDataSpec({
+      identity: "Org",
+      rows: await loadInputRows(file),
+    });
+    const light = buildDataSpec({
+      identity: "Org",
+      rows: { columns, rawRows },
+    });
+    expect(light.dataSpec).toEqual(full.dataSpec);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadInputRowsForInference: a `-` CSV from stdin infers the same terms as the file", async () => {
+  // init reads its input with allowStdin enabled; the bounded read must work over
+  // a non-rewindable stdin stream in a single pass, matching the file path.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-infer-stdin-"));
+  try {
+    const file = path.join(dir, "in.csv");
+    fs.writeFileSync(file, csvWithRows(10));
+    const fromFile = await loadInputRowsForInference(file, {
+      allowStdin: true,
+    });
+    const fromStdin = await withStdin(streamOf(csvWithRows(10)), () =>
+      loadInputRowsForInference("-", { allowStdin: true }),
+    );
+    expect(fromStdin).toEqual(fromFile);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // --- linkage strategy selection ----------------------------------------------

--- a/apps/cli/test/unit/init.test.ts
+++ b/apps/cli/test/unit/init.test.ts
@@ -26,6 +26,7 @@ import {
   handler as initHandler,
   resolveInitInput,
 } from "../../src/commands/init";
+import { buildDataSpec, loadInputRows } from "../../src/commands/bootstrap";
 import { streamOf, ttyStream, withStdin } from "../stdinStream";
 
 // promptConfirm is mocked so the handler's interactive overwrite branch is
@@ -226,6 +227,39 @@ test("buildTemplateData: a file input infers metadata, fields, and standardizati
   const data = await buildTemplateData(file, "Org", log);
   expect(data.metadata?.map((m) => m.name)).toContain("ssn");
   expect(data.standardization?.map((s) => s.output)).toContain("ssn");
+});
+
+test("buildTemplateData: the bounded read infers the same terms (incl. DOB format) as a full read", async () => {
+  // The acceptance constraint: init's lighter read must author terms identical to
+  // a full read of the same file. Use a non-default DOB format (MM/DD/YYYY) so the
+  // date inference is doing real work, and pin metadata, linkage fields, the
+  // standardization, and the inferred DOB format -- comparing init's path against
+  // buildDataSpec over a full loadInputRows of the same file.
+  const dir = scratchDir();
+  const file = path.join(dir, "in.csv");
+  fs.writeFileSync(
+    file,
+    "first_name,last_name,dob,ssn\n" +
+      "Alice,Smith,03/14/1990,123456789\n" +
+      "Bob,Jones,11/02/1985,234567891\n",
+  );
+  const data = await buildTemplateData(file, "Org", log);
+  const full = buildDataSpec({
+    identity: "Org",
+    rows: await loadInputRows(file),
+  });
+
+  expect(data.metadata).toEqual(full.dataSpec.metadata);
+  expect(data.linkageTerms.linkageFields).toEqual(
+    full.dataSpec.linkageTerms.linkageFields,
+  );
+  expect(data.standardization).toEqual(full.dataSpec.standardization);
+  const parseDate = (data.standardization ?? [])
+    .flatMap((s) => s.steps ?? [])
+    .find((s) => s.function === "parse_date");
+  expect(
+    (parseDate?.params as { inputFormat?: string } | undefined)?.inputFormat,
+  ).toBe("MM/DD/YYYY");
 });
 
 test("buildTemplateData: `-` reads the CSV from stdin", async () => {

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -159,14 +159,20 @@ export function loadCSVColumns(file: LocalFile): Promise<Array<string>> {
  * are the exact prefix it would see.
  *
  * Parsed inline (no `worker`), like the loaders above. Resolves with the header
- * field list (empty when the file has no header) and the bounded sample; rejects
- * on a read/parse error, the same contract as {@link loadCSVFile}.
+ * field list (empty when the file has no header), the column `selectColumn`
+ * chose (`undefined` when it selected none), and the bounded sample; rejects on a
+ * read/parse error, the same contract as {@link loadCSVFile}. Returning the
+ * resolved column lets a caller key the sample without re-running `selectColumn`.
  */
 export function loadCSVColumnSample(
   file: LocalFile,
   selectColumn: (columns: Array<string>) => string | undefined,
   sampleLimit: number,
-): Promise<{ columns: Array<string>; sample: Array<string> }> {
+): Promise<{
+  columns: Array<string>;
+  sampledColumn: string | undefined;
+  sample: Array<string>;
+}> {
   return new Promise((resolve, reject) => {
     let columns: Array<string> | undefined;
     let target: string | undefined;
@@ -191,8 +197,9 @@ export function loadCSVColumnSample(
             return;
           }
         }
-        // Unreachable once target is set (the no-column case aborted above), but
-        // keeps the indexing below well-typed across chunks.
+        // Once a column is selected it stays set for every later chunk, and the
+        // no-column case already aborted, so this never returns at runtime -- its
+        // job is to narrow `target` to a string for the indexing below.
         if (target === undefined) return;
         for (const row of results.data as Array<Record<string, string>>) {
           const value = row[target];
@@ -207,6 +214,14 @@ export function loadCSVColumnSample(
         }
       },
       complete: () => {
+        // An early `parser.abort()` tears down PapaParse's parser but not the
+        // underlying source, so a Node stream's listeners (and an
+        // fs.createReadStream's file descriptor) would linger until GC -- the
+        // opposite of the bounded read's intent. Release it explicitly; a no-op
+        // once a natural end-of-input has already closed it, and skipped for a
+        // non-stream LocalFile (a browser File/string has no `destroy`).
+        const source = file as { destroy?: () => void };
+        if (typeof source.destroy === "function") source.destroy();
         // chunk fires at least once for any input -- even an empty or header-only
         // file -- so columns is set unless the parse produced no chunk. Reject that
         // unreachable case rather than mask it, matching loadCSVFile's invariant.
@@ -214,7 +229,7 @@ export function loadCSVColumnSample(
           reject(new Error("CSV parse completed without producing a chunk"));
           return;
         }
-        resolve({ columns, sample });
+        resolve({ columns, sampledColumn: target, sample });
       },
       error: (error) => {
         reject(error);

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -146,11 +146,15 @@ export function loadCSVColumns(file: LocalFile): Promise<Array<string>> {
  * the header and the date-input format from the date-of-birth column, neither of
  * which needs every row.
  *
- * `selectColumn` is invoked once with the header field list and returns the name
- * of the column to sample (the DOB column, for date-format inference) or
- * `undefined` to collect no sample. Resolving the column from the header inside
- * the single pass -- rather than the caller re-opening the source -- is what lets
- * the same read serve a non-rewindable stdin stream.
+ * `selectColumn` is invoked with the header field list and returns the name of
+ * the column to sample (the DOB column, for date-format inference) or `undefined`
+ * to collect no sample. It is called once the header lands -- which, for a header
+ * longer than the source stream's read buffer, is a later chunk than the first
+ * (the same whole-header read `loadCSVFile` performs), so the returned columns are
+ * never the truncated prefix a first-chunk-only read would yield. Resolving the
+ * column from the header inside the single pass -- rather than the caller
+ * re-opening the source -- is what lets the same read serve a non-rewindable
+ * stdin stream.
  *
  * The sample holds only non-empty (after-trim) values, capped at `sampleLimit`.
  * Set the cap to {@link inferDateFormat}'s own non-empty-value scan cap and the
@@ -185,10 +189,16 @@ export function loadCSVColumnSample(
       header: true,
       skipEmptyLines: true,
       chunk: (results, parser) => {
-        if (columns === undefined) {
-          // The header field list persists across chunks, so the first chunk
-          // settles both the returned columns and which column (if any) to sample.
+        if (target === undefined) {
+          // Settle the header and the column to sample as soon as a non-empty
+          // header is available -- not unconditionally on the first chunk. A
+          // header longer than the source stream's read buffer arrives split
+          // across the first chunks, so `meta.fields` is `[]` until a later chunk
+          // completes the header row (loadCSVFile likewise reads the latest
+          // fields, not the first chunk's). Keep the latest and wait: until the
+          // header lands there are no data rows to sample anyway.
           columns = results.meta.fields ?? [];
+          if (columns.length === 0) return;
           target = selectColumn(columns);
           if (target === undefined) {
             // Nothing to sample: the header alone is the whole result, so stop
@@ -197,9 +207,9 @@ export function loadCSVColumnSample(
             return;
           }
         }
-        // Once a column is selected it stays set for every later chunk, and the
-        // no-column case already aborted, so this never returns at runtime -- its
-        // job is to narrow `target` to a string for the indexing below.
+        // `target` is non-undefined past this point, but it is an outer-scope
+        // `let` read inside this callback, which TypeScript will not narrow on its
+        // own; this guard does the narrowing for the indexing below.
         if (target === undefined) return;
         for (const row of results.data as Array<Record<string, string>>) {
           const value = row[target];

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -135,3 +135,90 @@ export function loadCSVColumns(file: LocalFile): Promise<Array<string>> {
     });
   });
 }
+
+/**
+ * Read a CSV's column header plus a bounded sample of one column's values,
+ * without materializing the full row set {@link loadCSVFile} returns. Streams the
+ * file in PapaParse chunks and stops (`parser.abort()`) as soon as the header
+ * yields no column to sample or `sampleLimit` non-empty values of the selected
+ * column have been collected, so peak memory is bounded by one parse chunk rather
+ * than the input size -- the read path `init` uses to infer column metadata from
+ * the header and the date-input format from the date-of-birth column, neither of
+ * which needs every row.
+ *
+ * `selectColumn` is invoked once with the header field list and returns the name
+ * of the column to sample (the DOB column, for date-format inference) or
+ * `undefined` to collect no sample. Resolving the column from the header inside
+ * the single pass -- rather than the caller re-opening the source -- is what lets
+ * the same read serve a non-rewindable stdin stream.
+ *
+ * The sample holds only non-empty (after-trim) values, capped at `sampleLimit`.
+ * Set the cap to {@link inferDateFormat}'s own non-empty-value scan cap and the
+ * sampled inference is identical to a full-column scan by construction: that scan
+ * never consumes past the cap either, so the first `sampleLimit` non-empty values
+ * are the exact prefix it would see.
+ *
+ * Parsed inline (no `worker`), like the loaders above. Resolves with the header
+ * field list (empty when the file has no header) and the bounded sample; rejects
+ * on a read/parse error, the same contract as {@link loadCSVFile}.
+ */
+export function loadCSVColumnSample(
+  file: LocalFile,
+  selectColumn: (columns: Array<string>) => string | undefined,
+  sampleLimit: number,
+): Promise<{ columns: Array<string>; sample: Array<string> }> {
+  return new Promise((resolve, reject) => {
+    let columns: Array<string> | undefined;
+    let target: string | undefined;
+    const sample: Array<string> = [];
+    Papa.parse(file, {
+      // Inline, never a Web Worker -- same reasoning as loadCSVFile (the bundled
+      // worker mis-applies header mode); init runs under Node, where the worker is
+      // unavailable regardless.
+      worker: false,
+      header: true,
+      skipEmptyLines: true,
+      chunk: (results, parser) => {
+        if (columns === undefined) {
+          // The header field list persists across chunks, so the first chunk
+          // settles both the returned columns and which column (if any) to sample.
+          columns = results.meta.fields ?? [];
+          target = selectColumn(columns);
+          if (target === undefined) {
+            // Nothing to sample: the header alone is the whole result, so stop
+            // rather than stream the rest of the file for values no one reads.
+            parser.abort();
+            return;
+          }
+        }
+        // Unreachable once target is set (the no-column case aborted above), but
+        // keeps the indexing below well-typed across chunks.
+        if (target === undefined) return;
+        for (const row of results.data as Array<Record<string, string>>) {
+          const value = row[target];
+          if (value !== undefined && value.trim() !== "") {
+            sample.push(value);
+            // Enough to reproduce a full scan; stop reading the rest of the file.
+            if (sample.length >= sampleLimit) {
+              parser.abort();
+              return;
+            }
+          }
+        }
+      },
+      complete: () => {
+        // chunk fires at least once for any input -- even an empty or header-only
+        // file -- so columns is set unless the parse produced no chunk. Reject that
+        // unreachable case rather than mask it, matching loadCSVFile's invariant.
+        if (columns === undefined) {
+          reject(new Error("CSV parse completed without producing a chunk"));
+          return;
+        }
+        resolve({ columns, sample });
+      },
+      error: (error) => {
+        reject(error);
+      },
+    });
+  });
+}

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -141,10 +141,16 @@ export function loadCSVColumns(file: LocalFile): Promise<Array<string>> {
  * without materializing the full row set {@link loadCSVFile} returns. Streams the
  * file in PapaParse chunks and stops (`parser.abort()`) as soon as the header
  * yields no column to sample or `sampleLimit` non-empty values of the selected
- * column have been collected, so peak memory is bounded by one parse chunk rather
- * than the input size -- the read path `init` uses to infer column metadata from
- * the header and the date-input format from the date-of-birth column, neither of
- * which needs every row.
+ * column have been collected -- the read path `init` uses to infer column metadata
+ * from the header and the date-input format from the date-of-birth column, neither
+ * of which needs every row.
+ *
+ * For a well-formed CSV this holds peak memory to the header plus one parse chunk
+ * rather than the whole input. The bound is on retained rows, not on a single
+ * line: like {@link loadCSVFile}, PapaParse must buffer one logical line (a row,
+ * or the header) whole before it yields a chunk, so a pathological line or header
+ * with no terminator is still read in full -- that worst case is unchanged from
+ * the full read, not introduced here.
  *
  * `selectColumn` is invoked with the header field list and returns the name of
  * the column to sample (the DOB column, for date-format inference) or `undefined`

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -63,9 +63,13 @@ export * from "./config/metadata";
 export * from "./config/signing";
 export * from "./signingIdentity";
 export * from "./standardization";
-export { loadCSVFile, loadCSVColumns } from "./file";
+export { loadCSVFile, loadCSVColumns, loadCSVColumnSample } from "./file";
 
-export { inferDateFormat, columnValues } from "./utils/date.js";
+export {
+  inferDateFormat,
+  columnValues,
+  INFER_DATE_SCAN_CAP,
+} from "./utils/date.js";
 export {
   computeHostKeyFingerprint,
   verifyHostKeyFingerprint,

--- a/packages/core/test/file.test.ts
+++ b/packages/core/test/file.test.ts
@@ -13,6 +13,28 @@ function streamOf(content: string): Readable {
   return s;
 }
 
+/**
+ * A readable emitting `content` in fixed-size pieces, so PapaParse sees multiple
+ * data events and a header longer than `pieceSize` lands split across chunks --
+ * the way `fs.createReadStream` (64 KB reads) delivers a large header, which a
+ * single-push {@link streamOf} cannot reproduce.
+ */
+function chunkedStreamOf(content: string, pieceSize: number): Readable {
+  const buf = Buffer.from(content, "utf8");
+  let off = 0;
+  return new Readable({
+    read() {
+      if (off >= buf.length) {
+        this.push(null);
+        return;
+      }
+      const end = Math.min(off + pieceSize, buf.length);
+      this.push(buf.subarray(off, end));
+      off = end;
+    },
+  });
+}
+
 /** Pick the `dob` column when present, the selector init uses in spirit. */
 const pickDob = (columns: string[]): string | undefined =>
   columns.find((c) => c === "dob");
@@ -121,4 +143,29 @@ test("loadCSVColumnSample: an empty input yields an empty header and sample", as
   );
   expect(columns).toEqual([]);
   expect(sample).toEqual([]);
+});
+
+test("loadCSVColumnSample: a header split across stream chunks is read whole", async () => {
+  // A header longer than one stream read arrives split across chunks, so the
+  // first chunk carries no fields yet. The loader must wait for the complete
+  // header rather than committing to the first chunk's empty field list -- else
+  // it returns an empty header and init's inference silently diverges from the
+  // full read. The header here (~8000 columns) far exceeds the 16 KiB piece size.
+  const cols = Array.from({ length: 8000 }, (_v, i) =>
+    i === 4000 ? "dob" : `column_${i}`,
+  );
+  const header = cols.join(",");
+  expect(Buffer.byteLength(header)).toBeGreaterThan(16384);
+  const row = cols.map((c) => (c === "dob" ? "1990-01-02" : "x")).join(",");
+  const csv = `${header}\n${row}\n${row}\n`;
+
+  const { columns, sampledColumn, sample } = await loadCSVColumnSample(
+    chunkedStreamOf(csv, 16384),
+    pickDob,
+    1000,
+  );
+  expect(columns).toHaveLength(8000);
+  expect(columns).toContain("dob");
+  expect(sampledColumn).toBe("dob");
+  expect(sample).toEqual(["1990-01-02", "1990-01-02"]);
 });

--- a/packages/core/test/file.test.ts
+++ b/packages/core/test/file.test.ts
@@ -1,6 +1,6 @@
 import { Readable } from "node:stream";
 
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 
 import { loadCSVColumnSample } from "../src/file";
 import { inferDateFormat, columnValues } from "../src/utils/date";
@@ -17,25 +17,28 @@ function streamOf(content: string): Readable {
 const pickDob = (columns: string[]): string | undefined =>
   columns.find((c) => c === "dob");
 
-test("loadCSVColumnSample: returns the header and the selected column's values", async () => {
+test("loadCSVColumnSample: returns the header, the sampled column, and its values", async () => {
   const csv =
     "first_name,dob,ssn\n" + "Alice,1990-01-02,111\n" + "Bob,1985-12-31,222\n";
-  const { columns, sample } = await loadCSVColumnSample(
+  const { columns, sampledColumn, sample } = await loadCSVColumnSample(
     streamOf(csv),
     pickDob,
     1000,
   );
   expect(columns).toEqual(["first_name", "dob", "ssn"]);
+  expect(sampledColumn).toBe("dob");
   expect(sample).toEqual(["1990-01-02", "1985-12-31"]);
 });
 
 test("loadCSVColumnSample: a header-only file yields the columns and an empty sample", async () => {
-  const { columns, sample } = await loadCSVColumnSample(
+  const { columns, sampledColumn, sample } = await loadCSVColumnSample(
     streamOf("first_name,dob,ssn\n"),
     pickDob,
     1000,
   );
   expect(columns).toEqual(["first_name", "dob", "ssn"]);
+  // The column was selected even though there were no rows to sample from it.
+  expect(sampledColumn).toBe("dob");
   expect(sample).toEqual([]);
 });
 
@@ -43,13 +46,31 @@ test("loadCSVColumnSample: no selected column reads only the header", async () =
   // The selector returns undefined (no DOB column), so nothing is sampled even
   // though the rows have values -- the header alone is the result.
   const csv = "first_name,ssn\nAlice,111\nBob,222\n";
-  const { columns, sample } = await loadCSVColumnSample(
+  const { columns, sampledColumn, sample } = await loadCSVColumnSample(
     streamOf(csv),
     pickDob,
     1000,
   );
   expect(columns).toEqual(["first_name", "ssn"]);
+  expect(sampledColumn).toBeUndefined();
   expect(sample).toEqual([]);
+});
+
+test("loadCSVColumnSample: destroys the source stream once the read stops early", async () => {
+  // The early parser.abort() must release the underlying stream rather than leak
+  // its descriptor until GC -- the bounded read's whole point. Both early-stop
+  // paths (sample cap reached, and no column to sample) end through completion.
+  const capStream = streamOf(
+    "name,dob\nA,1990-01-01\nB,1990-01-02\nC,1990-01-03\n",
+  );
+  const capDestroy = vi.spyOn(capStream, "destroy");
+  await loadCSVColumnSample(capStream, pickDob, 1);
+  expect(capDestroy).toHaveBeenCalled();
+
+  const noColStream = streamOf("name,ssn\nA,111\nB,222\n");
+  const noColDestroy = vi.spyOn(noColStream, "destroy");
+  await loadCSVColumnSample(noColStream, pickDob, 1000);
+  expect(noColDestroy).toHaveBeenCalled();
 });
 
 test("loadCSVColumnSample: empty (after-trim) values are skipped, not sampled", async () => {

--- a/packages/core/test/file.test.ts
+++ b/packages/core/test/file.test.ts
@@ -1,0 +1,103 @@
+import { Readable } from "node:stream";
+
+import { expect, test } from "vitest";
+
+import { loadCSVColumnSample } from "../src/file";
+import { inferDateFormat, columnValues } from "../src/utils/date";
+
+/** A readable emitting `content` then EOF, standing in for a CSV file/stream. */
+function streamOf(content: string): Readable {
+  const s = new Readable({ read() {} });
+  if (content.length > 0) s.push(Buffer.from(content, "utf8"));
+  s.push(null);
+  return s;
+}
+
+/** Pick the `dob` column when present, the selector init uses in spirit. */
+const pickDob = (columns: string[]): string | undefined =>
+  columns.find((c) => c === "dob");
+
+test("loadCSVColumnSample: returns the header and the selected column's values", async () => {
+  const csv =
+    "first_name,dob,ssn\n" + "Alice,1990-01-02,111\n" + "Bob,1985-12-31,222\n";
+  const { columns, sample } = await loadCSVColumnSample(
+    streamOf(csv),
+    pickDob,
+    1000,
+  );
+  expect(columns).toEqual(["first_name", "dob", "ssn"]);
+  expect(sample).toEqual(["1990-01-02", "1985-12-31"]);
+});
+
+test("loadCSVColumnSample: a header-only file yields the columns and an empty sample", async () => {
+  const { columns, sample } = await loadCSVColumnSample(
+    streamOf("first_name,dob,ssn\n"),
+    pickDob,
+    1000,
+  );
+  expect(columns).toEqual(["first_name", "dob", "ssn"]);
+  expect(sample).toEqual([]);
+});
+
+test("loadCSVColumnSample: no selected column reads only the header", async () => {
+  // The selector returns undefined (no DOB column), so nothing is sampled even
+  // though the rows have values -- the header alone is the result.
+  const csv = "first_name,ssn\nAlice,111\nBob,222\n";
+  const { columns, sample } = await loadCSVColumnSample(
+    streamOf(csv),
+    pickDob,
+    1000,
+  );
+  expect(columns).toEqual(["first_name", "ssn"]);
+  expect(sample).toEqual([]);
+});
+
+test("loadCSVColumnSample: empty (after-trim) values are skipped, not sampled", async () => {
+  const csv =
+    "name,dob\n" +
+    "Alice,1990-01-02\n" +
+    "Blank,\n" +
+    "Spaces,   \n" +
+    "Bob,1985-12-31\n";
+  const { sample } = await loadCSVColumnSample(streamOf(csv), pickDob, 1000);
+  expect(sample).toEqual(["1990-01-02", "1985-12-31"]);
+});
+
+test("loadCSVColumnSample: caps the sample at sampleLimit non-empty values", async () => {
+  // 50 rows but a cap of 3 -- the read stops once three non-empty DOB values are
+  // collected, demonstrating the bounded (non-full-file) read.
+  const rows = Array.from(
+    { length: 50 },
+    (_v, i) => `Person${i},1990-01-0${(i % 9) + 1}`,
+  ).join("\n");
+  const csv = `name,dob\n${rows}\n`;
+  const { sample } = await loadCSVColumnSample(streamOf(csv), pickDob, 3);
+  expect(sample).toHaveLength(3);
+  expect(sample).toEqual(["1990-01-01", "1990-01-02", "1990-01-03"]);
+});
+
+test("loadCSVColumnSample: the bounded sample reproduces a full-scan date format", async () => {
+  // The divergence guard: feeding the bounded sample to inferDateFormat must
+  // match feeding the whole column. The sample cap equals inferDateFormat's own
+  // scan cap, so the two see the same prefix and infer the same format.
+  const allRows: Array<Record<string, string>> = Array.from(
+    { length: 5000 },
+    (_v, i) => ({ dob: `1990-01-${String((i % 28) + 1).padStart(2, "0")}` }),
+  );
+  const csv = "dob\n" + allRows.map((r) => r.dob).join("\n") + "\n";
+  const { sample } = await loadCSVColumnSample(streamOf(csv), pickDob, 1000);
+  const fromSample = inferDateFormat(sample);
+  const fromFull = inferDateFormat(columnValues(allRows, "dob"));
+  expect(fromSample).toBe("YYYY-MM-DD");
+  expect(fromSample).toBe(fromFull);
+});
+
+test("loadCSVColumnSample: an empty input yields an empty header and sample", async () => {
+  const { columns, sample } = await loadCSVColumnSample(
+    streamOf(""),
+    pickDob,
+    1000,
+  );
+  expect(columns).toEqual([]);
+  expect(sample).toEqual([]);
+});


### PR DESCRIPTION
## Summary

psilink init no longer loads the whole input CSV into memory to infer its config template; it reads only the header and a bounded sample of the date-of-birth column. Peak memory for init on a well-formed input is now bounded instead of scaling with file size (the prior full read measured ~1.1 GB RSS on a 150 MB / 5M-row input). The terms init infers -- column metadata, linkage fields, standardization, and the date-of-birth input format -- are identical to what invite/accept author from the same file.

Implements [206482800](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=206482800).

## Changes

- packages/core/src/file.ts: add loadCSVColumnSample -- a single streaming pass returning the header plus a bounded, non-empty sample of one selected column; it aborts the read early, releases the source stream on completion, and reads a header split across multiple stream reads whole (not just the first chunk).
- packages/core/src/main.ts: export loadCSVColumnSample and INFER_DATE_SCAN_CAP.
- apps/cli/src/commands/bootstrap.ts: add loadInputRowsForInference, which projects the bounded date-of-birth sample into the {rawRows, columns} shape buildDataSpec already consumes, so init stays on the shared inference path.
- apps/cli/src/commands/init.ts: switch buildTemplateData onto the bounded read.
- packages/core/test/file.test.ts, apps/cli/test/unit/{bootstrap,init}.test.ts: tests pinning the inferred terms against a full read, the bounded row count, the split-header case, and stream release.

## Test plan

Ran: `npm run test` (core, cli, web unit suites -- 1937 / 929 / 558 pass); `npm run typecheck && npm run lint && npm run format` (clean); the empirical security-review probes (memory and divergence) were throwaway and removed.
New tests cover: loadCSVColumnSample header/sample/cap/empty-skip/full-scan-equivalence/split-header/stream-destroy; loadInputRowsForInference equivalence with the full read (metadata, linkage fields, standardization, DOB format), bounded row count, no-DOB-column, stdin, and a header larger than the stream read buffer; init buildTemplateData equivalence and the inferred DOB format.

## Background

The load-bearing constraint is that init's inference must not diverge from what invite/accept derive from the same file (a divergence could silently change which records match or which columns are disclosed downstream). buildDataSpec reads rawRows for exactly one thing -- the date-of-birth column's values, fed to inferDateFormat, which itself caps at INFER_DATE_SCAN_CAP non-empty values. The bounded read collects exactly that prefix and projects it into single-column rows, so the shared inference is reused unchanged and the result is identical by construction. Surfaced by the final security review of 206419244 as a low / non-gating efficiency concern.

## Out of scope / follow-on

- Byte ceiling for an unterminated line or header: the bounded read caps retained rows, not a single logical line, so a no-newline / giant-field / giant-header input still buffers in PapaParse -- equal to the prior full read, not a regression, and operator-local. Tracked as [206502855](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=206502855).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; init's inferred output and CLI surface are identical, this is an internal read-path change.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: init is itself unreleased (listed under Added this cycle) and the inferred output is unchanged, so there is no operator- or reviewer-visible change to record.
- [x] Security review -- done: an independent panel (resource-exhaustion, disclosure-integrity, and input-handling lenses) reviewed the new read path with no gating findings; the change does not alter what is disclosed (inferred output identical to the full read), and the one low-severity, non-regressive robustness gap is deferred as 206502855.