### PR TITLE
Pin the matching-keys list's accessible name

### DIFF
--- a/apps/web/test/browser/invitationTerms.test.ts
+++ b/apps/web/test/browser/invitationTerms.test.ts
@@ -282,6 +282,39 @@ describe("InvitationTerms: per-key matching disclosures", () => {
     );
   });
 
+  // The matching-keys list is a NAMED region: its role="list" derives its accessible
+  // name from the visible "Matching strategies" caption via aria-labelledby, not a
+  // second, separately-authored aria-label that could drift from it -- the same
+  // single-source-of-name idiom the send-columns chip lists use (see the send-columns
+  // describe block below). Keeping the list named is the consent-surface decision on
+  // this file's three disclosure lists: a named list is announced by its name at its
+  // boundary, so it stays discoverable when a screen-reader user lands on it out of
+  // linear order -- reaching it by expanding this default-collapsed disclosure and
+  // moving into the freshly-revealed content, without the caption fresh in earshot --
+  // at the accepted cost of a second utterance of the short caption in strict linear
+  // reading. This pins that decision (all three lists named, not unnamed) so a later
+  // change cannot silently drop the name.
+  test("the matching-keys list is named by its visible caption via aria-labelledby, not a duplicate aria-label", async () => {
+    renderTerms();
+    // Default-collapsed: the list is out of the accessibility tree until the
+    // "Matching strategies" disclosure is opened, so expand it before resolving the
+    // list by role + accessible name.
+    await userEvent.click(toggle("Matching strategies"));
+
+    const list = page.getByRole("list", { name: "Matching strategies" });
+    await expect.element(list).toBeInTheDocument();
+    const el = list.element();
+    // The name is sourced from the visible caption, not duplicated onto the list.
+    expect(el.getAttribute("aria-label")).toBeNull();
+    // Named via the visible caption instead: aria-labelledby -> the caption node,
+    // whose text is exactly the caption the list's accessible name derives from.
+    const labelledBy = el.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy!)?.textContent).toBe(
+      "Matching strategies",
+    );
+  });
+
   test("every disclosure on the screen has a distinct aria-controls id", async () => {
     renderTerms();
     await expect.element(toggle("Other details")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Pin, as a render test, that the web consent screen's matching-keys list keeps its accessible name sourced from its visible "Matching strategies" caption. This completes the decision recorded on item 208456914 -- keep all three consent-screen disclosure lists named rather than drop their names for a single screen-reader utterance -- by closing the one gap: the two send-columns lists were already pinned, the matching-keys list was not. No shipped behavior changes; this locks in existing, already-correct behavior as a check.

Implements [208456914](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=208456914).

## Changes

- apps/web/test/browser/invitationTerms.test.ts: add a test asserting the matching-keys list is a role=list named "Matching strategies" via aria-labelledby with no duplicate aria-label, resolved after expanding its default-collapsed disclosure.

## Test plan

Ran: `npm run test:browser -w apps/web -- invitationTerms.test.ts` (70 passed; the new test also verified in isolation), `npm run typecheck` (web project clean), and `npm run lint` / `npm run format` (clean).
New tests cover: the matching-keys list's accessible name is present and sourced from its visible caption via aria-labelledby, with no duplicate aria-label -- the third consent-surface disclosure list, mirroring the two send-columns lists already pinned. Verified by mutation during review: dropping the name, or swapping in an aria-label, fails the test.

## Background

The named-vs-unnamed choice was an owner-sensitive consent-surface tradeoff deferred from 208094926 and decided by an independent review panel: a named role=list is announced by its name at its boundary, so it stays discoverable when a screen-reader user lands on it out of linear order (notably this list, inside a default-collapsed disclosure), at the accepted cost of a second utterance of the short caption. Encoding the decision as a check rather than prose follows the repo convention that a runtime invariant belongs in an executable assertion.

Unrelated to this diff: `npm run typecheck` currently fails first in packages/core (`test/utils/nativeAddon.ts` cannot resolve the native PSI addon subpath added in #380); that file is byte-identical to staging and the web project typechecks clean.

## Checklist

- [x] Docs: n/a: no documented behavior changed -- this adds a render test pinning existing accessible-name state, touching no product code or documented behavior.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-only change with no operator/deployer- or security-reviewer-visible behavior change.
- [x] Security review -- n/a: no disclosure control added, removed, or weakened; the diff is a test asserting the consent surface's existing accessible-name state, changing nothing sent, displayed, logged, written, or consent-surfaced. Flagged in the PR discussion for maintainer confirmation given the consent-surface adjacency.
