### PR TITLE
Pin rendered colors in the web contrast harness

### DIFF
--- a/apps/web/src/components/FileDropzone.tsx
+++ b/apps/web/src/components/FileDropzone.tsx
@@ -11,6 +11,10 @@ import {
 
 import log from "loglevel";
 
+import {
+  DROPZONE_DRAG_ICON,
+  dragIconColor,
+} from "@components/dropzoneDragIcons";
 import { MAX_CSV_FILE_BYTES } from "@components/csvIntake";
 
 import type { FileRejection } from "@mantine/dropzone";
@@ -130,28 +134,24 @@ export default function FileDropzone({
               failure (2.71:1). In dark the tint becomes the dark surface
               darken(shade-9, .5), where a deeper icon drops the other way
               below the bar, so dark stays at shade 6 (blue-6 = 3.53:1, red-6 =
-              3.83:1). light-dark() selects per scheme; the icon takes no
-              `color` prop so its stroke follows currentColor, which this
-              inline color sets. Both schemes' ratios are enforced by
+              3.83:1). The per-scheme shades live in DROPZONE_DRAG_ICON, shared
+              with the harness so the value painted here and the value asserted
+              cannot drift; dragIconColor renders them as the light-dark() the
+              icon takes as its inline `color` (no `color` prop, so the stroke
+              follows currentColor). Both schemes' ratios are enforced by
               test/unit/themeContrast.test.ts. */}
           <Dropzone.Accept>
             <IconUpload
               size={52}
               stroke={1.5}
-              style={{
-                color:
-                  "light-dark(var(--mantine-color-blue-8), var(--mantine-color-blue-6))",
-              }}
+              style={{ color: dragIconColor(DROPZONE_DRAG_ICON.accept) }}
             />
           </Dropzone.Accept>
           <Dropzone.Reject>
             <IconX
               size={52}
               stroke={1.5}
-              style={{
-                color:
-                  "light-dark(var(--mantine-color-red-8), var(--mantine-color-red-6))",
-              }}
+              style={{ color: dragIconColor(DROPZONE_DRAG_ICON.reject) }}
             />
           </Dropzone.Reject>
           <Dropzone.Idle>

--- a/apps/web/src/components/dropzoneDragIcons.ts
+++ b/apps/web/src/components/dropzoneDragIcons.ts
@@ -1,0 +1,46 @@
+/**
+ * The Dropzone drag-state icon colors, shared between the component that paints
+ * them ({@link FileDropzone}) and the accessibility-contrast harness that proves
+ * they clear WCAG 2.1 1.4.11 (`test/unit/themeContrast.test.ts`). One source so an
+ * edit to the rendered shade is necessarily an edit to the asserted shade: a
+ * hand-copied `theme.colors.blue[8]` in the test re-derived the shade the
+ * component was *supposed* to use, so re-pointing the icon at an inaccessible
+ * shade still passed. This is the lighter, single-source-of-truth counterpart to
+ * the rendered-pixel pins in `test/browser/themeContrast.test.ts`; the icon color
+ * is a literal here (a component-owned inline style), so a shared constant the
+ * component consumes is enough -- no render needed to catch a regression.
+ */
+
+/** A Mantine palette coordinate: a color name and a shade index (0-9). */
+export type PaletteShade = readonly [name: string, shade: number];
+
+/**
+ * The accept/reject drag-state icon colors as Mantine palette coordinates, per
+ * color scheme. The shade inverts with the scheme because the Dropzone's
+ * light-variant drag-over tint does -- a light shade 8 on the light tint, a dark
+ * shade 6 on the inverted dark tint -- so both branches are pinned (the
+ * `light-dark()` {@link FileDropzone} renders selects per scheme). The shade
+ * choices and their measured ratios are documented at the FileDropzone drag-icon
+ * styles and enforced in `test/unit/themeContrast.test.ts`.
+ */
+export const DROPZONE_DRAG_ICON = {
+  accept: { light: ["blue", 8], dark: ["blue", 6] },
+  reject: { light: ["red", 8], dark: ["red", 6] },
+} as const satisfies Record<
+  "accept" | "reject",
+  { light: PaletteShade; dark: PaletteShade }
+>;
+
+/** The CSS custom property naming a palette shade, e.g. `var(--mantine-color-blue-8)`. */
+const paletteVar = ([name, shade]: PaletteShade) =>
+  `var(--mantine-color-${name}-${shade})`;
+
+/**
+ * A `light-dark()` color selecting the scheme-appropriate drag-icon shade -- the
+ * form {@link FileDropzone} sets as the icon's inline `color`, which its stroke
+ * follows through `currentColor`.
+ */
+export const dragIconColor = (icon: {
+  light: PaletteShade;
+  dark: PaletteShade;
+}): string => `light-dark(${paletteVar(icon.light)}, ${paletteVar(icon.dark)})`;

--- a/apps/web/src/components/dropzoneDragIcons.ts
+++ b/apps/web/src/components/dropzoneDragIcons.ts
@@ -11,8 +11,10 @@
  * component consumes is enough -- no render needed to catch a regression.
  */
 
+import type { MantineColorShade } from "@mantine/core";
+
 /** A Mantine palette coordinate: a color name and a shade index (0-9). */
-export type PaletteShade = readonly [name: string, shade: number];
+export type PaletteShade = readonly [name: string, shade: MantineColorShade];
 
 /**
  * The accept/reject drag-state icon colors as Mantine palette coordinates, per

--- a/apps/web/test/browser/themeContrast.test.ts
+++ b/apps/web/test/browser/themeContrast.test.ts
@@ -199,10 +199,10 @@ describe("rendered theme colour contrast (WCAG 2.1 AA)", () => {
         ),
       );
       const ai = await waitForEl(".mantine-ActionIcon-root");
-      // Let the light-variant color resolve before sampling, as the filled cases
-      // do (they poll it to its expected value first). The exact shade is
-      // Mantine's to own here, so settle on a resolved rgb() rather than pin one.
-      await expect.poll(() => getComputedStyle(ai).color).toMatch(/^rgb/);
+      // Unlike the filled cases, this does not poll the color to an expected value
+      // first: the shade is Mantine's to own (no value to await), and Mantine sets
+      // --ai-color inline at render, so the element never exists without its
+      // resolved color -- waitForEl plus restingBackground already settle the read.
       const backgroundColor = await restingBackground(ai);
       const { color } = getComputedStyle(ai);
       expect(contrast(color, backgroundColor)).toBeGreaterThanOrEqual(3);

--- a/apps/web/test/browser/themeContrast.test.ts
+++ b/apps/web/test/browser/themeContrast.test.ts
@@ -199,6 +199,10 @@ describe("rendered theme colour contrast (WCAG 2.1 AA)", () => {
         ),
       );
       const ai = await waitForEl(".mantine-ActionIcon-root");
+      // Let the light-variant color resolve before sampling, as the filled cases
+      // do (they poll it to its expected value first). The exact shade is
+      // Mantine's to own here, so settle on a resolved rgb() rather than pin one.
+      await expect.poll(() => getComputedStyle(ai).color).toMatch(/^rgb/);
       const backgroundColor = await restingBackground(ai);
       const { color } = getComputedStyle(ai);
       expect(contrast(color, backgroundColor)).toBeGreaterThanOrEqual(3);

--- a/apps/web/test/browser/themeContrast.test.ts
+++ b/apps/web/test/browser/themeContrast.test.ts
@@ -25,8 +25,9 @@ const PrimaryCheckbox = Checkbox as unknown as ComponentType<{
   defaultChecked?: boolean;
   "aria-label"?: string;
 }>;
-const FilledActionIcon = ActionIcon as unknown as ComponentType<{
+const PrimaryActionIcon = ActionIcon as unknown as ComponentType<{
   children?: ReactNode;
+  variant?: string;
   "aria-label"?: string;
 }>;
 
@@ -39,9 +40,16 @@ const FilledActionIcon = ActionIcon as unknown as ComponentType<{
 // idealized autoContrast stayed green), so this measures the REAL computed colors
 // of all three contrast-routed filled-primary surfaces -- the Button label, the
 // (consent-gate) Checkbox checkmark, and the copy ActionIcon glyph -- in both schemes
-// and checks them against the WCAG 2.1 AA 1.4.3 text floor. The focus ring / input
-// border use the per-scheme --mantine-primary-color-filled directly (a plain shade
-// lookup, not the autoContrast path), so the unit test covers them.
+// and checks them against the WCAG 2.1 AA 1.4.3 text floor.
+//
+// It also pins the copied-state copy ActionIcon (ShareBlock flips it to
+// variant="light"): a non-text check glyph (1.4.11, 3:1) whose color Mantine owns
+// through --mantine-color-{primary}-light-color and resolves per scheme, with no
+// per-component constant to share -- so, like the filled surfaces, only a render
+// pins what it paints. The focus ring / input border (the per-scheme
+// --mantine-primary-color-filled, a plain shade lookup) and the Dropzone drag-icon
+// shades (a literal inline color shared with the unit test through
+// DROPZONE_DRAG_ICON) stay in the unit test, which checks them by arithmetic.
 
 let container: HTMLElement | undefined;
 let root: Root | undefined;
@@ -160,7 +168,7 @@ describe("rendered theme colour contrast (WCAG 2.1 AA)", () => {
       mount(
         scheme,
         createElement(
-          FilledActionIcon,
+          PrimaryActionIcon,
           { "aria-label": "copy" },
           createElement("span", null, "i"),
         ),
@@ -170,6 +178,30 @@ describe("rendered theme colour contrast (WCAG 2.1 AA)", () => {
       const backgroundColor = await restingBackground(ai);
       const { color } = getComputedStyle(ai);
       expect(contrast(color, backgroundColor)).toBeGreaterThanOrEqual(4.5);
+    });
+
+    test(`copied-state copy icon glyph is AA-legible (${scheme})`, async () => {
+      // ShareBlock swaps the copy ActionIcon to variant="light" once copied; the
+      // check glyph is a non-text graphic, so the WCAG 1.4.11 3:1 floor. Mantine
+      // owns this color: --ai-color resolves to --mantine-color-{primary}-light-color
+      // on the --mantine-color-{primary}-light tint, both per scheme (light: cyan-9
+      // on cyan-1; dark: cyan-0 on darken(cyan-9, .5)). No variant override touches
+      // the light variant, so this reads exactly what Mantine paints -- the dark
+      // branch in particular was never covered by the unit test's single light case.
+      // Resting bg via restingBackground so a stale hover (light-variant hover =
+      // cyan-2, a darker tint) is not sampled in place of the resting fill.
+      mount(
+        scheme,
+        createElement(
+          PrimaryActionIcon,
+          { variant: "light", "aria-label": "copied" },
+          createElement("span", null, "i"),
+        ),
+      );
+      const ai = await waitForEl(".mantine-ActionIcon-root");
+      const backgroundColor = await restingBackground(ai);
+      const { color } = getComputedStyle(ai);
+      expect(contrast(color, backgroundColor)).toBeGreaterThanOrEqual(3);
     });
   }
 

--- a/apps/web/test/unit/themeContrast.test.ts
+++ b/apps/web/test/unit/themeContrast.test.ts
@@ -4,6 +4,10 @@ import { DEFAULT_THEME, darken, mergeMantineTheme } from "@mantine/core";
 
 import { cssVariablesResolver, mantineTheme } from "@theme";
 
+import { DROPZONE_DRAG_ICON } from "@components/dropzoneDragIcons";
+
+import type { PaletteShade } from "@components/dropzoneDragIcons";
+
 // Enforces the WCAG 2.1 AA contrast invariants the theme is tuned to: 4.5:1 for
 // normal-weight text (1.4.3) and 3:1 for non-text UI / focus indicators (1.4.11).
 // The JSDoc in theme.ts records the chosen colors and their ratios; this is the
@@ -77,25 +81,29 @@ const darkShade =
 const darkPrimary = theme.colors[theme.primaryColor][darkShade];
 const white = theme.white;
 const gray0 = theme.colors.gray[0];
-const cyan1 = theme.colors.cyan[1];
 const yellow1 = theme.colors.yellow[1];
 const red1 = theme.colors.red[1];
 const dark7 = theme.colors.dark[7];
 const dark6 = theme.colors.dark[6];
 
 // Per-component Dropzone drag-state icon overrides (FileDropzone.tsx), not theme
-// tokens, so these are read straight off the palette and checked against the
-// Dropzone's light-variant drag-over tints. The tint inverts with the scheme so
-// the icon shade does too (light shade 8, dark shade 6, via light-dark):
+// tokens, checked against the Dropzone's light-variant drag-over tints. The icon
+// SHADES are read from DROPZONE_DRAG_ICON -- the same source FileDropzone paints
+// from -- so re-pointing the icon at an inaccessible shade is necessarily an edit
+// to this assertion's input, the gap a hand-copied `theme.colors.blue[8]` left
+// open. The tint inverts with the scheme so the icon shade does too (light shade
+// 8, dark shade 6, via the shared constant's per-scheme branches):
 //   - light tints: accept = primary colour shade 1 (Dropzone's acceptColor
 //     defaults to theme.primaryColor), reject = red-1 (its default rejectColor);
 //   - dark tints: darken(shade-9, .5), Mantine's dark `-light` variant -- the
 //     real darken() so a resolver change re-runs the arithmetic, not a restated
 //     constant.
-const dropzoneAcceptIconLight = theme.colors.blue[8];
-const dropzoneRejectIconLight = theme.colors.red[8];
-const dropzoneAcceptIconDark = theme.colors.blue[6];
-const dropzoneRejectIconDark = theme.colors.red[6];
+const paletteShade = ([name, shade]: PaletteShade): string =>
+  theme.colors[name][shade];
+const dropzoneAcceptIconLight = paletteShade(DROPZONE_DRAG_ICON.accept.light);
+const dropzoneRejectIconLight = paletteShade(DROPZONE_DRAG_ICON.reject.light);
+const dropzoneAcceptIconDark = paletteShade(DROPZONE_DRAG_ICON.accept.dark);
+const dropzoneRejectIconDark = paletteShade(DROPZONE_DRAG_ICON.reject.dark);
 const dropzoneAcceptTintLight = theme.colors[theme.primaryColor][1];
 const dropzoneAcceptTintDark = darken(theme.colors[theme.primaryColor][9], 0.5);
 const dropzoneRejectTintDark = darken(theme.colors.red[9], 0.5);
@@ -159,12 +167,12 @@ describe("theme colour contrast (WCAG 2.1 AA)", () => {
         bg: white,
         floor: 3,
       },
-      {
-        name: "copied-state copy icon: primary on cyan-1 (non-text)",
-        fg: primary,
-        bg: cyan1,
-        floor: 3,
-      },
+      // The copied-state copy icon (ShareBlock's variant="light" ActionIcon) is
+      // pinned in test/browser/themeContrast.test.ts instead: Mantine owns that
+      // glyph's color through --mantine-color-{primary}-light-color (hardcoded to
+      // shade 9, independent of primaryShade), so there is no per-component
+      // constant to share and re-deriving the shade here would be the same blind
+      // re-statement this harness avoids -- only a real render pins what it paints.
       // Dark scheme primary (shade 6): the counterpart to the light primary fix. A
       // lighter dark shade lifts the focus indicators on the dark surfaces, and the
       // filled-primary text -- routed to --mantine-primary-color-contrast (black on


### PR DESCRIPTION
## Summary

Close a gap in the web accessibility-contrast harness: it proved a chosen palette shade cleared the WCAG floor but did not pin the color a component literally renders, so re-pointing a component at an inaccessible shade still passed the harness. This sources the Dropzone drag-state icon colors from a single constant the component and the harness share, and render-pins the copied-state copy icon in both color schemes, so such a regression now fails. The enforced ratios and floors are unchanged; this tightens what gets compared.

Implements [203282650](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=203282650).

## Changes

- apps/web/src/components/dropzoneDragIcons.ts: new module exporting DROPZONE_DRAG_ICON (the per-scheme accept/reject drag-icon palette coordinates) and dragIconColor (builds the light-dark() string) -- the single source for those colors.
- apps/web/src/components/FileDropzone.tsx: paint the drag-state icons from dragIconColor(DROPZONE_DRAG_ICON.*) instead of inline literals; the rendered CSS string is identical.
- apps/web/test/unit/themeContrast.test.ts: source the dropzone icon shades from DROPZONE_DRAG_ICON (was hand-copied theme.colors.blue[8] etc.); drop the copied-state case (now render-pinned) and its now-unused tint.
- apps/web/test/browser/themeContrast.test.ts: render-pin the copied-state copy icon (ShareBlock's variant="light" ActionIcon) in both schemes against the 3:1 non-text floor.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format`; `npx vitest run --project unit test/unit/themeContrast.test.ts` (22 passed) and the full web unit project (558 passed); `npx vitest run --project browser test/browser/themeContrast.test.ts` (9 passed) and `test/browser/fileSelect.test.ts` (3 passed).
New tests cover: the copied-state copy icon's rendered contrast in light and dark (the dark branch was previously uncovered); and the dropzone drag-icon cases now fail when the shared shade constant is re-pointed to an inaccessible shade (verified by a temporary mutation, then reverted).

## Background

Two mechanisms by surface, by necessity. The Dropzone drag-icon color is a component-owned inline literal, so a shared constant both sides consume is enough -- and the drag-state icons exist in the DOM only mid-drag, which a render pin would have to simulate. The copied-state copy icon has no such literal: Mantine owns that color through its light variant, so only a real render pins what it paints, alongside the existing filled-primary cases.

## Out of scope / follow-on

- Drive the browser harness from the real components and the app's full provider config (it currently mounts bare Mantine stand-ins under a partial provider): [206942253](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=206942253).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier -- n/a: no documented behavior changed (test hardening plus a behavior-preserving component refactor that renders an identical CSS string).
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-only plus an internal refactor, no operator- or reviewer-visible change.
- [x] Security review -- independent application-security and security-convention review run as a precaution (the change touches the file-drop component); both cleared it, and no security-review-scope control (crypto, AEAD/bounds, credential/secret handling, auth/pinning, disclosure, or a security-relevant dependency) is altered, so none was formally required.
