### PR TITLE
Extend web coverage to browser paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,11 +161,21 @@ and writes a text summary to the terminal plus a browsable HTML report and an
 `lcov.info` (for editors/tooling) under each workspace's `coverage/` directory.
 The denominator is scoped to product source under each `src/` tree, with the
 generated route tree and vendored `apps/web/src/contrib` excluded, so the numbers
-reflect hand-written product code. The report runs the node projects: `core`
-unit, `cli` unit and integration (the SFTP adapter is exercised only by the
-integration suite), and `web` unit. Browser-mode coverage (real Chromium) and the
-web black-box integration suite are not included; browser coverage is a deferred
-follow-up.
+reflect hand-written product code. The report runs `core` unit, `cli`
+unit and integration (the SFTP adapter is exercised only by the integration
+suite), and `web` unit plus `web` browser (real Chromium via Playwright). The web
+unit and browser projects run together and their coverage is merged, so the
+component, live-exchange, and consent-gate paths exercised only in the browser
+are reflected instead of reading as near-zero; running `npm run coverage` for the
+web workspace therefore stands up the dev server and Chromium the same way `npm
+run test:browser` does. The web black-box integration suite is deliberately
+excluded: it fetches a separately-spawned dev-server process and imports no
+`src`, so under `--coverage` it measures the empty runner process, not the
+server. Capturing that server-entry/route-handler code is feasible -- run the
+spawned server under `NODE_V8_COVERAGE` and merge its profile -- but low-value:
+it buys a bespoke merge step outside Vitest's model to cover thin server-entry
+and route glue whose behavior the integration suite already asserts end-to-end,
+so it is out of scope, not a deferred gap.
 
 There is deliberately NO global percentage gate, and adding one is not a missing
 piece to be "fixed": a blanket "N% or the build fails" bar rewards vanity tests

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,7 @@
     "test:unit": "vitest run --project unit",
     "test:integration": "vitest run --project integration",
     "test:integration:browser": "vitest run --project integration --project browser",
-    "coverage": "vitest run --project unit --coverage"
+    "coverage": "vitest run --project unit --project browser --coverage"
   },
   "keywords": [
     "private set intersection",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -88,12 +88,21 @@ export default defineConfig((_configEnv) => {
     test: {
       // Coverage is an informational REPORT, produced on demand by `npm run
       // coverage` (see package.json), never a gate: there is deliberately NO
-      // `thresholds` line (see CONTRIBUTING.md, Coverage). The coverage script
-      // runs the unit project only. The integration project is a black-box HTTP
-      // suite -- it fetches a separate dev-server process and imports no src, so
-      // it adds server-startup cost and flake risk for zero in-process coverage.
-      // The browser project (real Chromium) is a documented follow-up: v8
-      // coverage there needs separate handling and can perturb browser timing.
+      // `thresholds` line (see CONTRIBUTING.md, Coverage). The script runs the
+      // unit (node) and browser (real Chromium) projects together and merges
+      // their results, so the component, live-exchange, and consent-gate paths
+      // exercised only in the browser no longer read as near-zero. Browser
+      // coverage is folded into this default run rather than kept a separate
+      // opt-in because the report is on-demand and never gates: its cost is
+      // paid only when asked for, with no CI stability bar to protect.
+      // The integration project stays out: it is a black-box HTTP suite that
+      // fetches a separately-spawned dev-server process and imports no src, so
+      // under --coverage it measures the empty runner process, not the server.
+      // Capturing that server-entry/route-handler code is feasible -- run the
+      // spawned server under NODE_V8_COVERAGE and merge its profile -- but
+      // low-value: a bespoke merge step outside Vitest's model, to cover thin
+      // server-entry and route glue whose behavior the integration suite
+      // already asserts end-to-end. So it is out of scope, not a deferred gap.
       coverage: {
         provider: "v8",
         // text -> terminal summary; html + lcov -> browsable/tooling report


### PR DESCRIPTION
## Summary

Extend the web workspace's on-demand coverage report to include the browser (real Chromium) project, so the component, live-exchange, and consent-gate paths exercised only in the browser are reflected instead of reading as near-zero. Follow-on to #352, which scoped the initial report to the node-run projects and flagged web browser-mode coverage as a deferred gap. Still an informational report with no percentage gate.

Implements [207541432](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=207541432).

## Changes

- apps/web/package.json: `coverage` now runs `--project unit --project browser --coverage`, so the node unit and browser projects run together and their v8 coverage merges into one report.
- apps/web/vite.config.ts: rewrite the coverage comment block to document the merged unit+browser run and the integration-coverage decision; no executable config change.
- CONTRIBUTING.md: update the Coverage section to match -- what the default run now includes, and why the black-box integration suite's coverage is out of scope (feasible via `NODE_V8_COVERAGE`, but low-value) rather than a deferred gap.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format` (all clean); `npm run coverage -w apps/web` (exit 0, 58 files / 846 tests pass, HTML + lcov written; browser-only files such as ExchangeView/InvitePanel now report real numbers instead of ~0). Compared the browser suite with and without coverage (both green, ~27s vs ~26s) to confirm folding coverage in adds no timing regression or flake.
New tests cover: n/a -- no product code changed; this is a coverage-config/tooling and docs change, validated by running the coverage script itself.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no docs/ or docs/spec/ page covers on-demand coverage tooling; the Coverage section in CONTRIBUTING.md is updated in this PR.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test/CI/tooling change (on-demand coverage report, not run in CI), no operator- or reviewer-visible behavior.
- [x] Security review -- n/a: no security-review-scope surface touched (coverage tooling only; no crypto, channel-security, credential/disclosure, or security-relevant dependency -- no dependency change at all). Independent build/supply-chain, runtime/config, and secrets reviews were run as due diligence and found nothing.