### PR TITLE
Ignore within-major Dependabot action bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,7 +75,7 @@ updates:
       default-days: 7
 
   # GitHub Actions used by the workflows in .github/workflows. Every action is
-  # tag-pinned (e.g. actions/checkout@v6), so this tracks those tags for new
+  # tag-pinned (e.g. actions/checkout@v7), so this tracks those tags for new
   # releases and security advisories.
   - package-ecosystem: github-actions
     directory: "/"
@@ -88,3 +88,25 @@ updates:
       # Only default-days is valid for the docker and github-actions
       # ecosystems; the semver-*-days keys are supported for npm only.
       default-days: 7
+    ignore:
+      # Every action from these orgs is pinned to a floating major tag (e.g.
+      # actions/checkout@v7), which already tracks the latest release within that
+      # major at runtime. A minor/patch bump PR would only re-pin us to a
+      # specific, frozen version (dropping later fixes) and add churn -- so we
+      # ignore within-major bumps and let the major tags float. Major bumps
+      # (e.g. checkout v6 -> v7) are NOT ignored and still surface for review.
+      #
+      # sigstore/cosign-installer is intentionally NOT listed: it publishes no
+      # floating major tag, so it stays exact-pinned (@v4.1.2) and its patch
+      # bumps are legitimate, reviewable updates to the release-signing tool.
+      #
+      # A new floating-major action from another org should be added here.
+      - dependency-name: "actions/*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "docker/*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "aws-actions/*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
## Summary

Dependabot re-pinned a floating-major GitHub Action to a frozen version in #320 (aws-actions/configure-aws-credentials@v6 -> @v6.2.0), a churn PR that drops later patches without changing runtime behavior. This stops that class of PR at the source so it does not recur across the other floating-major actions in CI.

## Changes

- .github/dependabot.yml: add three org-scoped ignore rules to the github-actions ecosystem so within-major (semver-minor and semver-patch) bumps are ignored for actions/*, docker/*, and aws-actions/*; semver-major bumps (e.g. checkout v6 to v7) still surface for review. Correct a stale actions/checkout@v6 -> @v7 example in the adjacent comment.

## Test plan

Ran: `npx prettier --check .github/dependabot.yml` (passes); parsed the file with the `yaml` library to confirm the three ignore rules resolve as intended.
New tests cover: n/a -- Dependabot config is not exercised by the test suites; GitHub validates it on push.

## Background

sigstore/cosign-installer is intentionally excluded: it publishes no floating major tag (only v4.0.0/v4.1.0/v4.1.1/v4.1.2), so it stays exact-pinned and its patch bumps remain legitimate, reviewable updates to the release-signing tool. Floating-major actions already pull the latest within-major release at runtime, so a re-pin PR only freezes us behind that and reduces patch currency; suppressing those PRs preserves currency rather than reducing it.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; this is Dependabot scheduling config, and the WebRTC-stack `non-critical`/`webrtc-stack` npm grouping that CONTRIBUTING references is untouched.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: CI/tooling change with no operator- or reviewer-visible effect.
- [x] Security review -- n/a: no pinned action version or security control changes; floating-major tags still pull the latest within-major release at runtime, and cosign-installer's reviewable patch-bump stream is deliberately preserved.
