### PR TITLE
Announce data-prep editor statuses to assistive tech on mount

### DIFF
--- a/apps/web/src/components/LinkageTermsEditor.tsx
+++ b/apps/web/src/components/LinkageTermsEditor.tsx
@@ -62,6 +62,7 @@ import { FieldCoverage } from "@components/FieldCoverage";
 import { MetadataGrid } from "@components/MetadataGrid";
 import { StandardizationCards } from "@components/StandardizationCards";
 import { TermsImportExport } from "@components/TermsImportExport";
+import { useDeferredAnnouncement } from "@components/useDeferredAnnouncement";
 import { useNonEmptyRates } from "@components/useNonEmptyRates";
 
 import type {
@@ -256,6 +257,19 @@ export function LinkageTermsEditor({
   // new validation rule.
   const canGenerate =
     validation.canGenerate && !hasMultipleIdentifiers(draft.metadata);
+
+  // The footer status's spoken form for the deferred announcer below. Worded
+  // differently from the visible footer text on purpose (one concise spoken line),
+  // which also keeps the visible-text test query unambiguous. Deferred so the
+  // blocked state present on MOUNT (e.g. a two-identifier seed) is announced as an
+  // empty -> non-empty transition rather than skipped as present-on-mount content,
+  // while still queuing politely behind the heading focus.
+  const footerStatusAnnouncement = canGenerate
+    ? "The invitation is ready to generate."
+    : "Some highlighted items still need to be resolved before you can generate the invitation.";
+  const deferredFooterAnnouncement = useDeferredAnnouncement(
+    footerStatusAnnouncement,
+  );
 
   // Per-key satisfiability badge, derived from the draft's CURRENT metadata AND
   // authored standardization so it tracks both column-type edits and per-field
@@ -1089,15 +1103,14 @@ export function LinkageTermsEditor({
         }}
       >
         <Group justify="space-between">
-          {/* The validation status lives in ONE stable, polite, atomic live
-              region -- the same idiom as the acceptor's PrepareData verdict. The
-              wrapper persists across renders while the inner text swaps, so a
-              screen reader hears the Ready <-> Resolve transition (including the
-              inviter newly blocking on the two-identifier state), not only the
-              sighted footer change; a bare swap of two separately-mounted nodes
-              would not reliably announce it. Polite, not assertive, so it does
-              not fight the heading focus on mount. */}
-          <div role="status" aria-live="polite" aria-atomic="true">
+          {/* The VISIBLE footer status renders immediately and is NOT a live
+              region: the spoken Ready <-> Resolve status is voiced by the deferred
+              polite region below (the same decoupled idiom as PrepareData's
+              verdict). Decoupling lets the blocked state present on MOUNT (the
+              inviter seeded with two identifiers) announce as an empty ->
+              non-empty transition rather than be skipped as present-on-mount
+              content, while still queuing politely behind the heading focus. */}
+          <div>
             {canGenerate ? (
               <Text size="sm" c="dimmed">
                 Ready to generate.
@@ -1131,6 +1144,17 @@ export function LinkageTermsEditor({
       {/* Polite live region for validation/reorder announcements. */}
       <VisuallyHidden role="status" aria-live="polite">
         {announcement}
+      </VisuallyHidden>
+      {/* The footer status's announcement channel (see the footer wrapper above):
+          a stable polite region whose deferred text voices the Ready <-> Resolve
+          status to assistive tech without fighting the heading focus on mount. */}
+      <VisuallyHidden
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        data-testid="generate-status-announcement"
+      >
+        {deferredFooterAnnouncement}
       </VisuallyHidden>
     </Stack>
   );

--- a/apps/web/src/components/MetadataGrid.tsx
+++ b/apps/web/src/components/MetadataGrid.tsx
@@ -15,6 +15,8 @@ import {
   setColumnType,
 } from "@psi/metadataEditing";
 
+import { useDeferredAnnouncement } from "@components/useDeferredAnnouncement";
+
 import type { Metadata, SemanticType } from "@psilink/core";
 
 import type { DisclosureChoice } from "@psi/metadataEditing";
@@ -30,6 +32,11 @@ const TYPE_OPTIONS = SEMANTIC_TYPES.map((type) => ({
  * a burst of edits announces once rather than on every keystroke. The visible
  * summary updates synchronously; only the announcement is debounced. */
 const ANNOUNCE_DEBOUNCE_MS = 600;
+
+/** The single-identifier conflict text, shared by the visible error and its
+ * announcement so the two cannot drift. */
+const SINGLE_IDENTIFIER_MESSAGE =
+  "Only one column can be the row identifier. Choose a single identifier.";
 
 /**
  * The shared metadata grid: a real table mapping each input column to a semantic
@@ -114,6 +121,16 @@ export function MetadataGrid({
 
   const multipleIdentifiers = hasMultipleIdentifiers(metadata);
 
+  // The conflict announcement is deferred one commit (see useDeferredAnnouncement),
+  // so a seed that mounts ALREADY in the two-identifier state is announced as an
+  // empty -> non-empty transition rather than skipped as present-on-mount content;
+  // a conflict that appears later (e.g. Reset restoring such a seed) announces the
+  // same way. The visible error below is NOT deferred, so sighted users see it on
+  // the first paint.
+  const conflictAnnouncement = useDeferredAnnouncement(
+    multipleIdentifiers ? SINGLE_IDENTIFIER_MESSAGE : "",
+  );
+
   return (
     <Stack gap="xs">
       <Table withTableBorder withColumnBorders verticalSpacing="xs">
@@ -164,31 +181,21 @@ export function MetadataGrid({
         </Table.Tbody>
       </Table>
 
-      {/* The single-identifier conflict lives in ONE stable, polite, atomic live
-          region whose visible red Text swaps in and out -- the same idiom as the
-          two regions below and PrepareData's verdict. The wrapper persists in the
-          DOM whether or not the conflict is active, so a conflict that reappears
-          (Reset restores a two-identifier seed) is announced rather than silently
-          re-mounted with its content; polite, not assertive, so a seed that mounts
-          already in conflict does not fire on mount and fight the host editor's
-          heading focus. The Text carries no role of its own -- an inner
-          role="alert" would nest an assertive region inside this polite wrapper
-          (the gotcha PrepareData's role="presentation" inner Alert avoids), and a
-          single shared text node keeps each host's getByText conflict query
-          unambiguous. */}
-      <div
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
-        data-testid="identifier-conflict"
-      >
-        {multipleIdentifiers && (
-          <Text size="sm" c="red">
-            Only one column can be the row identifier. Choose a single
-            identifier.
-          </Text>
-        )}
-      </div>
+      {/* The single-identifier conflict is conveyed on two decoupled surfaces. The
+          VISIBLE red error renders immediately for sighted users and carries no
+          ARIA role of its own -- it is not the live region, so it neither
+          announces on mount (fighting focus) nor double-announces with the region
+          below, and being conditional it adds no empty in-flow box when there is
+          no conflict. The deferred polite region (last child, visually hidden) is
+          what reaches assistive tech: see the conflictAnnouncement note above for
+          why it is deferred. Both read the same message constant so they cannot
+          drift; tests query the visible error by its data-testid (the announcement
+          carries the same text, so a getByText would be ambiguous). */}
+      {multipleIdentifiers && (
+        <Text size="sm" c="red" data-testid="identifier-conflict">
+          {SINGLE_IDENTIFIER_MESSAGE}
+        </Text>
+      )}
 
       {/* The disclosure readout is shown VISIBLY by the host's column chips
           (the "Columns you will send to your partner" list beside the agreed
@@ -206,6 +213,18 @@ export function MetadataGrid({
           whole sentence is read, never a fragment. */}
       <VisuallyHidden role="status" aria-live="polite" aria-atomic="true">
         {actionAnnouncement}
+      </VisuallyHidden>
+      {/* The single-identifier conflict's announcement channel (see the visible
+          error above and conflictAnnouncement): a stable, always-present polite
+          region whose deferred text reaches assistive tech without fighting mount
+          focus. */}
+      <VisuallyHidden
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        data-testid="identifier-conflict-announcement"
+      >
+        {conflictAnnouncement}
       </VisuallyHidden>
     </Stack>
   );

--- a/apps/web/src/components/MetadataGrid.tsx
+++ b/apps/web/src/components/MetadataGrid.tsx
@@ -164,11 +164,31 @@ export function MetadataGrid({
         </Table.Tbody>
       </Table>
 
-      {multipleIdentifiers && (
-        <Text size="sm" c="red" role="alert">
-          Only one column can be the row identifier. Choose a single identifier.
-        </Text>
-      )}
+      {/* The single-identifier conflict lives in ONE stable, polite, atomic live
+          region whose visible red Text swaps in and out -- the same idiom as the
+          two regions below and PrepareData's verdict. The wrapper persists in the
+          DOM whether or not the conflict is active, so a conflict that reappears
+          (Reset restores a two-identifier seed) is announced rather than silently
+          re-mounted with its content; polite, not assertive, so a seed that mounts
+          already in conflict does not fire on mount and fight the host editor's
+          heading focus. The Text carries no role of its own -- an inner
+          role="alert" would nest an assertive region inside this polite wrapper
+          (the gotcha PrepareData's role="presentation" inner Alert avoids), and a
+          single shared text node keeps each host's getByText conflict query
+          unambiguous. */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        data-testid="identifier-conflict"
+      >
+        {multipleIdentifiers && (
+          <Text size="sm" c="red">
+            Only one column can be the row identifier. Choose a single
+            identifier.
+          </Text>
+        )}
+      </div>
 
       {/* The disclosure readout is shown VISIBLY by the host's column chips
           (the "Columns you will send to your partner" list beside the agreed

--- a/apps/web/src/components/PrepareData.tsx
+++ b/apps/web/src/components/PrepareData.tsx
@@ -46,6 +46,7 @@ import { ExchangeSummary } from "@components/ExchangeSummary";
 import { FieldCoverage } from "@components/FieldCoverage";
 import { MetadataGrid } from "@components/MetadataGrid";
 import { StandardizationCards } from "@components/StandardizationCards";
+import { useDeferredAnnouncement } from "@components/useDeferredAnnouncement";
 import { useNonEmptyRates } from "@components/useNonEmptyRates";
 
 import type {
@@ -245,6 +246,18 @@ export function PrepareData({
   const satisfiable = verdict.satisfiableKeyCount;
   const blocked = satisfiable === 0;
   const partial = satisfiable > 0 && satisfiable < totalKeys;
+  // The verdict's spoken form for the deferred announcer below. Deliberately worded
+  // differently from the visible Alert titles -- a screen reader hears one concise
+  // line rather than the alert prose, which also keeps the visible-title test
+  // queries unambiguous. Always non-empty (one of the three verdict states always
+  // holds), so the region is voiced on mount and on every transition.
+  const verdictAnnouncement = blocked
+    ? "No agreed linkage key can be satisfied by your columns yet."
+    : partial
+      ? `${satisfiable} of ${totalKeys} linkage keys can be satisfied by your columns.`
+      : `All ${totalKeys} linkage keys can be satisfied by your columns.`;
+  const deferredVerdictAnnouncement =
+    useDeferredAnnouncement(verdictAnnouncement);
   // Keys whose columns are all present (so the column verdict passes them) yet whose
   // declared cleaning can never produce a value -- a self-defeating parse_date in
   // the partner's adopted terms. Value-independent, so it does not change as the
@@ -386,22 +399,18 @@ export function PrepareData({
         {/* Primary column: verdict, disclosure/quick-fix, columns, cleaning. */}
         <Grid.Col span={{ base: 12, md: 7 }}>
           <Stack>
-            {/* The verdict lives in ONE stable, polite, atomic live region whose
-                inner Alert swaps as the verdict changes. Because the wrapper node
-                persists across the swap, a remap that flips blocked->all-clear is
-                announced. Kept polite, not assertive: the verdict is a standing
-                condition the operator is here to resolve. Each inner Alert is
-                role="presentation" -- Mantine's Alert defaults to "alert" (assertive)
-                when none is set, which would nest an assertive region inside this
-                polite one. tabIndex=-1 makes it the focus target after a remap. */}
-            <div
-              ref={verdictRef}
-              tabIndex={-1}
-              role="status"
-              aria-live="polite"
-              aria-atomic="true"
-              data-testid="verdict"
-            >
+            {/* The verdict's VISIBLE alerts render immediately, so the colored
+                verdict neither flashes nor shifts layout on mount. This wrapper is
+                NOT a live region and each inner Alert is role="presentation"
+                (Mantine's Alert defaults to assertive "alert"), so nothing here
+                announces directly. The spoken verdict is voiced by the deferred
+                polite region right after this div -- decoupled so a verdict already
+                present on MOUNT (e.g. a file that lands blocked) is announced as an
+                empty -> non-empty transition rather than skipped as
+                present-on-mount content, while still queuing politely behind the
+                heading focus. tabIndex=-1 keeps this the focus target after a
+                remap. */}
+            <div ref={verdictRef} tabIndex={-1} data-testid="verdict">
               {blocked ? (
                 <Alert
                   role="presentation"
@@ -436,6 +445,17 @@ export function PrepareData({
                 </Alert>
               )}
             </div>
+            {/* The verdict's announcement channel (see the wrapper above): a stable
+                polite region whose deferred text reaches assistive tech without
+                fighting the heading focus on mount. */}
+            <VisuallyHidden
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              data-testid="verdict-announcement"
+            >
+              {deferredVerdictAnnouncement}
+            </VisuallyHidden>
 
             {/* A dead key the column verdict cannot see: the columns are present
                 (so the verdict above may read all-clear), but a cleaning rule in

--- a/apps/web/src/components/useDeferredAnnouncement.ts
+++ b/apps/web/src/components/useDeferredAnnouncement.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Defer a polite live-region message by one commit so a value already present on
+ * MOUNT is still announced. A live region populated on its very first render is
+ * treated by assistive tech as initial page content and is NOT voiced; returning
+ * "" on the first render and the real `message` only after the mount commit turns
+ * a present-on-mount value into the empty -> non-empty transition screen readers
+ * do announce (and a later change announces the same way).
+ *
+ * The caller renders the returned string in a visually-hidden POLITE region; the
+ * VISIBLE UI for the same condition is rendered separately and immediately, so it
+ * neither flashes nor shifts layout. Polite (never assertive) so the announcement
+ * queues behind the host editor's initial heading focus rather than interrupting
+ * it -- the announcement reaches assistive tech without fighting focus on mount.
+ *
+ * Empty messages clear the region silently (the standard pattern for an advisory),
+ * so a resolved condition does not announce a disappearance.
+ */
+export function useDeferredAnnouncement(message: string): string {
+  const [announced, setAnnounced] = useState("");
+  useEffect(() => {
+    setAnnounced(message);
+  }, [message]);
+  return announced;
+}

--- a/apps/web/test/browser/acceptConsentGate.test.ts
+++ b/apps/web/test/browser/acceptConsentGate.test.ts
@@ -490,6 +490,23 @@ describe("prepare your data editor (verdict, disclosure, launch)", () => {
       .element(page.getByRole("button", { name: "Start exchange" }))
       .toBeDisabled();
     expect(exchangeMounted()).toBe(false);
+
+    // The grid's identifier-conflict message reaches assistive tech through a
+    // STABLE, always-present polite live region whose content swaps, not a
+    // conditionally-mounted assertive node: the wrapper carries
+    // role="status"/aria-live="polite" and the red text sits inside it with no
+    // nested role="alert" (which would fire assertively on mount and fight the
+    // "Prepare your data" heading focus when a seed mounts already in conflict).
+    // This is the acceptor half of the same fix the inviter test asserts.
+    const conflictRegion = document.querySelector(
+      '[data-testid="identifier-conflict"]',
+    );
+    expect(conflictRegion?.getAttribute("role")).toBe("status");
+    expect(conflictRegion?.getAttribute("aria-live")).toBe("polite");
+    expect(conflictRegion?.querySelector('[role="alert"]')).toBeNull();
+    expect(conflictRegion?.textContent).toContain(
+      "Only one column can be the row identifier",
+    );
   });
 
   test("a zero-coverage file shows the block and disables Start exchange, so nothing dials", async () => {

--- a/apps/web/test/browser/acceptConsentGate.test.ts
+++ b/apps/web/test/browser/acceptConsentGate.test.ts
@@ -389,7 +389,7 @@ describe("prepare your data editor (verdict, disclosure, launch)", () => {
     expect(exchange.lastProps.initialWarning).toBeUndefined();
   });
 
-  test("the verdict is announced from one stable live region, not the swapped alert", async () => {
+  test("the verdict is announced from a separate stable live region, not the visible alert", async () => {
     window.location.hash = await encodeAcceptToken();
     mountAcceptRoute();
     await expect
@@ -401,19 +401,30 @@ describe("prepare your data editor (verdict, disclosure, launch)", () => {
       .element(page.getByText("This file cannot match yet"))
       .toBeInTheDocument();
 
-    // The live region is the stable wrapper -- unconditional markup OUTSIDE the
-    // verdict ternary, so its node persists as the inner Alert swaps and a
-    // remap-driven transition is announced (three separately-mounted Alerts would
-    // not). The colored Alert inside must NOT be a live region of EITHER
-    // politeness: Mantine's Alert defaults role to "alert" (assertive) when none is
-    // set, which would nest an assertive region in this polite wrapper and fire on
-    // mount against the heading focus. This is the residue that regression guards.
+    // The VISIBLE verdict container is NOT a live region and its Alert is
+    // role="presentation": the colored verdict renders immediately (no flash or
+    // shift) but announces nothing directly, so it neither fires on mount against
+    // the heading focus nor nests an assertive region. This is the residue that
+    // regression guards.
     const verdict = document.querySelector('[data-testid="verdict"]');
-    expect(verdict?.getAttribute("role")).toBe("status");
-    expect(verdict?.getAttribute("aria-live")).toBe("polite");
+    expect(verdict?.getAttribute("role")).toBeNull();
+    expect(verdict?.getAttribute("aria-live")).toBeNull();
     expect(
       verdict?.querySelector('[role="alert"], [role="status"]'),
     ).toBeNull();
+
+    // The verdict reaches assistive tech through a SEPARATE, stable polite live
+    // region that carries the verdict text (the deferred empty -> non-empty timing
+    // that makes a present-on-mount verdict announce is the hook's job and is not
+    // observable here; this asserts the channel, the regression-guarded residue).
+    const announcement = page.getByTestId("verdict-announcement");
+    await expect
+      .element(announcement)
+      .toHaveTextContent(
+        "No agreed linkage key can be satisfied by your columns",
+      );
+    expect(announcement.element().getAttribute("role")).toBe("status");
+    expect(announcement.element().getAttribute("aria-live")).toBe("polite");
   });
 
   test("Back returns to the review screen and a different file reseeds the editor", async () => {
@@ -479,34 +490,45 @@ describe("prepare your data editor (verdict, disclosure, launch)", () => {
     await reachEditor(
       csvFile("id,identifier,first_name,last_name\n1,2,Alice,Smith\n"),
     );
+    // The VISIBLE error is shown for sighted users (queried by testid -- the
+    // announcement carries the same text, so a getByText would be ambiguous).
     await expect
-      .element(
-        page.getByText(
-          "Only one column can be the row identifier. Choose a single identifier.",
-        ),
-      )
-      .toBeInTheDocument();
+      .element(page.getByTestId("identifier-conflict"))
+      .toHaveTextContent(
+        "Only one column can be the row identifier. Choose a single identifier.",
+      );
     await expect
       .element(page.getByRole("button", { name: "Start exchange" }))
       .toBeDisabled();
     expect(exchangeMounted()).toBe(false);
 
-    // The grid's identifier-conflict message reaches assistive tech through a
-    // STABLE, always-present polite live region whose content swaps, not a
-    // conditionally-mounted assertive node: the wrapper carries
-    // role="status"/aria-live="polite" and the red text sits inside it with no
-    // nested role="alert" (which would fire assertively on mount and fight the
-    // "Prepare your data" heading focus when a seed mounts already in conflict).
-    // This is the acceptor half of the same fix the inviter test asserts.
-    const conflictRegion = document.querySelector(
-      '[data-testid="identifier-conflict"]',
+    // The visible error carries no role of its own, so it neither announces on
+    // mount nor double-announces with the channel below.
+    expect(
+      page.getByTestId("identifier-conflict").element().getAttribute("role"),
+    ).toBeNull();
+
+    // The grid's identifier-conflict reaches assistive tech through a SEPARATE,
+    // stable, always-present polite live region that carries the message with no
+    // nested role="alert" (which would fight the "Prepare your data" heading focus).
+    // The deferred empty -> non-empty timing that makes a present-on-mount conflict
+    // announce is the hook's job and is not observable here; this asserts the
+    // channel. This is the acceptor half of the same fix the inviter test asserts.
+    const conflictAnnouncement = page.getByTestId(
+      "identifier-conflict-announcement",
     );
-    expect(conflictRegion?.getAttribute("role")).toBe("status");
-    expect(conflictRegion?.getAttribute("aria-live")).toBe("polite");
-    expect(conflictRegion?.querySelector('[role="alert"]')).toBeNull();
-    expect(conflictRegion?.textContent).toContain(
-      "Only one column can be the row identifier",
+    await expect
+      .element(conflictAnnouncement)
+      .toHaveTextContent(
+        "Only one column can be the row identifier. Choose a single identifier.",
+      );
+    expect(conflictAnnouncement.element().getAttribute("role")).toBe("status");
+    expect(conflictAnnouncement.element().getAttribute("aria-live")).toBe(
+      "polite",
     );
+    expect(
+      conflictAnnouncement.element().querySelector('[role="alert"]'),
+    ).toBeNull();
   });
 
   test("a zero-coverage file shows the block and disables Start exchange, so nothing dials", async () => {
@@ -563,6 +585,13 @@ describe("prepare your data editor (verdict, disclosure, launch)", () => {
     await expect
       .element(page.getByText("1 of 2 keys can match"))
       .toBeInTheDocument();
+    // The verdict transition is also voiced through the separate announcer (the
+    // partial-state spoken string, distinct from the visible alert prose).
+    await expect
+      .element(page.getByTestId("verdict-announcement"))
+      .toHaveTextContent(
+        "1 of 2 linkage keys can be satisfied by your columns",
+      );
 
     // Map `beta` to Last name: now every key is satisfiable, the block is gone, and
     // "Start exchange" is enabled. Before the fix this remained "This file cannot
@@ -576,6 +605,11 @@ describe("prepare your data editor (verdict, disclosure, launch)", () => {
     await expect
       .element(page.getByText("All 2 keys can match"))
       .toBeInTheDocument();
+    // The all-clear transition is voiced through the announcer too -- proof the
+    // partial and all-clear announcer strings are wired, not just the blocked one.
+    await expect
+      .element(page.getByTestId("verdict-announcement"))
+      .toHaveTextContent("All 2 linkage keys can be satisfied by your columns");
     await expect
       .element(page.getByRole("button", { name: "Start exchange" }))
       .toBeEnabled();

--- a/apps/web/test/browser/linkageTermsEditor.test.ts
+++ b/apps/web/test/browser/linkageTermsEditor.test.ts
@@ -172,42 +172,66 @@ describe("LinkageTermsEditor", () => {
       "last_name",
       "dob",
     ]);
+    // The VISIBLE error is shown for sighted users (queried by testid -- the
+    // announcement carries the same text, so a getByText would be ambiguous).
     await expect
-      .element(
-        page.getByText(
-          "Only one column can be the row identifier. Choose a single identifier.",
-        ),
-      )
-      .toBeInTheDocument();
+      .element(page.getByTestId("identifier-conflict"))
+      .toHaveTextContent(
+        "Only one column can be the row identifier. Choose a single identifier.",
+      );
     await expect.element(generateButton()).toBeDisabled();
     await expect
       .element(page.getByText("Resolve the highlighted items to continue."))
       .toBeInTheDocument();
 
     // The block is announced, not a silent visual-only footer swap: the footer
-    // status sits in a polite live region (the acceptor verdict idiom), so a
-    // screen reader hears the gate engage and later release.
-    const footerStatus = page
+    // status's spoken form sits in a SEPARATE, stable polite live region, so a
+    // screen reader hears the gate even when the inviter mounts already blocked.
+    const footerAnnouncement = page.getByTestId("generate-status-announcement");
+    await expect
+      .element(footerAnnouncement)
+      .toHaveTextContent("still need to be resolved");
+    expect(footerAnnouncement.element().getAttribute("role")).toBe("status");
+    expect(footerAnnouncement.element().getAttribute("aria-live")).toBe(
+      "polite",
+    );
+    // The VISIBLE footer text is NOT itself a live region (it would otherwise
+    // double-announce and fire against the heading focus on mount) -- the symmetric
+    // guard to the acceptor verdict's "visible node is not a live region" check.
+    const visibleFooter = page
       .getByText("Resolve the highlighted items to continue.")
-      .element()
-      .closest('[role="status"]');
-    expect(footerStatus?.getAttribute("aria-live")).toBe("polite");
+      .element();
+    expect(visibleFooter.closest('[role="status"]')).toBeNull();
+    expect(visibleFooter.closest("[aria-live]")).toBeNull();
 
-    // The grid's identifier-conflict message itself reaches assistive tech
-    // through a STABLE, always-present polite live region whose content swaps,
-    // not a conditionally-mounted assertive node: the wrapper carries
-    // role="status"/aria-live="polite" and the red text sits inside it with no
-    // nested role="alert" (which would fire assertively on mount and fight the
-    // editor's heading focus when a seed mounts already in conflict).
-    const conflictRegion = document.querySelector(
-      '[data-testid="identifier-conflict"]',
+    // The grid's identifier-conflict reaches assistive tech through a SEPARATE,
+    // stable, always-present polite live region that carries the message with no
+    // nested role="alert" (which would fire assertively against the heading focus).
+    // The deferred empty -> non-empty timing that makes a present-on-mount conflict
+    // announce is the hook's job and is not observable here; this asserts the
+    // channel. The visible error carries no role of its own, so it neither
+    // announces on mount nor double-announces with this region.
+    expect(
+      page.getByTestId("identifier-conflict").element().getAttribute("role"),
+    ).toBeNull();
+    const conflictAnnouncement = page.getByTestId(
+      "identifier-conflict-announcement",
     );
-    expect(conflictRegion?.getAttribute("role")).toBe("status");
-    expect(conflictRegion?.getAttribute("aria-live")).toBe("polite");
-    expect(conflictRegion?.querySelector('[role="alert"]')).toBeNull();
-    expect(conflictRegion?.textContent).toContain(
-      "Only one column can be the row identifier",
+    await expect
+      .element(conflictAnnouncement)
+      .toHaveTextContent(
+        "Only one column can be the row identifier. Choose a single identifier.",
+      );
+    expect(conflictAnnouncement.element().getAttribute("role")).toBe("status");
+    expect(conflictAnnouncement.element().getAttribute("aria-live")).toBe(
+      "polite",
     );
+    expect(
+      conflictAnnouncement.element().querySelector('[role="alert"]'),
+    ).toBeNull();
+    // Capture the announcer node to prove the SAME node survives the swap below (a
+    // stable channel), not merely that some announcer exists after the re-render.
+    const announcerNode = conflictAnnouncement.element();
 
     // Demote one identifier to Ignored, leaving a single row identifier: the grid
     // error clears and Generate re-enables. The disclosure dropdown opens
@@ -219,25 +243,19 @@ describe("LinkageTermsEditor", () => {
     );
     await userEvent.keyboard("{ArrowDown}{ArrowDown}{Enter}");
     await expect
-      .element(
-        page.getByText(
-          "Only one column can be the row identifier. Choose a single identifier.",
-        ),
-      )
+      .element(page.getByTestId("identifier-conflict"))
       .not.toBeInTheDocument();
     await expect.element(generateButton()).toBeEnabled();
 
-    // The live region persists across the swap (it is the always-present wrapper,
-    // not the message node): its wrapper is still in the DOM, now emptied of the
-    // conflict text -- proof the announcement channel is stable rather than
-    // mounted with its content.
-    const persistedRegion = document.querySelector(
-      '[data-testid="identifier-conflict"]',
+    // The announcement channel is the SAME always-present node across the swap (not
+    // a teardown/remount) and clears to empty -- proof the channel is stable rather
+    // than mounted with its content.
+    expect(page.getByTestId("identifier-conflict-announcement").element()).toBe(
+      announcerNode,
     );
-    expect(persistedRegion).not.toBeNull();
-    expect(persistedRegion?.textContent).not.toContain(
-      "Only one column can be the row identifier",
-    );
+    await expect
+      .element(page.getByTestId("identifier-conflict-announcement"))
+      .not.toHaveTextContent("Only one column can be the row identifier");
   });
 
   test("Reset to recommended restores the seeded name after an edit", async () => {

--- a/apps/web/test/browser/linkageTermsEditor.test.ts
+++ b/apps/web/test/browser/linkageTermsEditor.test.ts
@@ -193,6 +193,22 @@ describe("LinkageTermsEditor", () => {
       .closest('[role="status"]');
     expect(footerStatus?.getAttribute("aria-live")).toBe("polite");
 
+    // The grid's identifier-conflict message itself reaches assistive tech
+    // through a STABLE, always-present polite live region whose content swaps,
+    // not a conditionally-mounted assertive node: the wrapper carries
+    // role="status"/aria-live="polite" and the red text sits inside it with no
+    // nested role="alert" (which would fire assertively on mount and fight the
+    // editor's heading focus when a seed mounts already in conflict).
+    const conflictRegion = document.querySelector(
+      '[data-testid="identifier-conflict"]',
+    );
+    expect(conflictRegion?.getAttribute("role")).toBe("status");
+    expect(conflictRegion?.getAttribute("aria-live")).toBe("polite");
+    expect(conflictRegion?.querySelector('[role="alert"]')).toBeNull();
+    expect(conflictRegion?.textContent).toContain(
+      "Only one column can be the row identifier",
+    );
+
     // Demote one identifier to Ignored, leaving a single row identifier: the grid
     // error clears and Generate re-enables. The disclosure dropdown opens
     // highlighting the current "Row identifier - not sent" choice; two steps down
@@ -210,6 +226,18 @@ describe("LinkageTermsEditor", () => {
       )
       .not.toBeInTheDocument();
     await expect.element(generateButton()).toBeEnabled();
+
+    // The live region persists across the swap (it is the always-present wrapper,
+    // not the message node): its wrapper is still in the DOM, now emptied of the
+    // conflict text -- proof the announcement channel is stable rather than
+    // mounted with its content.
+    const persistedRegion = document.querySelector(
+      '[data-testid="identifier-conflict"]',
+    );
+    expect(persistedRegion).not.toBeNull();
+    expect(persistedRegion?.textContent).not.toContain(
+      "Only one column can be the row identifier",
+    );
   });
 
   test("Reset to recommended restores the seeded name after an edit", async () => {


### PR DESCRIPTION
## Summary

The web data-prep editors now reach assistive technology with their standing status messages even when a file loads already in that state: the metadata grid's single-identifier conflict, the acceptor's linkage-satisfiability verdict, and the inviter's Generate-readiness footer. Previously these rendered their content in the same node present on mount, so a screen reader skipped them as initial content, and the conflict used an assertive `role="alert"` that fired on mount against the editor's heading focus. This is accessibility-only: the visible messages, what is sent or displayed, and every launch/generate gate are unchanged.

Implements [203326596](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=203326596).

## Changes

- `apps/web/src/components/useDeferredAnnouncement.ts`: new hook -- returns "" on the first render and the message after the mount commit, so a value present on mount becomes the empty -> non-empty transition assistive tech announces.
- `apps/web/src/components/MetadataGrid.tsx`: single-identifier conflict split into a visible role-less error and a separate deferred polite live region; the now-conditional visible node also drops the empty in-flow box the prior always-present wrapper introduced.
- `apps/web/src/components/PrepareData.tsx`: verdict decoupled -- the visible alerts render immediately (`role="presentation"`) while a separate deferred polite region voices a concise verdict; the div stays the post-remap focus target.
- `apps/web/src/components/LinkageTermsEditor.tsx`: Generate footer status decoupled the same way.
- `apps/web/test/browser/acceptConsentGate.test.ts`, `apps/web/test/browser/linkageTermsEditor.test.ts`: assert the visible node is not a live region, the separate announcer carries the status across mount and transitions, and the existing gates still hold.

## Test plan

Ran locally: `npm run typecheck`, `npm run lint`, `npm run format`; in `apps/web`, `npx vitest run --project browser` (273 passed) and `--project unit` (559 passed).
New tests cover: each editor's conflict/verdict/footer reaching assistive tech through a separate stable polite live region (not the visible node); the visible node carrying no ARIA live role (symmetric guard on both hosts); the announcer node persisting across a conflict resolve; the verdict announcer's blocked, partial, and all-clear strings; and the existing single-identifier and zero-coverage gate assertions still holding.

## Background

Two pre-existing accessibility defects, shared by both editors that render the grid: a conditionally-mounted live region does not reliably announce its content's appearance, and an assertive on-mount alert competes with the host editor's initial heading focus. Deferring the announcement one commit and decoupling it from the visible node fixes both without flashing or shifting the visible UI. The seeded two-identifier file is the conflict's primary trigger, so the mount case is the one that matters most.

## Out of scope / follow-on

- Associate the single-identifier error with the offending Type controls via `aria-invalid` / `aria-errormessage` (WCAG 3.3.1): [206891346](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=206891346).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; the editor's accessibility is described conceptually in `docs/COMMUNICATION.md` and that description still holds, while the deferred-announcement mechanism is implementation-level, not doc-tier.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: accessibility announcement refinement; no change to functional behavior, to what is sent or visibly displayed, or to any launch/generate gate (two independent security reviews confirmed it is disclosure-neutral and weakens no gate), so nothing an operator, deployer, or security reviewer acts on.
- [x] Security review -- done (two independent reviews): the disclosure / data-egress surface (the announcer renders only already-disclosed counts and static advisory text; no field/key names or cell values; no new wire, log, or disk path) and the control / gate integrity surface (the single-identifier and satisfiability gates are byte-unchanged; the deferred announcer feeds only a hidden region and never feeds back into gating). Both clean.
