### PR TITLE
Guard the vendored PSI prebuild tarball and confirm the Alpine native path

### DIFF
--- a/.github/workflows/native_alpine.yaml
+++ b/.github/workflows/native_alpine.yaml
@@ -1,13 +1,15 @@
 name: Native Addon (Alpine/musl)
 
 # Confirms the vendored native PSI addon loads and is byte-for-byte correct under
-# musl. The shipped CLI base image is node:26-alpine, where node-gyp-build serves
-# the musl-tagged prebuild; the vitest native suites run on the glibc CI host and
-# select the glibc build, so they cannot exercise musl -- this gate does. It
-# installs the committed tarball fresh inside the container (as the production
-# image does) rather than reusing the runner's node_modules, and runs the
-# native-only known-answer check. Scoped to changes that can affect the vendored
-# artifact or the check itself.
+# musl. The shipped CLI base image is Alpine (musl): node-gyp-build serves the
+# musl-tagged prebuild there, while the vitest native suites run on the glibc CI
+# host and select the glibc build, so they cannot exercise musl -- this gate does.
+# It derives the exact base image from the production Dockerfile (so it always
+# mirrors what ships, and fails loudly if that base ever leaves Alpine), installs
+# the committed tarball fresh inside it (as the production image does) rather than
+# reusing the runner's node_modules, and runs the native-only known-answer check.
+# Scoped to changes that can affect the vendored artifact, the base image, or the
+# check itself.
 on:
   pull_request:
     branches: [main, staging]
@@ -16,6 +18,9 @@ on:
       - "packages/core/test/vectors/psi-engine-wire-vectors.json"
       - "packages/core/test/vectors/verify-native-wire-vectors.mjs"
       - ".github/workflows/native_alpine.yaml"
+      # The run step derives its base image from the Dockerfile's FROM line, so a
+      # base-image change must re-trigger this gate to stay in sync with what ships.
+      - "Dockerfile"
 
 # Cancel a superseded run when a newer commit lands on the same PR/branch.
 concurrency:
@@ -32,9 +37,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Verify the native addon under node:26-alpine
-        # Fresh install of just the vendored tarball inside Alpine (mirrors the
-        # production image), then the native-only known-answer check. --ignore-scripts
+      - name: Verify the native addon under the shipped Alpine base
+        # Derive the base image from the production Dockerfile's RUNTIME stage so this
+        # gate always mirrors what ships, and fail loudly if that base is no longer a
+        # node:*-alpine (musl) image, since this gate only proves the musl native path.
+        # Then a fresh install of just the vendored tarball inside it (mirrors the
+        # production image) and the native-only known-answer check. --ignore-scripts
         # is safe: node-gyp-build resolves the prebuild at require time, not install.
+        # Install stderr is left un-suppressed so a failing install surfaces its log.
         run: |
-          docker run --rm -v "$PWD":/w node:26-alpine sh -c 'set -e; cd /w && sha256sum -c lib/openmined-psi.js-*.tgz.sha256 && mkdir -p /app && cd /app && npm init -y >/dev/null 2>&1 && npm install --no-audit --no-fund --ignore-scripts /w/lib/openmined-psi.js-*.tgz >/dev/null 2>&1 && cp /w/packages/core/test/vectors/verify-native-wire-vectors.mjs verify.mjs && node verify.mjs /w/packages/core/test/vectors/psi-engine-wire-vectors.json'
+          # The runtime stage is the LAST `FROM` -- the image that actually ships and
+          # loads the native addon (an earlier `FROM ... AS builder` only compiles TS
+          # and never touches musl). A digest-pinned `@sha256:...` is kept whole so the
+          # exact shipped artifact is tested. `|| true` so an unreadable/absent base
+          # falls to the case below instead of aborting under the runner's pipefail.
+          # Assumes a literal image ref; a variable/ARG base fails later at docker pull.
+          base=$(grep -iE '^FROM[[:space:]]' Dockerfile | tail -1 | awk '{print $2}' || true)
+          case "$base" in
+            node:*-alpine | node:*-alpine@*) ;;
+            *)
+              echo "Dockerfile runtime base '$base' is not a node:*-alpine image; this musl gate's premise is stale -- update or retire it." >&2
+              exit 1
+              ;;
+          esac
+          echo "Testing the native musl addon under $base (Dockerfile runtime stage)"
+          docker run --rm -v "$PWD":/w "$base" sh -c 'set -e; cd /w && sha256sum -c lib/openmined-psi.js-*.tgz.sha256 && mkdir -p /app && cd /app && npm init -y >/dev/null 2>&1 && npm install --no-audit --no-fund --ignore-scripts /w/lib/openmined-psi.js-*.tgz >/dev/null && cp /w/packages/core/test/vectors/verify-native-wire-vectors.mjs verify.mjs && node verify.mjs /w/packages/core/test/vectors/psi-engine-wire-vectors.json'

--- a/.github/workflows/native_alpine.yaml
+++ b/.github/workflows/native_alpine.yaml
@@ -1,0 +1,40 @@
+name: Native Addon (Alpine/musl)
+
+# Confirms the vendored native PSI addon loads and is byte-for-byte correct under
+# musl. The shipped CLI base image is node:26-alpine, where node-gyp-build serves
+# the musl-tagged prebuild; the vitest native suites run on the glibc CI host and
+# select the glibc build, so they cannot exercise musl -- this gate does. It
+# installs the committed tarball fresh inside the container (as the production
+# image does) rather than reusing the runner's node_modules, and runs the
+# native-only known-answer check. Scoped to changes that can affect the vendored
+# artifact or the check itself.
+on:
+  pull_request:
+    branches: [main, staging]
+    paths:
+      - "lib/**"
+      - "packages/core/test/vectors/psi-engine-wire-vectors.json"
+      - "packages/core/test/vectors/verify-native-wire-vectors.mjs"
+      - ".github/workflows/native_alpine.yaml"
+
+# Cancel a superseded run when a newer commit lands on the same PR/branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: this gate only needs to read the repo.
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: native byte-for-byte under Alpine/musl
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify the native addon under node:26-alpine
+        # Fresh install of just the vendored tarball inside Alpine (mirrors the
+        # production image), then the native-only known-answer check. --ignore-scripts
+        # is safe: node-gyp-build resolves the prebuild at require time, not install.
+        run: |
+          docker run --rm -v "$PWD":/w node:26-alpine sh -c 'set -e; cd /w && sha256sum -c lib/openmined-psi.js-*.tgz.sha256 && mkdir -p /app && cd /app && npm init -y >/dev/null 2>&1 && npm install --no-audit --no-fund --ignore-scripts /w/lib/openmined-psi.js-*.tgz >/dev/null 2>&1 && cp /w/packages/core/test/vectors/verify-native-wire-vectors.mjs verify.mjs && node verify.mjs /w/packages/core/test/vectors/psi-engine-wire-vectors.json'

--- a/apps/cli/src/protocol.ts
+++ b/apps/cli/src/protocol.ts
@@ -809,13 +809,23 @@ export async function runProtocol(
     // platform.
     const { library: psiLibrary, backend: psiBackend } =
       await loadCliPsiBackend({
-        onNativeUnavailable: ({ error }) =>
-          log.debug(
-            "native PSI addon unavailable, using WASM:",
-            error
-              ? sanitizeErrorForDisplay(error)
-              : "no prebuild for this platform",
-          ),
+        onNativeUnavailable: ({ error }) => {
+          if (error) {
+            // A prebuild for this platform loaded far enough to fail -- an ABI or
+            // libc mismatch (e.g. ERR_DLOPEN_FAILED from a glibc-linked addon on
+            // musl, or a host glibc older than the prebuild requires). The native
+            // accelerator is silently off when we expected it on, so warn; the
+            // ordinary "no prebuild ships for this platform" case stays at debug.
+            log.warn(
+              "native PSI addon failed to load, using WASM:",
+              sanitizeErrorForDisplay(error),
+            );
+          } else {
+            log.debug(
+              "native PSI addon unavailable (no prebuild for this platform), using WASM",
+            );
+          }
+        },
       });
     log.debug(`PSI crypto backend: ${psiBackend}`);
 

--- a/apps/cli/src/protocol.ts
+++ b/apps/cli/src/protocol.ts
@@ -805,8 +805,8 @@ export async function runProtocol(
     }
 
     // Select the PSI crypto backend: the CLI runs under Node, so it prefers the
-    // native addon and falls back to WASM when no prebuild is present for this
-    // platform (currently always, until the addon ships -- board item 199653275).
+    // native addon and falls back to WASM when no prebuild ships for this
+    // platform.
     const { library: psiLibrary, backend: psiBackend } =
       await loadCliPsiBackend({
         onNativeUnavailable: ({ error }) =>

--- a/apps/cli/src/psiBackend.ts
+++ b/apps/cli/src/psiBackend.ts
@@ -39,9 +39,11 @@ async function loadNativePsiAddon(): Promise<PSILibrary | null> {
 /**
  * Whether a native-addon load error is the ordinary "no native build for this
  * platform / package" case (quiet fallback) rather than a genuinely broken load
- * worth surfacing.
+ * worth surfacing. Exported so the classification the WASM fallback depends on is
+ * pinned by unit tests -- misclassifying a broken addon as "unavailable" would
+ * hide a real regression behind a silent fallback (see psiBackend.test.ts).
  */
-function isNativeUnavailable(error: unknown): boolean {
+export function isNativeUnavailable(error: unknown): boolean {
   const code = (error as { code?: unknown } | null)?.code;
   if (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") {
     return true;

--- a/apps/cli/test/unit/psiBackend.test.ts
+++ b/apps/cli/test/unit/psiBackend.test.ts
@@ -1,3 +1,8 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, test } from "vitest";
 
 import { isNativeUnavailable } from "../../src/psiBackend";
@@ -55,5 +60,39 @@ describe("isNativeUnavailable", () => {
     expect(isNativeUnavailable(new Error("boom"))).toBe(false);
     expect(isNativeUnavailable(null)).toBe(false);
     expect(isNativeUnavailable(undefined)).toBe(false);
+  });
+
+  test("node-gyp-build still throws the message the classifier keys on", () => {
+    // The quiet path above keys on a substring of node-gyp-build's no-match
+    // error -- an external contract, not a language guarantee. A future
+    // node-gyp-build reword, or a Node that stabilizes the experimental
+    // require.addon resolver node-gyp-build can dispatch to instead of its
+    // string-throwing JS path, would silently flip a genuine "no prebuild here"
+    // from quiet to a warning on every unsupported-platform run. Pin the
+    // contract at its source: invoke the node-gyp-build the vendored package
+    // actually loads (resolved through it, not a hoisted copy) against a dir
+    // with no prebuilds, and assert both the message and the classification.
+    const requireFrom = createRequire(import.meta.url);
+    const nodeGypBuild = createRequire(
+      requireFrom.resolve("@openmined/psi.js/package.json"),
+    )("node-gyp-build") as (dir: string) => unknown;
+    const emptyDir = mkdtempSync(join(tmpdir(), "ngb-contract-"));
+    try {
+      let thrown: unknown;
+      try {
+        nodeGypBuild(emptyDir);
+      } catch (error) {
+        thrown = error;
+      }
+      expect(
+        thrown,
+        "node-gyp-build resolved a prebuild in an empty dir",
+      ).toBeInstanceOf(Error);
+      expect((thrown as Error).message).toMatch(/No native build was found/i);
+      // The classifier must still map that real error to the quiet fallback.
+      expect(isNativeUnavailable(thrown)).toBe(true);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/cli/test/unit/psiBackend.test.ts
+++ b/apps/cli/test/unit/psiBackend.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+
+import { isNativeUnavailable } from "../../src/psiBackend";
+
+// Pins the classification the WASM fallback depends on: which native-load errors
+// are the ordinary "no prebuild here" case (resolve null, fall back quietly)
+// versus a genuinely broken addon that must surface. Getting this wrong either
+// hides a real regression -- a present-but-broken prebuild silently treated as
+// "absent" -- or warns on every run of a platform that simply has no prebuild.
+describe("isNativeUnavailable", () => {
+  test("treats a missing ESM subpath / module as unavailable (quiet fallback)", () => {
+    // The dynamic import of the native entry throws ERR_MODULE_NOT_FOUND when the
+    // subpath is absent from an older vendored package; MODULE_NOT_FOUND is the
+    // CJS-resolution equivalent.
+    expect(isNativeUnavailable({ code: "ERR_MODULE_NOT_FOUND" })).toBe(true);
+    expect(isNativeUnavailable({ code: "MODULE_NOT_FOUND" })).toBe(true);
+  });
+
+  test("treats node-gyp-build's 'No native build was found' as unavailable", () => {
+    // node-gyp-build throws this (no `code`) when no prebuild matches the running
+    // platform/libc -- the expected case on an unsupported platform.
+    expect(
+      isNativeUnavailable(
+        new Error("No native build was found for platform=linuxmusl arch=x64"),
+      ),
+    ).toBe(true);
+  });
+
+  test("treats a dlopen / ABI / libc mismatch as a genuine failure, not unavailable", () => {
+    // What a glibc-linked addon throws on musl, or when the host glibc is older
+    // than the prebuild requires (verified real-world: ERR_DLOPEN_FAILED with a
+    // "GLIBC_2.38 not found" message). A prebuild exists but won't load here, so
+    // it must NOT be swallowed as "no prebuild" -- the selector still falls back
+    // to WASM, but the CLI surfaces it at warn instead of hiding it.
+    const dlopen = Object.assign(
+      new Error(
+        "/lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found",
+      ),
+      { code: "ERR_DLOPEN_FAILED" },
+    );
+    expect(isNativeUnavailable(dlopen)).toBe(false);
+  });
+
+  test("treats an exports-map subpath rejection as a genuine failure", () => {
+    // If a future vendored package adds an `exports` map without listing the
+    // native subpath, resolution throws ERR_PACKAGE_PATH_NOT_EXPORTED -- not the
+    // "no prebuild" case, so it surfaces rather than being mislabeled. Pinning
+    // current behavior; flip this if the classifier is taught to absorb it.
+    expect(isNativeUnavailable({ code: "ERR_PACKAGE_PATH_NOT_EXPORTED" })).toBe(
+      false,
+    );
+  });
+
+  test("treats an unrecognized or non-error value as a genuine failure", () => {
+    expect(isNativeUnavailable(new Error("boom"))).toBe(false);
+    expect(isNativeUnavailable(null)).toBe(false);
+    expect(isNativeUnavailable(undefined)).toBe(false);
+  });
+});

--- a/packages/core/test/psiBackend.test.ts
+++ b/packages/core/test/psiBackend.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import type { PSILibrary } from "@openmined/psi.js/implementation/psi.d.ts";
 
@@ -80,7 +80,26 @@ describe("loadPsiBackend", () => {
 });
 
 describe("detectNodeRuntime", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   test("detects the Node runtime under the node-environment unit suite", () => {
     expect(detectNodeRuntime()).toBe(true);
+  });
+
+  test("reports non-Node when a DOM window is present, even with a process shim", () => {
+    // A bundled browser build can shim `process`, so a present `window` is what
+    // disambiguates it from real Node. Stubbing `window` exercises the guard the
+    // node-environment suite otherwise never runs false -- dropping it would let
+    // such a browser misdetect as Node and consult the native loader.
+    vi.stubGlobal("window", {});
+    expect(detectNodeRuntime()).toBe(false);
+  });
+
+  test("reports non-Node when no process is present", () => {
+    // The browser-without-shim case: no Node `process` at all.
+    vi.stubGlobal("process", undefined);
+    expect(detectNodeRuntime()).toBe(false);
   });
 });

--- a/packages/core/test/psiPrebuildManifest.test.ts
+++ b/packages/core/test/psiPrebuildManifest.test.ts
@@ -12,19 +12,17 @@ import {
 // Guards the vendored @openmined/psi.js native prebuild tarball against silent
 // drift. The sha256 sidecar (verified in CI before npm ci) proves the bytes are
 // the committed ones; this proves those bytes still mean what we expect -- the
-// same platform set, per-platform libc tagging, and glibc floor -- so a re-vendor
-// that quietly drops a platform, mis-tags a libc, corrupts the WASM fallback, or
-// raises the floor fails here instead of degrading to WASM unnoticed. Contract
-// lives in ./vectors/psi-prebuild-manifest.json; the target state (which the
-// contract asserts below force a deliberate update toward) is board item
-// 208541964.
+// same platform set, per-platform libc tagging, genuinely musl-linked musl
+// builds, and the glibc floor -- so a re-vendor that quietly drops a platform,
+// mis-tags or mis-links a libc, corrupts the WASM fallback, or raises the glibc
+// floor fails here instead of degrading to WASM unnoticed. Contract lives in
+// ./vectors/psi-prebuild-manifest.json.
 
 interface Manifest {
   tarball: string;
   platforms: string[];
   wasmEngines: string[];
   linux: { libcTags: string[]; maxGlibcFloor: string };
-  target: { maxGlibcFloor: string; requiredLibcTags: string[]; note: string };
 }
 
 const manifest = JSON.parse(
@@ -106,10 +104,10 @@ describe("vendored PSI prebuild tarball manifest", () => {
   });
 
   test("tags every linux prebuild exactly as recorded", () => {
-    // Per-platform, not a union across platforms: seclink.3 must ship both the
-    // glibc and musl tag on EVERY linux arch, so node-gyp-build can never select
-    // a glibc binary under musl on any of them. A union check would miss an arch
-    // that shipped only glibc. Untagged today ([] -> [""]) -- board 208541964.
+    // Per-platform, not a union across platforms: every linux arch must ship both
+    // the glibc and musl tag, so node-gyp-build can never select a glibc binary
+    // under musl on any of them. A union check would miss an arch that shipped
+    // only glibc.
     const expected = [
       ...new Set(
         manifest.linux.libcTags.length ? manifest.linux.libcTags : [""],
@@ -128,24 +126,38 @@ describe("vendored PSI prebuild tarball manifest", () => {
     }
   });
 
-  test("records the exact linux glibc floor", () => {
-    expect(linuxPrebuilds.length).toBeGreaterThan(0);
-    const floors = linuxPrebuilds.map((prebuild) => {
+  test("records the exact glibc floor of the glibc prebuilds", () => {
+    const glibcLinux = linuxPrebuilds.filter((p) => p.tag !== "musl");
+    expect(glibcLinux.length).toBeGreaterThan(0);
+    const floors = glibcLinux.map((prebuild) => {
       const floor = maxGlibcFloor(prebuild.data);
       expect(
         floor,
-        `${prebuild.platform} references no GLIBC symbols`,
+        `${prebuild.platform} glibc build references no GLIBC symbols`,
       ).not.toBeNull();
       return floor as string;
     });
-    // Exact equality with the highest floor across the linux prebuilds. A RISE
-    // (regression -- fewer hosts can load it, the GLIBC_2.38 class this guard
-    // exists for) fails; a DROP (the seclink.3 improvement) also fails, forcing a
-    // deliberate manifest update toward `target` rather than letting the recorded
-    // value silently rot out of date.
+    // Exact equality with the highest floor across the glibc prebuilds. A RISE
+    // (regression -- fewer hosts can load it, the GLIBC_2.38 class this guard was
+    // built for) fails; a DROP (an improvement) also fails, forcing a deliberate
+    // manifest update rather than letting the recorded value silently rot.
     const observed = floors.reduce((a, b) =>
       compareVersion(a, b) >= 0 ? a : b,
     );
     expect(observed).toBe(manifest.linux.maxGlibcFloor);
+  });
+
+  test("ships musl prebuilds that are genuinely musl-linked", () => {
+    // A musl-tagged build that still references glibc symbols is mis-built and
+    // would dlopen-fail under Alpine (the exact silent-WASM regression the musl
+    // build exists to remove); catch it here rather than at runtime.
+    const muslLinux = linuxPrebuilds.filter((p) => p.tag === "musl");
+    expect(muslLinux.length).toBeGreaterThan(0);
+    for (const prebuild of muslLinux) {
+      expect(
+        maxGlibcFloor(prebuild.data),
+        `${prebuild.platform} musl build references GLIBC symbols`,
+      ).toBeNull();
+    }
   });
 });

--- a/packages/core/test/psiPrebuildManifest.test.ts
+++ b/packages/core/test/psiPrebuildManifest.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import { describe, expect, test } from "vitest";
@@ -12,16 +12,19 @@ import {
 // Guards the vendored @openmined/psi.js native prebuild tarball against silent
 // drift. The sha256 sidecar (verified in CI before npm ci) proves the bytes are
 // the committed ones; this proves those bytes still mean what we expect -- the
-// same platform set, libc tagging, and glibc floor -- so a re-vendor that quietly
-// drops a platform or raises the floor fails here instead of degrading to WASM
-// unnoticed in production. Contract lives in ./vectors/psi-prebuild-manifest.json;
-// the target state is board item 208541964.
+// same platform set, per-platform libc tagging, and glibc floor -- so a re-vendor
+// that quietly drops a platform, mis-tags a libc, corrupts the WASM fallback, or
+// raises the floor fails here instead of degrading to WASM unnoticed. Contract
+// lives in ./vectors/psi-prebuild-manifest.json; the target state (which the
+// contract asserts below force a deliberate update toward) is board item
+// 208541964.
 
 interface Manifest {
   tarball: string;
   platforms: string[];
   wasmEngines: string[];
   linux: { libcTags: string[]; maxGlibcFloor: string };
+  target: { maxGlibcFloor: string; requiredLibcTags: string[]; note: string };
 }
 
 const manifest = JSON.parse(
@@ -35,6 +38,7 @@ const manifest = JSON.parse(
 
 // Repo root is three levels up from packages/core/test/.
 const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const tarballName = manifest.tarball.split("/").pop() as string;
 const entries = readTgz(`${repoRoot}${manifest.tarball}`);
 
 // A vendored addon is `package/prebuilds/<platform>/node.napi[.<libcTag>].node`.
@@ -50,13 +54,30 @@ const prebuilds: Prebuild[] = entries.flatMap((entry) => {
   return m ? [{ platform: m[1], tag: m[2] ?? null, data: entry.data }] : [];
 });
 const linuxPrebuilds = prebuilds.filter((p) => p.platform.startsWith("linux-"));
+const linuxPlatforms = [...new Set(linuxPrebuilds.map((p) => p.platform))];
 
 describe("vendored PSI prebuild tarball manifest", () => {
-  test("resolves the committed tarball named in the manifest", () => {
-    // A version bump that renames the tarball but forgets this manifest lands
-    // here (readTgz would have thrown on a missing path) rather than silently
-    // checking a stale artifact.
-    expect(entries.length).toBeGreaterThan(0);
+  test("names the one tarball the apps install, the sidecar pins, and lib/ holds", () => {
+    // Without this, the guard could validate an artifact the app never loads: a
+    // seclink.N bump that updates package.json but leaves the old .tgz in lib/
+    // (a forgotten `git rm`) would have this suite check the stale file green.
+    // Tie the manifest to every place the vendored version is named.
+    const libFiles = readdirSync(`${repoRoot}lib`);
+    expect(libFiles.filter((f) => f.endsWith(".tgz"))).toEqual([tarballName]);
+    expect(libFiles.filter((f) => f.endsWith(".tgz.sha256"))).toEqual([
+      `${tarballName}.sha256`,
+    ]);
+    expect(
+      readFileSync(`${repoRoot}lib/${tarballName}.sha256`, "utf8"),
+    ).toContain(tarballName);
+    for (const pkg of ["apps/cli", "apps/web", "packages/core"]) {
+      const dep = (
+        JSON.parse(readFileSync(`${repoRoot}${pkg}/package.json`, "utf8")) as {
+          dependencies?: Record<string, string>;
+        }
+      ).dependencies?.["@openmined/psi.js"];
+      expect(dep, `${pkg} @openmined/psi.js dependency`).toContain(tarballName);
+    }
   });
 
   test("ships exactly the recorded platform set", () => {
@@ -64,48 +85,67 @@ describe("vendored PSI prebuild tarball manifest", () => {
     expect(platforms).toEqual([...manifest.platforms].sort());
   });
 
-  test("ships the recorded WASM engines (the default-correct fallback)", () => {
-    const names = new Set(entries.map((entry) => entry.name));
-    for (const engine of manifest.wasmEngines) {
-      expect(names.has(`package/${engine}`)).toBe(true);
+  test("ships exactly the recorded WASM engines, none truncated", () => {
+    const engineRe = /^package\/(psi_wasm_[^/]+\.js)$/;
+    const engines = new Map<string, Buffer>();
+    for (const entry of entries) {
+      const m = engineRe.exec(entry.name);
+      if (m) engines.set(m[1], entry.data);
+    }
+    // Set-equality, not subset: a dropped, renamed, OR extra engine fails.
+    expect([...engines.keys()].sort()).toEqual(
+      [...manifest.wasmEngines].sort(),
+    );
+    for (const [name, data] of engines) {
+      // The WASM engine is the default-correct fallback; a 0-byte or truncated
+      // one must not pass. Real engines are ~2MB; 100KB is a generous floor.
+      expect(data.length, `${name} is implausibly small`).toBeGreaterThan(
+        100_000,
+      );
     }
   });
 
-  test("tags the linux prebuilds exactly as recorded", () => {
-    // Untagged today ([]). seclink.3 adds glibc/musl tags so node-gyp-build can
-    // never select a glibc binary under musl; that change must update the
-    // manifest deliberately -- board 208541964.
-    const tags = [...new Set(linuxPrebuilds.map((p) => p.tag ?? ""))].sort();
+  test("tags every linux prebuild exactly as recorded", () => {
+    // Per-platform, not a union across platforms: seclink.3 must ship both the
+    // glibc and musl tag on EVERY linux arch, so node-gyp-build can never select
+    // a glibc binary under musl on any of them. A union check would miss an arch
+    // that shipped only glibc. Untagged today ([] -> [""]) -- board 208541964.
     const expected = [
       ...new Set(
         manifest.linux.libcTags.length ? manifest.linux.libcTags : [""],
       ),
     ].sort();
-    expect(tags).toEqual(expected);
+    expect(linuxPlatforms.length).toBeGreaterThan(0);
+    for (const platform of linuxPlatforms) {
+      const tags = [
+        ...new Set(
+          linuxPrebuilds
+            .filter((p) => p.platform === platform)
+            .map((p) => p.tag ?? ""),
+        ),
+      ].sort();
+      expect(tags, `linux platform ${platform} libc tags`).toEqual(expected);
+    }
   });
 
-  test("keeps the linux glibc floor at or below the recorded ceiling", () => {
+  test("records the exact linux glibc floor", () => {
     expect(linuxPrebuilds.length).toBeGreaterThan(0);
-    for (const prebuild of linuxPrebuilds) {
+    const floors = linuxPrebuilds.map((prebuild) => {
       const floor = maxGlibcFloor(prebuild.data);
       expect(
         floor,
         `${prebuild.platform} references no GLIBC symbols`,
       ).not.toBeNull();
-      // <= ceiling: a rebuild that RAISES the floor (fewer hosts can load it, the
-      // exact GLIBC_2.38 regression this guard exists for) fails here.
-      expect(
-        compareVersion(floor as string, manifest.linux.maxGlibcFloor),
-        `${prebuild.platform} requires GLIBC_${floor}, above the recorded ceiling ${manifest.linux.maxGlibcFloor}`,
-      ).toBeLessThanOrEqual(0);
-    }
+      return floor as string;
+    });
+    // Exact equality with the highest floor across the linux prebuilds. A RISE
+    // (regression -- fewer hosts can load it, the GLIBC_2.38 class this guard
+    // exists for) fails; a DROP (the seclink.3 improvement) also fails, forcing a
+    // deliberate manifest update toward `target` rather than letting the recorded
+    // value silently rot out of date.
+    const observed = floors.reduce((a, b) =>
+      compareVersion(a, b) >= 0 ? a : b,
+    );
+    expect(observed).toBe(manifest.linux.maxGlibcFloor);
   });
-
-  // Target state (board 208541964): the fork must lower the linux glibc floor to
-  // <= 2.28 and ship tagged musl prebuilds so the native backend engages on the
-  // shipped Alpine image and on glibc 2.28-2.36 hosts. Turn this into a real
-  // assertion (and tighten the manifest ceiling + libcTags) when seclink.3 lands.
-  test.todo(
-    "linux prebuilds meet the target glibc floor (<= 2.28) and ship tagged musl builds",
-  );
 });

--- a/packages/core/test/psiPrebuildManifest.test.ts
+++ b/packages/core/test/psiPrebuildManifest.test.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, test } from "vitest";
+
+import {
+  compareVersion,
+  maxGlibcFloor,
+  readTgz,
+} from "./utils/prebuildTarball";
+
+// Guards the vendored @openmined/psi.js native prebuild tarball against silent
+// drift. The sha256 sidecar (verified in CI before npm ci) proves the bytes are
+// the committed ones; this proves those bytes still mean what we expect -- the
+// same platform set, libc tagging, and glibc floor -- so a re-vendor that quietly
+// drops a platform or raises the floor fails here instead of degrading to WASM
+// unnoticed in production. Contract lives in ./vectors/psi-prebuild-manifest.json;
+// the target state is board item 208541964.
+
+interface Manifest {
+  tarball: string;
+  platforms: string[];
+  wasmEngines: string[];
+  linux: { libcTags: string[]; maxGlibcFloor: string };
+}
+
+const manifest = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("./vectors/psi-prebuild-manifest.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+) as Manifest;
+
+// Repo root is three levels up from packages/core/test/.
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const entries = readTgz(`${repoRoot}${manifest.tarball}`);
+
+// A vendored addon is `package/prebuilds/<platform>/node.napi[.<libcTag>].node`.
+const prebuildRe =
+  /^package\/prebuilds\/([^/]+)\/node\.napi(?:\.([^/]+))?\.node$/;
+interface Prebuild {
+  platform: string;
+  tag: string | null;
+  data: Buffer;
+}
+const prebuilds: Prebuild[] = entries.flatMap((entry) => {
+  const m = prebuildRe.exec(entry.name);
+  return m ? [{ platform: m[1], tag: m[2] ?? null, data: entry.data }] : [];
+});
+const linuxPrebuilds = prebuilds.filter((p) => p.platform.startsWith("linux-"));
+
+describe("vendored PSI prebuild tarball manifest", () => {
+  test("resolves the committed tarball named in the manifest", () => {
+    // A version bump that renames the tarball but forgets this manifest lands
+    // here (readTgz would have thrown on a missing path) rather than silently
+    // checking a stale artifact.
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  test("ships exactly the recorded platform set", () => {
+    const platforms = [...new Set(prebuilds.map((p) => p.platform))].sort();
+    expect(platforms).toEqual([...manifest.platforms].sort());
+  });
+
+  test("ships the recorded WASM engines (the default-correct fallback)", () => {
+    const names = new Set(entries.map((entry) => entry.name));
+    for (const engine of manifest.wasmEngines) {
+      expect(names.has(`package/${engine}`)).toBe(true);
+    }
+  });
+
+  test("tags the linux prebuilds exactly as recorded", () => {
+    // Untagged today ([]). seclink.3 adds glibc/musl tags so node-gyp-build can
+    // never select a glibc binary under musl; that change must update the
+    // manifest deliberately -- board 208541964.
+    const tags = [...new Set(linuxPrebuilds.map((p) => p.tag ?? ""))].sort();
+    const expected = [
+      ...new Set(
+        manifest.linux.libcTags.length ? manifest.linux.libcTags : [""],
+      ),
+    ].sort();
+    expect(tags).toEqual(expected);
+  });
+
+  test("keeps the linux glibc floor at or below the recorded ceiling", () => {
+    expect(linuxPrebuilds.length).toBeGreaterThan(0);
+    for (const prebuild of linuxPrebuilds) {
+      const floor = maxGlibcFloor(prebuild.data);
+      expect(
+        floor,
+        `${prebuild.platform} references no GLIBC symbols`,
+      ).not.toBeNull();
+      // <= ceiling: a rebuild that RAISES the floor (fewer hosts can load it, the
+      // exact GLIBC_2.38 regression this guard exists for) fails here.
+      expect(
+        compareVersion(floor as string, manifest.linux.maxGlibcFloor),
+        `${prebuild.platform} requires GLIBC_${floor}, above the recorded ceiling ${manifest.linux.maxGlibcFloor}`,
+      ).toBeLessThanOrEqual(0);
+    }
+  });
+
+  // Target state (board 208541964): the fork must lower the linux glibc floor to
+  // <= 2.28 and ship tagged musl prebuilds so the native backend engages on the
+  // shipped Alpine image and on glibc 2.28-2.36 hosts. Turn this into a real
+  // assertion (and tighten the manifest ceiling + libcTags) when seclink.3 lands.
+  test.todo(
+    "linux prebuilds meet the target glibc floor (<= 2.28) and ship tagged musl builds",
+  );
+});

--- a/packages/core/test/utils/prebuildTarball.test.ts
+++ b/packages/core/test/utils/prebuildTarball.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { readTgz } from "./prebuildTarball";
+
+// readTgz is the manifest guard's parser, and the bytes it reads are the vendored
+// tarball -- which a malicious/compromised re-vendor controls (the sha256 sidecar
+// proves only that the bytes are the committed ones, not that they are honest). A
+// block readTgz mis-reads as a phantom entry is the highest-value bug: it would let
+// a dirty prebuild slip past the guard behind a clean-looking decoy. These pin the
+// fail-loud contract -- readTgz must reject anything that is not well-formed ustar
+// rather than desync its walk onto planted or mis-sized data.
+
+// Builds one well-formed ustar header (valid magic + self-checksum) so each case
+// below can corrupt exactly one property and prove readTgz rejects it.
+function ustarHeader(name: string, size: number, type = "0"): Buffer {
+  const h = Buffer.alloc(512);
+  h.write(name, 0, "utf8"); // name (0..99)
+  h.write("000644 \0", 100, "latin1"); // mode
+  h.write("000000 \0", 108, "latin1"); // uid
+  h.write("000000 \0", 116, "latin1"); // gid
+  h.write(size.toString(8).padStart(11, "0"), 124, "latin1"); // size (124..135)
+  h.write("00000000000", 136, "latin1"); // mtime
+  h.write(type, 156, "latin1"); // typeflag
+  h.write("ustar\0", 257, "latin1"); // magic (257..262)
+  h.write("00", 263, "latin1"); // version
+  return withChecksum(h);
+}
+
+// Fills the checksum field with spaces, sums the header, and writes the standard
+// "6 octal digits, NUL, space" checksum. Re-run after mutating any other byte.
+function withChecksum(h: Buffer): Buffer {
+  h.fill(0x20, 148, 156);
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += h[i];
+  h.write(sum.toString(8).padStart(6, "0") + "\0 ", 148, "latin1");
+  return h;
+}
+
+function member(name: string, data: Buffer, type = "0"): Buffer {
+  const pad = data.length % 512 === 0 ? 0 : 512 - (data.length % 512);
+  return Buffer.concat([
+    ustarHeader(name, data.length, type),
+    data,
+    Buffer.alloc(pad),
+  ]);
+}
+
+const eof = Buffer.alloc(1024); // two trailing zero blocks
+
+describe("readTgz fail-loud hardening", () => {
+  let dir = "";
+  const write = (buf: Buffer): string => {
+    dir = mkdtempSync(join(tmpdir(), "tgz-"));
+    const path = join(dir, "t.tgz");
+    writeFileSync(path, gzipSync(buf));
+    return path;
+  };
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("reads a well-formed ustar archive (positive control)", () => {
+    const tar = Buffer.concat([
+      member("package/a.txt", Buffer.from("hello")),
+      member("package/b.bin", Buffer.from([1, 2, 3, 4])),
+      eof,
+    ]);
+    const entries = readTgz(write(tar));
+    expect(entries.map((e) => e.name)).toEqual([
+      "package/a.txt",
+      "package/b.bin",
+    ]);
+    expect(entries[0].data.toString("utf8")).toBe("hello");
+    expect([...entries[1].data]).toEqual([1, 2, 3, 4]);
+  });
+
+  test("throws on a header whose self-checksum does not match", () => {
+    const h = ustarHeader("package/x", 0);
+    h[148] ^= 1; // perturb the stored checksum without touching the summed bytes
+    expect(() => readTgz(write(Buffer.concat([h, eof])))).toThrow(
+      /checksum mismatch/,
+    );
+  });
+
+  test("throws on a block missing the ustar magic (a non-header block)", () => {
+    const h = ustarHeader("package/x", 0);
+    h.fill(0, 257, 263); // wipe magic; models the walk landing on planted mid-data
+    expect(() => readTgz(write(Buffer.concat([h, eof])))).toThrow(
+      /not a ustar header/,
+    );
+  });
+
+  test("throws on a non-octal size field instead of truncating it", () => {
+    const h = ustarHeader("package/x", 0);
+    h.fill(0, 124, 136);
+    h.write("17778", 124, "latin1"); // lenient parseInt would read 1777 and desync
+    withChecksum(h); // recompute so the size check, not the checksum, is exercised
+    expect(() => readTgz(write(Buffer.concat([h, eof])))).toThrow(/non-octal/);
+  });
+
+  test("throws on a GNU/pax extension record it cannot resolve", () => {
+    const h = ustarHeader("././@LongLink", 0, "L");
+    expect(() => readTgz(write(Buffer.concat([h, eof])))).toThrow(
+      /unsupported tar extension record/,
+    );
+  });
+});

--- a/packages/core/test/utils/prebuildTarball.ts
+++ b/packages/core/test/utils/prebuildTarball.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { gunzipSync } from "node:zlib";
+
+export interface TarEntry {
+  readonly name: string;
+  readonly data: Buffer;
+}
+
+function readCString(block: Buffer, offset: number, length: number): string {
+  const raw = block.subarray(offset, offset + length);
+  const end = raw.indexOf(0);
+  return raw.toString("utf8", 0, end === -1 ? length : end);
+}
+
+/**
+ * Minimal gzip + ustar reader returning the regular-file entries of a `.tgz`.
+ * Enough to inspect the vendored @openmined/psi.js prebuild tarball's contents
+ * without a tar dependency -- deliberately NOT a general extractor: it skips GNU
+ * longname/pax records, which the tarball's short `package/prebuilds/<platform>/`
+ * paths (well under the 100-byte ustar name field) never need.
+ */
+export function readTgz(tarballPath: string): TarEntry[] {
+  const buf = gunzipSync(readFileSync(tarballPath));
+  const entries: TarEntry[] = [];
+  for (let off = 0; off + 512 <= buf.length; ) {
+    const header = buf.subarray(off, off + 512);
+    // The archive ends with (at least) one zero-filled block.
+    if (header.every((byte) => byte === 0)) break;
+    const name = readCString(header, 0, 100);
+    const prefix = readCString(header, 345, 155);
+    const size = parseInt(readCString(header, 124, 12).trim() || "0", 8);
+    const type = String.fromCharCode(header[156]);
+    const dataStart = off + 512;
+    if (type === "0" || type === "\0") {
+      entries.push({
+        name: prefix ? `${prefix}/${name}` : name,
+        data: buf.subarray(dataStart, dataStart + size),
+      });
+    }
+    off = dataStart + Math.ceil(size / 512) * 512;
+  }
+  return entries;
+}
+
+/**
+ * The highest `GLIBC_x.y[.z]` symbol version an ELF binary references, or null
+ * when it references none. glibc's ELF version check refuses to load a binary on
+ * a host whose libc is older than this value, so it is the binary's effective
+ * glibc floor. Read from the raw bytes (the versions live as ASCII in
+ * `.gnu.version_r`), which needs no binutils and works on any host.
+ */
+export function maxGlibcFloor(binary: Buffer): string | null {
+  const text = binary.toString("latin1");
+  let max: number[] | null = null;
+  for (const m of text.matchAll(/GLIBC_(\d+)\.(\d+)(?:\.(\d+))?/g)) {
+    const v = [Number(m[1]), Number(m[2]), Number(m[3] ?? 0)];
+    if (max === null || compareVersion(v, max) > 0) max = v;
+  }
+  if (max === null) return null;
+  return max[2] ? `${max[0]}.${max[1]}.${max[2]}` : `${max[0]}.${max[1]}`;
+}
+
+/** Compares dotted numeric versions ("2.28" vs "2.38"): -1, 0, or 1. */
+export function compareVersion(
+  a: number[] | string,
+  b: number[] | string,
+): number {
+  const pa = Array.isArray(a) ? a : a.split(".").map(Number);
+  const pb = Array.isArray(b) ? b : b.split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
+}

--- a/packages/core/test/utils/prebuildTarball.ts
+++ b/packages/core/test/utils/prebuildTarball.ts
@@ -15,9 +15,14 @@ function readCString(block: Buffer, offset: number, length: number): string {
 /**
  * Minimal gzip + ustar reader returning the regular-file entries of a `.tgz`.
  * Enough to inspect the vendored @openmined/psi.js prebuild tarball's contents
- * without a tar dependency -- deliberately NOT a general extractor: it skips GNU
- * longname/pax records, which the tarball's short `package/prebuilds/<platform>/`
- * paths (well under the 100-byte ustar name field) never need.
+ * without a tar dependency -- deliberately NOT a general extractor. Rather than
+ * silently mis-read the formats it does not handle, it throws: a GNU
+ * longname/longlink or pax record would override the following entry's name, so
+ * a >100-byte path could otherwise truncate and a prebuild go unseen; and a
+ * base-256 large-size field would desync the walk. The vendored tarball is plain
+ * ustar with short paths today, so neither fires -- but a future re-vendor that
+ * changes that breaks CI loudly instead of letting the guard check a mis-named
+ * or truncated entry set.
  */
 export function readTgz(tarballPath: string): TarEntry[] {
   const buf = gunzipSync(readFileSync(tarballPath));
@@ -26,10 +31,25 @@ export function readTgz(tarballPath: string): TarEntry[] {
     const header = buf.subarray(off, off + 512);
     // The archive ends with (at least) one zero-filled block.
     if (header.every((byte) => byte === 0)) break;
+    const type = String.fromCharCode(header[156]);
+    if (type === "L" || type === "K" || type === "x" || type === "g") {
+      throw new Error(
+        `readTgz: unsupported tar extension record (type '${type}') in ${tarballPath}; ` +
+          "the tarball uses long paths or pax metadata this minimal reader cannot " +
+          "resolve -- extend readTgz or re-pack as plain ustar",
+      );
+    }
     const name = readCString(header, 0, 100);
     const prefix = readCString(header, 345, 155);
     const size = parseInt(readCString(header, 124, 12).trim() || "0", 8);
-    const type = String.fromCharCode(header[156]);
+    // A GNU base-256 large-size field (>= 8 GiB) parses to NaN here; refuse it
+    // rather than let `Math.ceil(NaN / 512)` desync the walk and silently drop
+    // every later entry. No PSI prebuild is remotely this large.
+    if (!Number.isFinite(size) || size < 0) {
+      throw new Error(
+        `readTgz: unreadable entry size for "${name}" in ${tarballPath} (base-256 or corrupt header)`,
+      );
+    }
     const dataStart = off + 512;
     if (type === "0" || type === "\0") {
       entries.push({
@@ -43,11 +63,16 @@ export function readTgz(tarballPath: string): TarEntry[] {
 }
 
 /**
- * The highest `GLIBC_x.y[.z]` symbol version an ELF binary references, or null
- * when it references none. glibc's ELF version check refuses to load a binary on
- * a host whose libc is older than this value, so it is the binary's effective
- * glibc floor. Read from the raw bytes (the versions live as ASCII in
- * `.gnu.version_r`), which needs no binutils and works on any host.
+ * A conservative upper bound on the highest `GLIBC_x.y[.z]` symbol version an
+ * ELF binary requires, or null when it references none -- the binary's effective
+ * glibc floor (glibc refuses to load it on a host whose libc is older). This
+ * scans the raw bytes for any `GLIBC_` version token rather than parsing
+ * `.gnu.version_r`, so it needs no binutils and works on any host, but it is an
+ * OVER-approximation: a defined or optional version elsewhere in the string
+ * tables can only push the reported floor UP, never down. That direction is safe
+ * for the guard -- it may spuriously fail a good build (investigate the stray
+ * token) but can never pass a build whose real floor is too high. Matches
+ * `objdump -T` exactly for the current vendored prebuilds.
  */
 export function maxGlibcFloor(binary: Buffer): string | null {
   const text = binary.toString("latin1");

--- a/packages/core/test/utils/prebuildTarball.ts
+++ b/packages/core/test/utils/prebuildTarball.ts
@@ -12,25 +12,70 @@ function readCString(block: Buffer, offset: number, length: number): string {
   return raw.toString("utf8", 0, end === -1 ? length : end);
 }
 
+// The ustar header self-checksum: the unsigned sum of all 512 header bytes with
+// the 8-byte checksum field (148..155) counted as ASCII spaces. Validating it
+// lets the walk reject any 512-byte block that is not a header the standard
+// writer actually produced -- so an under-declared or mis-parsed size cannot
+// desync the walk onto bytes planted inside a member's data and have them read as
+// a legitimate entry.
+function ustarChecksum(header: Buffer): number {
+  let sum = 0;
+  for (let i = 0; i < 512; i++) {
+    sum += i >= 148 && i < 156 ? 0x20 : header[i];
+  }
+  return sum;
+}
+
+// The vendored tarball is ~39 MB uncompressed; a 256 MB ceiling is a wide margin
+// that still refuses a gzip bomb before it can exhaust the CI runner.
+const MAX_DECOMPRESSED_BYTES = 256 * 1024 * 1024;
+
 /**
  * Minimal gzip + ustar reader returning the regular-file entries of a `.tgz`.
  * Enough to inspect the vendored @openmined/psi.js prebuild tarball's contents
- * without a tar dependency -- deliberately NOT a general extractor. Rather than
- * silently mis-read the formats it does not handle, it throws: a GNU
- * longname/longlink or pax record would override the following entry's name, so
- * a >100-byte path could otherwise truncate and a prebuild go unseen; and a
- * base-256 large-size field would desync the walk. The vendored tarball is plain
- * ustar with short paths today, so neither fires -- but a future re-vendor that
- * changes that breaks CI loudly instead of letting the guard check a mis-named
- * or truncated entry set.
+ * without a tar dependency -- deliberately NOT a general extractor, and it treats
+ * anything it cannot faithfully read as fatal rather than guessing. Every 512-byte
+ * block must be a well-formed ustar header -- valid magic at offset 257 and a
+ * valid self-checksum at 148 -- with a strictly-octal size, so a corrupt or
+ * crafted archive cannot desync the walk and smuggle a 512-byte block planted
+ * inside a member's data past as a phantom entry (which would let a re-vendored
+ * tarball hide a mis-built prebuild behind a clean-looking decoy). It also throws
+ * on GNU longname/longlink or pax records (which would override the next entry's
+ * name) and on base-256 large sizes, and caps decompression against a gzip bomb.
+ * The vendored tarball is plain ustar with short paths and valid checksums today,
+ * so none of these fire -- but a future re-vendor that changes that breaks CI
+ * loudly instead of letting the guard check a mis-named, truncated, or laundered
+ * entry set.
  */
 export function readTgz(tarballPath: string): TarEntry[] {
-  const buf = gunzipSync(readFileSync(tarballPath));
+  const buf = gunzipSync(readFileSync(tarballPath), {
+    maxOutputLength: MAX_DECOMPRESSED_BYTES,
+  });
   const entries: TarEntry[] = [];
   for (let off = 0; off + 512 <= buf.length; ) {
     const header = buf.subarray(off, off + 512);
     // The archive ends with (at least) one zero-filled block.
     if (header.every((byte) => byte === 0)) break;
+    // Refuse any block that is not a genuine ustar header before trusting a single
+    // field from it. Without this, an under-declared size could advance the walk
+    // too little and land it on a 512-byte block planted inside a member's data,
+    // reading it as a legitimate entry -- the silent mis-read that would let a
+    // crafted re-vendor pass the manifest guard while shipping a dirty prebuild.
+    if (header.toString("latin1", 257, 262) !== "ustar") {
+      throw new Error(
+        `readTgz: block at offset ${off} in ${tarballPath} is not a ustar header ` +
+          "(missing magic) -- corrupt tarball or a walk desynced by a bad size field",
+      );
+    }
+    if (
+      parseInt(readCString(header, 148, 8).trim() || "-1", 8) !==
+      ustarChecksum(header)
+    ) {
+      throw new Error(
+        `readTgz: header checksum mismatch at offset ${off} in ${tarballPath} ` +
+          "(corrupt tarball or a block planted mid-data by a walk desync)",
+      );
+    }
     const type = String.fromCharCode(header[156]);
     if (type === "L" || type === "K" || type === "x" || type === "g") {
       throw new Error(
@@ -41,13 +86,21 @@ export function readTgz(tarballPath: string): TarEntry[] {
     }
     const name = readCString(header, 0, 100);
     const prefix = readCString(header, 345, 155);
-    const size = parseInt(readCString(header, 124, 12).trim() || "0", 8);
-    // A GNU base-256 large-size field (>= 8 GiB) parses to NaN here; refuse it
-    // rather than let `Math.ceil(NaN / 512)` desync the walk and silently drop
-    // every later entry. No PSI prebuild is remotely this large.
+    // ustar sizes are octal ASCII terminated by NUL/space. Parse strictly, not with
+    // lenient parseInt (which silently truncates "17778" -> 1777 octal): a size this
+    // reader reads differently from a conformant extractor is how the walk's entry
+    // boundaries would diverge from what actually installs. A base-256 large-size
+    // field (high bit set) also fails this test and is refused.
+    const rawSize = readCString(header, 124, 12).trim();
+    if (rawSize !== "" && !/^[0-7]+$/.test(rawSize)) {
+      throw new Error(
+        `readTgz: non-octal size field for "${name}" in ${tarballPath} (base-256 or corrupt header)`,
+      );
+    }
+    const size = rawSize === "" ? 0 : parseInt(rawSize, 8);
     if (!Number.isFinite(size) || size < 0) {
       throw new Error(
-        `readTgz: unreadable entry size for "${name}" in ${tarballPath} (base-256 or corrupt header)`,
+        `readTgz: unreadable entry size for "${name}" in ${tarballPath}`,
       );
     }
     const dataStart = off + 512;

--- a/packages/core/test/vectors/psi-prebuild-manifest.json
+++ b/packages/core/test/vectors/psi-prebuild-manifest.json
@@ -1,0 +1,21 @@
+{
+  "description": "Contract of the vendored @openmined/psi.js native prebuild tarball, re-derived from the committed lib/*.tgz by psiPrebuildManifest.test.ts. The .tgz.sha256 sidecar pins the exact bytes; this pins their MEANING -- which platforms ship, how the linux prebuilds are libc-tagged, and the glibc floor they link against -- so a silent re-vendor that drops a platform, changes tagging, or raises the glibc floor fails CI instead of degrading to WASM unnoticed. When the tarball is re-vendored (seclink.N bump), update this file to match the new artifact and confirm it moves toward `target`. The target state and the fork-side fix are tracked in board item 208541964.",
+  "tarball": "lib/openmined-psi.js-2.0.6-seclink.2.tgz",
+  "platforms": [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64",
+    "linux-x64",
+    "win32-x64"
+  ],
+  "wasmEngines": ["psi_wasm_node.js", "psi_wasm_web.js", "psi_wasm_worker.js"],
+  "linux": {
+    "libcTags": [],
+    "maxGlibcFloor": "2.38"
+  },
+  "target": {
+    "maxGlibcFloor": "2.28",
+    "requiredLibcTags": ["glibc", "musl"],
+    "note": "seclink.3 must lower the linux glibc floor to <= 2.28 and add tagged musl prebuilds (node.napi.glibc.node / node.napi.musl.node) so the native backend engages on the shipped Alpine CLI image and on glibc 2.28-2.36 hosts. Until then the Alpine image and glibc<2.38 hosts run WASM. Board 208541964."
+  }
+}

--- a/packages/core/test/vectors/psi-prebuild-manifest.json
+++ b/packages/core/test/vectors/psi-prebuild-manifest.json
@@ -1,5 +1,5 @@
 {
-  "description": "Contract of the vendored @openmined/psi.js native prebuild tarball, re-derived from the committed lib/*.tgz by psiPrebuildManifest.test.ts. The .tgz.sha256 sidecar pins the exact bytes; this pins their MEANING -- which platforms ship, how the linux prebuilds are libc-tagged, and the glibc floor they link against -- so a silent re-vendor that drops a platform, changes tagging, or raises the glibc floor fails CI instead of degrading to WASM unnoticed. When the tarball is re-vendored (seclink.N bump), update this file to match the new artifact and confirm it moves toward `target`. The target state and the fork-side fix are tracked in board item 208541964.",
+  "description": "Contract of the vendored @openmined/psi.js native prebuild tarball, re-derived from the committed lib/*.tgz by psiPrebuildManifest.test.ts. The .tgz.sha256 sidecar pins the exact bytes; this pins their MEANING -- which platforms ship, how the linux prebuilds are libc-tagged, that the musl builds are genuinely musl-linked, and the glibc floor the glibc builds link against -- so a silent re-vendor that drops a platform, changes tagging, corrupts the WASM fallback, or raises the glibc floor fails CI instead of degrading to WASM unnoticed. When the tarball is re-vendored (bytes change, sha256 updated), update this file to match the new artifact.",
   "tarball": "lib/openmined-psi.js-2.0.6-seclink.2.tgz",
   "platforms": [
     "darwin-arm64",
@@ -10,12 +10,7 @@
   ],
   "wasmEngines": ["psi_wasm_node.js", "psi_wasm_web.js", "psi_wasm_worker.js"],
   "linux": {
-    "libcTags": [],
-    "maxGlibcFloor": "2.38"
-  },
-  "target": {
-    "maxGlibcFloor": "2.28",
-    "requiredLibcTags": ["glibc", "musl"],
-    "note": "seclink.3 must lower the linux glibc floor to <= 2.28 and add tagged musl prebuilds (node.napi.glibc.node / node.napi.musl.node) so the native backend engages on the shipped Alpine CLI image and on glibc 2.28-2.36 hosts. Until then the Alpine image and glibc<2.38 hosts run WASM. Board 208541964."
+    "libcTags": ["glibc", "musl"],
+    "maxGlibcFloor": "2.17"
   }
 }

--- a/packages/core/test/vectors/verify-native-wire-vectors.mjs
+++ b/packages/core/test/vectors/verify-native-wire-vectors.mjs
@@ -1,0 +1,95 @@
+// Confirms the vendored native PSI addon selected for THIS runtime loads and
+// reproduces the committed byte-for-byte known-answer vectors (which are the WASM
+// engine's output, so a match proves native/WASM interop). Native-only, so a
+// minimal install of just the tarball is enough. The vitest native suites run on
+// the glibc CI host and select the glibc build, so they cannot exercise the musl
+// build; the native_alpine.yaml workflow runs this under node:26-alpine (the
+// shipped CLI base image) to close that gap.
+//
+// Local (dev machine, uses the workspace install), from the repo root:
+//
+//   node packages/core/test/vectors/verify-native-wire-vectors.mjs
+//
+// The fixture path may be passed as argv[2] so the script can run from a scratch
+// install directory -- see native_alpine.yaml, which installs the tarball fresh
+// inside Alpine and copies this script next to it.
+//
+// Exits non-zero on any mismatch. Mirrors generate-psi-engine-wire-vectors.mjs.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import loadNative from "@openmined/psi.js/psi_native_node.js";
+
+const fixturePath =
+  process.argv[2] ??
+  join(
+    process.cwd(),
+    "packages/core/test/vectors/psi-engine-wire-vectors.json",
+  );
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8"));
+
+const toHex = (bytes) => Buffer.from(bytes).toString("hex");
+const keyBytes = (hex) => Uint8Array.from(Buffer.from(hex, "hex"));
+
+const glibc = process.report?.getReport?.().header?.glibcVersionRuntime;
+console.log(
+  `runtime libc: ${glibc ? `glibc ${glibc}` : "musl (no glibc runtime)"}`,
+);
+
+const psi = await loadNative();
+const server = psi.server.createFromKey(
+  keyBytes(fixture.serverKeyHex),
+  fixture.revealIntersection,
+);
+const client = psi.client.createFromKey(
+  keyBytes(fixture.clientKeyHex),
+  fixture.revealIntersection,
+);
+const sortingPermutation = [];
+const setup = server.createSetupMessage(
+  fixture.createSetupMessage.fpr,
+  fixture.createSetupMessage.numClientInputs,
+  fixture.serverInputs,
+  psi.dataStructure.Raw,
+  sortingPermutation,
+);
+const request = client.createRequest(fixture.clientInputs);
+const response = server.processRequest(request);
+const associationTable = client.getAssociationTable(setup, response);
+const got = {
+  setupMessageHex: toHex(setup.serializeBinary()),
+  sortingPermutation: [...sortingPermutation],
+  requestHex: toHex(request.serializeBinary()),
+  responseHex: toHex(response.serializeBinary()),
+  associationTable: associationTable.map((row) => [...row]),
+};
+server.delete();
+client.delete();
+
+const fields = [
+  "setupMessageHex",
+  "sortingPermutation",
+  "requestHex",
+  "responseHex",
+  "associationTable",
+];
+let ok = true;
+for (const field of fields) {
+  const expected = JSON.stringify(fixture[field]);
+  const actual = JSON.stringify(got[field]);
+  const pass = actual === expected;
+  ok &&= pass;
+  console.log(`${pass ? "PASS" : "FAIL"}  ${field}`);
+  if (!pass) {
+    console.log(`   expected: ${expected}`);
+    console.log(`   native:   ${actual}`);
+  }
+}
+
+console.log(
+  ok
+    ? "\nOK: native backend reproduces the committed known-answer vectors byte-for-byte"
+    : "\nFAIL: native output diverged from the committed vectors",
+);
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
## Summary

This adds the consumer-side integrity and observability layer that pairs with the re-vendored native PSI tarball (#384): CI now fails when a re-vendored `lib/*.tgz` silently changes what it means -- a dropped platform, a mis-tagged or mis-linked libc, a corrupted WASM fallback, or a raised glibc floor -- and the shipped Alpine image's musl native path is confirmed byte-for-byte in CI rather than assumed. It also surfaces a present-but-broken native prebuild at warn instead of hiding it behind the silent WASM fallback. Correctness is unchanged throughout: WASM stays the default-correct backend and nothing here depends on the native addon.

Part of [208541964](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=208541964).

## Changes

- packages/core/test/psiPrebuildManifest.test.ts, test/vectors/psi-prebuild-manifest.json: a manifest guard that re-derives the committed tarball's meaning (platform set, per-platform libc tags, glibc floor, genuine musl-linkage, WASM engine presence and size) and fails CI on any unrecorded drift, forcing a conscious manifest update on every re-vendor.
- packages/core/test/utils/prebuildTarball.ts, test/utils/prebuildTarball.test.ts: the minimal tar/ELF reader the guard runs on, hardened to reject anything that is not well-formed ustar (magic, self-checksum, strictly-octal sizes) and to cap decompression, so a crafted archive throws instead of being silently mis-read past the guard; new tests pin the positive case and each fail-loud path.
- .github/workflows/native_alpine.yaml, packages/core/test/vectors/verify-native-wire-vectors.mjs: a CI gate that installs the vendored tarball fresh inside the shipped Alpine base (derived from the Dockerfile's runtime stage) and confirms the musl native addon loads and reproduces the committed known-answer wire vectors -- the musl path the glibc CI host cannot exercise.
- apps/cli/src/protocol.ts, apps/cli/src/psiBackend.ts, apps/cli/test/unit/psiBackend.test.ts: split the native-unavailable callback so a genuinely-broken prebuild (present but unloadable, e.g. a libc/ABI mismatch) warns while an absent one stays quiet; export and pin the error classifier, with a contract test against node-gyp-build's real no-match message.
- packages/core/test/psiBackend.test.ts: cover the browser runtime-detection guard.

## Test plan

Ran: `npm run test -w packages/core` (62 files, 2093 tests), `npm run test:unit -w apps/cli` (38 files, 1065 tests), and `npm run typecheck && npm run lint && npm run format`, all green. Verified the manifest guard and hardened parser against the real committed tarball (all 35 headers valid; guard 6/6). The Alpine gate's container path was confirmed manually on a musl host (native loads; all five wire-vector fields byte-identical); this PR is its first run in real CI.
New tests cover: the manifest drift contract; the parser's fail-loud behavior on a corrupt checksum, missing magic, non-octal size, and GNU/pax records; the native-unavailable error classification and the node-gyp-build message contract; the browser runtime guard.

## Background

Spun out of the code review of the native PSI backend selector (16108ce) and the vendored tarball (a631c3c): the native accelerator is an optimization the shipped Alpine image and older-glibc hosts could silently miss, so 208541964 re-vendored the tarball to cover psilink's real platforms (#384) and anticipated a consumer-side drift gate to keep it honest. This is that pairing. It went through an independent multi-lens security review (supply-chain, CI/CD, parser and info-leak); the one actionable finding -- a parser mis-read that could let a crafted re-vendor slip a mis-built prebuild past the guard -- is fixed here.

## Out of scope / follow-on

- Marking `native_alpine.yaml` as a required status check in branch protection: a path-filtered gate reports no status when it does not run, so it must be required to actually gate merges. Config, not code.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented operator or protocol behavior changed; the drift gate is an internal CI guard whose contract lives in its manifest vector, and the native-backend feature it protects is already documented (CHANGELOG Added, `docs/spec/PROTOCOL.md`).
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test, CI, and hardening work on the already-documented, still-unreleased native-backend entry; the sole runtime change is a diagnostic warn when a present-but-broken prebuild fails to load, a pre-release non-headline detail the Changelog policy defers.
- [x] Security review -- independent multi-lens review this cycle (supply-chain, CI/CD GitHub Actions, parser and info-leak), maintainer approved; touches the `@openmined/psi.js` vendoring guard and native-load logging.
