### PR TITLE
Consolidate CLI logging into configureLogging

### DIFF
--- a/apps/cli/src/commands/accept.ts
+++ b/apps/cli/src/commands/accept.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import { userInfo } from "node:os";
 
 import type { Argv, Arguments } from "yargs";
-import logLibrary from "loglevel";
 
 import {
   describeDecodeError,
@@ -30,12 +29,7 @@ import {
 import { detectFileConflicts } from "../fileUtils";
 import { parseSensitiveYaml } from "../sensitiveFile";
 import { resolveAtSignRefs } from "../util/atSignRefs";
-import {
-  configureLogFile,
-  configureStderrLogging,
-  type LogSink,
-  promptConfirm,
-} from "../util/cli";
+import { configureLogging, promptConfirm } from "../util/cli";
 import { resolveRecordOutput } from "../recordFile";
 import {
   checkLinkageSatisfiability,
@@ -615,7 +609,7 @@ const INVITATION_PREFLIGHT_MESSAGING: LinkagePreflightMessaging = {
 // --- Handler -----------------------------------------------------------------
 
 export async function handler(argv: Arguments): Promise<void> {
-  let logSink: LogSink | undefined;
+  let closeLogging: (() => void) | undefined;
   try {
     await runOrExit("accept", async () => {
       // Parse and apply the log level before creating the logger, so the
@@ -624,17 +618,18 @@ export async function handler(argv: Arguments): Promise<void> {
       // (e.g. an unrecognized --log-level) through the same error->exit path as
       // everything else, rather than yargs's noisier top-level catch.
       const options = parseCommonBootstrapArgs(argv);
-      // Install the logging sink before the level is applied and any logger is
-      // created, so getLogger("accept") below inherits it: the file sink when
-      // --log-file is given, otherwise the default stderr sink so stdout carries
-      // only result data (the exchange CSV when no OUTPUT_FILE positional is
-      // given). A missing parent directory is a UsageError -> exit 64 here.
-      logSink =
-        options.logFile !== undefined
-          ? configureLogFile(options.logFile)
-          : configureStderrLogging();
-      logLibrary.setDefaultLevel(options.logLevel);
-      const log = getLogger("accept");
+      // Install the sink, apply the level, and build getLogger("accept") through
+      // the shared configureLogging helper (in that order, so the logger inherits
+      // the sink): the file sink when --log-file is given, otherwise the default
+      // stderr sink so stdout carries only result data (the exchange CSV when no
+      // OUTPUT_FILE positional is given). A missing parent directory is a
+      // UsageError -> exit 64, mapped here by the enclosing runOrExit.
+      const { log, close } = configureLogging({
+        logLevel: options.logLevel,
+        logFile: options.logFile,
+        name: "accept",
+      });
+      closeLogging = close;
       const positionals = (argv["args"] as Array<string> | undefined) ?? [];
       const resolved = resolveAcceptPositionals(positionals);
       // --consent-to-terms records advance consent to the invitation's terms and
@@ -753,6 +748,6 @@ export async function handler(argv: Arguments): Promise<void> {
     // file sink) on the normal exit path. Writes are synchronous and already
     // durable, so the error path's process.exit (which bypasses this finally)
     // loses nothing -- this is only factory/descriptor cleanup.
-    logSink?.close();
+    closeLogging?.();
   }
 }

--- a/apps/cli/src/commands/exchange.ts
+++ b/apps/cli/src/commands/exchange.ts
@@ -1,6 +1,5 @@
 import type { Argv, Arguments } from "yargs";
 import fs from "node:fs";
-import logLibrary from "loglevel";
 import { userInfo } from "node:os";
 
 import {
@@ -32,8 +31,7 @@ import { resolveRecordOutput } from "../recordFile";
 import { parseSensitiveYaml } from "../sensitiveFile";
 import { resolveAtSignRefs, resolveExchangeSpecRefs } from "../util/atSignRefs";
 import {
-  configureLogFile,
-  configureStderrLogging,
+  configureLogging,
   exitWithError,
   parseOrExit,
   openInputSource,
@@ -627,17 +625,14 @@ export async function handler(argv: Arguments): Promise<void> {
     ...options
   } = parsed;
 
-  // Redirect logging to the file (if requested) before the level is applied and
-  // the logger is created, so getLogger("exchange") below inherits the file
-  // sink. A missing parent directory is a UsageError reported on stderr (the
-  // file is not the sink) and exits 64.
-  const logSink =
-    logFile !== undefined
-      ? parseOrExit(() => configureLogFile(logFile))
-      : configureStderrLogging();
-
-  logLibrary.setDefaultLevel(logLevel);
-  const log = getLogger("exchange");
+  // Install the sink, apply the level, and build getLogger("exchange") through the
+  // shared configureLogging helper (in that order, so the logger inherits the
+  // sink): the file sink when --log-file is given, otherwise the default stderr
+  // sink. A missing parent directory (configureLogFile) is a UsageError reported
+  // on stderr and mapped to exit 64 by parseOrExit here.
+  const { log, close: closeLogging } = parseOrExit(() =>
+    configureLogging({ logLevel, logFile, name: "exchange" }),
+  );
 
   try {
     try {
@@ -800,6 +795,6 @@ export async function handler(argv: Arguments): Promise<void> {
     // file sink) on the normal exit path. Writes are synchronous and already
     // durable, so exitWithError's process.exit (which bypasses this finally)
     // loses nothing -- this is only factory/descriptor cleanup.
-    logSink.close();
+    closeLogging();
   }
 }

--- a/apps/cli/src/commands/fingerprint.ts
+++ b/apps/cli/src/commands/fingerprint.ts
@@ -21,8 +21,7 @@ import {
   saveSigningIdentity,
 } from "../signingIdentityFile";
 import {
-  configureLogFile,
-  configureStderrLogging,
+  configureLogging,
   exitWithError,
   LOG_LEVELS,
   parseOrExit,
@@ -320,23 +319,23 @@ export async function handler(argv: Arguments): Promise<void> {
       throw new UsageError(`unrecognized log-level: ${argv["log-level"]}`);
     return resolved;
   });
-  // Install the logging sink before the level is applied and the logger is
-  // created, so getLogger("fingerprint") below inherits it: the file sink when
-  // --log-file is given, otherwise the default stderr sink, so the command's
-  // logged diagnostics (the preflight warnings and the report's banner, bound
-  // identity, regeneration warning, and sharing instructions) stay off stdout.
-  // report() prints only the bare fingerprint value through console.log;
-  // everything else it emits routes through this logger. singleValue rejects a
-  // repeated --log-file and configureLogFile rejects an unopenable path; both are
-  // UsageErrors mapped to stderr + exit 64 here.
-  const logSink = parseOrExit(() => {
-    const logFilePath = singleValue(argv, "log-file") as string | undefined;
-    return logFilePath !== undefined
-      ? configureLogFile(logFilePath)
-      : configureStderrLogging();
-  });
-  logLibrary.setDefaultLevel(logLevel);
-  const log = getLogger("fingerprint");
+  // Install the sink, apply the level, and build getLogger("fingerprint") through
+  // the shared configureLogging helper (in that order, so the logger inherits the
+  // sink): the file sink when --log-file is given, otherwise the default stderr
+  // sink, so the command's logged diagnostics (the preflight warnings and the
+  // report's banner, bound identity, regeneration warning, and sharing
+  // instructions) stay off stdout. report() prints only the bare fingerprint value
+  // through console.log; everything else it emits routes through this logger.
+  // singleValue rejects a repeated --log-file and configureLogFile rejects an
+  // unopenable path; both are UsageErrors mapped to stderr + exit 64 by the
+  // surrounding parseOrExit.
+  const { log, close: closeLogging } = parseOrExit(() =>
+    configureLogging({
+      logLevel,
+      logFile: singleValue(argv, "log-file") as string | undefined,
+      name: "fingerprint",
+    }),
+  );
 
   try {
     // Read the single-value flags through singleValue inside the try so a
@@ -407,6 +406,6 @@ export async function handler(argv: Arguments): Promise<void> {
     // file sink) on the normal exit path. Writes are synchronous and already
     // durable, so exitWithError's process.exit (which bypasses this finally)
     // loses nothing -- this is only factory/descriptor cleanup.
-    logSink.close();
+    closeLogging();
   }
 }

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -1,5 +1,4 @@
 import type { Argv, Arguments } from "yargs";
-import logLibrary from "loglevel";
 
 import { getDefaultLinkageTerms, getLogger, UsageError } from "@psilink/core";
 
@@ -13,9 +12,7 @@ import {
 import { renderConfigTemplate } from "../configTemplate";
 import type { TemplateDataSpec } from "../configTemplate";
 import {
-  configureLogFile,
-  configureStderrLogging,
-  type LogSink,
+  configureLogging,
   LOG_LEVELS,
   promptConfirm,
   singleValue,
@@ -76,7 +73,7 @@ export function builder(cmd: Argv): Argv {
 }
 
 export async function handler(argv: Arguments): Promise<void> {
-  let logSink: LogSink | undefined;
+  let closeLogging: (() => void) | undefined;
   try {
     await runOrExit("init", async () => {
       // Resolve the log level before creating the logger (loglevel binds a
@@ -89,18 +86,18 @@ export async function handler(argv: Arguments): Promise<void> {
       const logLevel = LOG_LEVELS[rawLogLevel];
       if (logLevel === undefined)
         throw new UsageError(`unrecognized log-level: ${argv["log-level"]}`);
-      // Install the logging sink before the level is applied and any logger is
-      // created, so getLogger("init") below inherits it: the file sink when
-      // --log-file is given, otherwise the default stderr sink so stdout carries
-      // only result data. A missing parent directory is a UsageError -> exit 64
-      // here.
-      const logFile = singleValue(argv, "log-file") as string | undefined;
-      logSink =
-        logFile !== undefined
-          ? configureLogFile(logFile)
-          : configureStderrLogging();
-      logLibrary.setDefaultLevel(logLevel);
-      const log = getLogger("init");
+      // Install the sink, apply the level, and build getLogger("init") through the
+      // shared configureLogging helper (in that order, so the logger inherits the
+      // sink): the file sink when --log-file is given, otherwise the default stderr
+      // sink so stdout carries only result data. A missing parent directory
+      // (configureLogFile) or a repeated --log-file (singleValue) is a UsageError
+      // -> exit 64, mapped here by the enclosing runOrExit.
+      const { log, close } = configureLogging({
+        logLevel,
+        logFile: singleValue(argv, "log-file") as string | undefined,
+        name: "init",
+      });
+      closeLogging = close;
 
       const configFile =
         expandTilde(singleValue(argv, "config-file") as string | undefined) ??
@@ -165,7 +162,7 @@ export async function handler(argv: Arguments): Promise<void> {
     // file sink) on the normal exit path. Writes are synchronous and already
     // durable, so the error path's process.exit (which bypasses this finally)
     // loses nothing -- this is only factory/descriptor cleanup.
-    logSink?.close();
+    closeLogging?.();
   }
 }
 

--- a/apps/cli/src/commands/invite.ts
+++ b/apps/cli/src/commands/invite.ts
@@ -1,5 +1,4 @@
 import type { Argv, Arguments } from "yargs";
-import logLibrary from "loglevel";
 import { userInfo } from "node:os";
 
 import {
@@ -26,9 +25,7 @@ import { detectFileConflicts } from "../fileUtils";
 import { resolveRecordOutput } from "../recordFile";
 import { DURATION_VALUE_HELP, parseDuration } from "../util/duration";
 import {
-  configureLogFile,
-  configureStderrLogging,
-  type LogSink,
+  configureLogging,
   durationFlagSeconds,
   MAX_TIMEOUT_SECONDS,
   singleValue,
@@ -540,7 +537,7 @@ export async function validateInvite(params: {
 // --- Handler -----------------------------------------------------------------
 
 export async function handler(argv: Arguments): Promise<void> {
-  let logSink: LogSink | undefined;
+  let closeLogging: (() => void) | undefined;
   try {
     await runOrExit("invite", async () => {
       // Parse and apply the log level before creating the logger, so the
@@ -549,17 +546,18 @@ export async function handler(argv: Arguments): Promise<void> {
       // (e.g. an unrecognized --log-level) through the same error->exit path as
       // everything else, rather than yargs's noisier top-level catch.
       const options = parseCommonBootstrapArgs(argv);
-      // Install the logging sink before the level is applied and any logger is
-      // created, so getLogger("invite") below inherits it: the file sink when
-      // --log-file is given, otherwise the default stderr sink so stdout carries
-      // only the invitation token. A missing parent directory is a UsageError ->
-      // exit 64 here.
-      logSink =
-        options.logFile !== undefined
-          ? configureLogFile(options.logFile)
-          : configureStderrLogging();
-      logLibrary.setDefaultLevel(options.logLevel);
-      const log = getLogger("invite");
+      // Install the sink, apply the level, and build getLogger("invite") through
+      // the shared configureLogging helper (in that order, so the logger inherits
+      // the sink): the file sink when --log-file is given, otherwise the default
+      // stderr sink so stdout carries only the invitation token. A missing parent
+      // directory is a UsageError -> exit 64, mapped here by the enclosing
+      // runOrExit.
+      const { log, close } = configureLogging({
+        logLevel: options.logLevel,
+        logFile: options.logFile,
+        name: "invite",
+      });
+      closeLogging = close;
       // accept-timeout is parsed to seconds here (not in validateInvite) so a
       // malformed or bare-integer value is a clean usage error (exit 64) before any
       // side effect; durationFlagSeconds also rejects a repeat (via singleValue)
@@ -674,7 +672,7 @@ export async function handler(argv: Arguments): Promise<void> {
     // file sink) on the normal exit path. Writes are synchronous and already
     // durable, so the error path's process.exit (which bypasses this finally)
     // loses nothing -- this is only factory/descriptor cleanup.
-    logSink?.close();
+    closeLogging?.();
   }
 }
 

--- a/apps/cli/src/commands/zeroSetup.ts
+++ b/apps/cli/src/commands/zeroSetup.ts
@@ -1,7 +1,6 @@
 import type { Argv, Arguments } from "yargs";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
-import logLibrary from "loglevel";
 import { userInfo } from "node:os";
 
 import {
@@ -33,8 +32,7 @@ import { resolveRecordOutput } from "../recordFile";
 import { resolveConnectionCredentials } from "../util/atSignRefs";
 import { establishHostKeyTrust } from "../hostKeyTrust";
 import {
-  configureLogFile,
-  configureStderrLogging,
+  configureLogging,
   exitWithError,
   parseOrExit,
   openInputSource,
@@ -515,17 +513,14 @@ export async function handler(argv: Arguments): Promise<void> {
     ...options
   } = parsed;
 
-  // Redirect logging to the file (if requested) before the level is applied and
-  // the logger is created, so getLogger("psilink") below inherits the file sink.
-  // A missing parent directory is a UsageError reported on stderr (the file is
-  // not the sink) and exits 64.
-  const logSink =
-    logFile !== undefined
-      ? parseOrExit(() => configureLogFile(logFile))
-      : configureStderrLogging();
-
-  logLibrary.setDefaultLevel(logLevel);
-  const log = getLogger("psilink");
+  // Install the sink, apply the level, and build getLogger("psilink") through the
+  // shared configureLogging helper (in that order, so the logger inherits the
+  // sink): the file sink when --log-file is given, otherwise the default stderr
+  // sink. A missing parent directory (configureLogFile) is a UsageError reported
+  // on stderr and mapped to exit 64 by parseOrExit here.
+  const { log, close: closeLogging } = parseOrExit(() =>
+    configureLogging({ logLevel, logFile, name: "psilink" }),
+  );
 
   try {
     try {
@@ -716,6 +711,6 @@ export async function handler(argv: Arguments): Promise<void> {
     // Writes are synchronous and already durable, so exitWithError's process.exit
     // (which bypasses this finally) loses nothing -- this is only
     // factory/descriptor cleanup.
-    logSink.close();
+    closeLogging();
   }
 }

--- a/apps/cli/src/util/cli.ts
+++ b/apps/cli/src/util/cli.ts
@@ -6,6 +6,7 @@ import type { Arguments } from "yargs";
 
 import {
   getDiagnosticSink,
+  getLogger,
   sanitizeErrorForDisplay,
   setDiagnosticSink,
   UsageError,
@@ -398,6 +399,56 @@ export function configureStderrLogging(): LogSink {
       // back out of a log call into the exchange.
     }
   });
+}
+
+/**
+ * The logger-and-cleanup pair returned by {@link configureLogging}: the command's
+ * logger, built after the sink and level are installed, and a `close` that
+ * restores the prior diagnostic sink and releases any file descriptor.
+ */
+export interface ConfiguredLogging {
+  /** The command's logger, created after the sink is installed and the level applied. */
+  log: ReturnType<typeof getLogger>;
+  /**
+   * Restore the diagnostic sink in place before the redirect and, for the file
+   * sink, close the underlying descriptor; best-effort and idempotent. A handler
+   * calls this in its `finally`; the error path's `process.exit` bypasses it, but
+   * the sink's writes are synchronous and already durable, so nothing is lost.
+   */
+  close(): void;
+}
+
+/**
+ * The one logging bootstrap every command handler shares: pick the diagnostic
+ * sink ({@link configureLogFile} when `logFile` is given, else the default
+ * {@link configureStderrLogging}), apply the resolved `logLevel`, and build the
+ * logger named `name` -- in that order, because core's sink must be installed and
+ * the level set before {@link getLogger} constructs the logger that inherits
+ * them. Returns the logger plus a single `close` that restores the prior sink and
+ * releases any file descriptor, so a handler installs and tears down its logging
+ * through one call rather than repeating the sink/level/getLogger/close sequence.
+ *
+ * `logLevel` and `logFile` are resolved by the caller -- through
+ * {@link LOG_LEVELS} inline, or `parseCommonBootstrapArgs` -- so this helper does
+ * no argv parsing and neither reads nor validates flags. It composes the two sink
+ * builders without changing them: {@link configureLogFile} still throws a
+ * {@link UsageError} on an unopenable `--log-file` path, so a caller keeps that
+ * mapped to exit 64 by invoking this inside its existing usage boundary
+ * ({@link parseOrExit}, or a command's `runOrExit`).
+ */
+export function configureLogging(params: {
+  logLevel: logLibrary.LogLevelNumbers;
+  logFile: string | undefined;
+  name: string;
+}): ConfiguredLogging {
+  const { logLevel, logFile, name } = params;
+  const sink =
+    logFile !== undefined
+      ? configureLogFile(logFile)
+      : configureStderrLogging();
+  logLibrary.setDefaultLevel(logLevel);
+  const log = getLogger(name);
+  return { log, close: () => sink.close() };
 }
 
 // Write the whole buffer to `fd`, looping over a partial write. fs.writeSync on a

--- a/apps/cli/test/unit/configureLogging.test.ts
+++ b/apps/cli/test/unit/configureLogging.test.ts
@@ -6,6 +6,7 @@ import logLibrary from "loglevel";
 import {
   getDiagnosticSink,
   setDiagnosticSink,
+  UsageError,
   type DiagnosticSink,
 } from "@psilink/core";
 
@@ -117,6 +118,33 @@ test("configureLogging: without a logFile, routes diagnostics to stderr, never s
   expect(stdoutWrites.join("")).toBe("");
   // No file is opened on the stderr branch.
   expect(fs.readdirSync(tmpDir)).toHaveLength(0);
+});
+
+// --- an unopenable --log-file surfaces as a UsageError -----------------------
+
+test("configureLogging: an unopenable logFile throws UsageError and installs no sink", () => {
+  // The helper is the single seam all six handlers route through, so its
+  // --log-file failure contract is load-bearing: configureLogFile opens the file
+  // synchronously and throws a UsageError on a missing parent directory, and
+  // configureLogging must let that propagate (not swallow or reshape it) so each
+  // handler's parseOrExit/runOrExit maps it to exit 64. The sink open runs before
+  // setDefaultLevel/getLogger, so a failed open must also leave the diagnostic
+  // sink untouched -- pin both, so a regression that catches the throw, or installs
+  // the sink before opening, is caught here rather than silently breaking
+  // --log-file for every command at once.
+  const before = getDiagnosticSink();
+  const logPath = path.join(tmpDir, "does-not-exist", "run.log");
+  expect(() =>
+    configureLogging({
+      logLevel: logLibrary.levels.INFO,
+      logFile: logPath,
+      name: "configlog-unopenable",
+    }),
+  ).toThrow(UsageError);
+  // The failed open installed nothing: the diagnostic sink is left as it was, and
+  // the synchronous open created no directory.
+  expect(getDiagnosticSink()).toBe(before);
+  expect(fs.existsSync(path.join(tmpDir, "does-not-exist"))).toBe(false);
 });
 
 // --- the closer's factory-restore --------------------------------------------

--- a/apps/cli/test/unit/configureLogging.test.ts
+++ b/apps/cli/test/unit/configureLogging.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import logLibrary from "loglevel";
+import {
+  getDiagnosticSink,
+  setDiagnosticSink,
+  type DiagnosticSink,
+} from "@psilink/core";
+
+import { configureLogging } from "../../src/util/cli";
+
+// configureLogging is the one logging bootstrap all six command handlers share:
+// it picks the file-or-stderr sink, applies the level, and builds the named
+// logger, returning that logger plus a single closer. These tests exercise both
+// sink branches and the closer's sink-restore directly, so a regression in the
+// shared seam surfaces here rather than through six per-command handler tests.
+// They snapshot and restore core's process-wide diagnostic sink -- and the level
+// -- around each case, and name each logger uniquely so state never bleeds across
+// tests.
+
+let tmpDir: string;
+let originalSink: DiagnosticSink | undefined;
+let originalLevel: number;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-configlog-"));
+  originalSink = getDiagnosticSink();
+  originalLevel = logLibrary.getLevel();
+});
+
+afterEach(() => {
+  setDiagnosticSink(originalSink);
+  logLibrary.setLevel(
+    originalLevel as Parameters<typeof logLibrary.setLevel>[0],
+  );
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// --- file-sink branch (logFile given) ----------------------------------------
+
+test("configureLogging: with a logFile, routes the named logger's output to the file", () => {
+  const logPath = path.join(tmpDir, "run.log");
+  const { log, close } = configureLogging({
+    logLevel: logLibrary.levels.INFO,
+    logFile: logPath,
+    name: "configlog-file",
+  });
+  try {
+    log.info("hello from the file branch");
+  } finally {
+    close();
+  }
+  // The logger carries the requested name and the file captures its output with
+  // the standard [LEVEL] [CONTEXT] prefix -- so the helper installed the file sink
+  // and built the logger under it, in that order.
+  const contents = fs.readFileSync(logPath, "utf8");
+  expect(contents).toMatch(
+    /\[INFO\] \[configlog-file\] hello from the file branch/,
+  );
+});
+
+test("configureLogging: applies the resolved level before building the logger", () => {
+  // Level filtering happens before the sink: SILENT installs noop for every
+  // method, so nothing reaches the file even though it was opened. This pins that
+  // the helper's setDefaultLevel takes effect for the logger it then builds.
+  const logPath = path.join(tmpDir, "silent.log");
+  const { log, close } = configureLogging({
+    logLevel: logLibrary.levels.SILENT,
+    logFile: logPath,
+    name: "configlog-silent",
+  });
+  try {
+    log.error("should not appear");
+    log.info("nor this");
+  } finally {
+    close();
+  }
+  expect(fs.readFileSync(logPath, "utf8")).toBe("");
+});
+
+// --- stderr-sink branch (logFile undefined) ----------------------------------
+
+test("configureLogging: without a logFile, routes diagnostics to stderr, never stdout", () => {
+  // The default sink reserves stdout for result data, so info -- which loglevel
+  // would otherwise send to stdout -- must land on stderr and stdout must stay
+  // clean.
+  const stdoutWrites: string[] = [];
+  const stderrWrites: string[] = [];
+  const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
+    chunk: string | Uint8Array,
+  ) => {
+    stdoutWrites.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write);
+  const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(((
+    chunk: string | Uint8Array,
+  ) => {
+    stderrWrites.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write);
+  const { log, close } = configureLogging({
+    logLevel: logLibrary.levels.INFO,
+    logFile: undefined,
+    name: "configlog-stderr",
+  });
+  try {
+    log.info("an info diagnostic line");
+  } finally {
+    close();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  }
+  expect(stderrWrites.join("")).toContain("an info diagnostic line");
+  expect(stderrWrites.join("")).toContain("[INFO]");
+  expect(stdoutWrites.join("")).toBe("");
+  // No file is opened on the stderr branch.
+  expect(fs.readdirSync(tmpDir)).toHaveLength(0);
+});
+
+// --- the closer's factory-restore --------------------------------------------
+
+test("configureLogging: close() restores the diagnostic sink in place before it (file sink)", () => {
+  const before = getDiagnosticSink();
+  const { close } = configureLogging({
+    logLevel: logLibrary.levels.INFO,
+    logFile: path.join(tmpDir, "restore.log"),
+    name: "configlog-restore-file",
+  });
+  expect(getDiagnosticSink()).not.toBe(before);
+  close();
+  expect(getDiagnosticSink()).toBe(before);
+});
+
+test("configureLogging: close() restores the diagnostic sink in place before it (stderr sink)", () => {
+  const before = getDiagnosticSink();
+  const { close } = configureLogging({
+    logLevel: logLibrary.levels.INFO,
+    logFile: undefined,
+    name: "configlog-restore-stderr",
+  });
+  expect(getDiagnosticSink()).not.toBe(before);
+  close();
+  expect(getDiagnosticSink()).toBe(before);
+});


### PR DESCRIPTION
## Summary

Extract the logging bootstrap that six CLI command handlers each repeated -- pick the file-or-stderr diagnostic sink, apply the resolved log level, build the named logger, and close the sink in a `finally` -- into one `configureLogging` helper in `apps/cli/src/util/cli.ts`, and route all six handlers through it. A design-review finding flagged the six-way duplication as the maintainability risk of the diagnostics-to-stderr work: the next logging change would otherwise have to touch six files identically. Pure refactor, no observable behavior change.

Implements [207023517](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=207023517).

## Changes

- `apps/cli/src/util/cli.ts`: add `configureLogging({ logLevel, logFile, name }) -> { log, close }`, composing the existing `configureLogFile`/`configureStderrLogging` sink builders; it installs the sink, applies the level, then builds the logger in that order, returning the logger plus one closer.
- `apps/cli/src/commands/{accept,exchange,invite,zeroSetup,init,fingerprint}.ts`: replace each handler's inlined sink/level/getLogger/close block with a call to the helper. Each keeps its own log-level resolution (inline for fingerprint/init, `parseCommonBootstrapArgs` for the rest) and its existing usage boundary, so the UsageError -> exit-64 mapping (`parseOrExit` for exchange/zeroSetup/fingerprint, `runOrExit` for accept/invite/init) is unchanged. Logger names are preserved (`psilink` for zero-setup).
- `apps/cli/test/unit/configureLogging.test.ts`: new focused test for the helper -- file-sink and stderr-sink branches, level-before-logger ordering, the closer's sink-restore, and that an unopenable `--log-file` surfaces as a `UsageError` without installing a sink.

## Test plan

Ran: `npm run typecheck && npm run lint && npm run format`; `npm run test:unit -w apps/cli` (964 pass); `npm run test:integration -w apps/cli` (35 pass, 3 skipped -- the console sentinel that guards diagnostic routing stays green under the refactor); `npx vitest run apps/cli/test/unit/configureLogging.test.ts` (6 pass).
New tests cover: the helper's file/stderr sink selection, that `setDefaultLevel` takes effect before `getLogger`, the closer restoring the prior diagnostic sink on both branches, and the unopenable-`--log-file` `UsageError` propagating out of the helper (the exit-64 contract all six handlers share).

## Background

The change preserves every disclosure and fail-closed guarantee the diagnostics-to-stderr work established: stdout stays reserved for result data (the exchange CSV, the invitation token, the `fingerprint` value), the `--log-file` remains owner-only (`0600`), diagnostics stay sanitized, and a bad flag still maps to exit 64. The underlying sink builders and their restore-then-close ordering are untouched -- the helper only sequences them.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; internal extraction of the apps/cli logging bootstrap, user-facing logging and exit behavior identical.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: internal refactor, apps/cli only, no operator- or reviewer-visible behavior change.
- [x] Security review -- done: the refactor modifies the diagnostic-sink bootstrap (a disclosure control), so three independent reviewers verified stdout purity, owner-only `--log-file`, sanitized error routing, and the fail-closed UsageError -> exit-64 mapping are all preserved, with no change to what is disclosed.
