### PR TITLE
Cover server-password @path parse-time resolution

### DIFF
--- a/apps/cli/test/unit/exchange.test.ts
+++ b/apps/cli/test/unit/exchange.test.ts
@@ -128,9 +128,35 @@ test("builder: exchange's command-specific option help reaches the rendered help
 // exchange resolves an @path credential flag eagerly in parseArgs: it never
 // persists a config, so there is no reference to preserve, and the override is
 // layered on AFTER the config-load resolution (resolveExchangeSpecRefs). Without
-// this, an @path passphrase from the flag would reach the live SFTP connection
-// unresolved. This pins that seam for the passphrase (the flag added here)
-// alongside its sibling private key.
+// this, an @path credential from the flag would reach the live SFTP connection
+// unresolved. This pins that seam for each of the three credential siblings the
+// eager resolution covers -- the server password, the SSH private key, and its
+// passphrase -- so a future edit that broke the @path resolution for any one
+// of them is caught.
+
+test("parseArgs resolves an @path server-password to the file contents", () => {
+  const passwordRef = path.join(dir, "sftp-password");
+  fs.writeFileSync(passwordRef, "S3cr3tSFTPPassw0rd\n");
+  const argv = {
+    _: [],
+    $0: "psilink",
+    input: "data.csv",
+    "server-password": `@${passwordRef}`,
+  } as unknown as Arguments;
+  const args = parseArgs(argv);
+  expect(args.serverPassword).toBe("S3cr3tSFTPPassw0rd");
+});
+
+test("parseArgs carries a literal server-password through unchanged", () => {
+  const argv = {
+    _: [],
+    $0: "psilink",
+    input: "data.csv",
+    "server-password": "inline-password",
+  } as unknown as Arguments;
+  const args = parseArgs(argv);
+  expect(args.serverPassword).toBe("inline-password");
+});
 
 test("parseArgs resolves an @path server-private-key-passphrase and private key to the file contents", () => {
   const keyRef = path.join(dir, "id_ed25519");


### PR DESCRIPTION
## Summary

Add parse-time `@path` resolution coverage for the `exchange` command's `--server-password` flag, closing a sibling test gap on a credential-referencing surface. `exchange` resolves an `@path` credential override eagerly in `parseArgs`; only the passphrase and its private key were pinned by a parse-time test, so a future edit that broke `--server-password`'s eager resolution would send the literal `@file` string to ssh2 as the password with no test to catch it. This adds the missing sibling coverage. Test-only; no production change.

Implements [207979214](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=207979214).

## Changes

- apps/cli/test/unit/exchange.test.ts: add two `parseArgs` tests -- one asserting `--server-password @file` resolves to the file's contents (the secret), one asserting a literal value passes through unchanged; broaden the credential-override block comment to cover all three eager-resolution siblings, scoped to `@path` resolution.

## Test plan

Ran: `npx vitest run apps/cli/test/unit/exchange.test.ts` (58 passed), plus `npm run typecheck`, `npm run lint`, `npm run format` (clean). Mutation-verified the new coverage: removing the `resolveAtSignRefs` wrapper from the `serverPassword` line in `parseArgs` fails the new `@path` test with an exact-string assertion, while the literal-passthrough test stays green.
New tests cover: parse-time `@path` resolution of `--server-password` (the reference resolves to the secret, not carried through literally) and literal passthrough (a non-`@` value is unchanged).

## Background

Pre-existing, project-wide coverage gap. PR #364, which added `--server-private-key-passphrase`, deliberately did not retrofit sibling coverage to stay focused; this is the quality follow-up. Each of the three eager-resolution calls in `parseArgs` (password, private key, passphrase) is now backed by its own `@path` assertion.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed (test-only, additive coverage).
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-only change, not visible to an operator/deployer or security reviewer.
- [x] Security review -- done: config `@path` credential-resolution surface; test-only, no control modified; two independent final security reviews found no issues.
