### PR TITLE
Name send-columns chip lists from their caption

### DIFF
--- a/apps/web/src/components/ColumnChips.tsx
+++ b/apps/web/src/components/ColumnChips.tsx
@@ -14,17 +14,37 @@ import { Badge, Group } from "@mantine/core";
  * so assistive tech reads it as a list of names. Keyed by index -- a sanitized
  * name is not guaranteed unique -- and tt="none" keeps each name verbatim rather
  * than upper-casing it into a system-looking token.
+ *
+ * The list's accessible name comes from exactly one of two mutually exclusive
+ * props: `label` sets it directly as the group's aria-label, for a caller with no
+ * visible caption naming the list; `labelledBy` points aria-labelledby at an
+ * existing visible caption's id, for a caller whose caption already names the list
+ * -- so the list's name derives from that one visible caption rather than a second,
+ * separately-authored aria-label string that could drift from it. This does not
+ * reduce how often a screen reader speaks the caption: a named list is still
+ * announced by name at its boundary, as any labelled region is (cf. a fieldset's
+ * legend); labelledby only makes the visible caption the single source of that name.
  */
 export function ColumnChips({
   columns,
   label,
+  labelledBy,
 }: {
   columns: Array<string>;
-  /** The list's accessible name (aria-label on the role=list group). */
-  label: string;
-}) {
+} & (
+  | {
+      /** The list's accessible name, set directly as aria-label. */
+      label: string;
+      labelledBy?: never;
+    }
+  | {
+      /** Id of a visible caption that names the list via aria-labelledby. */
+      labelledBy: string;
+      label?: never;
+    }
+)) {
   return (
-    <Group gap="xs" role="list" aria-label={label}>
+    <Group gap="xs" role="list" aria-label={label} aria-labelledby={labelledBy}>
       {columns.map((name, index) => (
         <Badge
           key={index}

--- a/apps/web/src/components/InvitationTerms.tsx
+++ b/apps/web/src/components/InvitationTerms.tsx
@@ -38,11 +38,23 @@ function joinList(items: Array<string>): string {
   return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
 }
 
-/** A labelled block: a bold caption above its value(s). */
-function Term({ label, children }: { label: string; children: ReactNode }) {
+/** A labelled block: a bold caption above its value(s). When `captionId` is set it
+ * is put on the caption, so a child that is itself a labelled region (a
+ * {@link ColumnChips} list) can name itself from the visible caption via
+ * aria-labelledby rather than carrying a second, separately-authored aria-label that
+ * could drift from the caption. */
+function Term({
+  label,
+  captionId,
+  children,
+}: {
+  label: string;
+  captionId?: string;
+  children: ReactNode;
+}) {
   return (
     <Stack gap={2}>
-      <Text size="sm" fw={600}>
+      <Text size="sm" fw={600} id={captionId}>
         {label}
       </Text>
       {children}
@@ -530,6 +542,16 @@ export function InvitationTerms({
   // this heading when the terms appear (headingRef + tabIndex), so this association
   // is what carries the caveat into that announcement.
   const identityNoteId = useId();
+  // The visible send-columns captions name their chip list via aria-labelledby (the
+  // ColumnChips below each references its Term's caption), so the list's accessible
+  // name derives from the one visible caption rather than a second, separately-
+  // authored aria-label that could drift from it. Two ids because the inviter's
+  // "proposing" send and the acceptor's own outbound send are distinct captions
+  // (mutually exclusive by perspective, but each names its own list). The pre-file
+  // forward-reference reuses the outbound caption text but wraps no list, so it needs
+  // no id.
+  const proposingSendCaptionId = useId();
+  const outboundSendCaptionId = useId();
   const reduceMotion = useReducedMotion();
   // Tier captions are headings one level below the terms heading, so a screen reader
   // can jump between tiers by heading and the outline nests under the page's own
@@ -609,12 +631,15 @@ export function InvitationTerms({
               declaration under "proposing", so an empty set reads as a positive "no
               columns" confirmation rather than an unknown. */}
           {perspective === "proposing" && (
-            <Term label="Columns sent to your partner">
+            <Term
+              label="Columns sent to your partner"
+              captionId={proposingSendCaptionId}
+            >
               {summary.payload !== undefined &&
               summary.payload.send.length > 0 ? (
                 <ColumnChips
                   columns={summary.payload.send}
-                  label="Columns sent to your partner"
+                  labelledBy={proposingSendCaptionId}
                 />
               ) : (
                 <Text size="sm" c="dimmed">
@@ -630,7 +655,10 @@ export function InvitationTerms({
               outboundSendListRenders boolean, which the group-render check also uses)
               so TypeScript narrows outboundColumns to defined inside. */}
           {perspective !== "proposing" && outboundColumns !== undefined && (
-            <Term label="What you will send to your partner">
+            <Term
+              label="What you will send to your partner"
+              captionId={outboundSendCaptionId}
+            >
               {outboundColumns.length > 0 ? (
                 // These are the operator's OWN CSV headers (from the live metadata
                 // disclosure), not a sanitized summary value, so sanitize them for
@@ -641,7 +669,7 @@ export function InvitationTerms({
                   columns={outboundColumns.map((name) =>
                     sanitizeForDisplay(name),
                   )}
-                  label="What you will send to your partner"
+                  labelledBy={outboundSendCaptionId}
                 />
               ) : (
                 <Text size="sm" c="dimmed">

--- a/apps/web/test/browser/invitationTerms.test.ts
+++ b/apps/web/test/browser/invitationTerms.test.ts
@@ -1441,3 +1441,65 @@ describe("InvitationTerms: proposed-but-not-applied caveats sit at their headlin
     expect(container!.textContent).not.toContain("(proposed; not yet applied)");
   });
 });
+
+describe("InvitationTerms: the send-columns chip list is named by its visible caption, not a duplicate aria-label", () => {
+  // The always-visible send-columns disclosure renders a visible bold caption (the
+  // Term) above a ColumnChips list. The list derives its accessible name from that
+  // caption via aria-labelledby rather than carrying a second, separately-authored
+  // aria-label with the same text -- so the visible caption is the single source of
+  // the list's name and the two cannot drift. (This does not change how often a screen
+  // reader speaks the caption: a named list is still announced by name at its boundary,
+  // as any labelled region is.) Both same-string call sites are pinned -- the inviter's
+  // "proposing" send and the acceptor's own outbound send -- so a fix cannot correct
+  // one and leave the twin on a duplicate aria-label.
+  function render(options: {
+    perspective?: "review" | "accepted" | "proposing";
+    outboundColumns?: Array<string>;
+  }) {
+    root!.render(
+      createElement(
+        MantineProvider,
+        null,
+        createElement(InvitationTerms, {
+          linkageTerms: terms,
+          ...(options.perspective ? { perspective: options.perspective } : {}),
+          ...(options.outboundColumns !== undefined
+            ? { outboundColumns: options.outboundColumns }
+            : {}),
+        }),
+      ),
+    );
+  }
+
+  // The list resolves by role + accessible name (so the caption still names it), AND
+  // carries no aria-label of its own (the name is not duplicated) but an
+  // aria-labelledby resolving to the visible caption text (its single source).
+  async function expectNamedByVisibleCaptionOnly(caption: string) {
+    const list = page.getByRole("list", { name: caption });
+    await expect.element(list).toBeInTheDocument();
+    const el = list.element();
+    // No second, identical name carried on the list itself.
+    expect(el.getAttribute("aria-label")).toBeNull();
+    // Named via the visible caption instead: aria-labelledby -> the caption node,
+    // whose text is exactly the caption the list's accessible name derives from.
+    const labelledBy = el.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy!)?.textContent).toBe(caption);
+  }
+
+  test("the inviter's proposing send list is named by its visible caption, not a duplicate aria-label", async () => {
+    // proposing + a non-empty send (the module terms send risk_score): the chips
+    // render under the "Columns sent to your partner" caption.
+    render({ perspective: "proposing" });
+    await expect.element(toggle("Other details")).toBeInTheDocument();
+    await expectNamedByVisibleCaptionOnly("Columns sent to your partner");
+  });
+
+  test("the acceptor's outbound send list is named by its visible caption, not a duplicate aria-label", async () => {
+    // A chosen file supplies outboundColumns: the acceptor's own send renders as
+    // chips under the "What you will send to your partner" caption.
+    render({ perspective: "accepted", outboundColumns: ["risk_score"] });
+    await expect.element(toggle("Other details")).toBeInTheDocument();
+    await expectNamedByVisibleCaptionOnly("What you will send to your partner");
+  });
+});


### PR DESCRIPTION
## Summary

On the web consent screen, the two always-visible send-columns disclosures named their column-chip list with an `aria-label` that duplicated the visible caption verbatim -- a second, separately-authored copy of the same string that could drift from the caption. This names each list from its visible caption via `aria-labelledby` instead, making the caption the single source of the list's accessible name. Visible text and layout are unchanged.

Implements [208094926](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=208094926).

## Changes

- `apps/web/src/components/ColumnChips.tsx`: add a `labelledBy` prop (sets `aria-labelledby`), mutually exclusive with `label` at the type level, and document the naming contract.
- `apps/web/src/components/InvitationTerms.tsx`: `Term` threads an optional `captionId` onto its caption; the inviter "proposing" send and the acceptor's own outbound send now name their `ColumnChips` list from that caption via `aria-labelledby` instead of a duplicate `aria-label`. `DefaultExchangeColumns` is untouched (its caption and list name are distinct strings), and the pre-file forward-reference `Term` wraps no list, so it carries no id.
- `apps/web/test/browser/invitationTerms.test.ts`: render tests pinning both call sites -- each list resolves its accessible name via `aria-labelledby` to the visible caption and carries no duplicate `aria-label`.

## Test plan

Ran: `npm run test:browser -w apps/web -- invitationTerms defaultExchangeColumns` (72 passed, including 2 new), `npm run typecheck`, `npm run lint`, `npm run format`.
New tests cover: both send-columns call sites resolve the chip list's accessible name from the visible caption via `aria-labelledby` and carry no duplicate `aria-label`; the untouched `DefaultExchangeColumns` and the forward-reference caption are unaffected.

## Background

Naming the list via `aria-labelledby` at a still-visible caption does not reduce how many times a screen reader speaks the caption: a named `role="list"` is still announced by its name at the list boundary, as any labelled region is (like a fieldset's legend). This PR removes the duplicated, drift-prone `aria-label` string and unifies the name onto the single visible caption; it does not claim to eliminate the double-utterance. A genuinely single utterance would require an unnamed list, which conflicts with keeping the list labelled -- deferred (see below).

## Out of scope / follow-on

- Decide whether the chip lists (including the pre-existing matching-keys list) should be unnamed for a single utterance: [208456914](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=208456914).
- Surface the outbound column count and unify the direction-tier disclosure blocks: [208456991](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=208456991).

## Checklist

- [x] Docs: n/a: no documented behavior changed -- the list's accessible-name source is a component implementation detail (no `docs/` or `docs/spec/` page covers `ColumnChips`), and the visible copy is unchanged.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: accessible-name plumbing only; the disclosed content, the visible text, and the list's accessible-name value are all unchanged, so nothing an operator/deployer or security reviewer acts on.
- [x] Security review -- consent/disclosure surface, so review applies and was done: two independent reviews on this diff (injection / untrusted-input, and consent/disclosure integrity), both clean; the change alters only the source of the list's accessible name, not what is disclosed.