### PR TITLE
Reword outbound-send caption to a topic phrase

### DIFF
--- a/apps/web/src/components/ExchangeSummary.tsx
+++ b/apps/web/src/components/ExchangeSummary.tsx
@@ -45,7 +45,7 @@ export function ExchangeSummary({
    * to {@link InvitationTerms}. */
   disclosedPayloadColumns?: Array<string>;
   headingRef?: Ref<HTMLHeadingElement>;
-  /** This party's own disclosed columns ("Columns you will send to your
+  /** This party's own disclosed columns ("What you will send to your
    * partner"), forwarded to {@link InvitationTerms} as `outboundColumns` and
    * rendered as chips just above "Other details". Omit where the set is not yet
    * known (the acceptor review screen) or already shown inside the terms (the

--- a/apps/web/src/components/InvitationTerms.tsx
+++ b/apps/web/src/components/InvitationTerms.tsx
@@ -642,12 +642,12 @@ export function InvitationTerms({
         )}
 
         {/* The acceptor's OWN outbound disclosure, in the same always-visible slot
-            as the inviter's proposing block above, so "Columns you will send" sits
+            as the inviter's proposing block above, so "What you will send" sits
             with the agreed terms and ABOVE "Other details" rather than after the
             whole panel. Only the acceptor passes outboundColumns; the inviter's own
             send already renders from its proposing block. */}
         {perspective !== "proposing" && outboundColumns !== undefined && (
-          <Term label="Columns you will send to your partner">
+          <Term label="What you will send to your partner">
             {outboundColumns.length > 0 ? (
               // These are the operator's OWN CSV headers (from the live metadata
               // disclosure), not a sanitized summary value, so sanitize them for
@@ -658,7 +658,7 @@ export function InvitationTerms({
                 columns={outboundColumns.map((name) =>
                   sanitizeForDisplay(name),
                 )}
-                label="Columns you will send to your partner"
+                label="What you will send to your partner"
               />
             ) : (
               <Text size="sm" c="dimmed">
@@ -684,7 +684,7 @@ export function InvitationTerms({
             partner-controlled text, so it needs no per-render sanitization; it names
             no column count or names, which are not yet known here. */}
         {perspective === "review" && outboundColumns === undefined && (
-          <Term label="Columns you will send to your partner">
+          <Term label="What you will send to your partner">
             <Text size="sm" c="dimmed">
               After you choose your file, you will confirm exactly which of its
               columns are sent to your partner for matched records.

--- a/apps/web/src/components/MetadataGrid.tsx
+++ b/apps/web/src/components/MetadataGrid.tsx
@@ -47,7 +47,7 @@ const SINGLE_IDENTIFIER_MESSAGE =
  * the edit means.
  *
  * The grid does not paint the disclosed-columns list itself: each host already
- * shows it visibly as the "Columns you will send to your partner" chips beside the
+ * shows it visibly as the "What you will send to your partner" chips beside the
  * agreed terms, so a second text copy here would be a same-screen duplicate. What
  * the grid keeps is the aria-live ANNOUNCEMENT of that list -- computed
  * synchronously from {@link disclosedColumnNames}, the same predicate
@@ -198,7 +198,7 @@ export function MetadataGrid({
       )}
 
       {/* The disclosure readout is shown VISIBLY by the host's column chips
-          (the "Columns you will send to your partner" list beside the agreed
+          (the "What you will send to your partner" list beside the agreed
           terms), so the grid no longer repeats it as text -- that was a
           duplicate on the same screen. What stays here is the announcement: a
           screen-reader user toggling a disclosure Select above gets no spoken

--- a/apps/web/src/components/PrepareData.tsx
+++ b/apps/web/src/components/PrepareData.tsx
@@ -641,7 +641,7 @@ export function PrepareData({
 
       {/* Sticky footer for the commit, mirroring the inviter's. Bottom padding on
           the page keeps it from occluding the last card. There is no confirm modal:
-          consent is already given on the review screen, and the live "Columns you
+          consent is already given on the review screen, and the live "What you
           will send" chips in the summary column are the standing last-look. */}
       <Box
         style={{

--- a/apps/web/test/browser/acceptConsentGate.test.ts
+++ b/apps/web/test/browser/acceptConsentGate.test.ts
@@ -335,7 +335,7 @@ describe("prepare your data editor (verdict, disclosure, launch)", () => {
     // The columns this party will send are surfaced there as a chip list (named for
     // assistive tech), with `notes` among the chips.
     const sendChips = page.getByRole("list", {
-      name: "Columns you will send to your partner",
+      name: "What you will send to your partner",
     });
     await expect.element(sendChips).toBeInTheDocument();
     await expect.element(sendChips.getByText("notes")).toBeInTheDocument();
@@ -355,7 +355,7 @@ describe("prepare your data editor (verdict, disclosure, launch)", () => {
     await expect
       .element(
         page
-          .getByRole("list", { name: "Columns you will send to your partner" })
+          .getByRole("list", { name: "What you will send to your partner" })
           .getByText("notes"),
       )
       .toBeInTheDocument();
@@ -442,7 +442,7 @@ describe("prepare your data editor (verdict, disclosure, launch)", () => {
     await expect
       .element(
         page
-          .getByRole("list", { name: "Columns you will send to your partner" })
+          .getByRole("list", { name: "What you will send to your partner" })
           .getByText("comment"),
       )
       .toBeInTheDocument();
@@ -470,7 +470,7 @@ describe("prepare your data editor (verdict, disclosure, launch)", () => {
     await expect
       .element(
         page
-          .getByRole("list", { name: "Columns you will send to your partner" })
+          .getByRole("list", { name: "What you will send to your partner" })
           .getByText("notes"),
       )
       .toBeInTheDocument();

--- a/apps/web/test/browser/invitationTerms.test.ts
+++ b/apps/web/test/browser/invitationTerms.test.ts
@@ -786,6 +786,63 @@ describe("InvitationTerms: the acceptor's outbound-disclosure forward-reference"
   });
 });
 
+describe("InvitationTerms: the outbound-send caption does not presuppose a non-empty send", () => {
+  // The caption above the acceptor's own outbound disclosure is a topic phrase
+  // ("What you will send to your partner"), not the declarative "Columns you will
+  // send ..." it replaced: that presupposed a non-empty send, so it contradicted its
+  // own empty-send body ("No columns are sent ...") and over-asserted a definite send
+  // on the pre-file review screen, where the set is not yet known. These pin that the
+  // caption reads truthfully over both branches -- and that the presupposing phrasing
+  // does not creep back at either call site.
+  function render(options: {
+    perspective: "review" | "accepted";
+    outboundColumns?: Array<string>;
+  }) {
+    root!.render(
+      createElement(
+        MantineProvider,
+        null,
+        createElement(InvitationTerms, {
+          linkageTerms: terms,
+          perspective: options.perspective,
+          ...(options.outboundColumns !== undefined
+            ? { outboundColumns: options.outboundColumns }
+            : {}),
+        }),
+      ),
+    );
+  }
+
+  const caption = "What you will send to your partner";
+  // The declarative phrasing this reword removed. Asserted absent so a revert that
+  // reintroduces the presupposition fails, rather than passing on the "send to your
+  // partner" tail both phrasings share.
+  const presupposingCaption = "Columns you will send to your partner";
+
+  test("reads as a topic phrase, not a definite send, above the empty-send confirmation", async () => {
+    // A chosen file that sends nothing (outboundColumns []): the caption sits above
+    // the explicit "No columns are sent ..." body. The topic phrasing no longer
+    // contradicts that body the way the old declarative caption did.
+    render({ perspective: "accepted", outboundColumns: [] });
+    await expect.element(toggle("Other details")).toBeInTheDocument();
+    expect(container!.textContent).toContain(caption);
+    expect(container!.textContent).toContain(
+      "No columns are sent to your partner",
+    );
+    expect(container!.textContent).not.toContain(presupposingCaption);
+  });
+
+  test("stays truthful on the pre-file review screen, where the send set is not yet known", async () => {
+    // perspective review, outboundColumns undefined: the forward-reference stands in
+    // for the not-yet-known send, and the caption above it must not assert a definite
+    // send at the consent decision point.
+    render({ perspective: "review" });
+    await expect.element(toggle("Other details")).toBeInTheDocument();
+    expect(container!.textContent).toContain(caption);
+    expect(container!.textContent).not.toContain(presupposingCaption);
+  });
+});
+
 describe("InvitationTerms: the presence hints form a labelled, disclosure-linked group", () => {
   // The a11y contract for the presence-hint block: it is one named group (so a
   // screen reader announces the flagged facts as a related set, not disconnected


### PR DESCRIPTION
## Summary

Reword the acceptor consent screen's outbound-send caption from the declarative "Columns you will send to your partner" to the topic phrase "What you will send to your partner", so it reads truthfully whether or not the acceptor actually sends columns. The old noun phrase presupposed a non-empty send: it contradicted its own empty-send body ("No columns are sent to your partner ...") and over-asserted a definite send on the pre-file review screen, where the set is not yet known -- an over-assertion at the consent decision point. Copy only; no change to what is disclosed, sent, or written.

Implements [208083235](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=208083235).

## Changes

- apps/web/src/components/InvitationTerms.tsx: reword the caption at both acceptor call sites -- the real outbound-send block's `Term` label and `ColumnChips` accessible label, and the review-screen forward-reference `Term` label -- plus the adjacent explanatory comment.
- apps/web/src/components/MetadataGrid.tsx: update the two JSDoc cross-references that quote the caption.
- apps/web/src/components/ExchangeSummary.tsx: update the JSDoc cross-reference that quotes the caption.
- apps/web/src/components/PrepareData.tsx: update the sticky-footer comment that quotes the caption.
- apps/web/test/browser/acceptConsentGate.test.ts: update the four accessible-name assertions to the new caption.
- apps/web/test/browser/invitationTerms.test.ts: add a render-test block covering the two acceptance cases and guarding the old phrasing.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format` (all clean); `npx vitest run --project browser test/browser/invitationTerms.test.ts test/browser/acceptConsentGate.test.ts` (green, including the two new caption tests).
New tests cover: the empty-send case (caption and body do not contradict) and the pre-file review case (caption truthful when the outbound set is not yet known), plus a guard that the old presupposing phrasing does not reappear at either call site.

## Background

The review-screen forward-reference call site was added by item 208071496 (#369) but reused the presupposing caption; this corrects both call sites in one pass, and aligns the caption with the phrasing the sibling "Prepare your data" editor already uses. The wording was chosen with maintainer sign-off.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; COMMUNICATION.md and SECURITY_DESIGN.md describe this surface conceptually and never quote the literal caption string.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: copy-only wording refinement to an as-yet-unreleased consent screen; no operator- or reviewer-visible behavior, wire, or on-disk change.
- [x] Security review -- done: independent review across disclosure-integrity, injection/sanitization, and control-integrity lenses; the change is display-only consent copy (a consent-surfaced field), with the disclosure predicate, wire path, sanitization guard, and gating conditions all untouched.