### PR TITLE
Add a per-logical-line byte ceiling to the CSV reads

### DIFF
--- a/apps/web/test/browser/loadCSVFile.test.ts
+++ b/apps/web/test/browser/loadCSVFile.test.ts
@@ -125,3 +125,48 @@ describe("loadCSVFile rejects a malformed header", () => {
     ).rejects.toThrow(/non-string column/);
   });
 });
+
+// The non-stream (browser File) byte-ceiling bound, exercised end to end in a real
+// browser where FileReader exists. loadCSVFile's stream `data`-event counter is
+// inert for a File, so a bounded pre-read of the leading line enforces the ceiling
+// for the web path; the core unit suite pins the pre-read's branches directly,
+// these confirm it is wired through loadCSVFile against a genuine File.
+describe("loadCSVFile bounds an oversized leading line for a browser File", () => {
+  test("rejects a File whose leading line exceeds the byte ceiling", async () => {
+    // One unterminated span past the ceiling: the pre-read rejects before parsing.
+    // A small explicit ceiling keeps the input tiny.
+    const ceiling = 512;
+    const file = new File(["x".repeat(ceiling * 2)], "huge-line.csv", {
+      type: "text/csv",
+    });
+    await expect(loadCSVFile(file, ceiling)).rejects.toThrow(
+      /single-line limit/,
+    );
+  });
+
+  test("parses a large File whose leading line is within the ceiling", async () => {
+    // The header terminates immediately, then a body far past the small ceiling
+    // streams through -- proving the pre-read gates only the LEADING line and a
+    // well-formed File still parses whole, every row intact.
+    const ceiling = 512;
+    const header = "id,value";
+    const rowCount = 2000;
+    const rows = Array.from(
+      { length: rowCount },
+      (_v, i) => `${i},${"v".repeat(8)}`,
+    ).join("\n");
+    const csv = `${header}\n${rows}\n`;
+    expect(csv.length).toBeGreaterThan(ceiling * 4);
+
+    const file = new File([csv], "ok.csv", { type: "text/csv" });
+    const result = await loadCSVFile(file, ceiling);
+    const rowsParsed = result.data as Array<Record<string, string>>;
+    expect(result.meta.fields).toEqual(["id", "value"]);
+    expect(rowsParsed.length).toBe(rowCount);
+    expect(rowsParsed[0]).toEqual({ id: "0", value: "vvvvvvvv" });
+    expect(rowsParsed[rowCount - 1]).toEqual({
+      id: String(rowCount - 1),
+      value: "vvvvvvvv",
+    });
+  });
+});

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -30,7 +30,7 @@ export const CSV_LINE_BYTE_CEILING = 8 * 1024 * 1024;
 
 /**
  * The single operator-readable error every {@link CSV_LINE_BYTE_CEILING} trip
- * raises, shared so the stream counter and the non-stream pre-read below cannot
+ * raises, shared so the stream guard and the non-stream pre-read below cannot
  * drift to differently-worded messages for the same condition.
  */
 function singleLineCeilingError(byteCeiling: number): Error {
@@ -43,10 +43,10 @@ function singleLineCeilingError(byteCeiling: number): Error {
 
 /**
  * Reject if the LEADING logical line of a materialized (non-stream) CSV exceeds
- * `byteCeiling` -- the bound {@link loadCSVFile}'s `data`-event counter cannot
- * enforce on a source it does not stream. The web caller passes a browser `File`,
- * which PapaParse reads whole through FileReader (no `data` events to count), so
- * the in-parse counter is inert there; this pre-read covers the no-newline and
+ * `byteCeiling` -- the bound {@link loadCSVFile}'s stream guard cannot enforce on a
+ * source it does not stream. The web caller passes a browser `File`, which
+ * PapaParse reads whole through FileReader (no `data` events to scan), so the
+ * stream guard is inert there; this pre-read covers the no-newline and
  * oversized-header shapes for that path before parsing, by scanning forward from
  * the start for the first line terminator (LF or CR). Finding none within
  * `byteCeiling` bytes of a larger input means the header -- or the whole file,
@@ -60,7 +60,7 @@ function singleLineCeilingError(byteCeiling: number): Error {
  * buried in a *later* row on this path is therefore not caught here; it stays
  * bounded by the web app's intake cap (apps/web's `MAX_CSV_FILE_BYTES`), which a
  * whole-file re-scan here would only duplicate at the cost of a second full read.
- * Inert for any input without the Blob read surface -- a Node stream (the counter
+ * Inert for any input without the Blob read surface -- a Node stream (the guard
  * bounds it) or a string (parsed whole in one pass, no cross-chunk growth) returns
  * at once.
  *
@@ -116,6 +116,75 @@ export async function assertLeadingLineWithinByteCeiling(
 }
 
 /**
+ * The Node-stream subset the byte-ceiling guard and the loaders' cleanup use,
+ * duck-typed so `@psilink/core` needs no `node:stream` import -- which would pull
+ * `node:stream` into the web bundle. A browser File/string lacks these members,
+ * which is what makes the stream guard inert for it.
+ */
+type StreamSource = {
+  on?: (event: "data", listener: (chunk: Buffer | string) => void) => void;
+  removeListener?: (
+    event: "data",
+    listener: (chunk: Buffer | string) => void,
+  ) => void;
+  destroy?: (error?: Error) => void;
+};
+
+/**
+ * Bound a single logical line on a Node stream `source`: across its `data` events
+ * it counts bytes since the last terminator (LF or CR) and, when one unterminated
+ * run exceeds `byteCeiling`, destroys the source with
+ * {@link singleLineCeilingError}. PapaParse, reading the same source, reports that
+ * as a read error through its documented `error` callback -- so the bound rests
+ * only on the stream's public `on`/`destroy` surface and PapaParse's public error
+ * contract, never on its `chunk`/`cursor` behavior. Returns a detach function the
+ * caller runs once the parse settles. Inert (a no-op detach) for a source without
+ * `on` -- a browser File, bounded by {@link assertLeadingLineWithinByteCeiling}.
+ *
+ * The byte scan deliberately ignores RFC 4180 quoting: a newline embedded in a
+ * quoted field resets the run early, which can only let a pathological line slip
+ * past (a false negative), never wrongly reject a valid file -- the safe direction
+ * for an operator-local backstop. Byte-wise is safe for UTF-8 (0x0a/0x0d are below
+ * 0x80, so neither occurs as a continuation byte of a multi-byte character).
+ */
+function guardStreamLineByteCeiling(
+  source: StreamSource,
+  byteCeiling: number,
+): () => void {
+  if (typeof source.on !== "function") return () => undefined;
+  let run = 0;
+  let tripped = false;
+  const onData = (chunk: Buffer | string): void => {
+    if (tripped) return;
+    const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    // Walk terminator to terminator: each segment between them extends the current
+    // run, each terminator resets it. Check the run AT each terminator (and at the
+    // chunk's unterminated tail) so a run that crosses the ceiling before a later
+    // terminator in the same chunk still trips -- the within-chunk overflow case.
+    let from = 0;
+    while (from < buf.length) {
+      const lf = buf.indexOf(0x0a, from);
+      const cr = buf.indexOf(0x0d, from);
+      const term = lf === -1 ? cr : cr === -1 ? lf : Math.min(lf, cr);
+      if (term === -1) {
+        run += buf.length - from;
+        break;
+      }
+      run += term - from;
+      if (run > byteCeiling) break;
+      run = 0;
+      from = term + 1;
+    }
+    if (run > byteCeiling) {
+      tripped = true;
+      source.destroy?.(singleLineCeilingError(byteCeiling));
+    }
+  };
+  source.on("data", onData);
+  return () => source.removeListener?.("data", onData);
+}
+
+/**
  * Parse a CSV file to its COMPLETE row set. Resolves a {@link Papa.ParseResult}
  * whose `data` and `errors` are accumulated across every PapaParse chunk, so a
  * file larger than one `Papa.LocalChunkSize` chunk is returned whole rather than
@@ -132,14 +201,16 @@ export async function assertLeadingLineWithinByteCeiling(
  * single pathological line, not a memory saving for well-formed input -- a normal
  * file reads exactly as it did before.
  *
- * Two complementary mechanisms enforce it across the inputs this read serves. For
- * the Node stream every CLI caller passes, the bound rides the source's raw `data`
- * events and bounds every line -- header or any data row -- at exactly the ceiling.
- * For the browser `File` the web caller passes -- which PapaParse reads whole
- * through FileReader, with no `data` events to count -- a bounded pre-read
- * ({@link assertLeadingLineWithinByteCeiling}) instead rejects an oversized
- * LEADING line (the header, or a no-newline file) before parsing; a giant field in
- * a LATER row on that path stays bounded by the web app's intake cap (apps/web's
+ * Two complementary mechanisms enforce it across the inputs this read serves, both
+ * on public API only. For the Node stream every CLI caller passes,
+ * {@link guardStreamLineByteCeiling} scans the source's own `data` events and
+ * destroys it past the ceiling, which PapaParse surfaces through its `error`
+ * callback -- bounding every line (header or any data row). For the browser `File`
+ * the web caller passes -- which PapaParse reads whole through FileReader, with no
+ * `data` events to scan -- a bounded pre-read
+ * ({@link assertLeadingLineWithinByteCeiling}) instead rejects an oversized LEADING
+ * line (the header, or a no-newline file) before parsing; a giant field in a LATER
+ * row on that path stays bounded by the web app's intake cap (apps/web's
  * `MAX_CSV_FILE_BYTES`) rather than scanned for here. See that helper for why the
  * web path is bounded only at its leading line, not every row.
  *
@@ -153,9 +224,9 @@ export async function loadCSVFile(
   file: LocalFile,
   byteCeiling: number = CSV_LINE_BYTE_CEILING,
 ): Promise<Papa.ParseResult<unknown>> {
-  // Bound the non-stream (browser File) path's leading line before parsing: its
-  // `data`-event counter below is inert, since PapaParse reads a File whole through
-  // FileReader. A Node stream or string is a no-op here and bounded below instead.
+  // Bound the non-stream (browser File) path's leading line before parsing: a File
+  // exposes no `data` events for the stream guard below to scan, since PapaParse
+  // reads it whole through FileReader. A Node stream or string is a no-op here.
   await assertLeadingLineWithinByteCeiling(file, byteCeiling);
   return new Promise((resolve, reject) => {
     // Accumulate every chunk's rows on THIS thread. PapaParse splits a file into
@@ -173,47 +244,13 @@ export async function loadCSVFile(
     const errors: Array<Papa.ParseError> = [];
     let meta: Papa.ParseMeta | undefined;
 
-    // Bound the span between row terminators (the accumulated partial line), the
-    // same technique loadCSVColumnSample uses. `bytesPulled` counts every byte the
-    // source emits; `spanStart` is reset to it each time the parse cursor advances
-    // past a completed line (the header, or a data row), so `bytesPulled -
-    // spanStart` is the bytes pulled since the last terminator -- the partial line
-    // PapaParse is still buffering. A well-formed input terminates each line well
-    // under the ceiling and never trips; a no-terminator / giant-field /
-    // giant-header input keeps the cursor pinned while bytes pile up, so the span
-    // crosses the ceiling and the read fails fast. Checked before that reset (chunk
-    // callback below) so a single read larger than the ceiling fails closed --
-    // rejected, never silently forgiven.
-    let bytesPulled = 0;
-    let spanStart = 0;
-    let lastCursor = 0;
-    let ceilingError: Error | undefined;
-
-    // Count bytes off the source's raw `data` events, BEFORE PapaParse buffers
-    // them: the unterminated partial line is invisible to the chunk callback, which
-    // sees only parsed rows. Registered before Papa.parse so it precedes
-    // PapaParse's own `data` listener and `bytesPulled` is current when the chunk
-    // callback reads it. The source is a Node stream for every CLI caller
-    // (invite/accept/exchange read a file path or stdin via openInputSource); a
-    // non-stream LocalFile (the browser File the web caller passes) has no `on`, so
-    // this counter is inert there -- such a source is materialized whole, with no
-    // streamed accumulation to bound. Its leading line is bounded instead by the
-    // pre-read above (assertLeadingLineWithinByteCeiling); a later-row span by the
-    // web app's MAX_CSV_FILE_BYTES intake cap.
-    const source = file as {
-      on?: (event: "data", listener: (chunk: Buffer | string) => void) => void;
-      removeListener?: (
-        event: "data",
-        listener: (chunk: Buffer | string) => void,
-      ) => void;
-      destroy?: () => void;
-    };
-    const isStream = typeof source.on === "function";
-    const countBytes = (chunk: Buffer | string): void => {
-      bytesPulled +=
-        typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.length;
-    };
-    if (isStream) source.on?.("data", countBytes);
+    // Bound a single logical line on the Node stream path (the CLI's file/stdin
+    // input): the guard scans the source's own `data` events and destroys it past
+    // the ceiling, which PapaParse -- reading the same source -- reports through the
+    // `error` callback below. Inert for a non-stream LocalFile (a browser File has
+    // no `data` events); that path is bounded by the pre-read above instead.
+    const source = file as StreamSource;
+    const detachGuard = guardStreamLineByteCeiling(source, byteCeiling);
 
     Papa.parse(file, {
       // Parse INLINE, never in a Web Worker. PapaParse's `worker: true` spawns its
@@ -237,24 +274,7 @@ export async function loadCSVFile(
       worker: false,
       header: true,
       skipEmptyLines: true,
-      chunk: (results, parser) => {
-        // Check the bytes pulled since the last completed line, THEN advance the
-        // baseline past it. The order matters: a single chunk that both completes a
-        // line and carries a huge unterminated remainder (the whole input arriving
-        // in one large `data` event) must be judged against the OLD baseline --
-        // resetting first would credit the remainder to `spanStart` and forgive the
-        // very span it should reject. An over-ceiling span is a line or header with
-        // no terminator in range, so abort and reject in `complete` (the
-        // operator-readable cause wins over the generic invariants there).
-        if (bytesPulled - spanStart > byteCeiling) {
-          ceilingError = singleLineCeilingError(byteCeiling);
-          parser.abort();
-          return;
-        }
-        if (results.meta.cursor > lastCursor) {
-          lastCursor = results.meta.cursor;
-          spanStart = bytesPulled;
-        }
+      chunk: (results) => {
         // Spread-push would pass one argument per row and can overflow the call
         // stack for a chunk holding hundreds of thousands of short rows, so append
         // in a loop (O(n) total, stack-safe).
@@ -266,23 +286,12 @@ export async function loadCSVFile(
         meta = results.meta;
       },
       complete: () => {
-        // A ceiling-trip `parser.abort()` tears down PapaParse's parser but not the
-        // underlying source, so a Node stream's listeners (and an
-        // fs.createReadStream's file descriptor) would linger until GC -- the
-        // opposite of failing fast. Detach the byte counter and release the source
-        // explicitly; destroy is a no-op once a natural end-of-input has already
-        // closed it (the well-formed path, which reads to EOF and never aborts), and
-        // skipped for a non-stream LocalFile (a browser File/string has no
-        // `destroy`).
-        if (isStream) source.removeListener?.("data", countBytes);
-        if (typeof source.destroy === "function") source.destroy();
-        // The byte ceiling tripped: reject before the invariants below, since a
-        // no-terminator input aborts before any header lands (leaving `meta` unset),
-        // and its operator-readable cause must win over the generic message.
-        if (ceilingError) {
-          reject(ceilingError);
-          return;
-        }
+        // Detach the guard and release the source. PapaParse's parser teardown does
+        // not close the underlying stream, so an fs.createReadStream descriptor
+        // would otherwise linger until GC; destroy is a no-op once a natural EOF has
+        // closed it, and skipped for a non-stream LocalFile (no `destroy`).
+        detachGuard();
+        source.destroy?.();
         // `meta` is set by the chunk callback, which fires at least once before
         // complete for any input (PapaParse parses at least one chunk, even an
         // empty file). Rejecting on the unreachable no-chunk case makes that an
@@ -310,12 +319,11 @@ export async function loadCSVFile(
         resolve({ data, errors, meta });
       },
       error: (error) => {
-        // Same release as complete, which the error path does not reach: PapaParse's
-        // _sendError detaches only its own listeners and never calls complete, so
-        // without this an fs.createReadStream descriptor (and the byte counter)
-        // would linger past a read error until GC.
-        if (isStream) source.removeListener?.("data", countBytes);
-        if (typeof source.destroy === "function") source.destroy();
+        // The guard's ceiling trip surfaces here -- it destroys the source with
+        // singleLineCeilingError, which PapaParse reports as a read error -- as does
+        // a genuine read/stream error. Same release as complete.
+        detachGuard();
+        source.destroy?.();
         reject(error);
       },
     });
@@ -365,15 +373,15 @@ export function loadCSVColumns(file: LocalFile): Promise<Array<string>> {
  *
  * For a well-formed CSV this holds peak memory to the header plus one parse chunk
  * rather than the whole input. Two bounds enforce that: `sampleLimit` caps the
- * retained rows, and `byteCeiling` caps the bytes pulled from the source between
- * row terminators -- the accumulated partial line PapaParse must buffer whole
- * before it yields a chunk. Because PapaParse buffers one logical line (a data
- * row, or the entire header) before its first chunk, without the byte ceiling an
- * input whose first terminator is far from the start -- one giant line with no
- * newline, one enormous field, or a multi-megabyte header -- would still drive
- * memory (and CPU, via repeated re-splitting of that partial line) with the span.
- * The ceiling makes those shapes reject fast with a clear error instead; see
- * {@link CSV_LINE_BYTE_CEILING}.
+ * retained rows, and `byteCeiling` bounds a single logical line. Without the line
+ * bound an input whose first terminator is far from the start -- one giant line
+ * with no newline, one enormous field, or a multi-megabyte header -- would drive
+ * memory (and CPU, via repeated re-splitting of that partial line) with the span,
+ * since PapaParse must buffer one whole logical line before it can yield a chunk.
+ * The line bound is enforced by {@link guardStreamLineByteCeiling} on the source's
+ * own `data` events (it destroys the stream past the ceiling, surfaced through
+ * PapaParse's `error` callback), so those shapes reject fast with a clear error;
+ * see {@link CSV_LINE_BYTE_CEILING}.
  *
  * `selectColumn` is invoked with the header field list and returns the name of
  * the column to sample (the DOB column, for date-format inference) or `undefined`
@@ -412,59 +420,18 @@ export function loadCSVColumnSample(
     let target: string | undefined;
     const sample: Array<string> = [];
 
-    // Bound the span between row terminators (the accumulated partial line), not
-    // just the retained rows. `bytesPulled` counts every byte the source emits;
-    // `spanStart` is reset to it each time the parse cursor advances past a
-    // completed line (the header, or a data row), so `bytesPulled - spanStart` is
-    // the bytes pulled since the last terminator -- the partial line PapaParse is
-    // still buffering. A well-formed input terminates each line well under the
-    // ceiling and never trips; a no-terminator / giant-field / giant-header input
-    // keeps the cursor pinned while bytes pile up, so the span crosses the ceiling
-    // and the read fails fast. The span is checked before that reset (chunk
-    // callback below), so a single read larger than the ceiling fails closed --
-    // rejected, never silently forgiven. Production sources (fs.createReadStream
-    // and stdin) deliver <=64 KiB reads, far below the 8 MiB default, so the
-    // per-callback span tracks the partial line to within one read and a
-    // legitimate file is never delivered in one over-ceiling read; a source that
-    // did would be rejected, which is the safe direction.
-    let bytesPulled = 0;
-    let spanStart = 0;
-    let lastCursor = 0;
-    let ceilingError: Error | undefined;
+    // Bound a single logical line on the streamed read (init reads a file path or
+    // stdin): the guard scans the source's own `data` events and destroys it past
+    // the ceiling, which PapaParse -- reading the same source -- reports through the
+    // `error` callback below. This bounds the no-terminator / giant-field /
+    // giant-header span using only the stream's public `on`/`destroy` and
+    // PapaParse's public `error` contract, not its `chunk`/`cursor` internals. The
+    // `sampleLimit` / no-column `parser.abort()` below is a separate, public-API
+    // early stop. Inert for a non-stream LocalFile (a browser File has no `data`
+    // events) -- no current caller passes one.
+    const source = file as StreamSource;
+    const detachGuard = guardStreamLineByteCeiling(source, byteCeiling);
 
-    // Count bytes off the source's raw `data` events, BEFORE PapaParse buffers
-    // them: the unterminated partial line is invisible to the chunk callback,
-    // which sees only parsed rows, never the remainder. Registered before
-    // Papa.parse so it precedes PapaParse's own `data` listener and `bytesPulled`
-    // is current when the chunk callback reads it -- the source is a Node stream
-    // for every caller (init reads a file path or stdin). A non-stream LocalFile
-    // (a browser File/string, no current caller) has no `on`, so the ceiling is
-    // inert there: such a source is already materialized whole, with no streamed
-    // accumulation to bound.
-    const source = file as {
-      on?: (event: "data", listener: (chunk: Buffer | string) => void) => void;
-      removeListener?: (
-        event: "data",
-        listener: (chunk: Buffer | string) => void,
-      ) => void;
-      destroy?: () => void;
-    };
-    const isStream = typeof source.on === "function";
-    const countBytes = (chunk: Buffer | string): void => {
-      bytesPulled +=
-        typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.length;
-    };
-    if (isStream) source.on?.("data", countBytes);
-
-    // The ceiling rides PapaParse's public streaming API: the `chunk` callback,
-    // `results.meta.cursor` (advancing as complete lines -- the header included --
-    // are consumed), and `parser.abort()`. The one behavior it leans on past the
-    // bare documented surface is that `chunk` fires once per source `data` event
-    // even when that read completed no row, which is what checks a no-terminator
-    // input before EOF. If a future PapaParse fired `chunk` only on a completed
-    // row, the early abort would degrade to buffering the span until EOF -- a lost
-    // optimization on the operator's own file, still a reject, not a correctness
-    // or security regression. file.test.ts exercises these behaviors.
     Papa.parse(file, {
       // Inline, never a Web Worker -- same reasoning as loadCSVFile (the bundled
       // worker mis-applies header mode); init runs under Node, where the worker is
@@ -473,25 +440,6 @@ export function loadCSVColumnSample(
       header: true,
       skipEmptyLines: true,
       chunk: (results, parser) => {
-        // Check the bytes pulled since the last completed line, THEN advance the
-        // baseline past it. The order matters: a single chunk that both completes
-        // a line and carries a huge unterminated remainder (e.g. the whole input
-        // arriving in one large `data` event) must be judged against the OLD
-        // baseline -- resetting first would credit the remainder to `spanStart`
-        // and forgive the very span it should reject. An over-ceiling span is a
-        // line or header with no terminator in range. This runs before the header
-        // logic below, which returns early until the header lands -- the exact
-        // window a no-terminator input would otherwise spin in, accumulating
-        // unbounded.
-        if (bytesPulled - spanStart > byteCeiling) {
-          ceilingError = singleLineCeilingError(byteCeiling);
-          parser.abort();
-          return;
-        }
-        if (results.meta.cursor > lastCursor) {
-          lastCursor = results.meta.cursor;
-          spanStart = bytesPulled;
-        }
         if (target === undefined) {
           // Settle the header and the column to sample as soon as a non-empty
           // header is available -- not unconditionally on the first chunk. A
@@ -527,23 +475,14 @@ export function loadCSVColumnSample(
         }
       },
       complete: () => {
-        // An early `parser.abort()` tears down PapaParse's parser but not the
-        // underlying source, so a Node stream's listeners (and an
-        // fs.createReadStream's file descriptor) would linger until GC -- the
-        // opposite of the bounded read's intent. Detach the byte counter and
-        // release the source explicitly; destroy is a no-op once a natural
-        // end-of-input has already closed it, and skipped for a non-stream
-        // LocalFile (a browser File/string has no `destroy`).
-        if (isStream) source.removeListener?.("data", countBytes);
-        if (typeof source.destroy === "function") source.destroy();
-        // The byte ceiling tripped: reject before the no-chunk invariant below,
-        // since a no-terminator input aborts before any header lands (leaving
-        // columns unset), and its operator-readable cause must win over the
-        // generic message.
-        if (ceilingError) {
-          reject(ceilingError);
-          return;
-        }
+        // An early `parser.abort()` (sample cap reached, or no column to sample)
+        // tears down PapaParse's parser but not the underlying source, so a Node
+        // stream's listeners and an fs.createReadStream's descriptor would linger
+        // until GC -- the opposite of the bounded read's intent. Detach the guard
+        // and release the source; destroy is a no-op once a natural EOF has closed
+        // it, and skipped for a non-stream LocalFile (no `destroy`).
+        detachGuard();
+        source.destroy?.();
         // chunk fires at least once for any input -- even an empty or header-only
         // file -- so columns is set unless the parse produced no chunk. Reject that
         // unreachable case rather than mask it, matching loadCSVFile's invariant.
@@ -554,12 +493,11 @@ export function loadCSVColumnSample(
         resolve({ columns, sampledColumn: target, sample });
       },
       error: (error) => {
-        // Same release as complete, which the error path does not reach:
-        // PapaParse's _sendError detaches only its own listeners and never calls
-        // complete, so without this an fs.createReadStream descriptor (and the
-        // byte counter) would linger past a read error until GC.
-        if (isStream) source.removeListener?.("data", countBytes);
-        if (typeof source.destroy === "function") source.destroy();
+        // The guard's ceiling trip surfaces here -- it destroys the source with
+        // singleLineCeilingError, which PapaParse reports as a read error -- as does
+        // a genuine read/stream error. Same release as complete.
+        detachGuard();
+        source.destroy?.();
         reject(error);
       },
     });

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -146,8 +146,12 @@ type StreamSource = {
  * past (a false negative), never wrongly reject a valid file -- the safe direction
  * for an operator-local backstop. Byte-wise is safe for UTF-8 (0x0a/0x0d are below
  * 0x80, so neither occurs as a continuation byte of a multi-byte character).
+ *
+ * @internal exported only for the unit tests, which drive its scan and trip
+ * directly against a fake stream source -- isolating the run accounting from
+ * PapaParse's row splitting (which never sees CR-only or the inner-overflow case).
  */
-function guardStreamLineByteCeiling(
+export function guardStreamLineByteCeiling(
   source: StreamSource,
   byteCeiling: number,
 ): () => void {

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -7,11 +7,133 @@ import type { LocalFile } from "papaparse";
 } */
 
 /**
+ * Per-logical-line byte ceiling for the streamed CSV reads ({@link loadCSVFile}
+ * and {@link loadCSVColumnSample}). PapaParse must buffer one whole logical line
+ * -- a data row, or the entire header -- before it can yield a chunk, so an input
+ * whose first row terminator is far from the start (one giant line with no
+ * newline, one enormous field, or a multi-megabyte header) would drive the
+ * accumulated partial line, and the repeated re-splitting of it,
+ * linearly-to-quadratically with that span no matter how the read is otherwise
+ * bounded -- loadCSVColumnSample's row cap, or nothing in loadCSVFile, which reads
+ * every row. This ceiling bounds the bytes pulled from the source between row
+ * terminators, so those shapes fail fast with a clear error rather than consuming
+ * memory and CPU proportional to the span.
+ *
+ * 8 MiB sits comfortably above any realistic operator CSV's single line -- even a
+ * pathologically wide file of tens of thousands of columns is a header of low
+ * single-digit MiB and a data row far smaller -- and well below the
+ * hundred-MiB-plus spans that drove the gigabyte-scale memory growth this guards
+ * against. The input is the operator's own local file, so this is a robustness
+ * backstop, not a partner- or transport-reachable bound.
+ */
+export const CSV_LINE_BYTE_CEILING = 8 * 1024 * 1024;
+
+/**
+ * The single operator-readable error every {@link CSV_LINE_BYTE_CEILING} trip
+ * raises, shared so the stream counter and the non-stream pre-read below cannot
+ * drift to differently-worded messages for the same condition.
+ */
+function singleLineCeilingError(byteCeiling: number): Error {
+  return new Error(
+    `CSV input exceeded the ${byteCeiling}-byte single-line limit before a ` +
+      "line terminator; the file may be malformed (no newline) or carry an " +
+      "oversized header or field",
+  );
+}
+
+/**
+ * Reject if the LEADING logical line of a materialized (non-stream) CSV exceeds
+ * `byteCeiling` -- the bound {@link loadCSVFile}'s `data`-event counter cannot
+ * enforce on a source it does not stream. The web caller passes a browser `File`,
+ * which PapaParse reads whole through FileReader (no `data` events to count), so
+ * the in-parse counter is inert there; this pre-read covers the no-newline and
+ * oversized-header shapes for that path before parsing, by scanning forward from
+ * the start for the first line terminator (LF or CR). Finding none within
+ * `byteCeiling` bytes of a larger input means the header -- or the whole file,
+ * when it carries no terminator at all -- is a single line past the ceiling, so it
+ * rejects with the same {@link singleLineCeilingError} the stream path raises.
+ *
+ * Scoped to the leading line by design: it reads only up to the first terminator
+ * (one short window for a well-formed header) and never the whole file, so a
+ * normal file pays a single small read -- and skips even that when it is no larger
+ * than the ceiling, which cannot then hold an over-ceiling line. A giant field
+ * buried in a *later* row on this path is therefore not caught here; it stays
+ * bounded by the web app's intake cap (apps/web's `MAX_CSV_FILE_BYTES`), which a
+ * whole-file re-scan here would only duplicate at the cost of a second full read.
+ * Inert for any input without the Blob read surface -- a Node stream (the counter
+ * bounds it) or a string (parsed whole in one pass, no cross-chunk growth) returns
+ * at once.
+ *
+ * @internal
+ */
+export async function assertLeadingLineWithinByteCeiling(
+  file: LocalFile,
+  byteCeiling: number,
+): Promise<void> {
+  const source = file as Partial<{
+    size: number;
+    slice: (
+      start: number,
+      end: number,
+    ) => {
+      arrayBuffer: () => Promise<ArrayBuffer>;
+    };
+  }>;
+  if (typeof source.size !== "number" || typeof source.slice !== "function")
+    return;
+  // A file no larger than the ceiling cannot hold a line that exceeds it, so the
+  // common case reads nothing at all.
+  if (source.size <= byteCeiling) return;
+
+  // Read the first window only; a well-formed header terminates inside it, so a
+  // legitimate large file reads one small slice rather than its whole body. Only
+  // an input with no terminator in that window -- already pathological -- reads on
+  // to the ceiling to confirm the leading line crosses it. Two reads at most, so
+  // no await-in-loop.
+  const limit = byteCeiling + 1;
+  const window = 256 * 1024;
+  const hasTerminator = (bytes: Uint8Array): boolean =>
+    bytes.indexOf(0x0a) !== -1 || bytes.indexOf(0x0d) !== -1;
+  const head = new Uint8Array(
+    await source.slice(0, Math.min(window, limit)).arrayBuffer(),
+  );
+  if (hasTerminator(head)) return;
+  if (limit > window) {
+    const tail = new Uint8Array(
+      await source.slice(window, limit).arrayBuffer(),
+    );
+    if (hasTerminator(tail)) return;
+  }
+  throw singleLineCeilingError(byteCeiling);
+}
+
+/**
  * Parse a CSV file to its COMPLETE row set. Resolves a {@link Papa.ParseResult}
  * whose `data` and `errors` are accumulated across every PapaParse chunk, so a
  * file larger than one `Papa.LocalChunkSize` chunk is returned whole rather than
  * truncated to its final chunk (see the accumulation note in the body). Rejects
  * on a read/stream error.
+ *
+ * `byteCeiling` bounds a single logical line -- the partial line PapaParse must
+ * buffer whole before it yields a chunk -- so a no-newline file, an oversized
+ * header, or one enormous field fails fast with a clear, operator-readable error
+ * rather than driving memory and CPU with that span; see
+ * {@link CSV_LINE_BYTE_CEILING}. Unlike loadCSVColumnSample (whose row cap also
+ * removes real waste), this read genuinely consumes every row of the operator's
+ * own file (invite/accept/exchange), so the ceiling is a robustness backstop on a
+ * single pathological line, not a memory saving for well-formed input -- a normal
+ * file reads exactly as it did before.
+ *
+ * Two complementary mechanisms enforce it across the inputs this read serves. For
+ * the Node stream every CLI caller passes, the bound rides the source's raw `data`
+ * events and bounds every line -- header or any data row -- at exactly the ceiling.
+ * For the browser `File` the web caller passes -- which PapaParse reads whole
+ * through FileReader, with no `data` events to count -- a bounded pre-read
+ * ({@link assertLeadingLineWithinByteCeiling}) instead rejects an oversized
+ * LEADING line (the header, or a no-newline file) before parsing; a giant field in
+ * a LATER row on that path stays bounded by the web app's intake cap (apps/web's
+ * `MAX_CSV_FILE_BYTES`) rather than scanned for here. See that helper for why the
+ * web path is bounded only at its leading line, not every row.
  *
  * Caveat on `meta`: only `meta.fields` (the header) is whole-file-stable. The
  * rest of `meta` (`cursor`, `truncated`, `aborted`, ...) is the FINAL chunk's --
@@ -19,9 +141,14 @@ import type { LocalFile } from "papaparse";
  * consumer must not read whole-file position or truncation state off it. Every
  * current consumer reads only `data` and `meta.fields`.
  */
-export function loadCSVFile(
+export async function loadCSVFile(
   file: LocalFile,
+  byteCeiling: number = CSV_LINE_BYTE_CEILING,
 ): Promise<Papa.ParseResult<unknown>> {
+  // Bound the non-stream (browser File) path's leading line before parsing: its
+  // `data`-event counter below is inert, since PapaParse reads a File whole through
+  // FileReader. A Node stream or string is a no-op here and bounded below instead.
+  await assertLeadingLineWithinByteCeiling(file, byteCeiling);
   return new Promise((resolve, reject) => {
     // Accumulate every chunk's rows on THIS thread. PapaParse splits a file into
     // `Papa.LocalChunkSize` chunks, and neither mode's `complete` argument is the
@@ -37,6 +164,49 @@ export function loadCSVFile(
     const data: Array<unknown> = [];
     const errors: Array<Papa.ParseError> = [];
     let meta: Papa.ParseMeta | undefined;
+
+    // Bound the span between row terminators (the accumulated partial line), the
+    // same technique loadCSVColumnSample uses. `bytesPulled` counts every byte the
+    // source emits; `spanStart` is reset to it each time the parse cursor advances
+    // past a completed line (the header, or a data row), so `bytesPulled -
+    // spanStart` is the bytes pulled since the last terminator -- the partial line
+    // PapaParse is still buffering. A well-formed input terminates each line well
+    // under the ceiling and never trips; a no-terminator / giant-field /
+    // giant-header input keeps the cursor pinned while bytes pile up, so the span
+    // crosses the ceiling and the read fails fast. Checked before that reset (chunk
+    // callback below) so a single read larger than the ceiling fails closed --
+    // rejected, never silently forgiven.
+    let bytesPulled = 0;
+    let spanStart = 0;
+    let lastCursor = 0;
+    let ceilingError: Error | undefined;
+
+    // Count bytes off the source's raw `data` events, BEFORE PapaParse buffers
+    // them: the unterminated partial line is invisible to the chunk callback, which
+    // sees only parsed rows. Registered before Papa.parse so it precedes
+    // PapaParse's own `data` listener and `bytesPulled` is current when the chunk
+    // callback reads it. The source is a Node stream for every CLI caller
+    // (invite/accept/exchange read a file path or stdin via openInputSource); a
+    // non-stream LocalFile (the browser File the web caller passes) has no `on`, so
+    // this counter is inert there -- such a source is materialized whole, with no
+    // streamed accumulation to bound. Its leading line is bounded instead by the
+    // pre-read above (assertLeadingLineWithinByteCeiling); a later-row span by the
+    // web app's MAX_CSV_FILE_BYTES intake cap.
+    const source = file as {
+      on?: (event: "data", listener: (chunk: Buffer | string) => void) => void;
+      removeListener?: (
+        event: "data",
+        listener: (chunk: Buffer | string) => void,
+      ) => void;
+      destroy?: () => void;
+    };
+    const isStream = typeof source.on === "function";
+    const countBytes = (chunk: Buffer | string): void => {
+      bytesPulled +=
+        typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.length;
+    };
+    if (isStream) source.on?.("data", countBytes);
+
     Papa.parse(file, {
       // Parse INLINE, never in a Web Worker. PapaParse's `worker: true` spawns its
       // worker from its own bundled source by reading the running script's URL -- a
@@ -59,7 +229,24 @@ export function loadCSVFile(
       worker: false,
       header: true,
       skipEmptyLines: true,
-      chunk: (results) => {
+      chunk: (results, parser) => {
+        // Check the bytes pulled since the last completed line, THEN advance the
+        // baseline past it. The order matters: a single chunk that both completes a
+        // line and carries a huge unterminated remainder (the whole input arriving
+        // in one large `data` event) must be judged against the OLD baseline --
+        // resetting first would credit the remainder to `spanStart` and forgive the
+        // very span it should reject. An over-ceiling span is a line or header with
+        // no terminator in range, so abort and reject in `complete` (the
+        // operator-readable cause wins over the generic invariants there).
+        if (bytesPulled - spanStart > byteCeiling) {
+          ceilingError = singleLineCeilingError(byteCeiling);
+          parser.abort();
+          return;
+        }
+        if (results.meta.cursor > lastCursor) {
+          lastCursor = results.meta.cursor;
+          spanStart = bytesPulled;
+        }
         // Spread-push would pass one argument per row and can overflow the call
         // stack for a chunk holding hundreds of thousands of short rows, so append
         // in a loop (O(n) total, stack-safe).
@@ -71,6 +258,23 @@ export function loadCSVFile(
         meta = results.meta;
       },
       complete: () => {
+        // A ceiling-trip `parser.abort()` tears down PapaParse's parser but not the
+        // underlying source, so a Node stream's listeners (and an
+        // fs.createReadStream's file descriptor) would linger until GC -- the
+        // opposite of failing fast. Detach the byte counter and release the source
+        // explicitly; destroy is a no-op once a natural end-of-input has already
+        // closed it (the well-formed path, which reads to EOF and never aborts), and
+        // skipped for a non-stream LocalFile (a browser File/string has no
+        // `destroy`).
+        if (isStream) source.removeListener?.("data", countBytes);
+        if (typeof source.destroy === "function") source.destroy();
+        // The byte ceiling tripped: reject before the invariants below, since a
+        // no-terminator input aborts before any header lands (leaving `meta` unset),
+        // and its operator-readable cause must win over the generic message.
+        if (ceilingError) {
+          reject(ceilingError);
+          return;
+        }
         // `meta` is set by the chunk callback, which fires at least once before
         // complete for any input (PapaParse parses at least one chunk, even an
         // empty file). Rejecting on the unreachable no-chunk case makes that an
@@ -98,6 +302,12 @@ export function loadCSVFile(
         resolve({ data, errors, meta });
       },
       error: (error) => {
+        // Same release as complete, which the error path does not reach: PapaParse's
+        // _sendError detaches only its own listeners and never calls complete, so
+        // without this an fs.createReadStream descriptor (and the byte counter)
+        // would linger past a read error until GC.
+        if (isStream) source.removeListener?.("data", countBytes);
+        if (typeof source.destroy === "function") source.destroy();
         reject(error);
       },
     });
@@ -135,28 +345,6 @@ export function loadCSVColumns(file: LocalFile): Promise<Array<string>> {
     });
   });
 }
-
-/**
- * Per-logical-line byte ceiling for {@link loadCSVColumnSample}'s streamed read.
- * Its row cap bounds the number of retained rows, but PapaParse must buffer one
- * whole logical line -- a data row, or the entire header -- before it can yield a
- * chunk and the read can stop, so an input whose first row terminator is far from
- * the start (one giant line with no newline, one enormous field, or a
- * multi-megabyte header) would drive the accumulated partial line, and the
- * repeated re-splitting of it, linearly-to-quadratically with that span no matter
- * the row cap. This ceiling bounds the bytes pulled from the source between row
- * terminators, so those shapes fail fast with a clear error rather than consuming
- * memory and CPU proportional to the span.
- *
- * 8 MiB sits comfortably above any realistic operator CSV's single line -- even a
- * pathologically wide file of tens of thousands of columns is a header of low
- * single-digit MiB and a data row far smaller -- and well below the
- * hundred-MiB-plus spans that drove the gigabyte-scale memory growth this guards
- * against. The input is the operator's own local file, so this is a robustness
- * backstop on the bounded read's own guarantee, not a partner- or
- * transport-reachable bound.
- */
-export const CSV_LINE_BYTE_CEILING = 8 * 1024 * 1024;
 
 /**
  * Read a CSV's column header plus a bounded sample of one column's values,
@@ -288,11 +476,7 @@ export function loadCSVColumnSample(
         // window a no-terminator input would otherwise spin in, accumulating
         // unbounded.
         if (bytesPulled - spanStart > byteCeiling) {
-          ceilingError = new Error(
-            `CSV input exceeded the ${byteCeiling}-byte single-line limit ` +
-              "before a line terminator; the file may be malformed (no newline) " +
-              "or carry an oversized header or field",
-          );
+          ceilingError = singleLineCeilingError(byteCeiling);
           parser.abort();
           return;
         }

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -94,6 +94,12 @@ export async function assertLeadingLineWithinByteCeiling(
   // no await-in-loop.
   const limit = byteCeiling + 1;
   const window = 256 * 1024;
+  // Scan raw bytes for LF or CR. This deliberately does not honor RFC 4180
+  // quoting, so a newline embedded in a quoted field counts as a terminator here;
+  // that can only let a pathological line slip past (a false negative) and never
+  // wrongly reject a valid file, the safe direction for an operator-local backstop.
+  // Byte-wise is safe for UTF-8: 0x0a/0x0d are below 0x80, so neither can occur as
+  // a continuation byte of a multi-byte character.
   const hasTerminator = (bytes: Uint8Array): boolean =>
     bytes.indexOf(0x0a) !== -1 || bytes.indexOf(0x0d) !== -1;
   const head = new Uint8Array(

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -94,12 +94,12 @@ export async function assertLeadingLineWithinByteCeiling(
   // no await-in-loop.
   const limit = byteCeiling + 1;
   const window = 256 * 1024;
-  // Scan raw bytes for LF or CR. This deliberately does not honor RFC 4180
-  // quoting, so a newline embedded in a quoted field counts as a terminator here;
-  // that can only let a pathological line slip past (a false negative) and never
-  // wrongly reject a valid file, the safe direction for an operator-local backstop.
-  // Byte-wise is safe for UTF-8: 0x0a/0x0d are below 0x80, so neither can occur as
-  // a continuation byte of a multi-byte character.
+  // Scan raw bytes for LF or CR. Like the stream guard, this does not honor RFC
+  // 4180 quoting -- a quoted newline counts as a terminator, so it never wrongly
+  // rejects a valid file (the safe direction), at the cost of not bounding a single
+  // quoted field full of embedded newlines (bounded instead by MAX_CSV_FILE_BYTES
+  // on this web path). Byte-wise is safe for UTF-8: 0x0a/0x0d are below 0x80, so
+  // neither can occur as a continuation byte of a multi-byte character.
   const hasTerminator = (bytes: Uint8Array): boolean =>
     bytes.indexOf(0x0a) !== -1 || bytes.indexOf(0x0d) !== -1;
   const head = new Uint8Array(
@@ -141,11 +141,16 @@ type StreamSource = {
  * caller runs once the parse settles. Inert (a no-op detach) for a source without
  * `on` -- a browser File, bounded by {@link assertLeadingLineWithinByteCeiling}.
  *
- * The byte scan deliberately ignores RFC 4180 quoting: a newline embedded in a
- * quoted field resets the run early, which can only let a pathological line slip
- * past (a false negative), never wrongly reject a valid file -- the safe direction
- * for an operator-local backstop. Byte-wise is safe for UTF-8 (0x0a/0x0d are below
- * 0x80, so neither occurs as a continuation byte of a multi-byte character).
+ * The byte scan deliberately ignores RFC 4180 quoting, so it never wrongly rejects
+ * a valid file (a newline inside a quoted field just resets the run -- the safe,
+ * false-negative direction). The cost is one shape this ceiling does NOT bound: a
+ * single quoted field carrying embedded newlines, which PapaParse buffers whole as
+ * one logical row while the run keeps resetting, so its memory and (quadratic)
+ * re-split CPU scale with the field, not the ceiling. That shape stays bounded only
+ * by the input being operator-local -- the CLI sets no size cap -- or, on the web,
+ * by MAX_CSV_FILE_BYTES; it is not a regression, the read was unbounded for it
+ * before this ceiling too. Byte-wise is safe for UTF-8 (0x0a/0x0d are below 0x80,
+ * so neither occurs as a continuation byte of a multi-byte character).
  *
  * @internal exported only for the unit tests, which drive its scan and trip
  * directly against a fake stream source -- isolating the run accounting from

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -64,7 +64,9 @@ function singleLineCeilingError(byteCeiling: number): Error {
  * bounds it) or a string (parsed whole in one pass, no cross-chunk growth) returns
  * at once.
  *
- * @internal
+ * @internal exported only so the unit tests can drive its resolve cases directly:
+ * loadCSVFile cannot reach them in Node, where a File hits PapaParse's FileReader
+ * path (absent there). Not re-exported from the package entry point.
  */
 export async function assertLeadingLineWithinByteCeiling(
   file: LocalFile,

--- a/packages/core/test/file.test.ts
+++ b/packages/core/test/file.test.ts
@@ -456,6 +456,39 @@ test("assertLeadingLineWithinByteCeiling: a non-sliceable input (a stream) is in
   ).resolves.toBeUndefined();
 });
 
+// The cases above use a tiny ceiling, so `limit` stays under the helper's 256 KiB
+// head window and only the head read runs. These two reach the tail read (the
+// `limit > window` branch) with a ceiling above that window, which the small-ceiling
+// cases never exercise -- the path where a head/tail seam off-by-one could wrongly
+// reject a valid file, the one false-positive direction this backstop must avoid.
+const HEAD_WINDOW = 256 * 1024;
+
+test("assertLeadingLineWithinByteCeiling: a terminator past the first read window is still found", async () => {
+  // A header that terminates only after the head window but within the ceiling must
+  // resolve: the head/tail split must drop no bytes at the seam, so a legitimate
+  // large header is never wrongly rejected.
+  const ceiling = 2 * HEAD_WINDOW;
+  const headerLen = HEAD_WINDOW + 4096; // past the head window, well under the ceiling
+  const file = new File(
+    [`${"h".repeat(headerLen)}\n${"v".repeat(HEAD_WINDOW)}`],
+    "wide-header.csv",
+  );
+  expect(file.size).toBeGreaterThan(ceiling);
+  await expect(
+    assertLeadingLineWithinByteCeiling(file, ceiling),
+  ).resolves.toBeUndefined();
+});
+
+test("assertLeadingLineWithinByteCeiling: a no-terminator file over a ceiling above the window rejects via the tail read", async () => {
+  // The reject path through the tail read: with the ceiling above the head window
+  // and no terminator anywhere, head and tail are both scanned and then it rejects.
+  const ceiling = 2 * HEAD_WINDOW;
+  const file = new File(["x".repeat(ceiling * 2)], "huge.csv");
+  await expect(
+    assertLeadingLineWithinByteCeiling(file, ceiling),
+  ).rejects.toThrow(/single-line limit/);
+});
+
 test("loadCSVFile: a browser File with a no-newline leading line over the ceiling fails fast", async () => {
   // Wires the pre-read into loadCSVFile end to end: the File the web caller passes
   // rejects before parsing, so PapaParse's FileReader path is never reached. This

--- a/packages/core/test/file.test.ts
+++ b/packages/core/test/file.test.ts
@@ -2,7 +2,12 @@ import { Readable } from "node:stream";
 
 import { expect, test, vi } from "vitest";
 
-import { CSV_LINE_BYTE_CEILING, loadCSVColumnSample } from "../src/file";
+import {
+  assertLeadingLineWithinByteCeiling,
+  CSV_LINE_BYTE_CEILING,
+  loadCSVColumnSample,
+  loadCSVFile,
+} from "../src/file";
 import { inferDateFormat, columnValues } from "../src/utils/date";
 
 /** A readable emitting `content` then EOF, standing in for a CSV file/stream. */
@@ -292,4 +297,172 @@ test("loadCSVColumnSample: a header split across stream chunks is read whole", a
   expect(columns).toContain("dob");
   expect(sampledColumn).toBe("dob");
   expect(sample).toEqual(["1990-01-02", "1990-01-02"]);
+});
+
+test("loadCSVFile: a no-newline span over the byte ceiling fails fast", async () => {
+  // One logical line with no terminator anywhere: PapaParse can never yield a row
+  // or settle the header, so without the ceiling the read would buffer the whole
+  // span. The byte ceiling aborts it with an operator-readable error once the bytes
+  // pulled since the (never-advancing) cursor cross the limit. Delivered in small
+  // chunks, as fs.createReadStream / stdin would deliver a large file.
+  const ceiling = 512;
+  const giant = "x".repeat(ceiling * 4);
+  await expect(
+    loadCSVFile(chunkedStreamOf(giant, 64), ceiling),
+  ).rejects.toThrow(/single-line limit/);
+});
+
+test("loadCSVFile: a single field over the byte ceiling fails fast", async () => {
+  // The header terminates normally, then one data field grows without a row
+  // terminator. The cursor advances past the header and then stalls, so the span
+  // measured since that last terminator -- the unbounded field -- crosses the
+  // ceiling and the read fails fast rather than buffering the whole field.
+  const ceiling = 512;
+  const giantField = "y".repeat(ceiling * 4);
+  const csv = `name,dob\nAlice,${giantField}`;
+  await expect(loadCSVFile(chunkedStreamOf(csv, 64), ceiling)).rejects.toThrow(
+    /single-line limit/,
+  );
+});
+
+test("loadCSVFile: a header over the byte ceiling fails fast", async () => {
+  // A header of very many columns with its terminator beyond the ceiling: the
+  // cursor stays at zero until that newline, so the header span crosses the limit
+  // first and the read aborts before settling -- the giant-header shape.
+  const ceiling = 512;
+  const cols = Array.from({ length: 400 }, (_v, i) => `col_${i}`);
+  const header = cols.join(",");
+  expect(Buffer.byteLength(header)).toBeGreaterThan(ceiling);
+  const row = cols.map(() => "v").join(",");
+  await expect(
+    loadCSVFile(chunkedStreamOf(`${header}\n${row}\n`, 64), ceiling),
+  ).rejects.toThrow(/single-line limit/);
+});
+
+test("loadCSVFile: a giant field arriving in one data event fails fast", async () => {
+  // Delivery-shape independence: when the header completes and an unterminated
+  // giant field arrive in a SINGLE data event (a lone push, or any source with a
+  // read buffer larger than the span), the span must be judged before the
+  // cursor-advance reset can credit the remainder to the baseline -- otherwise the
+  // whole span is forgiven and the bound silently does not fire. streamOf pushes
+  // the entire content as one event, reproducing that shape.
+  const ceiling = 512;
+  const csv = `name,dob\nAlice,${"y".repeat(ceiling * 4)}`;
+  await expect(loadCSVFile(streamOf(csv), ceiling)).rejects.toThrow(
+    /single-line limit/,
+  );
+});
+
+test("loadCSVFile: destroys the source stream once the ceiling aborts the read", async () => {
+  // The ceiling trip's parser.abort() tears down the parser but not the source, so
+  // the loader must release the stream rather than leak its descriptor until GC --
+  // the same release loadCSVColumnSample makes on its early aborts, now reachable in
+  // loadCSVFile through the ceiling.
+  const ceiling = 512;
+  const stream = chunkedStreamOf("x".repeat(ceiling * 4), 64);
+  const destroySpy = vi.spyOn(stream, "destroy");
+  await expect(loadCSVFile(stream, ceiling)).rejects.toThrow(
+    /single-line limit/,
+  );
+  expect(destroySpy).toHaveBeenCalled();
+});
+
+test("loadCSVFile: many short rows whose total exceeds the ceiling do not trip", async () => {
+  // The ceiling bounds a single line, not the total bytes pulled: a file of many
+  // short, terminated rows whose cumulative size far exceeds the ceiling reads
+  // whole, because the span resets at every row terminator. This is the distinction
+  // that keeps a legitimate large operator file -- which loadCSVFile reads in full --
+  // from tripping the limit, delivered in tiny chunks to exercise the reset.
+  const ceiling = 256;
+  const rows = Array.from(
+    { length: 400 },
+    (_v, i) => `Person${i},1990-01-0${(i % 9) + 1}`,
+  ).join("\n");
+  const csv = `name,dob\n${rows}\n`;
+  expect(Buffer.byteLength(csv)).toBeGreaterThan(ceiling * 4);
+  const result = await loadCSVFile(chunkedStreamOf(csv, 64), ceiling);
+  expect(result.meta.fields).toEqual(["name", "dob"]);
+  expect(result.data).toHaveLength(400);
+});
+
+test("loadCSVFile: a well-formed input under the ceiling reads unchanged", async () => {
+  // The ceiling leaves a normal input untouched: the same header and every parsed
+  // row as without it, even delivered in tiny chunks (lines split mid-field across
+  // reads) so the per-line span reset is exercised. Pins both data and meta.fields
+  // against the pre-ceiling behavior.
+  const csv =
+    "first_name,dob,ssn\n" + "Alice,1990-01-02,111\n" + "Bob,1985-12-31,222\n";
+  const result = await loadCSVFile(chunkedStreamOf(csv, 8), 256);
+  expect(result.meta.fields).toEqual(["first_name", "dob", "ssn"]);
+  expect(result.data).toEqual([
+    { first_name: "Alice", dob: "1990-01-02", ssn: "111" },
+    { first_name: "Bob", dob: "1985-12-31", ssn: "222" },
+  ]);
+});
+
+// The non-stream (browser File) bound. loadCSVFile's data-event counter is inert
+// for a File -- PapaParse reads it whole through FileReader, which Node lacks -- so
+// the leading-line pre-read enforces the ceiling there instead. These exercise the
+// pre-read directly (no FileReader needed); the end-to-end parse of a real File is
+// pinned in apps/web's browser suite, where FileReader exists.
+
+test("assertLeadingLineWithinByteCeiling: a File whose leading line exceeds the ceiling rejects", async () => {
+  // No terminator anywhere and a body past the ceiling: the header (here, the whole
+  // file) is one over-ceiling line, so the pre-read rejects before any parse.
+  const ceiling = 512;
+  const file = new File(["x".repeat(ceiling * 2)], "huge.csv");
+  await expect(
+    assertLeadingLineWithinByteCeiling(file, ceiling),
+  ).rejects.toThrow(/single-line limit/);
+});
+
+test("assertLeadingLineWithinByteCeiling: an oversized header preceding a terminator rejects", async () => {
+  // The first terminator exists but sits past the ceiling: the leading line (the
+  // header) alone exceeds it, so the pre-read still rejects.
+  const ceiling = 512;
+  const file = new File([`${"h".repeat(ceiling * 2)}\nrow\n`], "wide.csv");
+  await expect(
+    assertLeadingLineWithinByteCeiling(file, ceiling),
+  ).rejects.toThrow(/single-line limit/);
+});
+
+test("assertLeadingLineWithinByteCeiling: a terminator within the ceiling resolves despite a huge body", async () => {
+  // Only the LEADING line is gated: a short header terminates early, so a body far
+  // past the ceiling (a later-row span, left to the intake cap) reads through.
+  const ceiling = 512;
+  const file = new File([`name,dob\n${"y".repeat(ceiling * 8)}`], "ok.csv");
+  await expect(
+    assertLeadingLineWithinByteCeiling(file, ceiling),
+  ).resolves.toBeUndefined();
+});
+
+test("assertLeadingLineWithinByteCeiling: a File no larger than the ceiling is not read", async () => {
+  // A file that cannot hold an over-ceiling line is passed through without a read,
+  // so the common case pays nothing -- pinned by spying on slice().
+  const ceiling = 512;
+  const file = new File(["x".repeat(ceiling)], "small.csv");
+  const sliceSpy = vi.spyOn(file, "slice");
+  await expect(
+    assertLeadingLineWithinByteCeiling(file, ceiling),
+  ).resolves.toBeUndefined();
+  expect(sliceSpy).not.toHaveBeenCalled();
+});
+
+test("assertLeadingLineWithinByteCeiling: a non-sliceable input (a stream) is inert", async () => {
+  // A Node stream has no Blob read surface; it is bounded by the data-event counter
+  // instead, so the pre-read returns at once rather than mis-handling it.
+  await expect(
+    assertLeadingLineWithinByteCeiling(streamOf("a,b\n1,2\n"), 512),
+  ).resolves.toBeUndefined();
+});
+
+test("loadCSVFile: a browser File with a no-newline leading line over the ceiling fails fast", async () => {
+  // Wires the pre-read into loadCSVFile end to end: the File the web caller passes
+  // rejects before parsing, so PapaParse's FileReader path is never reached. This
+  // bounds the web path the data-event counter cannot observe.
+  const ceiling = 512;
+  const file = new File(["x".repeat(ceiling * 2)], "data.csv", {
+    type: "text/csv",
+  });
+  await expect(loadCSVFile(file, ceiling)).rejects.toThrow(/single-line limit/);
 });

--- a/packages/core/test/file.test.ts
+++ b/packages/core/test/file.test.ts
@@ -5,6 +5,7 @@ import { expect, test, vi } from "vitest";
 import {
   assertLeadingLineWithinByteCeiling,
   CSV_LINE_BYTE_CEILING,
+  guardStreamLineByteCeiling,
   loadCSVColumnSample,
   loadCSVFile,
 } from "../src/file";
@@ -354,10 +355,9 @@ test("loadCSVFile: a giant field arriving in one data event fails fast", async (
 });
 
 test("loadCSVFile: destroys the source stream once the ceiling aborts the read", async () => {
-  // The ceiling trip's parser.abort() tears down the parser but not the source, so
-  // the loader must release the stream rather than leak its descriptor until GC --
-  // the same release loadCSVColumnSample makes on its early aborts, now reachable in
-  // loadCSVFile through the ceiling.
+  // On a ceiling trip the guard destroys the source itself (surfacing the error
+  // through PapaParse), and the error path releases it again; either way the stream
+  // is destroyed rather than leaked until GC. The spy fires on the guard's destroy.
   const ceiling = 512;
   const stream = chunkedStreamOf("x".repeat(ceiling * 4), 64);
   const destroySpy = vi.spyOn(stream, "destroy");
@@ -492,10 +492,134 @@ test("assertLeadingLineWithinByteCeiling: a no-terminator file over a ceiling ab
 test("loadCSVFile: a browser File with a no-newline leading line over the ceiling fails fast", async () => {
   // Wires the pre-read into loadCSVFile end to end: the File the web caller passes
   // rejects before parsing, so PapaParse's FileReader path is never reached. This
-  // bounds the web path the data-event counter cannot observe.
+  // bounds the web path, which exposes no `data` events for the stream guard.
   const ceiling = 512;
   const file = new File(["x".repeat(ceiling * 2)], "data.csv", {
     type: "text/csv",
   });
   await expect(loadCSVFile(file, ceiling)).rejects.toThrow(/single-line limit/);
+});
+
+// The stream guard's run accounting, exercised directly against a fake stream
+// source so the cases PapaParse's row splitting cannot reach -- CR-only endings,
+// and an over-ceiling run terminated LATER in the same chunk (the inner-overflow
+// path, which must trip rather than be forgiven by that later terminator) -- are
+// pinned. A false positive (tripping a valid stream) is the dangerous direction;
+// these confirm well-formed input never trips.
+
+/**
+ * A stand-in for the Node stream the guard attaches to: it captures the guard's
+ * `data` listener so the test can feed chunks, and records destroy() calls (the
+ * trip). Mirrors only the public surface the guard touches (on/removeListener/
+ * destroy), no real stream.
+ */
+function fakeGuardSource() {
+  let listener: ((chunk: Buffer | string) => void) | undefined;
+  const destroyedWith: Array<Error | undefined> = [];
+  const source = {
+    on(_event: "data", l: (chunk: Buffer | string) => void) {
+      listener = l;
+    },
+    removeListener() {
+      listener = undefined;
+    },
+    destroy(error?: Error) {
+      destroyedWith.push(error);
+    },
+  };
+  return {
+    source,
+    push: (chunk: Buffer | string) => listener?.(chunk),
+    tripped: () => destroyedWith.length > 0,
+    trippedMessage: () => destroyedWith[0]?.message,
+  };
+}
+
+test("guardStreamLineByteCeiling: well-formed CRLF lines under the ceiling do not trip", () => {
+  const g = fakeGuardSource();
+  guardStreamLineByteCeiling(g.source, 16);
+  g.push(Buffer.from("a,b\r\n"));
+  g.push(Buffer.from("c,d\r\n"));
+  g.push(Buffer.from("ee,ff\r\n"));
+  expect(g.tripped()).toBe(false);
+});
+
+test("guardStreamLineByteCeiling: CR-only line endings reset the run like LF/CRLF", () => {
+  // Lines separated only by CR (0x0d), each well under the ceiling, total far over.
+  // PapaParse's row splitting never exercises a lone CR, so the guard owns this.
+  const g = fakeGuardSource();
+  guardStreamLineByteCeiling(g.source, 8);
+  g.push(Buffer.from("ab\rcd\ref\rgh\r"));
+  expect(g.tripped()).toBe(false);
+});
+
+test("guardStreamLineByteCeiling: an over-ceiling run terminated later in the same chunk still trips", () => {
+  // The inner-overflow path: the over-ceiling segment must trip BEFORE the
+  // terminator that follows it in the same chunk resets the run -- otherwise an
+  // oversized-but-terminated leading line would be silently forgiven.
+  const g = fakeGuardSource();
+  const ceiling = 10;
+  guardStreamLineByteCeiling(g.source, ceiling);
+  g.push(Buffer.from(`${"x".repeat(ceiling + 2)}\nshort\n`));
+  expect(g.tripped()).toBe(true);
+  expect(g.trippedMessage()).toMatch(/single-line limit/);
+});
+
+test("guardStreamLineByteCeiling: an over-ceiling run accumulated across chunks trips before a later terminator", () => {
+  // The same inner overflow, but the run is carried across `data` events: the bytes
+  // that cross the ceiling arrive in a later chunk, ahead of that chunk's terminator.
+  const g = fakeGuardSource();
+  guardStreamLineByteCeiling(g.source, 10);
+  g.push(Buffer.from("xxxxxxx")); // run = 7, no terminator
+  expect(g.tripped()).toBe(false);
+  g.push(Buffer.from("xxxx\ny")); // 4 more before the \n -> run = 11 > 10
+  expect(g.tripped()).toBe(true);
+  expect(g.trippedMessage()).toMatch(/single-line limit/);
+});
+
+test("guardStreamLineByteCeiling: a line of exactly the ceiling passes, one byte over trips", () => {
+  // The terminator byte is not counted, so content == ceiling is accepted and
+  // content == ceiling + 1 trips -- the same boundary the pre-read uses.
+  const atCeiling = fakeGuardSource();
+  guardStreamLineByteCeiling(atCeiling.source, 10);
+  atCeiling.push(Buffer.from(`${"x".repeat(10)}\n`));
+  expect(atCeiling.tripped()).toBe(false);
+
+  const overCeiling = fakeGuardSource();
+  guardStreamLineByteCeiling(overCeiling.source, 10);
+  overCeiling.push(Buffer.from(`${"x".repeat(11)}\n`));
+  expect(overCeiling.tripped()).toBe(true);
+});
+
+test("guardStreamLineByteCeiling: many short lines whose total exceeds the ceiling do not trip", () => {
+  // The run resets at every terminator, so cumulative bytes far over the ceiling are
+  // fine. Pushes strings to exercise the Buffer.from(chunk) path.
+  const g = fakeGuardSource();
+  guardStreamLineByteCeiling(g.source, 8);
+  for (let i = 0; i < 100; i++) g.push("ab,cd\n");
+  expect(g.tripped()).toBe(false);
+});
+
+test("guardStreamLineByteCeiling: the detach function stops further scanning", () => {
+  const g = fakeGuardSource();
+  const detach = guardStreamLineByteCeiling(g.source, 8);
+  detach();
+  g.push(Buffer.from("x".repeat(100))); // would trip if still attached
+  expect(g.tripped()).toBe(false);
+});
+
+test("guardStreamLineByteCeiling: a non-stream source (no `on`) is inert", () => {
+  // A browser File has no `on`; the guard returns a no-op detach and never touches
+  // it (that path is bounded by assertLeadingLineWithinByteCeiling instead).
+  let destroyed = false;
+  const detach = guardStreamLineByteCeiling(
+    {
+      destroy: () => {
+        destroyed = true;
+      },
+    },
+    8,
+  );
+  detach();
+  expect(destroyed).toBe(false);
 });

--- a/packages/core/test/file.test.ts
+++ b/packages/core/test/file.test.ts
@@ -167,10 +167,10 @@ test("loadCSVColumnSample: an empty input yields an empty header and sample", as
 
 test("loadCSVColumnSample: a no-newline span over the byte ceiling fails fast", async () => {
   // One logical line with no terminator anywhere: PapaParse can never yield a row
-  // or settle the header, so the read would buffer the whole span. The byte
-  // ceiling aborts it with an operator-readable error once the bytes pulled since
-  // the (never-advancing) cursor cross the limit. Delivered in small chunks, as
-  // fs.createReadStream / stdin would deliver a large file.
+  // or settle the header, so the read would buffer the whole span. The guard
+  // destroys the stream with an operator-readable error once the run since the last
+  // terminator crosses the limit. Delivered in small chunks, as fs.createReadStream
+  // / stdin would deliver a large file.
   const ceiling = 512;
   const giant = "x".repeat(ceiling * 4);
   await expect(
@@ -180,9 +180,9 @@ test("loadCSVColumnSample: a no-newline span over the byte ceiling fails fast", 
 
 test("loadCSVColumnSample: a single field over the byte ceiling fails fast", async () => {
   // The header terminates normally, then one data field grows without a row
-  // terminator. The cursor advances past the header and then stalls, so the span
-  // measured since that last terminator -- the unbounded field -- crosses the
-  // ceiling and the read fails fast rather than buffering the whole field.
+  // terminator. The guard's run resets at the header's newline, then the unbounded
+  // field drives the run past the ceiling, so the read fails fast rather than
+  // buffering the whole field.
   const ceiling = 512;
   const giantField = "y".repeat(ceiling * 4);
   const csv = `name,dob\nAlice,${giantField}`;
@@ -192,9 +192,9 @@ test("loadCSVColumnSample: a single field over the byte ceiling fails fast", asy
 });
 
 test("loadCSVColumnSample: a header over the byte ceiling fails fast", async () => {
-  // A header of very many columns with its terminator beyond the ceiling: the
-  // cursor stays at zero until that newline, so the header span crosses the limit
-  // first and the read aborts before settling -- the giant-header shape.
+  // A header of very many columns with its terminator beyond the ceiling: the run
+  // grows from the first byte with no terminator to reset it, so it crosses the
+  // limit before the header settles -- the giant-header shape.
   const ceiling = 512;
   const cols = Array.from({ length: 400 }, (_v, i) => `col_${i}`);
   const header = cols.join(",");
@@ -211,11 +211,11 @@ test("loadCSVColumnSample: a header over the byte ceiling fails fast", async () 
 });
 
 test("loadCSVColumnSample: a giant field arriving in one data event fails fast", async () => {
-  // Delivery-shape independence: when the header completes and an unterminated
-  // giant field arrive in a SINGLE data event (a lone push, or any source with a
-  // read buffer larger than the span), the span must be judged before the
-  // cursor-advance reset can credit the remainder to the baseline -- otherwise
-  // the whole span is forgiven and the bound silently does not fire. streamOf
+  // Delivery-shape independence: the header and an unterminated giant field arrive
+  // in a SINGLE data event (a lone push, or any source with a read buffer larger
+  // than the span). The guard scans within that one chunk -- resetting the run at
+  // the header's newline, then accumulating the field past the ceiling -- so a
+  // chunk carrying both a terminator and an over-ceiling tail still trips. streamOf
   // pushes the entire content as one event, reproducing that shape.
   const ceiling = 512;
   const csv = `name,dob\nAlice,${"y".repeat(ceiling * 4)}`;
@@ -302,9 +302,9 @@ test("loadCSVColumnSample: a header split across stream chunks is read whole", a
 test("loadCSVFile: a no-newline span over the byte ceiling fails fast", async () => {
   // One logical line with no terminator anywhere: PapaParse can never yield a row
   // or settle the header, so without the ceiling the read would buffer the whole
-  // span. The byte ceiling aborts it with an operator-readable error once the bytes
-  // pulled since the (never-advancing) cursor cross the limit. Delivered in small
-  // chunks, as fs.createReadStream / stdin would deliver a large file.
+  // span. The guard destroys the stream with an operator-readable error once the
+  // run since the last terminator crosses the limit. Delivered in small chunks, as
+  // fs.createReadStream / stdin would deliver a large file.
   const ceiling = 512;
   const giant = "x".repeat(ceiling * 4);
   await expect(
@@ -314,9 +314,9 @@ test("loadCSVFile: a no-newline span over the byte ceiling fails fast", async ()
 
 test("loadCSVFile: a single field over the byte ceiling fails fast", async () => {
   // The header terminates normally, then one data field grows without a row
-  // terminator. The cursor advances past the header and then stalls, so the span
-  // measured since that last terminator -- the unbounded field -- crosses the
-  // ceiling and the read fails fast rather than buffering the whole field.
+  // terminator. The guard's run resets at the header's newline, then the unbounded
+  // field drives the run past the ceiling, so the read fails fast rather than
+  // buffering the whole field.
   const ceiling = 512;
   const giantField = "y".repeat(ceiling * 4);
   const csv = `name,dob\nAlice,${giantField}`;
@@ -326,9 +326,9 @@ test("loadCSVFile: a single field over the byte ceiling fails fast", async () =>
 });
 
 test("loadCSVFile: a header over the byte ceiling fails fast", async () => {
-  // A header of very many columns with its terminator beyond the ceiling: the
-  // cursor stays at zero until that newline, so the header span crosses the limit
-  // first and the read aborts before settling -- the giant-header shape.
+  // A header of very many columns with its terminator beyond the ceiling: the run
+  // grows from the first byte with no terminator to reset it, so it crosses the
+  // limit before the header settles -- the giant-header shape.
   const ceiling = 512;
   const cols = Array.from({ length: 400 }, (_v, i) => `col_${i}`);
   const header = cols.join(",");
@@ -340,12 +340,12 @@ test("loadCSVFile: a header over the byte ceiling fails fast", async () => {
 });
 
 test("loadCSVFile: a giant field arriving in one data event fails fast", async () => {
-  // Delivery-shape independence: when the header completes and an unterminated
-  // giant field arrive in a SINGLE data event (a lone push, or any source with a
-  // read buffer larger than the span), the span must be judged before the
-  // cursor-advance reset can credit the remainder to the baseline -- otherwise the
-  // whole span is forgiven and the bound silently does not fire. streamOf pushes
-  // the entire content as one event, reproducing that shape.
+  // Delivery-shape independence: the header and an unterminated giant field arrive
+  // in a SINGLE data event (a lone push, or any source with a read buffer larger
+  // than the span). The guard scans within that one chunk -- resetting the run at
+  // the header's newline, then accumulating the field past the ceiling -- so a
+  // chunk carrying both a terminator and an over-ceiling tail still trips. streamOf
+  // pushes the entire content as one event, reproducing that shape.
   const ceiling = 512;
   const csv = `name,dob\nAlice,${"y".repeat(ceiling * 4)}`;
   await expect(loadCSVFile(streamOf(csv), ceiling)).rejects.toThrow(


### PR DESCRIPTION
## Summary

The shared CSV reads now fail fast on a pathological single logical line. `loadCSVFile` (used by `invite`, `accept`, the zero-setup exchange, and the web inviter) and `loadCSVColumnSample` (used by `init`) reject with a clear, operator-readable error when one logical line -- a no-newline file, a multi-megabyte header, or one enormous field -- has no terminator within an 8 MiB ceiling, instead of letting PapaParse buffer and repeatedly re-split that span and drive memory and CPU with it. The input is the operator's own local file, so this is defense-in-depth, not a regression: a well-formed input reads exactly as before, returning the same rows and header. The bound is enforced entirely on public APIs -- a byte-counting guard on the source stream's `data` events that destroys the source past the ceiling, surfaced through PapaParse's documented `error` callback, plus a public `Blob` pre-read for the browser `File` path -- so it adds no dependency on PapaParse internals.

Implements [206824391](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=206824391).

## Changes

- packages/core/src/file.ts: add the `byteCeiling` bound to `loadCSVFile` and enforce it for both loaders. `guardStreamLineByteCeiling` counts bytes since the last terminator across the source's `data` events and destroys the stream past the ceiling (the CLI file/stdin path); `assertLeadingLineWithinByteCeiling` pre-reads the leading line via `Blob.slice` (the browser `File` path, where PapaParse reads whole through FileReader and emits no `data` events). Both share `CSV_LINE_BYTE_CEILING` and one error builder. Replaces `loadCSVColumnSample`'s prior in-chunk counter, dropping its reliance on PapaParse `chunk`/`cursor` behavior.
- packages/core/test/file.test.ts: unit tests for both loaders' ceiling behavior, the guard's run accounting in isolation, and the pre-read's branches.
- apps/web/test/browser/loadCSVFile.test.ts: browser `File` tests -- an oversized leading line rejects, and a large well-formed `File` parses whole through FileReader.

## Test plan

Ran: `npm run test` (packages/core 1975, apps/cli 931, apps/web unit 559), `npm run test:integration -w apps/cli` (35 passed, chroot leg skipped off-root), `npm run test:browser -w apps/web` (275), and `npm run typecheck && npm run lint && npm run format`.

New tests cover: each pathological shape (no-newline, oversized header, giant field) failing fast on both loaders; the stream guard's run accounting driven directly against a fake source (CRLF/CR-only do not trip, inner overflow within and across chunks, content at the ceiling passes while one byte over trips, many short lines do not trip, detach stops scanning, a non-stream source is inert); source-stream release on a trip and on an early abort; the `Blob` pre-read branches (size-skip, head/tail seam, tail-read reject); and a well-formed input reading unchanged -- rows and header pinned -- on the stream path and end to end through a real browser `File`.

## Background

Follow-on of [206502855](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=206502855) (PR #333), which added the same ceiling to `loadCSVColumnSample` only and scoped `loadCSVFile` out. Extending it here surfaced that the original mechanism leaned on undocumented PapaParse behavior (the `chunk` callback firing per `data` event even with no completed row); this PR reworks both loaders to enforce the bound on public stream and PapaParse-`error` APIs instead, so PapaParse stays an ordinary, unpinned dependency. The byte scan ignores RFC 4180 quoting (a quoted newline resets the run), which never wrongly rejects a valid file; the one shape it does not bound -- a single quoted field full of embedded newlines -- stays bounded by the input being operator-local (CLI) or by `MAX_CSV_FILE_BYTES` (web).

## Out of scope / follow-on

- Document the CSV-read single-line byte ceiling in docs/spec, with the quoted-newline coverage caveat folded in: [206859972](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=206859972).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: operator-local `@psilink/core` robustness with no documented behavior change; the constant's rationale lives in JSDoc and a `docs/spec/` note is filed as a follow-on (206859972), matching PR #333 which documented the same ceiling in JSDoc only.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: operator-local robustness backstop on a malformed local file, with no change to normal operation an operator or reviewer acts on; matches PR #333, which added the same ceiling to `loadCSVColumnSample` with no changelog entry; `@psilink/core`-internal.
- [x] Security review -- n/a: none of the Dependency Policy triggers are touched (the CSV is operator-local input, outside the bounded-untrusted-input class); a defense-in-depth review was nonetheless conducted and confirmed the bound operator-local and non-gating.
