### PR TITLE
Add coverage as a report, no percentage gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .DS_Store
 .worktrees
 dist
+coverage
 *.local*
 count.txt
 .env

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,36 @@ which provisions Chromium on the runner; run it locally too when changing the we
 PSI exchange, the cross-implementation vectors, or a web UI component it covers
 (such as the accept consent gate).
 
+### Coverage
+
+Coverage is an informational REPORT to help you and reviewers see which product
+paths a change leaves unexercised. It is produced on demand -- it is not part of
+`npm test` and does not run in CI.
+
+```sh
+npm run coverage                    # all workspaces; writes a report per workspace
+npm run coverage -w packages/core   # a single workspace
+```
+
+It uses `@vitest/coverage-v8` (first-party Vitest tooling, so no second runner)
+and writes a text summary to the terminal plus a browsable HTML report and an
+`lcov.info` (for editors/tooling) under each workspace's `coverage/` directory.
+The denominator is scoped to product source under each `src/` tree, with the
+generated route tree and vendored `apps/web/src/contrib` excluded, so the numbers
+reflect hand-written product code. The report runs the node projects: `core`
+unit, `cli` unit and integration (the SFTP adapter is exercised only by the
+integration suite), and `web` unit. Browser-mode coverage (real Chromium) and the
+web black-box integration suite are not included; browser coverage is a deferred
+follow-up.
+
+There is deliberately NO global percentage gate, and adding one is not a missing
+piece to be "fixed": a blanket "N% or the build fails" bar rewards vanity tests
+that raise the number without raising confidence, so the report informs review
+rather than blocking merges. Do not add a `thresholds` line to the Vitest
+coverage config. If coverage gating is ever wanted, it is scoped to
+`packages/core` and expressed as diff/patch coverage (coverage of the lines a PR
+changes), never an absolute whole-repo percentage -- and even that stays opt-in.
+
 ## Code Conventions
 
 - **TypeScript** with strict mode throughout. Avoid `any`; if you must use it, add a comment explaining why.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run --project unit",
     "test:unit": "vitest run --project unit",
     "test:integration": "vitest run --project integration",
-    "test:integration:native-chroot": "node test/sftpServer/runChrootProfile.mjs"
+    "test:integration:native-chroot": "node test/sftpServer/runChrootProfile.mjs",
+    "coverage": "vitest run --project unit --project integration --coverage"
   },
   "dependencies": {
     "@openmined/psi.js": "file:../../lib/openmined-psi.js-2.0.6-seclink.1.tgz",

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -2,6 +2,22 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    // Coverage is an informational REPORT, produced on demand by `npm run
+    // coverage` (see package.json), never a gate: there is deliberately NO
+    // `thresholds` line (see CONTRIBUTING.md, Coverage). The coverage script
+    // runs the unit AND integration projects here, because the SFTP adapter
+    // runs in-process and is exercised only by the integration suite -- a
+    // unit-only report would misleadingly show it near-uncovered.
+    coverage: {
+      provider: "v8",
+      // text -> terminal summary; html + lcov -> browsable/tooling report
+      // under coverage/.
+      reporter: ["text", "html", "lcov"],
+      // Confine the denominator to product source: the test/ suite, fixtures,
+      // and this config are all siblings of src/, so scoping include here keeps
+      // them out of the report without a per-file exclude list.
+      include: ["src/**"],
+    },
     projects: [
       {
         test: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,8 @@
     "test:browser": "vitest run --project browser",
     "test:unit": "vitest run --project unit",
     "test:integration": "vitest run --project integration",
-    "test:integration:browser": "vitest run --project integration --project browser"
+    "test:integration:browser": "vitest run --project integration --project browser",
+    "coverage": "vitest run --project unit --coverage"
   },
   "keywords": [
     "private set intersection",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -86,6 +86,33 @@ export default defineConfig((_configEnv) => {
       port: config.PORT,
     },
     test: {
+      // Coverage is an informational REPORT, produced on demand by `npm run
+      // coverage` (see package.json), never a gate: there is deliberately NO
+      // `thresholds` line (see CONTRIBUTING.md, Coverage). The coverage script
+      // runs the unit project only. The integration project is a black-box HTTP
+      // suite -- it fetches a separate dev-server process and imports no src, so
+      // it adds server-startup cost and flake risk for zero in-process coverage.
+      // The browser project (real Chromium) is a documented follow-up: v8
+      // coverage there needs separate handling and can perturb browser timing.
+      coverage: {
+        provider: "v8",
+        // text -> terminal summary; html + lcov -> browsable/tooling report
+        // under coverage/.
+        reporter: ["text", "html", "lcov"],
+        // Confine the denominator to product source: the test/ suite, fixtures,
+        // and this config are all siblings of src/, so scoping include here
+        // keeps them out of the report.
+        include: ["src/**"],
+        // vitest applies its own default excludes (node_modules, the config,
+        // test files) on top of these, so list only the code that lives inside
+        // src/ but is not hand-written product code.
+        exclude: [
+          // Vendored PeerJS signaling server (third-party, also eslint-ignored).
+          "src/contrib/**",
+          // TanStack Router codegen (routeTree.gen.ts).
+          "**/*.gen.ts",
+        ],
+      },
       projects: [
         {
           test: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",
         "prettier": "^3.8.4",
         "typescript": "^6.0.3",
@@ -417,6 +418,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@blazediff/core": {
@@ -4546,6 +4557,37 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
@@ -4962,6 +5004,35 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -6949,6 +7020,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -6966,6 +7047,13 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7291,6 +7379,58 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -7900,6 +8040,35 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "linkcheck": "node scripts/check-doc-links.mjs",
     "typecheck": "tsc -p packages/core/tsconfig.json --noEmit && tsc -p apps/cli/tsconfig.test.json && tsc -p apps/web/tsconfig.json",
     "test": "npm run test -w packages/core -w apps/cli -w apps/web",
-    "test:scripts": "vitest run --project scripts"
+    "test:scripts": "vitest run --project scripts",
+    "coverage": "npm run coverage -w packages/core -w apps/cli -w apps/web"
   },
   "keywords": [
     "private set intersection",
@@ -26,6 +27,7 @@
     "node": ">=26"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.5.0",
     "prettier": "^3.8.4",
     "typescript": "^6.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,9 @@
     "pretest": "npm run build",
     "test": "vitest run --project unit",
     "test:unit": "vitest run --project unit",
-    "test:stress": "vitest run --project stress"
+    "test:stress": "vitest run --project stress",
+    "precoverage": "npm run build",
+    "coverage": "vitest run --project unit --coverage"
   },
   "files": [
     "dist"

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -2,6 +2,21 @@ import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    // Coverage is an informational REPORT, produced on demand by `npm run
+    // coverage` (see package.json), never a gate: there is deliberately NO
+    // `thresholds` line. A blanket "N% or the build fails" bar rewards vanity
+    // tests that raise the number without raising confidence; any future gating
+    // stays diff-scoped to this package (see CONTRIBUTING.md, Coverage).
+    coverage: {
+      provider: "v8",
+      // text -> terminal summary; html + lcov -> browsable/tooling report
+      // under coverage/.
+      reporter: ["text", "html", "lcov"],
+      // Confine the denominator to product source: the test/ suite, fixtures,
+      // and this config are all siblings of src/, so scoping include here keeps
+      // them out of the report without a per-file exclude list.
+      include: ["src/**"],
+    },
     projects: [
       {
         test: {


### PR DESCRIPTION
## Summary

Add on-demand test-coverage reporting so contributors and reviewers can see which product paths a change leaves unexercised, without a percentage gate that would reward coverage theater. It uses `@vitest/coverage-v8` (first-party Vitest tooling, so no second runner), is informational only, and is not wired into CI.

Implements [207302946](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=207302946).

## Changes

- `package.json` (root): add the `@vitest/coverage-v8` devDependency and a `coverage` script that fans out to the workspaces.
- `packages/core`, `apps/cli`, `apps/web` `package.json`: per-workspace `coverage` scripts (cli spans unit + integration so the SFTP adapter, exercised only under integration, is not shown near-uncovered); core gains a `precoverage` build hook mirroring `pretest`.
- `packages/core/vitest.config.ts`, `apps/cli/vitest.config.ts`, `apps/web/vite.config.ts`: v8 coverage config with text/html/lcov reporters and the denominator scoped to each `src/**` tree; the web config excludes the vendored `src/contrib` and the generated route tree. No `thresholds`.
- `CONTRIBUTING.md`: new Coverage section covering how to run it and the deliberate no-global-gate policy.
- `.gitignore`: ignore the per-workspace `coverage/` output.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run formatcheck` (all clean); `npm run coverage` across all workspaces -- core unit 2002 passed, cli unit + integration 1014 passed / 3 skipped, web unit 559 passed -- each producing a text summary plus html and lcov under `coverage/`. Verified a normal `npm test` is unaffected (coverage is inert without `--coverage`) and that the coverage artifacts are gitignored at every workspace depth.
New tests cover: n/a -- tooling change; it adds no product code and no new asserted behavior.

## Background

Coverage config lives per workspace rather than in the root aggregate config because each workspace defines nested Vitest projects that the root `projects` globs do not flatten; the root `coverage` script fans out, mirroring `npm test`. Web coverage is unit-only: the web integration suite is black-box HTTP against a separate dev-server process and imports no `src`, so it contributes no in-process coverage.

## Out of scope / follow-on

- Browser-mode (real Chromium) coverage for `apps/web`, and web black-box integration coverage -- deferred per the issue; not yet filed as a board item.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no product or wire behavior changed; the operator-facing note lives in `CONTRIBUTING.md` (Coverage), and there is no spec-tier detail to record.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test/tooling-only change with no operator- or reviewer-observable behavior.
- [x] Security review -- done this cycle (supply-chain, disclosure/secret-leak, and build/CI-integrity angles, all clean); formally out of scope: `@vitest/coverage-v8` is dev-only test tooling, not a security-relevant dependency, and the change touches no crypto, AEAD, channel-hardening, credential, auth, or disclosure surface.
