### PR TITLE
Drive the web contrast browser harness from real components and the app provider

### DIFF
--- a/apps/web/src/components/TermsImportExport.tsx
+++ b/apps/web/src/components/TermsImportExport.tsx
@@ -197,7 +197,10 @@ export function TermsImportExport({
         </Alert>
       )}
       {imported && (
-        <Text size="xs" c="green">
+        // Route through the tuned accessible green (theme.ts STATUS_TEXT.success)
+        // rather than a bare c="green": that resolves to green-9, which is only
+        // 4.37:1 on the white page, under the WCAG 2.1 AA 1.4.3 text floor.
+        <Text size="xs" c="var(--mantine-color-green-light-color)">
           {IMPORT_SUCCESS}
         </Text>
       )}

--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -240,10 +240,12 @@ const MUTED_TEXT = {
 } as const;
 
 /**
- * Accessible text color for the yellow "warning" and red "error" Mantine `light`
- * variant surfaces in the light scheme -- the Alert title and icon, and the
- * yellow constraint-warning Badge label (the StandardizationPreview violation
- * badge). Mantine's default
+ * Accessible text color for the yellow "warning", red "error", and green
+ * "success" Mantine `light` variant surfaces in the light scheme -- the Alert
+ * title and icon, the yellow constraint-warning Badge label (the
+ * StandardizationPreview violation badge), and the green satisfiability surfaces
+ * (the "All keys can match" Alert in PrepareData; the satisfiable key Badges in
+ * ExpertKeyEditor / LinkageTermsEditor). Mantine's default
  * `--mantine-color-{c}-light-color` is the color's shade 9 on its shade-1 tint,
  * which fails WCAG 2.1 AA 1.4.3 for normal-weight text:
  * - yellow-9 (#e67700) on yellow-1 (#fff3bf) = 2.69:1 -- and no yellow/orange
@@ -251,13 +253,18 @@ const MUTED_TEXT = {
  *   leave the yellow ramp entirely.
  * - red-9 (#c92a2a) on red-1 (#ffe3e3) = 4.51:1 -- a hairline pass, fragile to a
  *   future palette nudge.
+ * - green-9 (#2b8a3e) on green-1 (#d3f9d8) = 3.81:1 -- and as plain page text
+ *   (the TermsImportExport import-success message, `c="green"` = green-9) =
+ *   4.37:1 on the white page.
  *
  * Darkened in-hue rather than to plain black so each title still reads as
- * amber/caution and red/error; warning-vs-error no longer rests on the title
- * color alone, because the Alerts now also carry a severity icon (WCAG 1.4.1).
- * Ratios against the real shade-1 tints:
+ * amber/caution, red/error, and green/success; the meaning no longer rests on
+ * the title color alone, because the Alerts also carry a severity icon (WCAG
+ * 1.4.1). Ratios against the real shade-1 tints:
  * - warning #92400e on yellow-1 = 6.36:1.
  * - error #a51111 on red-1 = 6.45:1.
+ * - success #22683a on green-1 = 5.89:1 (and 6.75:1 as page text on white,
+ *   6.41:1 on the gray-0 card -- see the success-text call site below).
  *
  * Only the light scheme is overridden -- it is where these failures are. The
  * dark scheme is left at Mantine's defaults, where the same tokens are a
@@ -268,6 +275,7 @@ const MUTED_TEXT = {
 const STATUS_TEXT = {
   warning: "#92400e",
   error: "#a51111",
+  success: "#22683a",
 } as const;
 
 /**
@@ -285,7 +293,7 @@ const ERROR_TEXT = "#c92a2a";
 
 /**
  * Raises the `dimmed` and input `placeholder` tokens to {@link MUTED_TEXT} in
- * both color schemes, and the yellow/red `light`-variant text tokens to
+ * both color schemes, and the yellow/red/green `light`-variant text tokens to
  * {@link STATUS_TEXT} plus the `error` token to {@link ERROR_TEXT} in the light
  * scheme. Mantine deep-merges this over the default resolver, so only the
  * overridden variables need be returned. Passed to `MantineProvider` in the root
@@ -298,6 +306,7 @@ export const cssVariablesResolver: CSSVariablesResolver = () => ({
     "--mantine-color-placeholder": MUTED_TEXT.light,
     "--mantine-color-yellow-light-color": STATUS_TEXT.warning,
     "--mantine-color-red-light-color": STATUS_TEXT.error,
+    "--mantine-color-green-light-color": STATUS_TEXT.success,
     "--mantine-color-error": ERROR_TEXT,
   },
   dark: {

--- a/apps/web/test/browser/themeContrast.test.ts
+++ b/apps/web/test/browser/themeContrast.test.ts
@@ -78,10 +78,11 @@ const StatusAlert = Alert as unknown as ComponentType<{
 //    error, and the yellow/red light-variant status text. The harness now mounts under
 //    the app's real cssVariablesResolver (see mount below), so these are exercised at
 //    the render level for the first time -- previously only the arithmetic unit test
-//    saw them. Each token's raised value clears the AA floor while Mantine's default
-//    (which the resolver overrides) fails it (e.g. placeholder gray-5 = 2.08:1), so a
-//    case's floor assertion doubles as proof the resolver reached the surface: drop
-//    the resolver and the failing default trips the floor.
+//    saw them. Each case pins the EXACT resolved token colour (proof the resolver
+//    reached the surface) as well as the AA floor (proof it is legible). Pinning the
+//    colour, not just the floor, is necessary: one default the resolver replaces
+//    (red's light-variant, red-9-on-red-1 = 4.51:1) already clears the floor, so a
+//    floor-only check would not notice that token regressing back to its default.
 
 let container: HTMLElement | undefined;
 let root: Root | undefined;
@@ -92,6 +93,20 @@ const SHARE = {
   deepLink: "https://example.test/accept#invitation-token",
   encoded: "INVITATION-TOKEN",
 };
+
+// Exact computed colours the resolver paints, pinned by the token cases below so a
+// case cannot pass on a coincidental value or a default that happens to clear the
+// floor. Mirror theme.ts: MUTED_TEXT (dimmed + placeholder) per scheme, ERROR_TEXT,
+// and STATUS_TEXT (yellow warning / red error), the last three light-scheme only.
+const MUTED_TEXT = {
+  light: "rgb(99, 107, 115)",
+  dark: "rgb(146, 150, 155)",
+} as const;
+const ERROR_TEXT = "rgb(201, 42, 42)";
+const STATUS_TEXT = {
+  yellow: "rgb(146, 64, 14)",
+  red: "rgb(165, 17, 17)",
+} as const;
 
 function mount(scheme: "light" | "dark", node: ReactNode) {
   container = document.createElement("div");
@@ -221,9 +236,17 @@ describe("rendered filled-primary contrast (WCAG 2.1 AA)", () => {
       // Query the first of the two copy buttons (the invitation-link row).
       mount(scheme, createElement(ShareBlock, SHARE));
       const ai = await waitForEl(".mantine-ActionIcon-root");
-      await expect.poll(() => getComputedStyle(ai).color).toBe(expectedText);
+      // Measure the glyph's OWN paint (its SVG stroke), not the ActionIcon root's
+      // color. The root always reports --ai-color, but the glyph only wears that by
+      // inheriting currentColor; reading the root would stay green if the glyph were
+      // re-wrapped to hardcode its own colour (a Gap A regression this case names).
+      // For the real control the two agree; the stroke is what the checkmark paints.
+      const glyph = await waitForEl(".mantine-ActionIcon-root svg");
+      await expect
+        .poll(() => getComputedStyle(glyph).stroke)
+        .toBe(expectedText);
       const backgroundColor = await restingBackground(ai);
-      const { color } = getComputedStyle(ai);
+      const color = getComputedStyle(glyph).stroke;
       expect(contrast(color, backgroundColor)).toBeGreaterThanOrEqual(4.5);
     });
 
@@ -245,11 +268,20 @@ describe("rendered filled-primary contrast (WCAG 2.1 AA)", () => {
       await expect
         .poll(() => ai.getAttribute("aria-label"))
         .toContain("copied");
+      // Query the glyph AFTER the flip: React swaps IconCopy for IconCheck, so the
+      // pre-click SVG node is stale. Measure the check glyph's own stroke, not the
+      // ActionIcon root (see the filled case).
+      const glyph = await waitForEl(".mantine-ActionIcon-root svg");
       // Resting bg via restingBackground so a stale hover (light-variant hover =
       // cyan-2, a darker tint) is not sampled in place of the resting fill.
       const backgroundColor = await restingBackground(ai);
-      const { color } = getComputedStyle(ai);
+      const color = getComputedStyle(glyph).stroke;
       expect(contrast(color, backgroundColor)).toBeGreaterThanOrEqual(3);
+      // useClipboard reverts `copied` to false 1000ms after writeText resolves, which
+      // would silently restore the (also-passing) filled colours. The reads above run
+      // well inside that window; assert we were still copied at read time so a
+      // pathologically slow run fails loudly rather than measuring the reverted state.
+      expect(ai.getAttribute("aria-label")).toContain("copied");
     });
   }
 
@@ -313,10 +345,12 @@ describe("rendered resolver-owned token contrast (WCAG 2.1 AA)", () => {
       );
       const text = await waitForEl('[data-testid="dimmed"]');
       const surface = await waitForEl('[data-testid="surface"]');
+      const color = getComputedStyle(text).color;
       const bg = getComputedStyle(surface).backgroundColor;
-      expect(contrast(getComputedStyle(text).color, bg)).toBeGreaterThanOrEqual(
-        4.5,
-      );
+      // Pin the resolved token colour (proof the resolver reached the surface), then
+      // the AA floor against the real body background.
+      expect(color).toBe(MUTED_TEXT[scheme]);
+      expect(contrast(color, bg)).toBeGreaterThanOrEqual(4.5);
     });
 
     test(`input placeholder is AA-legible (${scheme})`, async () => {
@@ -333,11 +367,10 @@ describe("rendered resolver-owned token contrast (WCAG 2.1 AA)", () => {
       const input = await waitForEl("input");
       const placeholderColor = getComputedStyle(input, "::placeholder").color;
       const bg = getComputedStyle(input).backgroundColor;
-      // Guard against a vacuous pass: if the ::placeholder pseudo read ever fell back
-      // to the input's own (dark, high-contrast) text color, the floor below would
-      // pass without measuring the placeholder token at all. The muted placeholder is
-      // deliberately lower-emphasis than the entered text, so the two must differ.
-      expect(placeholderColor).not.toBe(getComputedStyle(input).color);
+      // Pin the resolved token colour: this both proves the resolver reached the
+      // placeholder and guards the vacuous pass where the ::placeholder pseudo read
+      // falls back to the input's own (dark, high-contrast) text colour.
+      expect(placeholderColor).toBe(MUTED_TEXT[scheme]);
       expect(contrast(placeholderColor, bg)).toBeGreaterThanOrEqual(4.5);
     });
   }
@@ -368,16 +401,16 @@ describe("rendered resolver-owned token contrast (WCAG 2.1 AA)", () => {
       throw new Error("errored input has no aria-describedby message");
     const errorEl = await waitForEl(`#${CSS.escape(errorId)}`);
     const surface = await waitForEl('[data-testid="surface"]');
+    const color = getComputedStyle(errorEl).color;
     const bg = getComputedStyle(surface).backgroundColor;
-    expect(
-      contrast(getComputedStyle(errorEl).color, bg),
-    ).toBeGreaterThanOrEqual(4.5);
+    expect(color).toBe(ERROR_TEXT);
+    expect(contrast(color, bg)).toBeGreaterThanOrEqual(4.5);
   });
 
   for (const { color, label } of [
     { color: "yellow", label: "warning" },
     { color: "red", label: "error" },
-  ]) {
+  ] as const) {
     test(`${label} alert title is AA-legible (light)`, async () => {
       // --mantine-color-{color}-light-color on the {color}-light tint, raised by the
       // resolver in light (Mantine's yellow-9 on yellow-1 = 2.69:1 fails even 3:1;
@@ -396,10 +429,12 @@ describe("rendered resolver-owned token contrast (WCAG 2.1 AA)", () => {
       // change surfaces as a clear waitForEl timeout rather than a getComputedStyle
       // TypeError on a null cast.
       const title = await waitForEl('[role="alert"] [class*="title"]');
+      const titleColor = getComputedStyle(title).color;
       const bg = getComputedStyle(alert).backgroundColor;
-      expect(
-        contrast(getComputedStyle(title).color, bg),
-      ).toBeGreaterThanOrEqual(4.5);
+      // Pin the resolved status colour: unlike the other tokens, red's Mantine
+      // default clears the floor, so only pinning the colour catches it regressing.
+      expect(titleColor).toBe(STATUS_TEXT[color]);
+      expect(contrast(titleColor, bg)).toBeGreaterThanOrEqual(4.5);
     });
   }
 });

--- a/apps/web/test/browser/themeContrast.test.ts
+++ b/apps/web/test/browser/themeContrast.test.ts
@@ -357,11 +357,16 @@ describe("rendered resolver-owned token contrast (WCAG 2.1 AA)", () => {
         }),
       ),
     );
+    // The input references its validation message (the --mantine-color-error text)
+    // through aria-describedby; resolve that element within the container -- scoped
+    // to this mount and polled until present, not a global getElementById that could
+    // race the render or match another test's id. CSS.escape because React's useId
+    // ids contain colons, which are querySelector metacharacters.
     const input = await waitForEl("input");
-    const describedBy = input.getAttribute("aria-describedby");
-    const errorEl = describedBy
-      ? (document.getElementById(describedBy) as HTMLElement)
-      : await waitForEl('[class*="Error"]');
+    const errorId = input.getAttribute("aria-describedby");
+    if (errorId === null)
+      throw new Error("errored input has no aria-describedby message");
+    const errorEl = await waitForEl(`#${CSS.escape(errorId)}`);
     const surface = await waitForEl('[data-testid="surface"]');
     const bg = getComputedStyle(surface).backgroundColor;
     expect(
@@ -387,7 +392,10 @@ describe("rendered resolver-owned token contrast (WCAG 2.1 AA)", () => {
         ),
       );
       const alert = await waitForEl('[role="alert"]');
-      const title = alert.querySelector('[class*="title"]') as HTMLElement;
+      // Scope the title lookup to the alert and poll for it, so a Mantine markup
+      // change surfaces as a clear waitForEl timeout rather than a getComputedStyle
+      // TypeError on a null cast.
+      const title = await waitForEl('[role="alert"] [class*="title"]');
       const bg = getComputedStyle(alert).backgroundColor;
       expect(
         contrast(getComputedStyle(title).color, bg),

--- a/apps/web/test/browser/themeContrast.test.ts
+++ b/apps/web/test/browser/themeContrast.test.ts
@@ -1,23 +1,33 @@
 /// <reference types="@vitest/browser-playwright/context" />
 
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { userEvent } from "vitest/browser";
 
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
 import "@mantine/core/styles.css";
-import { ActionIcon, Button, Checkbox, MantineProvider } from "@mantine/core";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  MantineProvider,
+  Text,
+  TextInput,
+} from "@mantine/core";
 
-import { mantineTheme } from "@theme";
+import { ShareBlock } from "@components/ShareBlock";
+
+import { cssVariablesResolver, mantineTheme } from "@theme";
 
 import type { ComponentType, ReactNode } from "react";
 import type { Root } from "react-dom/client";
 
-// Button and Checkbox are polymorphic factory components; this is a `.ts` file (the
-// browser project globs `.ts`, not `.tsx`, so no JSX), and createElement cannot
-// resolve their overloaded type directly -- cast each to the plain component shape
-// this test renders.
+// Button / Checkbox / Text / TextInput / Alert are polymorphic factory components;
+// this is a `.ts` file (the browser project globs `.ts`, not `.tsx`, so no JSX), and
+// createElement cannot resolve their overloaded type directly -- cast each to the
+// plain component shape this test renders. ShareBlock is a plain function component
+// and needs no cast.
 const FilledButton = Button as unknown as ComponentType<{
   children?: ReactNode;
 }>;
@@ -25,34 +35,63 @@ const PrimaryCheckbox = Checkbox as unknown as ComponentType<{
   defaultChecked?: boolean;
   "aria-label"?: string;
 }>;
-const PrimaryActionIcon = ActionIcon as unknown as ComponentType<{
+const DimmedText = Text as unknown as ComponentType<{
+  c?: string;
+  "data-testid"?: string;
   children?: ReactNode;
-  variant?: string;
+}>;
+const AppInput = TextInput as unknown as ComponentType<{
+  placeholder?: string;
+  error?: ReactNode;
   "aria-label"?: string;
 }>;
+const StatusAlert = Alert as unknown as ComponentType<{
+  color?: string;
+  title?: ReactNode;
+  children?: ReactNode;
+}>;
 
-// Render-level counterpart to test/unit/themeContrast.test.ts. The unit test
-// asserts the palette arithmetic and that the theme ROUTES filled-primary text
-// through --mantine-primary-color-contrast; it cannot prove the browser actually
-// paints that color, because Mantine resolves a filled surface's text color
-// color-scheme-blind in JS. That blind spot already shipped one regression (a dark
-// button rendered white-on-cyan-6 = 2.79:1 while a unit test that modeled an
-// idealized autoContrast stayed green), so this measures the REAL computed colors
-// of all three contrast-routed filled-primary surfaces -- the Button label, the
-// (consent-gate) Checkbox checkmark, and the copy ActionIcon glyph -- in both schemes
-// and checks them against the WCAG 2.1 AA 1.4.3 text floor.
+// Render-level counterpart to test/unit/themeContrast.test.ts. The unit test asserts
+// the palette arithmetic (an idealized model); it cannot prove the browser actually
+// paints those colors, because Mantine resolves several theme colors in JS
+// color-scheme-blind. That blind spot already shipped one regression (a dark button
+// rendered white-on-cyan-6 = 2.79:1 while a unit test that modeled an idealized
+// autoContrast stayed green), so this measures the REAL computed colors the browser
+// paints, in both schemes, against the WCAG 2.1 AA floors.
 //
-// It also pins the copied-state copy ActionIcon (ShareBlock flips it to
-// variant="light"): a non-text check glyph (1.4.11, 3:1) whose color Mantine owns
-// through --mantine-color-{primary}-light-color and resolves per scheme, with no
-// per-component constant to share -- so, like the filled surfaces, only a render
-// pins what it paints. The focus ring / input border (the per-scheme
-// --mantine-primary-color-filled, a plain shade lookup) and the Dropzone drag-icon
-// shades (a literal inline color shared with the unit test through
-// DROPZONE_DRAG_ICON) stay in the unit test, which checks them by arithmetic.
+// Two groups:
+//  - Filled-primary surfaces (1.4.3 text, 4.5:1). The copy ActionIcon glyph is driven
+//    from the REAL component (ShareBlock's CopyRow), in both its filled and its copied
+//    (variant="light", a non-text glyph judged on 1.4.11's 3:1) states, so a
+//    contrast-affecting change authored inside that component -- an added color prop,
+//    a flipped variant conditional, a re-wrapped glyph -- fails here rather than
+//    slipping past a hardcoded stand-in. The Button label and consent Checkbox
+//    checkmark are rendered as bare Mantine defaults on purpose: the app paints those
+//    surfaces with a bare <Button>/<Checkbox> (the theme's default variant, no color)
+//    and no wrapping component, so a bare primitive IS what the app paints -- there is
+//    no component to author a regression into, and the theme's isFilledPrimary scoping
+//    (proven by the unit test) is what routes their contrast color. The focus ring /
+//    input border (a plain per-scheme shade) and the Dropzone drag-icon shades (a
+//    literal inline color shared with the unit test through DROPZONE_DRAG_ICON) stay
+//    in the unit test, which checks them by arithmetic.
+//  - Resolver-owned tokens (theme.ts cssVariablesResolver): dimmed, placeholder,
+//    error, and the yellow/red light-variant status text. The harness now mounts under
+//    the app's real cssVariablesResolver (see mount below), so these are exercised at
+//    the render level for the first time -- previously only the arithmetic unit test
+//    saw them. Each token's raised value clears the AA floor while Mantine's default
+//    (which the resolver overrides) fails it (e.g. placeholder gray-5 = 2.08:1), so a
+//    case's floor assertion doubles as proof the resolver reached the surface: drop
+//    the resolver and the failing default trips the floor.
 
 let container: HTMLElement | undefined;
 let root: Root | undefined;
+
+// ShareBlock renders a copy control per artifact; the copied color is theme-driven and
+// independent of the value, so any non-empty strings suffice.
+const SHARE = {
+  deepLink: "https://example.test/accept#invitation-token",
+  encoded: "INVITATION-TOKEN",
+};
 
 function mount(scheme: "light" | "dark", node: ReactNode) {
   container = document.createElement("div");
@@ -61,17 +100,31 @@ function mount(scheme: "light" | "dark", node: ReactNode) {
   root.render(
     createElement(
       MantineProvider,
-      { theme: mantineTheme, forceColorScheme: scheme },
+      // The app root (routes/__root.tsx) configures the provider with BOTH the theme
+      // and the cssVariablesResolver; render under the same config so a resolver
+      // override on a covered surface is exercised here, not only in the idealized
+      // arithmetic of the unit test.
+      { theme: mantineTheme, cssVariablesResolver, forceColorScheme: scheme },
       node,
     ),
   );
 }
+
+beforeEach(() => {
+  // Drive the real CopyButton without depending on the headless browser's clipboard
+  // permission or secure-context state: CopyRow's guard only needs navigator.clipboard
+  // to exist (it does in the browser project) and useClipboard only flips `copied`
+  // once writeText RESOLVES. Stubbing writeText to resolve makes the copied-state case
+  // deterministic; it is otherwise unused (the other cases never click).
+  vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+});
 
 afterEach(() => {
   root?.unmount();
   container?.remove();
   root = undefined;
   container = undefined;
+  vi.restoreAllMocks();
 });
 
 /** Wait for a mounted element (createRoot.render is not synchronous), then return
@@ -122,7 +175,7 @@ function contrast(a: string, b: string): number {
   return (hi + 0.05) / (lo + 0.05);
 }
 
-describe("rendered theme colour contrast (WCAG 2.1 AA)", () => {
+describe("rendered filled-primary contrast (WCAG 2.1 AA)", () => {
   // Black resolves brighter on cyan-6 (7.53) than white does on cyan-9 (5.59), so a
   // single >= 4.5 floor covers both schemes; expectedText pins WHICH text colour
   // renders, the half that regressed before. The background is read through
@@ -161,18 +214,12 @@ describe("rendered theme colour contrast (WCAG 2.1 AA)", () => {
       ).toBeGreaterThanOrEqual(4.5);
     });
 
-    test(`filled-primary action icon glyph is AA-legible (${scheme})`, async () => {
-      // The copy ActionIcon (ShareBlock) in its filled state; glyph colour is
-      // --ai-color, routed to the contrast variable. No variant prop -> the default
-      // filled, matching how the override is scoped.
-      mount(
-        scheme,
-        createElement(
-          PrimaryActionIcon,
-          { "aria-label": "copy" },
-          createElement("span", null, "i"),
-        ),
-      );
+    test(`filled copy icon glyph is AA-legible (${scheme})`, async () => {
+      // The REAL copy control (ShareBlock's CopyRow) in its resting, filled state.
+      // ShareBlock is the app's only filled-primary ActionIcon; its glyph colour is
+      // --ai-color, routed to the per-scheme contrast variable by the theme override.
+      // Query the first of the two copy buttons (the invitation-link row).
+      mount(scheme, createElement(ShareBlock, SHARE));
       const ai = await waitForEl(".mantine-ActionIcon-root");
       await expect.poll(() => getComputedStyle(ai).color).toBe(expectedText);
       const backgroundColor = await restingBackground(ai);
@@ -180,29 +227,26 @@ describe("rendered theme colour contrast (WCAG 2.1 AA)", () => {
       expect(contrast(color, backgroundColor)).toBeGreaterThanOrEqual(4.5);
     });
 
-    test(`copied-state copy icon glyph is AA-legible (${scheme})`, async () => {
-      // ShareBlock swaps the copy ActionIcon to variant="light" once copied; the
-      // check glyph is a non-text graphic, so the WCAG 1.4.11 3:1 floor. Mantine
-      // owns this color: --ai-color resolves to --mantine-color-{primary}-light-color
-      // on the --mantine-color-{primary}-light tint, both per scheme (light: cyan-9
-      // on cyan-1; dark: cyan-0 on darken(cyan-9, .5)). No variant override touches
-      // the light variant, so this reads exactly what Mantine paints -- the dark
-      // branch in particular was never covered by the unit test's single light case.
+    test(`copied copy icon glyph is AA-legible (${scheme})`, async () => {
+      // Drive the SAME real control into its copied state: CopyRow swaps the
+      // ActionIcon to variant="light" and the glyph to IconCheck once copied. The
+      // check glyph is a non-text graphic, so the WCAG 1.4.11 3:1 floor. Mantine owns
+      // this colour: --ai-color resolves to --mantine-color-{primary}-light-color on
+      // the --mantine-color-{primary}-light tint, both per scheme (light: cyan-9 on
+      // cyan-1; dark: cyan-0 on darken(cyan-9, .5)) -- no override touches the light
+      // variant, so this reads exactly what Mantine paints, including the dark branch
+      // the unit test's single light case never covered.
+      mount(scheme, createElement(ShareBlock, SHARE));
+      const ai = await waitForEl(".mantine-ActionIcon-root");
+      await userEvent.click(ai);
+      // The copied state is signalled by the ActionIcon's aria-label flipping to
+      // "<label> copied" (CopyRow); poll it rather than a timer so the read happens
+      // only once the variant has actually flipped to light.
+      await expect
+        .poll(() => ai.getAttribute("aria-label"))
+        .toContain("copied");
       // Resting bg via restingBackground so a stale hover (light-variant hover =
       // cyan-2, a darker tint) is not sampled in place of the resting fill.
-      mount(
-        scheme,
-        createElement(
-          PrimaryActionIcon,
-          { variant: "light", "aria-label": "copied" },
-          createElement("span", null, "i"),
-        ),
-      );
-      const ai = await waitForEl(".mantine-ActionIcon-root");
-      // Unlike the filled cases, this does not poll the color to an expected value
-      // first: the shade is Mantine's to own (no value to await), and Mantine sets
-      // --ai-color inline at render, so the element never exists without its
-      // resolved color -- waitForEl plus restingBackground already settle the read.
       const backgroundColor = await restingBackground(ai);
       const { color } = getComputedStyle(ai);
       expect(contrast(color, backgroundColor)).toBeGreaterThanOrEqual(3);
@@ -236,4 +280,118 @@ describe("rendered theme colour contrast (WCAG 2.1 AA)", () => {
     expect(restingContrast).toBeGreaterThanOrEqual(4.5);
     expect(restingContrast).toBeGreaterThan(hoverContrast);
   });
+});
+
+describe("rendered resolver-owned token contrast (WCAG 2.1 AA)", () => {
+  // dimmed and error text sit on the app body surface; wrap the render in a container
+  // painted with --mantine-color-body so the measured background is the real
+  // per-scheme body (white light / dark-7 dark) rather than a transparent ancestor.
+  function bodySurface(node: ReactNode): ReactNode {
+    return createElement(
+      "div",
+      {
+        "data-testid": "surface",
+        style: { background: "var(--mantine-color-body)" },
+      },
+      node,
+    );
+  }
+
+  for (const scheme of ["light", "dark"] as const) {
+    test(`dimmed text is AA-legible (${scheme})`, async () => {
+      // c="dimmed" -> --mantine-color-dimmed, raised by the resolver in both schemes
+      // (Mantine's gray-6 / dark-2 default fails 4.5:1 on the body).
+      mount(
+        scheme,
+        bodySurface(
+          createElement(
+            DimmedText,
+            { c: "dimmed", "data-testid": "dimmed" },
+            "Secondary supporting text",
+          ),
+        ),
+      );
+      const text = await waitForEl('[data-testid="dimmed"]');
+      const surface = await waitForEl('[data-testid="surface"]');
+      const bg = getComputedStyle(surface).backgroundColor;
+      expect(contrast(getComputedStyle(text).color, bg)).toBeGreaterThanOrEqual(
+        4.5,
+      );
+    });
+
+    test(`input placeholder is AA-legible (${scheme})`, async () => {
+      // --mantine-color-placeholder, raised by the resolver in both schemes (Mantine's
+      // gray-5 / dark-3 default is the lightest failing token, 2.08:1 / 2.47:1). The
+      // placeholder paints on the input's own fill (white light / dark-6 dark).
+      mount(
+        scheme,
+        createElement(AppInput, {
+          placeholder: "Your name",
+          "aria-label": "name",
+        }),
+      );
+      const input = await waitForEl("input");
+      const placeholderColor = getComputedStyle(input, "::placeholder").color;
+      const bg = getComputedStyle(input).backgroundColor;
+      // Guard against a vacuous pass: if the ::placeholder pseudo read ever fell back
+      // to the input's own (dark, high-contrast) text color, the floor below would
+      // pass without measuring the placeholder token at all. The muted placeholder is
+      // deliberately lower-emphasis than the entered text, so the two must differ.
+      expect(placeholderColor).not.toBe(getComputedStyle(input).color);
+      expect(contrast(placeholderColor, bg)).toBeGreaterThanOrEqual(4.5);
+    });
+  }
+
+  // error and the yellow/red light-variant status text are overridden by the resolver
+  // in the LIGHT scheme only (that is where the dark-on-light failures are; the dark
+  // scheme keeps Mantine's inverse near-white-on-tint arrangement, which passes).
+  test("error validation text is AA-legible (light)", async () => {
+    // --mantine-color-error, raised by the resolver in light (Mantine's red-6 default
+    // = 3.28:1 on the white page fails the 1.4.3 validation-text floor).
+    mount(
+      "light",
+      bodySurface(
+        createElement(AppInput, {
+          "aria-label": "field",
+          error: "This field is required",
+        }),
+      ),
+    );
+    const input = await waitForEl("input");
+    const describedBy = input.getAttribute("aria-describedby");
+    const errorEl = describedBy
+      ? (document.getElementById(describedBy) as HTMLElement)
+      : await waitForEl('[class*="Error"]');
+    const surface = await waitForEl('[data-testid="surface"]');
+    const bg = getComputedStyle(surface).backgroundColor;
+    expect(
+      contrast(getComputedStyle(errorEl).color, bg),
+    ).toBeGreaterThanOrEqual(4.5);
+  });
+
+  for (const { color, label } of [
+    { color: "yellow", label: "warning" },
+    { color: "red", label: "error" },
+  ]) {
+    test(`${label} alert title is AA-legible (light)`, async () => {
+      // --mantine-color-{color}-light-color on the {color}-light tint, raised by the
+      // resolver in light (Mantine's yellow-9 on yellow-1 = 2.69:1 fails even 3:1;
+      // red-9 on red-1 = 4.51:1 is a fragile hairline). The Alert owns both the title
+      // colour and its tint background, so this is self-contained.
+      mount(
+        "light",
+        createElement(
+          StatusAlert,
+          { color, title: "Heads up" },
+          "Body copy for the alert.",
+        ),
+      );
+      const alert = await waitForEl('[role="alert"]');
+      const title = alert.querySelector('[class*="title"]') as HTMLElement;
+      const bg = getComputedStyle(alert).backgroundColor;
+      expect(
+        contrast(getComputedStyle(title).color, bg),
+      ).toBeGreaterThanOrEqual(4.5);
+    });
+  }
 });

--- a/apps/web/test/browser/themeContrast.test.ts
+++ b/apps/web/test/browser/themeContrast.test.ts
@@ -35,7 +35,7 @@ const PrimaryCheckbox = Checkbox as unknown as ComponentType<{
   defaultChecked?: boolean;
   "aria-label"?: string;
 }>;
-const DimmedText = Text as unknown as ComponentType<{
+const ColoredText = Text as unknown as ComponentType<{
   c?: string;
   "data-testid"?: string;
   children?: ReactNode;
@@ -75,7 +75,8 @@ const StatusAlert = Alert as unknown as ComponentType<{
 //    literal inline color shared with the unit test through DROPZONE_DRAG_ICON) stay
 //    in the unit test, which checks them by arithmetic.
 //  - Resolver-owned tokens (theme.ts cssVariablesResolver): dimmed, placeholder,
-//    error, and the yellow/red light-variant status text. The harness now mounts under
+//    error, and the yellow/red/green light-variant status text (the last also as the
+//    green import-success page text). The harness now mounts under
 //    the app's real cssVariablesResolver (see mount below), so these are exercised at
 //    the render level for the first time -- previously only the arithmetic unit test
 //    saw them. Each case pins the EXACT resolved token colour (proof the resolver
@@ -96,8 +97,9 @@ const SHARE = {
 
 // Exact computed colours the resolver paints, pinned by the token cases below so a
 // case cannot pass on a coincidental value or a default that happens to clear the
-// floor. Mirror theme.ts: MUTED_TEXT (dimmed + placeholder) per scheme, ERROR_TEXT,
-// and STATUS_TEXT (yellow warning / red error), the last three light-scheme only.
+// floor. Mirror theme.ts: MUTED_TEXT (dimmed + placeholder) applies in both schemes;
+// ERROR_TEXT and STATUS_TEXT (yellow warning / red error / green success) are
+// light-scheme only.
 const MUTED_TEXT = {
   light: "rgb(99, 107, 115)",
   dark: "rgb(146, 150, 155)",
@@ -106,6 +108,7 @@ const ERROR_TEXT = "rgb(201, 42, 42)";
 const STATUS_TEXT = {
   yellow: "rgb(146, 64, 14)",
   red: "rgb(165, 17, 17)",
+  green: "rgb(34, 104, 58)",
 } as const;
 
 function mount(scheme: "light" | "dark", node: ReactNode) {
@@ -320,9 +323,9 @@ describe("rendered filled-primary contrast (WCAG 2.1 AA)", () => {
 });
 
 describe("rendered resolver-owned token contrast (WCAG 2.1 AA)", () => {
-  // dimmed and error text sit on the app body surface; wrap the render in a container
-  // painted with --mantine-color-body so the measured background is the real
-  // per-scheme body (white light / dark-7 dark) rather than a transparent ancestor.
+  // dimmed, error, and green page text sit on the app body surface; wrap the render
+  // in a container painted with --mantine-color-body so the measured background is
+  // the real per-scheme body (white light / dark-7 dark), not a transparent ancestor.
   function bodySurface(node: ReactNode): ReactNode {
     return createElement(
       "div",
@@ -342,7 +345,7 @@ describe("rendered resolver-owned token contrast (WCAG 2.1 AA)", () => {
         scheme,
         bodySurface(
           createElement(
-            DimmedText,
+            ColoredText,
             { c: "dimmed", "data-testid": "dimmed" },
             "Secondary supporting text",
           ),
@@ -380,9 +383,10 @@ describe("rendered resolver-owned token contrast (WCAG 2.1 AA)", () => {
     });
   }
 
-  // error and the yellow/red light-variant status text are overridden by the resolver
-  // in the LIGHT scheme only (that is where the dark-on-light failures are; the dark
-  // scheme keeps Mantine's inverse near-white-on-tint arrangement, which passes).
+  // error and the yellow/red/green light-variant status text are overridden by the
+  // resolver in the LIGHT scheme only (that is where the dark-on-light failures are;
+  // the dark scheme keeps Mantine's inverse near-white-on-tint arrangement, which
+  // passes).
   test("error validation text is AA-legible (light)", async () => {
     // --mantine-color-error, raised by the resolver in light (Mantine's red-6 default
     // = 3.28:1 on the white page fails the 1.4.3 validation-text floor).
@@ -412,8 +416,39 @@ describe("rendered resolver-owned token contrast (WCAG 2.1 AA)", () => {
     expect(contrast(color, bg)).toBeGreaterThanOrEqual(4.5);
   });
 
+  test("green status token is AA-legible as page text (light)", async () => {
+    // The green status token rendered as plain page text -- the surface
+    // TermsImportExport's import-success message uses, a white/body background
+    // distinct from the Alert case's green tint (a bare c="green" = green-9 is only
+    // 4.37:1 here, under the 1.4.3 floor). This pins the TOKEN on a page surface; it
+    // is deliberately a stand-in, not a render of TermsImportExport, so it does not
+    // catch that component reverting its c prop to "green" -- driving the real
+    // component to its imported state would pull its import-validation deps' mocks
+    // into this shared harness. That call-site is guarded by its own comment instead.
+    mount(
+      "light",
+      bodySurface(
+        createElement(
+          ColoredText,
+          {
+            c: "var(--mantine-color-green-light-color)",
+            "data-testid": "success",
+          },
+          "Terms imported",
+        ),
+      ),
+    );
+    const text = await waitForEl('[data-testid="success"]');
+    const surface = await waitForEl('[data-testid="surface"]');
+    const color = getComputedStyle(text).color;
+    const bg = getComputedStyle(surface).backgroundColor;
+    expect(color).toBe(STATUS_TEXT.green);
+    expect(contrast(color, bg)).toBeGreaterThanOrEqual(4.5);
+  });
+
   for (const { color, label } of [
     { color: "yellow", label: "warning" },
+    { color: "green", label: "success" },
     { color: "red", label: "error" },
   ] as const) {
     test(`${label} alert title is AA-legible (light)`, async () => {

--- a/apps/web/test/browser/themeContrast.test.ts
+++ b/apps/web/test/browser/themeContrast.test.ts
@@ -174,7 +174,11 @@ function channels(color: string): [number, number, number] {
   return [Number(m[0]), Number(m[1]), Number(m[2])];
 }
 
-/** WCAG 2.1 relative luminance of a computed color string. */
+/** WCAG 2.1 relative luminance of a computed color string. The 0.03928 threshold is
+ * the value printed in the WCAG 2.1 text (and used by Mantine's own luminance()), not
+ * the more precise 0.04045; keep it as-is so this matches the spec and the byte-for-
+ * byte copy in test/unit/themeContrast.test.ts (a naive "correction" would silently
+ * diverge the two harnesses). */
 function relativeLuminance(color: string): number {
   const linear = (v: number) =>
     v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
@@ -194,9 +198,10 @@ describe("rendered filled-primary contrast (WCAG 2.1 AA)", () => {
   // Black resolves brighter on cyan-6 (7.53) than white does on cyan-9 (5.59), so a
   // single >= 4.5 floor covers both schemes; expectedText pins WHICH text colour
   // renders, the half that regressed before. The background is read through
-  // restingBackground so a stale-pointer hover -- a lighter fill that dips the light
-  // case under the floor (only light: dark's hover fill is darker and raises the
-  // black-on-fill ratio) -- is never sampled in place of the resting fill.
+  // restingBackground so a stale-pointer hover fill -- in the light scheme one shade
+  // lighter (cyan-9 -> cyan-8), which drops white-on-fill under the floor -- is never
+  // sampled in place of the resting fill. Only light is at risk: the dark scheme's
+  // black-on-fill starts at 7.53:1 resting and clears the floor in either state.
   for (const { scheme, expectedText } of [
     { scheme: "light" as const, expectedText: "rgb(255, 255, 255)" },
     { scheme: "dark" as const, expectedText: "rgb(0, 0, 0)" },
@@ -239,8 +244,8 @@ describe("rendered filled-primary contrast (WCAG 2.1 AA)", () => {
       // Measure the glyph's OWN paint (its SVG stroke), not the ActionIcon root's
       // color. The root always reports --ai-color, but the glyph only wears that by
       // inheriting currentColor; reading the root would stay green if the glyph were
-      // re-wrapped to hardcode its own colour (a Gap A regression this case names).
-      // For the real control the two agree; the stroke is what the checkmark paints.
+      // re-wrapped to hardcode its own colour (the regression this case guards). For
+      // the real control the two agree; the stroke is what the checkmark paints.
       const glyph = await waitForEl(".mantine-ActionIcon-root svg");
       await expect
         .poll(() => getComputedStyle(glyph).stroke)

--- a/apps/web/test/unit/themeContrast.test.ts
+++ b/apps/web/test/unit/themeContrast.test.ts
@@ -83,6 +83,7 @@ const white = theme.white;
 const gray0 = theme.colors.gray[0];
 const yellow1 = theme.colors.yellow[1];
 const red1 = theme.colors.red[1];
+const green1 = theme.colors.green[1];
 const dark7 = theme.colors.dark[7];
 const dark6 = theme.colors.dark[6];
 
@@ -110,6 +111,7 @@ const dropzoneRejectTintDark = darken(theme.colors.red[9], 0.5);
 
 const warningText = vars.light["--mantine-color-yellow-light-color"];
 const errorText = vars.light["--mantine-color-red-light-color"];
+const successText = vars.light["--mantine-color-green-light-color"];
 const errorToken = vars.light["--mantine-color-error"];
 const dimmedLight = vars.light["--mantine-color-dimmed"];
 const placeholderLight = vars.light["--mantine-color-placeholder"];
@@ -211,6 +213,12 @@ describe("theme colour contrast (WCAG 2.1 AA)", () => {
         name: "error Alert title: deep red on red-1",
         fg: errorText,
         bg: red1,
+        floor: 4.5,
+      },
+      {
+        name: "success Alert title + Badge: deep green on green-1",
+        fg: successText,
+        bg: green1,
         floor: 4.5,
       },
       {


### PR DESCRIPTION
## Summary

The web accessibility-contrast browser harness measured WCAG 2.1 AA contrast on bare Mantine primitives rendered under a partial provider, so a contrast regression authored inside a real component -- or a change to a resolver-owned token -- could paint an inaccessible color it never saw. This drives each covered surface from the real component under the app's real `MantineProvider` (theme plus `cssVariablesResolver`), measures the glyph's own paint rather than an ancestor's inherited color, and extends coverage to the resolver-owned tokens that previously had only arithmetic checks. It also fixes two green light-scheme surfaces the hardened harness then flagged as failing the AA text floor -- the "All keys can match" Alert title and the import-success text -- tuning an accessible green the way the theme already tunes its yellow and red status text.

Implements [206942253](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=206942253).

## Changes

- apps/web/test/browser/themeContrast.test.ts: render the copy ActionIcon from the real `ShareBlock` in its filled and driven-copied states, reading the SVG glyph's own stroke so a re-colored glyph fails; mount under the app's `cssVariablesResolver`; add render cases pinning the resolver-owned tokens (dimmed, placeholder, error, yellow/red/green status, plus green as page text) at the exact painted color and the AA floor; keep the button and consent-checkbox as bare Mantine defaults (documented); scope and poll every element lookup (no null-suppressing casts, no global `getElementById`).
- apps/web/src/theme.ts: add an accessible in-hue green (#22683a) as `STATUS_TEXT.success` and override `--mantine-color-green-light-color` in the light scheme (5.89:1 on the green tint, 6.75:1 as page text).
- apps/web/src/components/TermsImportExport.tsx: route the import-success text through the tuned green token instead of a bare `c="green"` (green-9 was 4.37:1 on the page).
- apps/web/test/unit/themeContrast.test.ts: add the green light-color arithmetic assertion.

## Test plan

Ran: the browser contrast file (18 tests, run twice), the unit contrast file (23), the full web browser project `npx vitest run --project browser` (30 files / 286), and the full web unit project (28 / 559) -- all green. typecheck, lint, and format clean.
New tests cover: the real `ShareBlock` copy glyph contrast in filled and copied states (both schemes); the resolver-owned dimmed/placeholder/error/yellow/red/green tokens at the render level (green Alert title and green page text); a direct test of the `restingBackground` stale-hover de-flake invariant; and the green light-color ratio in the unit harness.

## Out of scope / follow-on

- [207020574](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=207020574): extract a shared real-provider browser mount helper and migrate the web browser suite onto it.
- [207020664](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=207020664): add an automated color-contrast sweep over representative rendered routes.
- [207020762](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=207020762): add a lint rule guarding the filled-primary contrast scope.
- Dark-scheme contrast gaps surfaced during review (a failing dark `error` token; red inline errors on dark cards) are latent -- the app renders light-only today -- and are best addressed together when the dark scheme is enabled.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed (a test harness plus a presentational status-color token).
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: presentational accessibility color tuning, consistent with the existing yellow/red/error status tokens; nothing an operator or reviewer acts on.
- [x] Security review -- done: independent review of the production change (theme.ts + TermsImportExport.tsx) confirmed it is presentational and touches no cryptographic, channel-security, credential/disclosure, auth, or dependency surface, and that the TermsImportExport import-validation chokepoint is unchanged.
