### PR TITLE
Give parsed CSV rows an honest type in core

### DIFF
--- a/apps/cli/src/commands/bootstrap.ts
+++ b/apps/cli/src/commands/bootstrap.ts
@@ -26,6 +26,7 @@ import {
 import type {
   ConnectionConfig,
   ConnectionEndpoint,
+  CSVRow,
   ExchangeSpec,
   ExchangeDataSpec,
   FileDropConnectionConfig,
@@ -808,10 +809,10 @@ export function expiresFromNow(durationSeconds: number): string {
 export async function loadInputRows(
   input: string,
   { allowStdin = false }: { allowStdin?: boolean } = {},
-): Promise<{ rawRows: Array<Record<string, string>>; columns: string[] }> {
+): Promise<{ rawRows: Array<CSVRow>; columns: string[] }> {
   const csvResult = await loadCSVFile(openInputSource(input, { allowStdin }));
   return {
-    rawRows: csvResult.data as Array<Record<string, string>>,
+    rawRows: csvResult.data,
     columns: csvResult.meta.fields ?? [],
   };
 }
@@ -844,7 +845,7 @@ export async function loadInputRows(
 export async function loadInputRowsForInference(
   input: string,
   { allowStdin = false }: { allowStdin?: boolean } = {},
-): Promise<{ rawRows: Array<Record<string, string>>; columns: string[] }> {
+): Promise<{ rawRows: Array<CSVRow>; columns: string[] }> {
   const { columns, sampledColumn, sample } = await loadCSVColumnSample(
     openInputSource(input, { allowStdin }),
     (cols) => inferMetadata(cols).find((c) => c.type === "date_of_birth")?.name,
@@ -947,7 +948,7 @@ export function singlePassDisclosureNotice(): string {
 export function buildDataSpec(args: {
   terms?: LinkageTerms;
   identity: string;
-  rows?: { rawRows: Array<Record<string, string>>; columns: string[] };
+  rows?: { rawRows: Array<CSVRow>; columns: string[] };
   linkageStrategy?: LinkageStrategy;
 }): { dataSpec: ResolvedDataSpec; warnings: string[] } {
   const { terms, identity, rows, linkageStrategy } = args;
@@ -1003,7 +1004,7 @@ export { unsatisfiedLinkageFields } from "@psilink/core";
 export async function prepareForOnlineExchange(
   dataSpec: ResolvedDataSpec,
   identity: string,
-  rows: { rawRows: Array<Record<string, string>>; columns: string[] },
+  rows: { rawRows: Array<CSVRow>; columns: string[] },
 ): Promise<PreparedExchange> {
   const prepared = prepareForExchange(
     dataSpec as ExchangeDataSpec,

--- a/apps/cli/src/commands/exchange.ts
+++ b/apps/cli/src/commands/exchange.ts
@@ -547,7 +547,7 @@ export async function prepareDataset(
   const csvResult = await loadCSVFile(
     openInputSource(input, { allowStdin: true }),
   );
-  const rawRows = csvResult.data as Array<Record<string, string>>;
+  const rawRows = csvResult.data;
   const columns = csvResult.meta.fields ?? [];
 
   // Pre-flight this run's CSV against the committed linkage terms before any

--- a/apps/cli/src/commands/zeroSetup.ts
+++ b/apps/cli/src/commands/zeroSetup.ts
@@ -346,7 +346,7 @@ async function prepareDataset(
   const csvResult = await loadCSVFile(
     openInputSource(input, { allowStdin: true }),
   );
-  const rawRows = csvResult.data as Array<Record<string, string>>;
+  const rawRows = csvResult.data;
   const prepared = prepareForExchange(
     {},
     identity,

--- a/apps/web/src/components/AdvancedInvite.tsx
+++ b/apps/web/src/components/AdvancedInvite.tsx
@@ -33,7 +33,12 @@ import { ExchangeView } from "@components/ExchangeView";
 import FileSelect from "@components/FileSelect";
 import { LinkageTermsEditor } from "@components/LinkageTermsEditor";
 
-import type { LinkageTerms, Metadata, Standardization } from "@psilink/core";
+import type {
+  CSVRow,
+  LinkageTerms,
+  Metadata,
+  Standardization,
+} from "@psilink/core";
 
 import type { AdvancedInviteSeed } from "@psi/advancedInvite";
 import type { AlertContent } from "@components/FileAcquire";
@@ -65,7 +70,7 @@ type Phase =
       identity: string;
       file: File;
       /** The parsed rows, for the workbench's before/after preview. */
-      rawRows: Array<Record<string, string>>;
+      rawRows: Array<CSVRow>;
     }
   | {
       status: "exchange";
@@ -101,10 +106,10 @@ export function AdvancedInvite() {
     setError(undefined);
     setPhase({ status: "loading" });
     let columns: Array<string>;
-    let rawRows: Array<Record<string, string>>;
+    let rawRows: Array<CSVRow>;
     try {
       const csv = await loadCSVFile(file);
-      rawRows = csv.data as Array<Record<string, string>>;
+      rawRows = csv.data;
       columns = csv.meta.fields ?? [];
     } catch (cause) {
       if (!mountedRef.current) return;

--- a/apps/web/src/components/FileAcquire.tsx
+++ b/apps/web/src/components/FileAcquire.tsx
@@ -6,6 +6,8 @@ import { emptyColumnPositions, unnameableColumnsAlert } from "@psi/columnNames";
 
 import FileSelect from "@components/FileSelect";
 
+import type { CSVRow } from "@psilink/core";
+
 /** A titled alert. The acquire phase emits its read-failure message through this
  * shape; the review screen renders it in the same slot. */
 export interface AlertContent {
@@ -17,7 +19,7 @@ export interface AlertContent {
  * the two inputs `prepareForExchange` (and the "Prepare your data" editor's
  * satisfiability verdict) consume. Nothing here is connection- or role-specific. */
 export interface AcquiredBundle {
-  rawRows: Array<Record<string, string>>;
+  rawRows: Array<CSVRow>;
   columns: Array<string>;
 }
 
@@ -112,7 +114,7 @@ export default function FileAcquire(props: FileAcquireProps) {
       // handing off.
       if (submitSignal.aborted || csvResult === undefined) return;
 
-      const rawRows = csvResult.data as Array<Record<string, string>>;
+      const rawRows = csvResult.data;
       const columns = csvResult.meta.fields ?? [];
 
       // Refuse an unnamed-column header before handing off: the editor seeds its

--- a/apps/web/src/components/LinkageTermsEditor.tsx
+++ b/apps/web/src/components/LinkageTermsEditor.tsx
@@ -67,6 +67,7 @@ import { useNonEmptyRates } from "@components/useNonEmptyRates";
 
 import type {
   Algorithm,
+  CSVRow,
   LinkageField,
   LinkageTerms,
   Metadata,
@@ -172,7 +173,7 @@ export function LinkageTermsEditor({
     standardization: Standardization,
   ) => void;
   /** The parsed rows, for the data-prep workbench's before/after preview. */
-  rawRows: Array<Record<string, string>>;
+  rawRows: Array<CSVRow>;
   /** Holds Generate disabled while an invitation is being generated. */
   generating?: boolean;
 }) {

--- a/apps/web/src/components/PrepareData.tsx
+++ b/apps/web/src/components/PrepareData.tsx
@@ -50,6 +50,7 @@ import { useDeferredAnnouncement } from "@components/useDeferredAnnouncement";
 import { useNonEmptyRates } from "@components/useNonEmptyRates";
 
 import type {
+  CSVRow,
   LinkageField,
   LinkageTerms,
   Metadata,
@@ -107,7 +108,7 @@ export function PrepareData({
   /** The acceptor's own CSV column names, from the parsed file. */
   columns: Array<string>;
   /** The parsed CSV rows, the sample source for the before->after preview. */
-  rawRows: Array<Record<string, string>>;
+  rawRows: Array<CSVRow>;
   /** Commit the prepared data and move to the exchange: the edited metadata and
    * standardization, plus an optional partial-coverage advisory to surface through
    * the run. */

--- a/apps/web/src/components/StandardizationCards.tsx
+++ b/apps/web/src/components/StandardizationCards.tsx
@@ -10,6 +10,7 @@ import { StandardizationPreview } from "@components/StandardizationPreview";
 import { StandardizationStepEditor } from "@components/StandardizationStepEditor";
 
 import type {
+  CSVRow,
   LinkageField,
   Metadata,
   Standardization,
@@ -66,7 +67,7 @@ export function StandardizationCards({
   /** The operator's column metadata, for the per-type input-column options. */
   metadata: Metadata;
   /** The parsed rows the preview samples. */
-  rawRows: Array<Record<string, string>>;
+  rawRows: Array<CSVRow>;
   /** Emit a step edit: `output` names the field, `input` is the transformation's
    * input column AS RENDERED (echoed for the acceptor's stale-override check), and
    * `steps` is the next pipeline. */
@@ -241,7 +242,7 @@ function StandardizationCard({
   field: LinkageField;
   inputColumn: string;
   steps: Array<StandardizationStep>;
-  rawRows: Array<Record<string, string>>;
+  rawRows: Array<CSVRow>;
   inputColumnOptions: Array<string>;
   onInputColumnChange: (column: string) => void;
   onStepsChange: (steps: Array<StandardizationStep>) => void;

--- a/apps/web/src/components/StandardizationPreview.tsx
+++ b/apps/web/src/components/StandardizationPreview.tsx
@@ -19,6 +19,7 @@ import {
 import { isStepValid } from "@psi/standardizationAuthoring";
 
 import type {
+  CSVRow,
   FieldValue,
   LinkageField,
   StandardizationStep,
@@ -39,15 +40,15 @@ export const PREVIEW_SAMPLE_SIZE = 5;
  * whose value is missing or blank after trimming carries no signal for the
  * preview, so it is skipped rather than shown as an empty before->after pair. */
 function sampleInputValues(
-  rawRows: ReadonlyArray<Record<string, string>>,
+  rawRows: ReadonlyArray<CSVRow>,
   inputColumn: string,
   limit: number,
 ): Array<string> {
   const values: Array<string> = [];
   for (const row of rawRows) {
-    // `Record<string, string>` types a missing column as `string`, but a row may
-    // lack the column; widen so the absence check is honest.
-    const raw = row[inputColumn] as string | undefined;
+    // A short row may lack the column, so the read is honestly `string | undefined`
+    // (CSVRow's value type); the absence check below handles it.
+    const raw = row[inputColumn];
     if (raw !== undefined && raw.trim() !== "") {
       values.push(raw);
       if (values.length >= limit) break;
@@ -184,7 +185,7 @@ export function StandardizationPreview({
   /** The current pipeline steps, in order. */
   steps: Array<StandardizationStep>;
   /** The parsed CSV rows the sample is drawn from. */
-  rawRows: ReadonlyArray<Record<string, string>>;
+  rawRows: ReadonlyArray<CSVRow>;
   /** Override the provisional sample size (testing/aesthetics). */
   sampleSize?: number;
 }) {

--- a/apps/web/src/components/TermsImportExport.tsx
+++ b/apps/web/src/components/TermsImportExport.tsx
@@ -17,8 +17,8 @@ import {
   importedConstraintDivergenceMessage,
 } from "@psi/advancedInvite";
 
+import type { CSVRow, LinkageTerms } from "@psilink/core";
 import type { AdvancedInviteSeed } from "@psi/advancedInvite";
-import type { LinkageTerms } from "@psilink/core";
 
 /** How long to keep a download's object URL alive after the click before revoking
  * it. The browser may copy the blob asynchronously, so revoking too soon (even on
@@ -82,7 +82,7 @@ export function TermsImportExport({
   /** The inviter's parsed rows, threaded into the same reconstruction (the date
    * format it infers does not affect the constraint comparison, but the rebuild
    * takes them). */
-  rawRows: ReadonlyArray<Record<string, string>>;
+  rawRows: ReadonlyArray<CSVRow>;
   /** Called with validated, non-gated terms to load into the editor. */
   onImport: (terms: LinkageTerms) => void;
 }) {

--- a/apps/web/src/components/useNonEmptyRates.ts
+++ b/apps/web/src/components/useNonEmptyRates.ts
@@ -6,7 +6,7 @@ import { defaultSpawnAggregateWorker } from "@psi/nonEmptyAggregateWorkerClient"
 import type { FieldValueCoverage } from "@psi/nonEmptyAggregate";
 import type { SpawnAggregateWorker } from "@psi/nonEmptyAggregateController";
 
-import type { Standardization } from "@psilink/core";
+import type { CSVRow, Standardization } from "@psilink/core";
 
 /** Debounce (ms) before a standardization edit triggers a recompute, so a burst of
  * keystrokes recomputes the full-CSV coverage once rather than per edit. Distinct
@@ -33,7 +33,7 @@ export interface NonEmptyRatesState {
  * `spawnWorker` is injectable for tests; production uses the real worker.
  */
 export function useNonEmptyRates(
-  rawRows: ReadonlyArray<Record<string, string>>,
+  rawRows: ReadonlyArray<CSVRow>,
   standardization: Standardization,
   spawnWorker: SpawnAggregateWorker = defaultSpawnAggregateWorker,
 ): NonEmptyRatesState {

--- a/apps/web/src/psi/advancedInvite.ts
+++ b/apps/web/src/psi/advancedInvite.ts
@@ -21,6 +21,7 @@ import { isStepValid } from "./standardizationAuthoring";
 
 import type {
   Algorithm,
+  CSVRow,
   LinkageField,
   LinkageKey,
   LinkageKeyElement,
@@ -253,7 +254,7 @@ export interface AdvancedValidation {
 export function defaultStandardizationForRows(
   metadata: Metadata,
   terms: LinkageTerms,
-  rawRows: ReadonlyArray<Record<string, string>>,
+  rawRows: ReadonlyArray<CSVRow>,
 ): Standardization {
   const dobColumn = metadata.find(
     (column) => column.type === "date_of_birth" && column.role === "linkage",
@@ -277,7 +278,7 @@ export function defaultStandardizationForRows(
 export function seedAdvancedInvite(
   identity: string,
   columns: Array<string>,
-  rawRows: ReadonlyArray<Record<string, string>> = [],
+  rawRows: ReadonlyArray<CSVRow> = [],
 ): { draft: AdvancedInviteDraft; seed: AdvancedInviteSeed } {
   // Normalized so the collapsed disclosure control opens on a faithful diagonal
   // (an inferred identifier column is not silently disclosed). Normalization only
@@ -328,7 +329,7 @@ export function seedAdvancedInvite(
 export function setDraftMetadata(
   draft: AdvancedInviteDraft,
   metadata: Metadata,
-  rawRows: ReadonlyArray<Record<string, string>> = [],
+  rawRows: ReadonlyArray<CSVRow> = [],
 ): AdvancedInviteDraft {
   const offerable = getDefaultLinkageTerms(
     draft.identity,
@@ -364,7 +365,7 @@ function reconcileStandardization(
   prev: Standardization,
   metadata: Metadata,
   identity: string,
-  rawRows: ReadonlyArray<Record<string, string>>,
+  rawRows: ReadonlyArray<CSVRow>,
 ): Standardization {
   const columnByName = new Map(metadata.map((column) => [column.name, column]));
   const kept = prev.filter((transformation) => {
@@ -1221,7 +1222,7 @@ export function gatedActiveSettingMessage(
 export function importedConstraintDivergenceMessage(
   terms: LinkageTerms,
   seed: AdvancedInviteSeed,
-  rawRows: ReadonlyArray<Record<string, string>> = [],
+  rawRows: ReadonlyArray<CSVRow> = [],
 ): string | undefined {
   const rebuilt = buildAdvancedTerms(
     draftFromTerms(terms, seed, INVITATION_LIFETIME_SECONDS, rawRows),
@@ -1299,7 +1300,7 @@ function standardizationForImportedTerms(
   metadata: Metadata,
   defaultTerms: LinkageTerms,
   terms: LinkageTerms,
-  rawRows: ReadonlyArray<Record<string, string>>,
+  rawRows: ReadonlyArray<CSVRow>,
 ): Standardization {
   const base = defaultStandardizationForRows(metadata, defaultTerms, rawRows);
   // The recommended steps each imported field's type cleans with, keyed by field
@@ -1387,7 +1388,7 @@ export function draftFromTerms(
   terms: LinkageTerms,
   seed: AdvancedInviteSeed,
   lifetimeSeconds: number = INVITATION_LIFETIME_SECONDS,
-  rawRows: ReadonlyArray<Record<string, string>> = [],
+  rawRows: ReadonlyArray<CSVRow> = [],
 ): AdvancedInviteDraft {
   const standardization = standardizationForImportedTerms(
     seed.metadata,

--- a/apps/web/src/psi/invitation.ts
+++ b/apps/web/src/psi/invitation.ts
@@ -15,6 +15,7 @@ import { emptyColumnPositions } from "./columnNames";
 import { payloadSendForMetadata } from "./metadataEditing";
 
 import type {
+  CSVRow,
   InvitationToken,
   LinkageField,
   LinkageTerms,
@@ -120,7 +121,7 @@ export interface GeneratedInvitation {
    * inviter's exchange runs on the exact data with no re-parse and no second file
    * prompt. Local-only: the rows are never encoded into the token or shared.
    */
-  rawRows: Array<Record<string, string>>;
+  rawRows: Array<CSVRow>;
   /** The CSV column names, paired with {@link rawRows} -- the two inputs the
    * inviter's exchange feeds to `prepareForExchange`. Local-only. */
   columns: Array<string>;
@@ -373,11 +374,11 @@ export async function generateInvitation(params: {
   // file aborts with no token. loadCSVFile rejects only on a read/stream error (a
   // malformed-but-readable CSV resolves with rows); wrap that into the typed
   // user-actionable failure.
-  let rawRows: Array<Record<string, string>>;
+  let rawRows: Array<CSVRow>;
   let columns: Array<string>;
   try {
     const csvResult = await loadCSVFile(file);
-    rawRows = csvResult.data as Array<Record<string, string>>;
+    rawRows = csvResult.data;
     columns = csvResult.meta.fields ?? [];
   } catch (cause) {
     throw new InvitationFileError({ kind: "unreadable", cause });

--- a/apps/web/src/psi/nonEmptyAggregate.ts
+++ b/apps/web/src/psi/nonEmptyAggregate.ts
@@ -2,7 +2,7 @@ import { StandardizedField } from "@psilink/core";
 
 import { isStepValid } from "./standardizationAuthoring";
 
-import type { Standardization } from "@psilink/core";
+import type { CSVRow, Standardization } from "@psilink/core";
 
 /**
  * Whole-CSV per-field value coverage: the silent-empty defense.
@@ -63,13 +63,15 @@ export const NON_EMPTY_WORKER_CHAR_THRESHOLD = 2_000_000;
  * column could still sweep inline; that is an out-of-shape, partner-bounded config.
  */
 export function shouldComputeOffThread(
-  rawRows: ReadonlyArray<Record<string, string>>,
+  rawRows: ReadonlyArray<CSVRow>,
 ): boolean {
   if (rawRows.length > NON_EMPTY_WORKER_ROW_THRESHOLD) return true;
   let chars = 0;
   for (const row of rawRows)
+    // A CSVRow's values are `string | undefined` (a short row omits columns), so
+    // an absent cell contributes no characters.
     for (const value of Object.values(row)) {
-      chars += value.length;
+      chars += value?.length ?? 0;
       if (chars > NON_EMPTY_WORKER_CHAR_THRESHOLD) return true;
     }
   return false;
@@ -141,7 +143,7 @@ export interface FieldValueCoverage {
  * caught rather than blanking the aggregate.
  */
 export function computeFieldCoverage(
-  rawRows: ReadonlyArray<Record<string, string>>,
+  rawRows: ReadonlyArray<CSVRow>,
   standardization: Standardization,
 ): Array<FieldValueCoverage> {
   const total = rawRows.length;

--- a/apps/web/src/psi/nonEmptyAggregate.worker.ts
+++ b/apps/web/src/psi/nonEmptyAggregate.worker.ts
@@ -5,6 +5,8 @@ import type {
   AggregateResponse,
 } from "./nonEmptyAggregateController";
 
+import type { CSVRow } from "@psilink/core";
+
 /**
  * The off-main-thread entry for the silent-empty aggregate. Seeded once with the
  * full row set, it recomputes {@link computeFieldCoverage} for each standardization
@@ -22,7 +24,7 @@ interface WorkerScope {
 }
 const scope = globalThis as unknown as WorkerScope;
 
-let rows: ReadonlyArray<Record<string, string>> = [];
+let rows: ReadonlyArray<CSVRow> = [];
 let seeded = false;
 
 scope.onmessage = (event) => {

--- a/apps/web/src/psi/nonEmptyAggregateController.ts
+++ b/apps/web/src/psi/nonEmptyAggregateController.ts
@@ -5,7 +5,7 @@ import {
 
 import type { FieldValueCoverage } from "./nonEmptyAggregate";
 
-import type { Standardization } from "@psilink/core";
+import type { CSVRow, Standardization } from "@psilink/core";
 
 /**
  * Orchestrates the silent-empty aggregate ({@link computeFieldCoverage}) on or off
@@ -37,7 +37,7 @@ export type SpawnAggregateWorker = () => AggregateWorker;
 
 /** Worker request: seed the rows once, then compute per standardization edit. */
 export type AggregateRequest =
-  | { kind: "rows"; rawRows: ReadonlyArray<Record<string, string>> }
+  | { kind: "rows"; rawRows: ReadonlyArray<CSVRow> }
   | { kind: "compute"; token: number; standardization: Standardization };
 
 /** Worker response: the rates for the compute identified by `token`. */
@@ -47,7 +47,7 @@ export interface AggregateResponse {
 }
 
 export class NonEmptyRateController {
-  private readonly rawRows: ReadonlyArray<Record<string, string>>;
+  private readonly rawRows: ReadonlyArray<CSVRow>;
   private readonly worker: AggregateWorker | undefined;
   private nextToken = 0;
   private readonly pending = new Map<
@@ -59,7 +59,7 @@ export class NonEmptyRateController {
   private failed = false;
 
   constructor(
-    rawRows: ReadonlyArray<Record<string, string>>,
+    rawRows: ReadonlyArray<CSVRow>,
     spawnWorker: SpawnAggregateWorker,
   ) {
     this.rawRows = rawRows;

--- a/apps/web/test/browser/loadCSVFile.test.ts
+++ b/apps/web/test/browser/loadCSVFile.test.ts
@@ -69,7 +69,7 @@ describe("loadCSVFile multi-chunk parsing", () => {
     }) as unknown as typeof Papa.parse);
 
     const result = await loadCSVFile(file);
-    const rows = result.data as Array<Record<string, string>>;
+    const rows = result.data;
 
     expect(chunkCalls).toBeGreaterThan(1);
     expect(rows.length).toBe(rowCount);
@@ -160,7 +160,7 @@ describe("loadCSVFile bounds an oversized leading line for a browser File", () =
 
     const file = new File([csv], "ok.csv", { type: "text/csv" });
     const result = await loadCSVFile(file, ceiling);
-    const rowsParsed = result.data as Array<Record<string, string>>;
+    const rowsParsed = result.data;
     expect(result.meta.fields).toEqual(["id", "value"]);
     expect(rowsParsed.length).toBe(rowCount);
     expect(rowsParsed[0]).toEqual({ id: "0", value: "vvvvvvvv" });

--- a/apps/web/test/unit/nonEmptyAggregate.test.ts
+++ b/apps/web/test/unit/nonEmptyAggregate.test.ts
@@ -16,7 +16,7 @@ import type {
   AggregateWorker,
 } from "../../src/psi/nonEmptyAggregateController.js";
 
-import type { Standardization } from "@psilink/core";
+import type { CSVRow, Standardization } from "@psilink/core";
 
 describe("computeFieldCoverage: the silent-empty defense", () => {
   test("a transform that collapses every row to null surfaces a 0% coverage alarm", () => {
@@ -193,7 +193,7 @@ class FakeAggregateWorker implements AggregateWorker {
   onerror: ((event: unknown) => void) | null = null;
   readonly received: Array<AggregateRequest> = [];
   terminated = false;
-  private rows: ReadonlyArray<Record<string, string>> = [];
+  private rows: ReadonlyArray<CSVRow> = [];
 
   postMessage(message: AggregateRequest): void {
     this.received.push(message);

--- a/packages/core/src/exchange.ts
+++ b/packages/core/src/exchange.ts
@@ -9,6 +9,7 @@ import {
 } from "./standardization.js";
 import { columnValues, inferDateFormat } from "./utils/date.js";
 import { sanitizeForDisplay } from "./utils/sanitizeForDisplay.js";
+import type { CSVRow } from "./file.js";
 import { PSIParticipant } from "./participant.js";
 import {
   exchangeTerms,
@@ -105,7 +106,7 @@ export interface PreparedExchange {
    * holding only the standardized dataset. If streaming over input data is
    * ever supported, this field will need to be revisited.
    */
-  rawRows: Array<Record<string, string>>;
+  rawRows: Array<CSVRow>;
   rowCount: number;
   /**
    * Non-fatal issues detected during preparation (e.g. unknown standardization
@@ -141,7 +142,7 @@ export interface PreparedExchange {
 export function prepareForExchange(
   exchangeDataSpec: ExchangeDataSpec,
   identity: string,
-  rawRows: Array<Record<string, string>>,
+  rawRows: Array<CSVRow>,
   columnNames: Array<string>,
 ): PreparedExchange {
   const log = getLogger("exchange");

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -197,6 +197,42 @@ export function guardStreamLineByteCeiling(
 }
 
 /**
+ * A parsed CSV row as {@link loadCSVFile} returns it under PapaParse's
+ * `header: true`: an object keyed by column name. PapaParse gives no per-cell
+ * string guarantee -- a row shorter than the header omits its trailing columns (a
+ * by-name read is then `undefined`), and a row with fields beyond the header
+ * carries a non-string `__parsed_extra` array. {@link loadCSVFile} normalizes that
+ * away -- keeping only the string-valued cells (see {@link normalizeCSVRow}) -- so
+ * a present column is a `string` and a missing one reads as `undefined`, which this
+ * type states honestly: the `| undefined` holds even with `noUncheckedIndexedAccess`
+ * off, and no cell is ever a non-string a generic value iteration could trip over.
+ * Every row consumer -- the exchange pipeline, standardization, payload extraction
+ * -- threads this type rather than the `Record<string, string>` the raw cast once
+ * asserted but could not back.
+ */
+export type CSVRow = Record<string, string | undefined>;
+
+/**
+ * Normalize one raw PapaParse row to a {@link CSVRow}, dropping any non-string
+ * cell -- in practice the `__parsed_extra` array PapaParse attaches to a row longer
+ * than the header -- so every retained value is a genuine string. A row that is
+ * already all-string (the common well-formed row) is returned by reference; only a
+ * row carrying a non-string cell is rebuilt without it.
+ */
+function normalizeCSVRow(row: unknown): CSVRow {
+  const source = row as Record<string, unknown>;
+  const keys = Object.keys(source);
+  if (keys.every((key) => typeof source[key] === "string"))
+    return source as CSVRow;
+  const cleaned: CSVRow = {};
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "string") cleaned[key] = value;
+  }
+  return cleaned;
+}
+
+/**
  * Parse a CSV file to its COMPLETE row set. Resolves a {@link Papa.ParseResult}
  * whose `data` and `errors` are accumulated across every PapaParse chunk, so a
  * file larger than one `Papa.LocalChunkSize` chunk is returned whole rather than
@@ -235,7 +271,7 @@ export function guardStreamLineByteCeiling(
 export async function loadCSVFile(
   file: LocalFile,
   byteCeiling: number = CSV_LINE_BYTE_CEILING,
-): Promise<Papa.ParseResult<unknown>> {
+): Promise<Papa.ParseResult<CSVRow>> {
   // Bound the non-stream (browser File) path's leading line before parsing: a File
   // exposes no `data` events for the stream guard below to scan, since PapaParse
   // reads it whole through FileReader. A Node stream or string is a no-op here.
@@ -252,7 +288,7 @@ export async function loadCSVFile(
     // missing `chunk` callback is exactly the silent multi-chunk truncation this
     // accumulation removes (the older single-chunk-only contract); a >1-chunk file
     // therefore parses whole rather than to a truncated subset with no error.
-    const data: Array<unknown> = [];
+    const data: Array<CSVRow> = [];
     const errors: Array<Papa.ParseError> = [];
     let meta: Papa.ParseMeta | undefined;
 
@@ -289,8 +325,10 @@ export async function loadCSVFile(
       chunk: (results) => {
         // Spread-push would pass one argument per row and can overflow the call
         // stack for a chunk holding hundreds of thousands of short rows, so append
-        // in a loop (O(n) total, stack-safe).
-        for (const row of results.data) data.push(row);
+        // in a loop (O(n) total, stack-safe). Normalize each row to a CSVRow at this
+        // single boundary -- dropping PapaParse's non-string __parsed_extra -- so the
+        // honest row type holds for every consumer without a per-site cast.
+        for (const row of results.data) data.push(normalizeCSVRow(row));
         for (const error of results.errors) errors.push(error);
         // Every chunk's meta carries the header field list (the parser's fields
         // persist across chunks), so keep the latest for `complete`, whose own
@@ -474,9 +512,9 @@ export function loadCSVColumnSample(
         // `let` read inside this callback, which TypeScript will not narrow on its
         // own; this guard does the narrowing for the indexing below.
         if (target === undefined) return;
-        for (const row of results.data as Array<Record<string, string>>) {
+        for (const row of results.data as Array<Record<string, unknown>>) {
           const value = row[target];
-          if (value !== undefined && value.trim() !== "") {
+          if (typeof value === "string" && value.trim() !== "") {
             sample.push(value);
             // Enough to reproduce a full scan; stop reading the rest of the file.
             if (sample.length >= sampleLimit) {

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -72,6 +72,7 @@ export {
   loadCSVColumnSample,
   CSV_LINE_BYTE_CEILING,
 } from "./file";
+export type { CSVRow } from "./file";
 
 export {
   inferDateFormat,

--- a/packages/core/src/payloadExchange.ts
+++ b/packages/core/src/payloadExchange.ts
@@ -8,6 +8,7 @@ import {
 } from "./config/metadata.js";
 import type { Payload } from "./config/linkageTerms.js";
 import { MAX_NAME_LENGTH } from "./config/linkageTerms.js";
+import type { CSVRow } from "./file.js";
 import type { CommittedPayload } from "./exchangeRecord.js";
 import type { MessageConnection } from "./connection/messageConnection.js";
 import {
@@ -137,7 +138,7 @@ export type PayloadWireMessage = z.infer<typeof payloadWireSchema>;
  * dataset has no transmittable payload columns or no matched rows.
  */
 export function preparePayload(
-  rawRows: Array<Record<string, string>>,
+  rawRows: Array<CSVRow>,
   metadata: Metadata,
   associationTable: AssociationTable,
 ): PayloadWireMessage {
@@ -429,7 +430,7 @@ function quoteCsvField(value: string): string {
  */
 export function buildOutputTable(
   associationTable: AssociationTable,
-  rawRows: Array<Record<string, string>>,
+  rawRows: Array<CSVRow>,
   metadata: Metadata,
   partnerPayload: PartnerPayload,
 ): { headers: string[]; rows: Array<Array<string>> } {

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -26,6 +26,7 @@ import {
 } from "./config/linkageTerms.js";
 import { inferMetadata } from "./config/metadata.js";
 import type { ColumnMetadata } from "./config/metadata.js";
+import type { CSVRow } from "./file.js";
 
 const logger = getLogger("cleaning");
 
@@ -1028,14 +1029,14 @@ export class StandardizedField {
   readonly name: string;
   private readonly inputColumn: string;
   private readonly compiledSteps: CompiledStep[];
-  private readonly rawRows: ReadonlyArray<Record<string, string>>;
+  private readonly rawRows: ReadonlyArray<CSVRow>;
   private readonly cache = new Map<number, string[]>();
 
   constructor(
     name: string,
     inputColumn: string,
     steps: StandardizationStep[],
-    rawRows: ReadonlyArray<Record<string, string>>,
+    rawRows: ReadonlyArray<CSVRow>,
   ) {
     this.name = name;
     this.inputColumn = inputColumn;
@@ -1232,7 +1233,7 @@ export function resolveFieldColumns(
  */
 export function buildStandardizedDataset(
   standardization: Standardization | undefined,
-  rawRows: ReadonlyArray<Record<string, string>>,
+  rawRows: ReadonlyArray<CSVRow>,
   metadata: ColumnMetadata[],
   terms: LinkageTerms,
 ): StandardizedDataset {

--- a/packages/core/src/utils/date.ts
+++ b/packages/core/src/utils/date.ts
@@ -1,5 +1,7 @@
 import { DateTime } from "luxon";
 
+import type { CSVRow } from "../file.js";
+
 // ─── Date format inference ────────────────────────────────────────────────────
 
 /**
@@ -126,7 +128,7 @@ export function inferDateFormat(values: Iterable<string>): string | undefined {
  * `inferDateFormat(columnValues(rows, dobColumn))`.
  */
 export function* columnValues(
-  rows: Iterable<Record<string, string>>,
+  rows: Iterable<CSVRow>,
   column: string,
 ): Generator<string> {
   for (const row of rows) yield row[column] ?? "";

--- a/packages/core/test/file.test.ts
+++ b/packages/core/test/file.test.ts
@@ -400,6 +400,39 @@ test("loadCSVFile: a well-formed input under the ceiling reads unchanged", async
   ]);
 });
 
+test("loadCSVFile: normalizes rows to an honest CSVRow shape", async () => {
+  // PapaParse (header:true) gives no per-cell string guarantee: a row longer than
+  // the header attaches a non-string `__parsed_extra` array, and a shorter row omits
+  // its trailing columns. loadCSVFile normalizes both away so every returned cell is
+  // a genuine string (a CSVRow), which the row type states honestly -- the laundering
+  // the by-name-access cleanup targets.
+  const csv =
+    "a,b,c\n" +
+    "1,2,3\n" + // well-formed
+    "4,5\n" + // short: c is absent, not undefined-typed-as-string
+    "6,7,8,9,10\n"; // over-long: 9,10 land in a non-string __parsed_extra
+  const result = await loadCSVFile(streamOf(csv), 256);
+
+  expect(result.data).toEqual([
+    { a: "1", b: "2", c: "3" },
+    { a: "4", b: "5" },
+    { a: "6", b: "7", c: "8" },
+  ]);
+
+  // The over-long row's non-string __parsed_extra is dropped, so a generic value
+  // iteration sees only strings -- never the array the raw cast would have typed as a
+  // string.
+  const overLong = result.data[2];
+  expect("__parsed_extra" in overLong).toBe(false);
+  expect(Object.values(overLong).every((v) => typeof v === "string")).toBe(
+    true,
+  );
+
+  // The short row's missing column reads as undefined, not a mis-typed string.
+  expect(result.data[1].c).toBeUndefined();
+  expect("c" in result.data[1]).toBe(false);
+});
+
 // The non-stream (browser File) bound. loadCSVFile's data-event counter is inert
 // for a File -- PapaParse reads it whole through FileReader, which Node lacks -- so
 // the leading-line pre-read enforces the ceiling there instead. These exercise the


### PR DESCRIPTION
## Summary

The web app and the CLI parsed core's `loadCSVFile` output through `Record<string, string>` casts that PapaParse (`header: true`) does not back: a row shorter than the header omits its trailing columns (a by-name read is then `undefined`), and a row with extra fields carries a non-string `__parsed_extra` array. The cast asserted a per-cell string guarantee the parser never gives, which a future generic value iteration would have hit as a non-string typed as a string. This makes the row type honest at the single parse boundary: `loadCSVFile` normalizes each row and returns `Papa.ParseResult<CSVRow>`, and `CSVRow` (`Record<string, string | undefined>`) is threaded through every consumer, removing the five casts. Behavior is unchanged for well-formed CSVs.

Implements [203414168](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=203414168).

## Changes

- `packages/core/src/file.ts`: add exported `CSVRow`; `loadCSVFile` normalizes each row at the parse boundary (drops any non-string cell, i.e. `__parsed_extra`) and returns `Papa.ParseResult<CSVRow>`; `loadCSVColumnSample` narrows its one-column sample read via `typeof value === "string"` instead of an unchecked cast.
- `packages/core` (`exchange.ts`, `payloadExchange.ts`, `standardization.ts`, `utils/date.ts`, `main.ts`): thread `CSVRow` through the row consumers and export it. Type-only; core already guarded its row reads.
- `apps/cli` (`bootstrap.ts`, `exchange.ts`, `zeroSetup.ts`): drop the `Array<Record<string, string>>` casts and type the row helpers as `CSVRow`.
- `apps/web`: drop the casts and use `CSVRow` across the components and modules that thread `rawRows` (`invitation.ts`, `FileAcquire.tsx`, `AdvancedInvite.tsx`, `StandardizationPreview.tsx`, `advancedInvite.ts`, the non-empty-aggregate module/worker/controller, and the editor components); the silent-empty size heuristic now accounts for `string | undefined`. The web-only `csvRows` laundering helper is removed, superseded by the core fix.
- `packages/core/test/file.test.ts`: new test pins the normalization -- a short row omits its missing column and an over-long row's `__parsed_extra` is dropped, leaving every retained cell a genuine string.

## Test plan

Ran: `npm run typecheck && npm run lint`; core/cli/web unit suites; web browser suites (`fileAcquire`, `advancedInvite`, `exchangeView`, `linkageTermsEditor`, `loadCSVFile`); `npm run test:integration -w apps/cli`. All green.
New tests cover: `loadCSVFile` row normalization -- an over-long row's non-string `__parsed_extra` is dropped so every retained value is a string, and a short row's missing column reads as `undefined` rather than a mis-typed string.

## Background

The casts were harmless only because every consumer reads rows by explicit column name; the latent risk was a future generic value iteration hitting a non-string. Core already guarded its row reads (`?? ""`, `?.[col]`, `=== undefined`), so making the type honest is a pure type-annotation change there plus the one-boundary normalization. Independent review confirmed the disclosure surfaces are byte-identical: the wire (`preparePayload`) and on-disk result table (`buildOutputTable`) derive transmitted columns from metadata over the header, never from row keys, and `__parsed_extra` is never read by name.

## Out of scope / follow-on

- Harden by-name CSV row reads against `Object.prototype` column names -- a pre-existing inherited-member read hazard surfaced by the security review (a column named e.g. `toString` plus a short row returns the inherited function past the `?? null` guards): [207394749](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=207394749).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; `CSVRow` is an internal type at the parse boundary and the wire/on-disk formats are unchanged.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: a `@psilink/core` API reshape and internal refactor with no operator- or reviewer-visible behavior change (well-formed CSVs behave identically; the dropped `__parsed_extra` was read by no consumer).
- [x] Security review -- in scope (touches the disclosure surface: data sent via `preparePayload`, written to the result CSV via `buildOutputTable`). Independent review found the wire, on-disk, consent, and control surfaces byte-identical (type-only change) and introduced no prototype-pollution / injection / DoS; one pre-existing, unrelated hazard was filed as 207394749.