### PR TITLE
Add a byte ceiling to init's bounded CSV read

### DIFF
--- a/apps/cli/test/unit/bootstrap.test.ts
+++ b/apps/cli/test/unit/bootstrap.test.ts
@@ -6,6 +6,7 @@ import { expect, test, vi } from "vitest";
 import type { Arguments } from "yargs";
 import YAML from "yaml";
 import {
+  CSV_LINE_BYTE_CEILING,
   getDefaultLinkageTerms,
   getLogger,
   INFER_DATE_SCAN_CAP,
@@ -2255,6 +2256,20 @@ test("loadInputRowsForInference: a `-` CSV from stdin infers the same terms as t
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("loadInputRowsForInference: a no-newline input fails fast rather than buffering the span", async () => {
+  // init's bounded read carries the byte ceiling end to end: a pathological local
+  // CSV with no row terminator (one giant line) aborts with an operator-readable
+  // error instead of consuming memory proportional to the span. Exercised over
+  // stdin to match init's allowStdin path, with a span just over the default
+  // ceiling so init -- which passes no explicit ceiling -- still trips it.
+  const giant = "x".repeat(CSV_LINE_BYTE_CEILING + 1024);
+  await withStdin(streamOf(giant), async () => {
+    await expect(
+      loadInputRowsForInference("-", { allowStdin: true }),
+    ).rejects.toThrow(/single-line limit/);
+  });
 });
 
 // --- linkage strategy selection ----------------------------------------------

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -225,9 +225,12 @@ export function loadCSVColumnSample(
     // ceiling and never trips; a no-terminator / giant-field / giant-header input
     // keeps the cursor pinned while bytes pile up, so the span crosses the ceiling
     // and the read fails fast. The span is checked before that reset (chunk
-    // callback below), so the bound fails closed whether the span accrues
-    // gradually across reads or arrives in one oversized read -- it does not rely
-    // on the source framing its reads at any particular size.
+    // callback below), so a single read larger than the ceiling fails closed --
+    // rejected, never silently forgiven. Production sources (fs.createReadStream
+    // and stdin) deliver <=64 KiB reads, far below the 8 MiB default, so the
+    // per-callback span tracks the partial line to within one read and a
+    // legitimate file is never delivered in one over-ceiling read; a source that
+    // did would be rejected, which is the safe direction.
     let bytesPulled = 0;
     let spanStart = 0;
     let lastCursor = 0;
@@ -257,6 +260,15 @@ export function loadCSVColumnSample(
     };
     if (isStream) source.on?.("data", countBytes);
 
+    // The ceiling rides PapaParse's public streaming API: the `chunk` callback,
+    // `results.meta.cursor` (advancing as complete lines -- the header included --
+    // are consumed), and `parser.abort()`. The one behavior it leans on past the
+    // bare documented surface is that `chunk` fires once per source `data` event
+    // even when that read completed no row, which is what checks a no-terminator
+    // input before EOF. If a future PapaParse fired `chunk` only on a completed
+    // row, the early abort would degrade to buffering the span until EOF -- a lost
+    // optimization on the operator's own file, still a reject, not a correctness
+    // or security regression. file.test.ts exercises these behaviors.
     Papa.parse(file, {
       // Inline, never a Web Worker -- same reasoning as loadCSVFile (the bundled
       // worker mis-applies header mode); init runs under Node, where the worker is

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -137,6 +137,28 @@ export function loadCSVColumns(file: LocalFile): Promise<Array<string>> {
 }
 
 /**
+ * Per-logical-line byte ceiling for {@link loadCSVColumnSample}'s streamed read.
+ * Its row cap bounds the number of retained rows, but PapaParse must buffer one
+ * whole logical line -- a data row, or the entire header -- before it can yield a
+ * chunk and the read can stop, so an input whose first row terminator is far from
+ * the start (one giant line with no newline, one enormous field, or a
+ * multi-megabyte header) would drive the accumulated partial line, and the
+ * repeated re-splitting of it, linearly-to-quadratically with that span no matter
+ * the row cap. This ceiling bounds the bytes pulled from the source between row
+ * terminators, so those shapes fail fast with a clear error rather than consuming
+ * memory and CPU proportional to the span.
+ *
+ * 8 MiB sits comfortably above any realistic operator CSV's single line -- even a
+ * pathologically wide file of tens of thousands of columns is a header of low
+ * single-digit MiB and a data row far smaller -- and well below the
+ * hundred-MiB-plus spans that drove the gigabyte-scale memory growth this guards
+ * against. The input is the operator's own local file, so this is a robustness
+ * backstop on the bounded read's own guarantee, not a partner- or
+ * transport-reachable bound.
+ */
+export const CSV_LINE_BYTE_CEILING = 8 * 1024 * 1024;
+
+/**
  * Read a CSV's column header plus a bounded sample of one column's values,
  * without materializing the full row set {@link loadCSVFile} returns. Streams the
  * file in PapaParse chunks and stops (`parser.abort()`) as soon as the header
@@ -146,11 +168,16 @@ export function loadCSVColumns(file: LocalFile): Promise<Array<string>> {
  * of which needs every row.
  *
  * For a well-formed CSV this holds peak memory to the header plus one parse chunk
- * rather than the whole input. The bound is on retained rows, not on a single
- * line: like {@link loadCSVFile}, PapaParse must buffer one logical line (a row,
- * or the header) whole before it yields a chunk, so a pathological line or header
- * with no terminator is still read in full -- that worst case is unchanged from
- * the full read, not introduced here.
+ * rather than the whole input. Two bounds enforce that: `sampleLimit` caps the
+ * retained rows, and `byteCeiling` caps the bytes pulled from the source between
+ * row terminators -- the accumulated partial line PapaParse must buffer whole
+ * before it yields a chunk. Because PapaParse buffers one logical line (a data
+ * row, or the entire header) before its first chunk, without the byte ceiling an
+ * input whose first terminator is far from the start -- one giant line with no
+ * newline, one enormous field, or a multi-megabyte header -- would still drive
+ * memory (and CPU, via repeated re-splitting of that partial line) with the span.
+ * The ceiling makes those shapes reject fast with a clear error instead; see
+ * {@link CSV_LINE_BYTE_CEILING}.
  *
  * `selectColumn` is invoked with the header field list and returns the name of
  * the column to sample (the DOB column, for date-format inference) or `undefined`
@@ -178,6 +205,7 @@ export function loadCSVColumnSample(
   file: LocalFile,
   selectColumn: (columns: Array<string>) => string | undefined,
   sampleLimit: number,
+  byteCeiling: number = CSV_LINE_BYTE_CEILING,
 ): Promise<{
   columns: Array<string>;
   sampledColumn: string | undefined;
@@ -187,6 +215,47 @@ export function loadCSVColumnSample(
     let columns: Array<string> | undefined;
     let target: string | undefined;
     const sample: Array<string> = [];
+
+    // Bound the span between row terminators (the accumulated partial line), not
+    // just the retained rows. `bytesPulled` counts every byte the source emits;
+    // `spanStart` is reset to it each time the parse cursor advances past a
+    // completed line (the header, or a data row), so `bytesPulled - spanStart` is
+    // the bytes pulled since the last terminator -- the partial line PapaParse is
+    // still buffering. A well-formed input terminates each line well under the
+    // ceiling and never trips; a no-terminator / giant-field / giant-header input
+    // keeps the cursor pinned while bytes pile up, so the span crosses the ceiling
+    // and the read fails fast. The source streams in chunks (fs.createReadStream
+    // and stdin deliver <=64 KiB reads), so the cursor advances chunk by chunk and
+    // the span tracks the partial line to within one chunk.
+    let bytesPulled = 0;
+    let spanStart = 0;
+    let lastCursor = 0;
+    let ceilingError: Error | undefined;
+
+    // Count bytes off the source's raw `data` events, BEFORE PapaParse buffers
+    // them: the unterminated partial line is invisible to the chunk callback,
+    // which sees only parsed rows, never the remainder. Registered before
+    // Papa.parse so it precedes PapaParse's own `data` listener and `bytesPulled`
+    // is current when the chunk callback reads it -- the source is a Node stream
+    // for every caller (init reads a file path or stdin). A non-stream LocalFile
+    // (a browser File/string, no current caller) has no `on`, so the ceiling is
+    // inert there: such a source is already materialized whole, with no streamed
+    // accumulation to bound.
+    const source = file as {
+      on?: (event: "data", listener: (chunk: Buffer | string) => void) => void;
+      removeListener?: (
+        event: "data",
+        listener: (chunk: Buffer | string) => void,
+      ) => void;
+      destroy?: () => void;
+    };
+    const isStream = typeof source.on === "function";
+    const countBytes = (chunk: Buffer | string): void => {
+      bytesPulled +=
+        typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.length;
+    };
+    if (isStream) source.on?.("data", countBytes);
+
     Papa.parse(file, {
       // Inline, never a Web Worker -- same reasoning as loadCSVFile (the bundled
       // worker mis-applies header mode); init runs under Node, where the worker is
@@ -195,6 +264,24 @@ export function loadCSVColumnSample(
       header: true,
       skipEmptyLines: true,
       chunk: (results, parser) => {
+        // Reset the span baseline whenever the cursor advances past a completed
+        // line, then check the bytes pulled since: an over-ceiling span is a line
+        // or header with no terminator in range. Checked before the header logic
+        // below, which returns early until the header lands -- the exact window a
+        // no-terminator input would otherwise spin in, accumulating unbounded.
+        if (results.meta.cursor > lastCursor) {
+          lastCursor = results.meta.cursor;
+          spanStart = bytesPulled;
+        }
+        if (bytesPulled - spanStart > byteCeiling) {
+          ceilingError = new Error(
+            `CSV input exceeded the ${byteCeiling}-byte single-line limit ` +
+              "before a line terminator; the file may be malformed (no newline) " +
+              "or carry an oversized header or field",
+          );
+          parser.abort();
+          return;
+        }
         if (target === undefined) {
           // Settle the header and the column to sample as soon as a non-empty
           // header is available -- not unconditionally on the first chunk. A
@@ -233,11 +320,20 @@ export function loadCSVColumnSample(
         // An early `parser.abort()` tears down PapaParse's parser but not the
         // underlying source, so a Node stream's listeners (and an
         // fs.createReadStream's file descriptor) would linger until GC -- the
-        // opposite of the bounded read's intent. Release it explicitly; a no-op
-        // once a natural end-of-input has already closed it, and skipped for a
-        // non-stream LocalFile (a browser File/string has no `destroy`).
-        const source = file as { destroy?: () => void };
+        // opposite of the bounded read's intent. Detach the byte counter and
+        // release the source explicitly; destroy is a no-op once a natural
+        // end-of-input has already closed it, and skipped for a non-stream
+        // LocalFile (a browser File/string has no `destroy`).
+        if (isStream) source.removeListener?.("data", countBytes);
         if (typeof source.destroy === "function") source.destroy();
+        // The byte ceiling tripped: reject before the no-chunk invariant below,
+        // since a no-terminator input aborts before any header lands (leaving
+        // columns unset), and its operator-readable cause must win over the
+        // generic message.
+        if (ceilingError) {
+          reject(ceilingError);
+          return;
+        }
         // chunk fires at least once for any input -- even an empty or header-only
         // file -- so columns is set unless the parse produced no chunk. Reject that
         // unreachable case rather than mask it, matching loadCSVFile's invariant.
@@ -248,6 +344,7 @@ export function loadCSVColumnSample(
         resolve({ columns, sampledColumn: target, sample });
       },
       error: (error) => {
+        if (isStream) source.removeListener?.("data", countBytes);
         reject(error);
       },
     });

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -344,7 +344,12 @@ export function loadCSVColumnSample(
         resolve({ columns, sampledColumn: target, sample });
       },
       error: (error) => {
+        // Same release as complete, which the error path does not reach:
+        // PapaParse's _sendError detaches only its own listeners and never calls
+        // complete, so without this an fs.createReadStream descriptor (and the
+        // byte counter) would linger past a read error until GC.
         if (isStream) source.removeListener?.("data", countBytes);
+        if (typeof source.destroy === "function") source.destroy();
         reject(error);
       },
     });

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -224,9 +224,10 @@ export function loadCSVColumnSample(
     // still buffering. A well-formed input terminates each line well under the
     // ceiling and never trips; a no-terminator / giant-field / giant-header input
     // keeps the cursor pinned while bytes pile up, so the span crosses the ceiling
-    // and the read fails fast. The source streams in chunks (fs.createReadStream
-    // and stdin deliver <=64 KiB reads), so the cursor advances chunk by chunk and
-    // the span tracks the partial line to within one chunk.
+    // and the read fails fast. The span is checked before that reset (chunk
+    // callback below), so the bound fails closed whether the span accrues
+    // gradually across reads or arrives in one oversized read -- it does not rely
+    // on the source framing its reads at any particular size.
     let bytesPulled = 0;
     let spanStart = 0;
     let lastCursor = 0;
@@ -264,15 +265,16 @@ export function loadCSVColumnSample(
       header: true,
       skipEmptyLines: true,
       chunk: (results, parser) => {
-        // Reset the span baseline whenever the cursor advances past a completed
-        // line, then check the bytes pulled since: an over-ceiling span is a line
-        // or header with no terminator in range. Checked before the header logic
-        // below, which returns early until the header lands -- the exact window a
-        // no-terminator input would otherwise spin in, accumulating unbounded.
-        if (results.meta.cursor > lastCursor) {
-          lastCursor = results.meta.cursor;
-          spanStart = bytesPulled;
-        }
+        // Check the bytes pulled since the last completed line, THEN advance the
+        // baseline past it. The order matters: a single chunk that both completes
+        // a line and carries a huge unterminated remainder (e.g. the whole input
+        // arriving in one large `data` event) must be judged against the OLD
+        // baseline -- resetting first would credit the remainder to `spanStart`
+        // and forgive the very span it should reject. An over-ceiling span is a
+        // line or header with no terminator in range. This runs before the header
+        // logic below, which returns early until the header lands -- the exact
+        // window a no-terminator input would otherwise spin in, accumulating
+        // unbounded.
         if (bytesPulled - spanStart > byteCeiling) {
           ceilingError = new Error(
             `CSV input exceeded the ${byteCeiling}-byte single-line limit ` +
@@ -281,6 +283,10 @@ export function loadCSVColumnSample(
           );
           parser.abort();
           return;
+        }
+        if (results.meta.cursor > lastCursor) {
+          lastCursor = results.meta.cursor;
+          spanStart = bytesPulled;
         }
         if (target === undefined) {
           // Settle the header and the column to sample as soon as a non-empty

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -63,7 +63,12 @@ export * from "./config/metadata";
 export * from "./config/signing";
 export * from "./signingIdentity";
 export * from "./standardization";
-export { loadCSVFile, loadCSVColumns, loadCSVColumnSample } from "./file";
+export {
+  loadCSVFile,
+  loadCSVColumns,
+  loadCSVColumnSample,
+  CSV_LINE_BYTE_CEILING,
+} from "./file";
 
 export {
   inferDateFormat,

--- a/packages/core/test/file.test.ts
+++ b/packages/core/test/file.test.ts
@@ -2,7 +2,7 @@ import { Readable } from "node:stream";
 
 import { expect, test, vi } from "vitest";
 
-import { loadCSVColumnSample } from "../src/file";
+import { CSV_LINE_BYTE_CEILING, loadCSVColumnSample } from "../src/file";
 import { inferDateFormat, columnValues } from "../src/utils/date";
 
 /** A readable emitting `content` then EOF, standing in for a CSV file/stream. */
@@ -143,6 +143,101 @@ test("loadCSVColumnSample: an empty input yields an empty header and sample", as
   );
   expect(columns).toEqual([]);
   expect(sample).toEqual([]);
+});
+
+test("loadCSVColumnSample: a no-newline span over the byte ceiling fails fast", async () => {
+  // One logical line with no terminator anywhere: PapaParse can never yield a row
+  // or settle the header, so the read would buffer the whole span. The byte
+  // ceiling aborts it with an operator-readable error once the bytes pulled since
+  // the (never-advancing) cursor cross the limit. Delivered in small chunks, as
+  // fs.createReadStream / stdin would deliver a large file.
+  const ceiling = 512;
+  const giant = "x".repeat(ceiling * 4);
+  await expect(
+    loadCSVColumnSample(chunkedStreamOf(giant, 64), pickDob, 1000, ceiling),
+  ).rejects.toThrow(/single-line limit/);
+});
+
+test("loadCSVColumnSample: a single field over the byte ceiling fails fast", async () => {
+  // The header terminates normally, then one data field grows without a row
+  // terminator. The cursor advances past the header and then stalls, so the span
+  // measured since that last terminator -- the unbounded field -- crosses the
+  // ceiling and the read fails fast rather than buffering the whole field.
+  const ceiling = 512;
+  const giantField = "y".repeat(ceiling * 4);
+  const csv = `name,dob\nAlice,${giantField}`;
+  await expect(
+    loadCSVColumnSample(chunkedStreamOf(csv, 64), pickDob, 1000, ceiling),
+  ).rejects.toThrow(/single-line limit/);
+});
+
+test("loadCSVColumnSample: a header over the byte ceiling fails fast", async () => {
+  // A header of very many columns with its terminator beyond the ceiling: the
+  // cursor stays at zero until that newline, so the header span crosses the limit
+  // first and the read aborts before settling -- the giant-header shape.
+  const ceiling = 512;
+  const cols = Array.from({ length: 400 }, (_v, i) => `col_${i}`);
+  const header = cols.join(",");
+  expect(Buffer.byteLength(header)).toBeGreaterThan(ceiling);
+  const row = cols.map(() => "v").join(",");
+  await expect(
+    loadCSVColumnSample(
+      chunkedStreamOf(`${header}\n${row}\n`, 64),
+      pickDob,
+      1000,
+      ceiling,
+    ),
+  ).rejects.toThrow(/single-line limit/);
+});
+
+test("loadCSVColumnSample: many short rows whose total exceeds the ceiling do not trip", async () => {
+  // The ceiling bounds a single line, not the total bytes pulled: a file of many
+  // short, terminated rows whose cumulative size far exceeds the ceiling reads
+  // normally, because the span resets at every row terminator. This is the
+  // distinction that keeps a legitimate large input -- which the bounded sample
+  // walks up to the scan cap -- from tripping the limit.
+  const ceiling = 256;
+  const rows = Array.from(
+    { length: 400 },
+    (_v, i) => `Person${i},1990-01-0${(i % 9) + 1}`,
+  ).join("\n");
+  const csv = `name,dob\n${rows}\n`;
+  expect(Buffer.byteLength(csv)).toBeGreaterThan(ceiling * 4);
+  const { columns, sampledColumn, sample } = await loadCSVColumnSample(
+    chunkedStreamOf(csv, 64),
+    pickDob,
+    1000,
+    ceiling,
+  );
+  expect(columns).toEqual(["name", "dob"]);
+  expect(sampledColumn).toBe("dob");
+  expect(sample).toHaveLength(400);
+});
+
+test("loadCSVColumnSample: a well-formed input under the ceiling reads unchanged", async () => {
+  // The ceiling leaves a normal input untouched: the same header, sampled column,
+  // and bounded sample as without it, even delivered in tiny chunks (lines split
+  // mid-field across reads) so the per-line span reset is exercised.
+  const csv =
+    "first_name,dob,ssn\n" + "Alice,1990-01-02,111\n" + "Bob,1985-12-31,222\n";
+  const { columns, sampledColumn, sample } = await loadCSVColumnSample(
+    chunkedStreamOf(csv, 8),
+    pickDob,
+    1000,
+    256,
+  );
+  expect(columns).toEqual(["first_name", "dob", "ssn"]);
+  expect(sampledColumn).toBe("dob");
+  expect(sample).toEqual(["1990-01-02", "1985-12-31"]);
+});
+
+test("loadCSVColumnSample: the default ceiling is well above a realistic header", () => {
+  // A guard on the constant itself: 8 MiB must clear any realistic operator CSV
+  // (a wide header here is tens of KiB) so a well-formed input never trips.
+  const header = Array.from({ length: 2000 }, (_v, i) => `column_${i}`).join(
+    ",",
+  );
+  expect(Buffer.byteLength(header)).toBeLessThan(CSV_LINE_BYTE_CEILING);
 });
 
 test("loadCSVColumnSample: a header split across stream chunks is read whole", async () => {

--- a/packages/core/test/file.test.ts
+++ b/packages/core/test/file.test.ts
@@ -95,6 +95,21 @@ test("loadCSVColumnSample: destroys the source stream once the read stops early"
   expect(noColDestroy).toHaveBeenCalled();
 });
 
+test("loadCSVColumnSample: a source error releases the stream and rejects", async () => {
+  // A read error settles through PapaParse's error path, which never reaches
+  // completion, so the stream must still be released there -- otherwise an
+  // fs.createReadStream descriptor would leak past the failure until GC.
+  const stream = new Readable({ read() {} });
+  const destroySpy = vi.spyOn(stream, "destroy");
+  // Emit after PapaParse has attached its listeners (it parses on the microtask
+  // queue, so a queued error fires once the error listener is in place).
+  queueMicrotask(() => stream.emit("error", new Error("read failed")));
+  await expect(loadCSVColumnSample(stream, pickDob, 1000)).rejects.toThrow(
+    "read failed",
+  );
+  expect(destroySpy).toHaveBeenCalled();
+});
+
 test("loadCSVColumnSample: empty (after-trim) values are skipped, not sampled", async () => {
   const csv =
     "name,dob\n" +

--- a/packages/core/test/file.test.ts
+++ b/packages/core/test/file.test.ts
@@ -205,6 +205,20 @@ test("loadCSVColumnSample: a header over the byte ceiling fails fast", async () 
   ).rejects.toThrow(/single-line limit/);
 });
 
+test("loadCSVColumnSample: a giant field arriving in one data event fails fast", async () => {
+  // Delivery-shape independence: when the header completes and an unterminated
+  // giant field arrive in a SINGLE data event (a lone push, or any source with a
+  // read buffer larger than the span), the span must be judged before the
+  // cursor-advance reset can credit the remainder to the baseline -- otherwise
+  // the whole span is forgiven and the bound silently does not fire. streamOf
+  // pushes the entire content as one event, reproducing that shape.
+  const ceiling = 512;
+  const csv = `name,dob\nAlice,${"y".repeat(ceiling * 4)}`;
+  await expect(
+    loadCSVColumnSample(streamOf(csv), pickDob, 1000, ceiling),
+  ).rejects.toThrow(/single-line limit/);
+});
+
 test("loadCSVColumnSample: many short rows whose total exceeds the ceiling do not trip", async () => {
   // The ceiling bounds a single line, not the total bytes pulled: a file of many
   // short, terminated rows whose cumulative size far exceeds the ceiling reads


### PR DESCRIPTION
## Summary

init infers its config template from a CSV by streaming only the header and a bounded sample of the date-of-birth column, but that bounded read capped the retained rows, not the length of a single logical line. PapaParse must buffer one whole logical line -- a row, or the entire header -- before it can yield a chunk and the read can stop, so an input whose first row terminator is far from the start (one giant line with no newline, one enormous field, or a multi-megabyte header) drove init's memory and CPU with that span. This adds a per-logical-line byte ceiling so those shapes fail fast with a clear, operator-readable error instead. It is operator-local robustness on the bounded read's own guarantee, not a partner- or transport-reachable bound, and not a regression -- the prior full read behaved identically on these vectors, so the bounded branch is equal-or-better everywhere.

Implements [206502855](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=206502855).

## Changes

- `packages/core/src/file.ts`: add `CSV_LINE_BYTE_CEILING` (8 MiB) and enforce it in `loadCSVColumnSample`. A `data`-event observer counts source bytes; the read aborts when the bytes pulled since the last completed line exceed the ceiling. The span is checked before its per-line baseline reset, so a single oversized read fails closed rather than being silently forgiven. The error path now also releases the source stream and detaches the counter, matching the completion path.
- `packages/core/src/main.ts`: re-export `CSV_LINE_BYTE_CEILING`.
- `packages/core/test/file.test.ts`: cover the three pathological shapes (no-newline, giant field, giant header) failing fast, a giant field arriving in one `data` event, many short rows whose total exceeds the ceiling not tripping (the single-line-not-total distinction), a well-formed input unchanged, and the error-path stream release.
- `apps/cli/test/unit/bootstrap.test.ts`: end-to-end check that init's `loadInputRowsForInference` surfaces the ceiling error on a no-newline input.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format`, and `npm run test` (core 1952, cli 931, web 559 unit tests). Also `npx vitest run packages/core/test/file.test.ts` directly while iterating.
New tests cover: each of the three pathological shapes rejecting with the operator-readable error; a single-`data`-event giant field rejecting (the delivery shape the per-line reset must not forgive); many short terminated rows over the ceiling reading normally; a well-formed input returning the same header, sampled column, and sample as before; the error path destroying the source stream; and init's inference entry point surfacing the error.

## Background

Surfaced by the final security review (resource-exhaustion lens) of the parent bounded-read change (board item 206482800); the reviewer classified this follow-up Low severity and deferred it. The ceiling is per-logical-line, not cumulative, so a legitimate file of many short rows whose total exceeds the ceiling reads normally; a well-formed input under the ceiling infers identically to a full read, preserving the inference-equivalence the bounded read rests on. The ceiling rides PapaParse's public streaming API (the chunk callback, `meta.cursor`, `parser.abort`), not private internals.

## Out of scope / follow-on

- `loadCSVFile` (the full read serving `invite` / `accept` / the zero-setup exchange) shares the same per-line unboundedness, but it also serves the web app's non-stream inputs where this Node-stream mechanism does not apply, so it is left as a candidate rather than folded in here. Not yet filed as a board item.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no operator-facing or spec-level behavior changed. init still rejects invalid input; the ceiling only makes one class of malformed local CSV fail fast. The robustness constant and its rationale live in code JSDoc, following the existing init-read constant precedent (`INFER_DATE_SCAN_CAP`).
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: defense-in-depth on a `@psilink/core` read against the operator's own local file. No operator- or reviewer-actionable change (not partner/transport-reachable, not a regression; the prior full read behaved identically on these vectors), matching how the parent bounded-read landed.
- [x] Security review -- conducted: three independent reviewers (availability/resource-exhaustion, confidentiality/integrity-disclosure, trust-boundary/dependency), all returned READY. The change is operator-local robustness, outside the partner/transport channel-hardening controls in the mandatory-review list, but reviewed because it is a resource-exhaustion control. Confirmed: the error discloses only the integer ceiling (no CSV content, field, column, or path), the trip path is fail-closed, and no result/key/identity/token/wire surface is touched.
