### PR TITLE
Deflake the prod-bundle CSV worker deploy test

### DIFF
--- a/apps/web/test/integration/csvWorkerProd.test.ts
+++ b/apps/web/test/integration/csvWorkerProd.test.ts
@@ -38,6 +38,11 @@ const hasBuild = existsSync(prodEntry);
 
 const READY_TIMEOUT_MS = 30_000;
 const GENERATE_TIMEOUT_MS = 30_000;
+// Budget for the app to hydrate before the invite interactions "stick". The page is
+// server-rendered and hydrates asynchronously; an interaction landing before React
+// attaches its handlers is lost, so the invite flow re-applies its inputs until the
+// Generate button reflects them within this window.
+const HYDRATION_TIMEOUT_MS = 20_000;
 const STOP_TIMEOUT_MS = 5_000;
 
 function sleep(ms: number): Promise<void> {
@@ -200,17 +205,52 @@ describe.skipIf(!hasBuild)(
           page.on("worker", (worker) => workerUrls.push(worker.url()));
 
           await page.goto(`http://127.0.0.1:${port}/`, {
-            waitUntil: "domcontentloaded",
+            waitUntil: "load",
+            timeout: GENERATE_TIMEOUT_MS,
           });
 
-          await page.getByLabel("Your name").fill("Prod Worker Test");
-          await page
-            .locator('input[type="file"]')
-            .first()
-            .setInputFiles(csvPath);
-          await page
-            .getByRole("button", { name: "Generate invitation" })
-            .click();
+          // Re-apply the name and file until Generate enables, then click. The page is
+          // server-rendered and hydrates asynchronously; an interaction that lands
+          // before React attaches its handlers is lost -- a controlled field re-renders
+          // from empty state and the file input's change event is dropped -- leaving
+          // Generate disabled. That is the race that flaked this deploy under CI load.
+          // `load` only guarantees the bundle fetched, not that hydration ran, so the
+          // real fix is to re-apply both inputs until the button reflects them: an
+          // enabled button IS the hydration signal. Each action is short-bounded so one
+          // stuck call cannot overrun the loop's own deadline (its 30s default would).
+          const ACTION_TIMEOUT_MS = 5_000;
+          const nameField = page.getByLabel("Your name");
+          const fileInput = page.locator('input[type="file"]').first();
+          const generate = page.getByRole("button", {
+            name: "Generate invitation",
+          });
+          const enableDeadline = Date.now() + HYDRATION_TIMEOUT_MS;
+          for (;;) {
+            await nameField.fill("Prod Worker Test", {
+              timeout: ACTION_TIMEOUT_MS,
+            });
+            await fileInput.setInputFiles(csvPath, {
+              timeout: ACTION_TIMEOUT_MS,
+            });
+            if (await generate.isEnabled({ timeout: ACTION_TIMEOUT_MS })) break;
+            if (Date.now() >= enableDeadline) {
+              // Distinguish a hydration stall from a real rejection (the accept filter,
+              // the 100 MB cap, or a broken name/file binding) so the failure is
+              // diagnosable rather than a bare "still disabled": report whether the file
+              // registered in the dropzone and the button's disabled attribute.
+              const fileShown =
+                (await page.getByText("large.csv", { exact: false }).count()) >
+                0;
+              const disabledAttr = await generate.getAttribute("disabled");
+              throw new Error(
+                `Generate invitation stayed disabled after ${HYDRATION_TIMEOUT_MS}ms ` +
+                  `(file shown in dropzone: ${fileShown}, disabled attr: ${disabledAttr}); ` +
+                  "the invite interactions may not have hydrated, or the file was rejected",
+              );
+            }
+            await sleep(200);
+          }
+          await generate.click();
 
           // The share block appears only after generateInvitation resolves, which
           // requires a clean parse (a corrupted header crashes generation). Its
@@ -232,7 +272,11 @@ describe.skipIf(!hasBuild)(
           await page.close();
         }
       },
-      GENERATE_TIMEOUT_MS + 20_000,
+      // Cover the three bounded phases serially -- goto (<= GENERATE_TIMEOUT_MS),
+      // the enable loop (<= HYDRATION_TIMEOUT_MS), and the share-block wait
+      // (<= GENERATE_TIMEOUT_MS) -- plus margin, so a slow phase surfaces its own
+      // error rather than a bare per-test timeout.
+      GENERATE_TIMEOUT_MS * 2 + HYDRATION_TIMEOUT_MS + 20_000,
     );
   },
 );


### PR DESCRIPTION
## Summary

The staging deploy of #357 failed on the production-bundle CSV worker integration test. The test drove the invite flow after `page.goto` with `waitUntil: "domcontentloaded"`, which resolves before the server-rendered app hydrates, so under CI load the name and file interactions landed before React attached its handlers and were lost (the controlled name field re-renders from empty state; the file input's change event is dropped). The "Generate invitation" button therefore stayed disabled and the click timed out. The PR build-and-test gate and local runs, with faster hydration, did not trip it. This waits for the `load` event and re-applies the inputs until the button enables before clicking, so the interactions cannot race hydration.

## Changes

- `apps/web/test/integration/csvWorkerProd.test.ts`: goto now waits for `load`; the invite flow re-applies the name and file until the Generate button reflects them (bounded by a new `HYDRATION_TIMEOUT_MS`, with the per-test timeout raised to cover it), then clicks.

## Test plan

Ran `npm run test:integration -w apps/web -- test/integration/csvWorkerProd.test.ts` three times against a fresh `npm run build -w apps/web` -- all green -- plus `npm run typecheck`, `npm run lint`, and `npm run formatcheck`.

New tests cover: n/a -- this hardens the existing production-bundle test's interaction against the SSR-hydration race; no new behavior. The flake is timing-dependent, so the retry-until-enabled loop removes the race by construction rather than by a reproduction.

## Checklist

- [x] Docs: n/a -- test-only change, no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-only change, not visible to an operator, deployer, or security reviewer.
- [x] Security review -- n/a: test-only change; no cryptographic, disclosure, bounds, credential, auth, or dependency surface is touched.
