### PR TITLE
Add plain-unmount abort test for ExchangeView

### DIFF
--- a/apps/web/test/browser/exchangeView.test.ts
+++ b/apps/web/test/browser/exchangeView.test.ts
@@ -247,6 +247,33 @@ describe("ExchangeView Start->run wiring", () => {
     expect(lifecycle.calls[1].signal).not.toBe(firstSignal);
   });
 
+  test("a plain unmount aborts the in-flight run's signal (leaving the screen mid-exchange)", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    render(inviterConfig("secret-a"));
+
+    // The run auto-starts on mount (no Start press in the current flow), so the
+    // owner's AbortController is armed and its signal is live.
+    await vi.waitFor(() => expect(lifecycle.calls).toHaveLength(1));
+    const { signal } = lifecycle.calls[0];
+    expect(signal.aborted).toBe(false);
+
+    // A plain unmount -- the user navigating away or closing the tab, NOT the
+    // keyed regenerate the remount test above covers -- must run ExchangeView's
+    // useEffect cleanup, which aborts the owner's controller. That abort is the
+    // seam the owner keys teardown off of: the node exchangeLifecycle owner-
+    // contract test asserts abort -> connection close / teardown-once, so this
+    // asserts only the other half, unmount -> abort (the effect-cleanup wiring
+    // that was otherwise left to manual verification). The cleanup is a passive
+    // effect, so wait for the abort to settle. Null the root so afterEach's
+    // unmount does not double-unmount an already-unmounted tree, but leave
+    // container set so afterEach still removes it from the DOM.
+    root.unmount();
+    root = undefined;
+    await vi.waitFor(() => expect(signal.aborted).toBe(true));
+  });
+
   const warning = {
     title: "Partial CSV coverage",
     message: "some keys inactive",


### PR DESCRIPTION
## Summary

Add automated coverage that ExchangeView aborts its in-flight run on a plain unmount -- the navigate-away or tab-close path -- so the owner tears down any in-flight wait or exchange when the user leaves the screen. This closes the effect-cleanup half of the unmount-abort contract that was otherwise left to manual verification.

Implements [193886235](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=193886235).

## Changes

- apps/web/test/browser/exchangeView.test.ts: add a mount, auto-start, unmount test that captures the owner's AbortController signal from the stubbed lifecycle and asserts a plain root.unmount() aborts it.

## Test plan

Ran: npm run typecheck, npm run lint, and npm run test:browser -- exchangeView (13 passed).
New tests cover: unmount -> abort(signal) for ExchangeView, decoupled from the keyed-regenerate path the existing remount test already covers.

## Background

The component-render harness this test needs (createRoot + MantineProvider mount, a lifecycle stub capturing the owner's signal) already landed in #197, which also renamed Exchange.tsx to ExchangeView.tsx. The remount-abort case was covered there; this adds the plain-unmount case, where a user leaving mid-exchange exercises the effect cleanup. The node exchangeLifecycle owner-contract test asserts the other half, that an aborted signal closes the connection and tears down once.

## Checklist

- [x] Docs: enumerated docs/ and docs/spec/ and updated affected pages -- n/a: test-only change, no documented behavior changed
- [x] CHANGELOG.md [Unreleased] updated -- n/a: test-only change, not operator- or reviewer-visible
- [x] Security review -- done: independent final review across client-side, protocol/lifecycle, and test-assurance lenses. No security-relevant production surface or dependency is touched (test-only); the unmount -> abort teardown it guards is sound (real connection close and peer disconnect under a teardown-once latch, no dangling peer, no unrevoked result/record PII blob) and the added test is non-vacuous (asserts the real component controller's signal; fails if the cleanup regresses).