### PR TITLE
Declutter the web exchange-terms summary

### DIFF
--- a/apps/web/src/components/AcceptForm.tsx
+++ b/apps/web/src/components/AcceptForm.tsx
@@ -61,7 +61,9 @@ export default function AcceptForm({ files }: AcceptFormProps) {
   });
 
   return (
-    <Paper>
+    // h=100% so the home grid can stretch this panel to the taller invite panel's
+    // height -- the two compose boxes then read as a pair of equal-height cards.
+    <Paper h="100%">
       <Title order={2}>Accept an invitation you were sent</Title>
       <form
         onSubmit={(e) => {

--- a/apps/web/src/components/ExchangeSummary.tsx
+++ b/apps/web/src/components/ExchangeSummary.tsx
@@ -32,6 +32,7 @@ export function ExchangeSummary({
   disclosedPayloadColumns,
   headingRef,
   sendColumns,
+  condensed,
 }: {
   linkageTerms: LinkageTerms;
   /** Which viewer this renders for; drives the heading and per-party copy (see
@@ -52,6 +53,12 @@ export function ExchangeSummary({
    * inviter's "proposing" preview). An empty array renders the explicit
    * "no columns are sent" confirmation. */
   sendColumns?: Array<string>;
+  /** Condense the panel for a viewer who authored these terms (the inviter's
+   * post-generate exchange screen): the disclose/produce facts stay visible and the
+   * lower reference tiers fold into one disclosure, so the panel stays short and the
+   * share block above it stays in view. Forwarded to {@link InvitationTerms}. Left
+   * off (full terms) for the acceptor's consent and during-run views. */
+  condensed?: boolean;
 }) {
   return (
     <Paper withBorder p="md">
@@ -63,6 +70,7 @@ export function ExchangeSummary({
         disclosedPayloadColumns={disclosedPayloadColumns}
         headingRef={headingRef}
         outboundColumns={sendColumns}
+        condensed={condensed}
       />
     </Paper>
   );

--- a/apps/web/src/components/ExchangeView.tsx
+++ b/apps/web/src/components/ExchangeView.tsx
@@ -233,11 +233,12 @@ export function ExchangeView(config: ExchangeConfig) {
 
   // The screen-level accessibility throughline. Three focus targets, each its own
   // ref so the effects below stay independent:
-  //  - leadingHeadingRef: the exchange-summary heading both roles now lead with --
-  //    the summary sits in the left column, and the inviter's share block moved
-  //    below the two columns. Focused once on mount so a keyboard/screen-reader
-  //    user who pressed Generate/Accept lands on the new screen rather than on the
-  //    unmounted button. This is the entry move, not a mid-protocol one.
+  //  - leadingHeadingRef: the heading each role leads with, focused once on mount so
+  //    a keyboard/screen-reader user who pressed Generate/Accept lands on the new
+  //    screen rather than on the unmounted button. The inviter leads with the share
+  //    block heading (it sits above the columns, since sharing the link is the urgent
+  //    post-generate task); the acceptor, which renders no share block, leads with
+  //    the exchange-summary heading. This is the entry move, not a mid-protocol one.
   //  - resultsHeadingRef: the Status heading, focused on `done` so the results are
   //    announced, and also when the partner connects -- the inviter's share block
   //    unmounts then, so this recovers the focus that unmount would otherwise
@@ -263,7 +264,7 @@ export function ExchangeView(config: ExchangeConfig) {
   // The partner is connected once the run has advanced past the pre-stages
   // ("before start"/"waiting for peer") into a protocol stage. Drives the inviter
   // share block's removal: once connected there is nothing left to share, so the
-  // link/code block (rendered below the columns) drops out entirely.
+  // link/code block (rendered above the columns) drops out entirely.
   const peerConnected = !preStages.some((stage) => stage.id === stageId);
 
   // Recover focus orphaned by the inviter share block UNMOUNTING on peer-connect:
@@ -618,11 +619,24 @@ export function ExchangeView(config: ExchangeConfig) {
           {warningAlert.message}
         </Alert>
       )}
-      {/* The summary stays on the RIGHT -- the same side it sits on while setting
-          up -- so the agreed reference keeps a consistent place across the flow.
-          Status (the run's progress and downloads) takes the LEFT, upper area, so it
-          is visible without scrolling. Columns stack on a narrow viewport
-          (base: 12). */}
+      {/* The inviter's link/code leads the screen: sharing it out-of-band is the one
+          urgent task right after generating, so it sits ABOVE the columns (and takes
+          initial focus, see leadingHeadingRef) rather than below a tall summary where
+          it would scroll off. It drops out once the partner connects -- nothing left
+          to share, and Status then shows the run is underway, so the block (and any
+          "Partner connected" restatement) would only add noise. The acceptor renders
+          no share block. */}
+      {config.role === "inviter" && !peerConnected && (
+        <ShareBlock
+          deepLink={config.share.deepLink}
+          encoded={config.share.encoded}
+          expires={config.expires}
+          headingRef={leadingHeadingRef}
+        />
+      )}
+      {/* The summary stays on the RIGHT; Status (the run's progress and downloads)
+          takes the LEFT so it is visible without scrolling. Columns stack on a narrow
+          viewport (base: 12). */}
       <Grid gap="xl" align="flex-start">
         <Grid.Col span={{ base: 12, md: 5 }}>
           <Status
@@ -643,10 +657,20 @@ export function ExchangeView(config: ExchangeConfig) {
             linkageTerms={config.linkageTerms}
             perspective={config.role === "inviter" ? "proposing" : "accepted"}
             headingOrder={headingOrder}
-            // Both roles lead with the summary heading (the inviter's share block
-            // moved below the columns).
-            headingRef={leadingHeadingRef}
-            // The inviter's expiry is shown in the share block below, so it is
+            // The inviter leads with the share block above (which takes initial
+            // focus); the acceptor renders no share block, so it leads with the
+            // summary heading here instead.
+            headingRef={
+              config.role === "inviter" ? undefined : leadingHeadingRef
+            }
+            // Both roles condense here: the run screen shows the terms as reference,
+            // not a decision -- the inviter authored them, and the acceptor already
+            // consented on the review screen -- so the disclose/produce facts stay
+            // visible and the lower tiers fold into one disclosure, keeping the panel
+            // short (and, for the inviter, the share block above it in view). The
+            // acceptor's pre-consent review screen is the one that stays full.
+            condensed
+            // The inviter's expiry is shown in the share block above, so it is
             // withheld here to avoid showing the same deadline twice; the acceptor
             // has no share block, so its summary carries the expiry.
             expires={config.role === "inviter" ? undefined : config.expires}
@@ -674,18 +698,6 @@ export function ExchangeView(config: ExchangeConfig) {
           />
         </Grid.Col>
       </Grid>
-      {/* The inviter's link/code to share out-of-band, below the columns so the
-          summary and Status lead. It drops out entirely once the partner connects:
-          there is nothing left to share, and Status then shows the run is underway,
-          so the block (and any "Partner connected" restatement) would only add
-          noise. The acceptor renders no share block. */}
-      {config.role === "inviter" && !peerConnected && (
-        <ShareBlock
-          deepLink={config.share.deepLink}
-          encoded={config.share.encoded}
-          expires={config.expires}
-        />
-      )}
     </Stack>
   );
 }

--- a/apps/web/src/components/HomePage.tsx
+++ b/apps/web/src/components/HomePage.tsx
@@ -26,9 +26,11 @@ import type { InviterSession } from "@components/InvitePanel";
  * generated.
  *
  * While no session exists the two compose panels sit side by side, equal-width and
- * top-aligned so each sizes to its own content (the invite flow is the taller of
- * the two), with the shared drop below; on a narrow viewport they stack (the
- * `base: 12` span). Once {@link InvitePanel} generates an invitation it stores the
+ * equal-height -- the grid stretches both columns to the taller of the two (the
+ * invite flow), so the shorter accept panel matches its height and the two read as a
+ * pair of equal cards rather than each sizing to its own content -- with the shared
+ * drop below; on a narrow viewport they stack (the `base: 12` span). Once
+ * {@link InvitePanel} generates an invitation it stores the
  * session here, and the page drops the grid, the accept form, and the shared drop
  * to render the panel -- now showing the {@link ExchangeView} -- across the full
  * route width, so the exchange screen takes over the view the way the accept route
@@ -61,7 +63,7 @@ export function HomePage() {
       )}
       {session === undefined ? (
         <Stack mt="md">
-          <Grid align="flex-start">
+          <Grid align="stretch">
             <Grid.Col span={{ base: 12, md: 6 }}>
               <InvitePanel
                 session={session}

--- a/apps/web/src/components/InvitationTerms.tsx
+++ b/apps/web/src/components/InvitationTerms.tsx
@@ -256,6 +256,77 @@ function MatchKeyDetails({ summary }: { summary: InvitationKeySummary }) {
 }
 
 /**
+ * Wraps the terms panel's lower reference tiers (what you receive, how records are
+ * matched, the legal agreement, and "Other details") in one default-collapsed
+ * disclosure when {@link condensed}; otherwise renders them inline unchanged.
+ * condensed is set on the surfaces that show the terms as post-consent or authored
+ * REFERENCE -- both roles' during-run exchange screens, the acceptor's "prepare your
+ * data" screen, and the inviter's own live authoring preview -- so the panel stays
+ * short (and, for the inviter's run screen, keeps the share block above it in view).
+ * It is NEVER set on the acceptor's pre-consent "review" screen, the one place
+ * informed consent is captured, which keeps every tier always-visible. So even though
+ * this can fold a tier, it never hides one from the party at the consent decision
+ * point. The always-mounted wrapper carrying aria-controls and the
+ * self-describing describedby summary mirror the "Other details" idiom, so a folded
+ * tier stays out of the accessibility tree and tab order while collapsed yet remains
+ * reachable and announced.
+ */
+function CondensableDetails({
+  condensed,
+  children,
+}: {
+  condensed: boolean;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  // Stable ids across SSR/hydration for the toggle -> panel and toggle -> summary
+  // associations, matching every other disclosure on this screen.
+  const panelId = useId();
+  const summaryId = useId();
+  const reduceMotion = useReducedMotion();
+  // Non-condensed: a transparent passthrough (a Fragment adds no DOM node), so the
+  // acceptor's full render is byte-identical to the un-wrapped tree.
+  if (!condensed) return <>{children}</>;
+  return (
+    <Stack gap={2}>
+      <UnstyledButton
+        onClick={() => setOpen((isOpen) => !isOpen)}
+        aria-expanded={open}
+        aria-controls={panelId}
+        aria-describedby={summaryId}
+      >
+        <Group gap={4}>
+          <IconChevronRight
+            size={16}
+            aria-hidden
+            style={{
+              transform: open ? "rotate(90deg)" : "rotate(0deg)",
+              transition: reduceMotion ? undefined : "transform 150ms ease",
+            }}
+          />
+          <Text size="sm" fw={500}>
+            See the full terms
+          </Text>
+        </Group>
+      </UnstyledButton>
+      {/* Self-describing, like "Other details": always truthful across configs -- the
+          matching keys are always present, and "the other terms" covers the
+          receive/legal/dedup/payload sections whichever render. Perspective-neutral
+          ("terms", not "proposed terms") so it reads correctly on the acceptor's
+          post-consent "accepted" surfaces, where the terms are agreed, not proposed. */}
+      <Text id={summaryId} size="xs" c="dimmed">
+        Contains how records are matched and the other terms.
+      </Text>
+      <div id={panelId}>
+        <Collapse expanded={open}>
+          <Stack gap="sm">{children}</Stack>
+        </Collapse>
+      </div>
+    </Stack>
+  );
+}
+
+/**
  * Renders the inviter's linkage terms decoded from an invitation for review. The
  * always-visible core is organized by disclosure DIRECTION rather than as one flat
  * list, so a reader can tell what each fact is about, and ordered by how much the
@@ -370,6 +441,7 @@ export function InvitationTerms({
   perspective = "review",
   headingOrder = 2,
   headingRef,
+  condensed = false,
 }: {
   linkageTerms: LinkageTerms;
   /** The invitation's expiry instant (ISO 8601), if it carries one. */
@@ -405,6 +477,15 @@ export function InvitationTerms({
   // tabIndex + ref so a screen the terms lead can move focus here when they
   // appear, announcing them to assistive tech.
   headingRef?: Ref<HTMLHeadingElement>;
+  /** Fold the lower reference tiers (what you receive, how records are matched, the
+   * legal agreement, and "Other details") into one default-collapsed disclosure,
+   * keeping only "What you disclose" and "What the exchange produces" always visible.
+   * Set on the surfaces that show the terms as post-consent or authored REFERENCE
+   * (both roles' during-run exchange screens, the acceptor's "prepare your data"
+   * screen, and the inviter's live authoring preview). NEVER set on the acceptor's
+   * pre-consent "review" screen, whose every tier must stay always-visible for
+   * informed consent. See {@link CondensableDetails}. */
+  condensed?: boolean;
 }) {
   const summary = summarizeInvitation({
     linkageTerms,
@@ -843,37 +924,38 @@ export function InvitationTerms({
         </Term>
       </Stack>
 
-      {/* Direction tier -- WHAT YOU RECEIVE: partner data arriving to this viewer.
+      <CondensableDetails condensed={condensed}>
+        {/* Direction tier -- WHAT YOU RECEIVE: partner data arriving to this viewer.
           The acceptor's ingress (a count of the columns the invitation will send it
           for matched records) -- the weaker signal, since receiving is not a
           disclosure BY the acceptor -- or, mirrored, the inviter's own request of its
           partner under "proposing" (that request is the inviter's inbound). A
           labelled role="group" captioned by a heading, rendered only when this viewer
           receives partner data. */}
-      {showsReceiveGroup && (
-        <Stack role="group" aria-labelledby={receiveGroupLabelId} gap="xs">
-          <Title
-            order={tierHeadingOrder}
-            fz="sm"
-            fw={600}
-            id={receiveGroupLabelId}
-          >
-            What you receive
-          </Title>
-          {ingressNotice !== undefined && (
-            <Text size="sm" fw={500}>
-              {ingressNotice}
-            </Text>
-          )}
-          {perspective === "proposing" && egressNotice !== undefined && (
-            <Text size="sm" fw={500}>
-              {egressNotice}
-            </Text>
-          )}
-        </Stack>
-      )}
+        {showsReceiveGroup && (
+          <Stack role="group" aria-labelledby={receiveGroupLabelId} gap="xs">
+            <Title
+              order={tierHeadingOrder}
+              fz="sm"
+              fw={600}
+              id={receiveGroupLabelId}
+            >
+              What you receive
+            </Title>
+            {ingressNotice !== undefined && (
+              <Text size="sm" fw={500}>
+                {ingressNotice}
+              </Text>
+            )}
+            {perspective === "proposing" && egressNotice !== undefined && (
+              <Text size="sm" fw={500}>
+                {egressNotice}
+              </Text>
+            )}
+          </Stack>
+        )}
 
-      {/* Tier -- HOW RECORDS ARE MATCHED: the mechanics of the match, split out of
+        {/* Tier -- HOW RECORDS ARE MATCHED: the mechanics of the match, split out of
           "What the exchange produces" and placed below the disclosure/result tiers
           because it is verification detail the diligent open, not the headline the
           consent decision turns on. Holds the linkage strategy (single-pass only) and
@@ -881,17 +963,17 @@ export function InvitationTerms({
           a default-collapsed "Matching strategies" disclosure. A labelled
           role="group" captioned by a heading; always rendered, since there is always
           at least one linkage key. */}
-      <Stack role="group" aria-labelledby={matchingGroupLabelId} gap="xs">
-        <Title
-          order={tierHeadingOrder}
-          fz="sm"
-          fw={600}
-          id={matchingGroupLabelId}
-        >
-          How records are matched
-        </Title>
+        <Stack role="group" aria-labelledby={matchingGroupLabelId} gap="xs">
+          <Title
+            order={tierHeadingOrder}
+            fz="sm"
+            fw={600}
+            id={matchingGroupLabelId}
+          >
+            How records are matched
+          </Title>
 
-        {/* Single-pass is disclosure-affecting AND a mandatory-consistency term the
+          {/* Single-pass is disclosure-affecting AND a mandatory-consistency term the
             acceptor adopts, so it must be visible at the consent point, not only on
             the inviter's authoring control. Surfaced only for single-pass (cascade
             is the baseline that discloses less, like algorithm=psi); viewer-neutral,
@@ -899,82 +981,85 @@ export function InvitationTerms({
             time. Mirrors the inviter's Alert and the CLI's singlePassDisclosureNotice
             so both parties read the same framing. The value is a fixed schema enum,
             so the copy is static -- no partner text enters here. */}
-        {summary.linkageStrategy === "single-pass" && (
-          // No emphasis tag on the lead: the Term's bold "Linkage strategy"
-          // caption already anchors the block, so a second bold restating it would
-          // double up for screen readers and visual scanning alike.
-          <Term label="Linkage strategy">
-            <Text size="sm">
-              This exchange uses single-pass linkage. To run the match in one
-              batched round -- fewer network round trips -- one party hands the
-              other its full per-key value structure, so that party also sees
-              matches on less precise keys that cascade would have filtered out
-              first. Which party that is gets settled at exchange time, so it
-              may be you. Both parties must agree to single-pass. The matched
-              result is unchanged -- only what is observed along the way.
-            </Text>
-          </Term>
-        )}
+          {summary.linkageStrategy === "single-pass" && (
+            // No emphasis tag on the lead: the Term's bold "Linkage strategy"
+            // caption already anchors the block, so a second bold restating it would
+            // double up for screen readers and visual scanning alike.
+            <Term label="Linkage strategy">
+              <Text size="sm">
+                This exchange uses single-pass linkage. To run the match in one
+                batched round -- fewer network round trips -- one party hands
+                the other its full per-key value structure, so that party also
+                sees matches on less precise keys that cascade would have
+                filtered out first. Which party that is gets settled at exchange
+                time, so it may be you. Both parties must agree to single-pass.
+                The matched result is unchanged -- only what is observed along
+                the way.
+              </Text>
+            </Term>
+          )}
 
-        {/* The matching list as a default-collapsed disclosure, mirroring the
+          {/* The matching list as a default-collapsed disclosure, mirroring the
             per-key and "Other details" disclosures below: aria-expanded +
             aria-controls on the toggle, the id on the always-mounted wrapper (not
             the Collapse panel) so it stays a stable target however Mantine mounts
             the panel, and
             the per-key list hidden from assistive tech + the tab order while closed.
             The toggle text doubles as the list's group label (matchedOnLabelId). */}
-        <Stack gap={2}>
-          <UnstyledButton
-            onClick={() => setMatchingOpen((open) => !open)}
-            aria-expanded={matchingOpen}
-            aria-controls={matchingPanelId}
-            aria-describedby={
-              summary.matchedFields.length > 0 ? matchingSublineId : undefined
-            }
-          >
-            <Group gap={4}>
-              <IconChevronRight
-                size={16}
-                aria-hidden
-                style={{
-                  transform: matchingOpen ? "rotate(90deg)" : "rotate(0deg)",
-                  transition: reduceMotion ? undefined : "transform 150ms ease",
-                }}
-              />
-              <Text size="sm" fw={600} id={matchedOnLabelId}>
-                Matching strategies
-              </Text>
-            </Group>
-          </UnstyledButton>
-          {/* The always-visible field summary: WHICH fields the keys match on,
+          <Stack gap={2}>
+            <UnstyledButton
+              onClick={() => setMatchingOpen((open) => !open)}
+              aria-expanded={matchingOpen}
+              aria-controls={matchingPanelId}
+              aria-describedby={
+                summary.matchedFields.length > 0 ? matchingSublineId : undefined
+              }
+            >
+              <Group gap={4}>
+                <IconChevronRight
+                  size={16}
+                  aria-hidden
+                  style={{
+                    transform: matchingOpen ? "rotate(90deg)" : "rotate(0deg)",
+                    transition: reduceMotion
+                      ? undefined
+                      : "transform 150ms ease",
+                  }}
+                />
+                <Text size="sm" fw={600} id={matchedOnLabelId}>
+                  Matching strategies
+                </Text>
+              </Group>
+            </UnstyledButton>
+            {/* The always-visible field summary: WHICH fields the keys match on,
               kept outside the collapse so the single fact consent most depends on
               is legible without expanding the detail. The compact field labels and
               the deduped order are derived (and sanitized) by summarizeInvitation;
               the per-key grouping and breadth markers stay one expand down. */}
-          {summary.matchedFields.length > 0 && (
-            <Text id={matchingSublineId} size="sm">
-              Matching on {summary.matchedFields.join(", ")}.
-            </Text>
-          )}
-          {/* A labelled list of per-key disclosures: each key's collapsed header
+            {summary.matchedFields.length > 0 && (
+              <Text id={matchingSublineId} size="sm">
+                Matching on {summary.matchedFields.join(", ")}.
+              </Text>
+            )}
+            {/* A labelled list of per-key disclosures: each key's collapsed header
               (name + derived field one-liner), its rule detail one further expand
               down. role=list/listitem (not Mantine List.Item, whose inline span body
               cannot hold the disclosure's flow content) so AT announces the set;
               keyed by index -- the list is static and key names are not unique once
               sanitized. */}
-          <div id={matchingPanelId}>
-            <Collapse expanded={matchingOpen}>
-              <Stack gap="xs" role="list" aria-labelledby={matchedOnLabelId}>
-                {summary.linkageKeys.map((key, index) => (
-                  <MatchKeyDisclosure key={index} summary={key} />
-                ))}
-              </Stack>
-            </Collapse>
-          </div>
+            <div id={matchingPanelId}>
+              <Collapse expanded={matchingOpen}>
+                <Stack gap="xs" role="list" aria-labelledby={matchedOnLabelId}>
+                  {summary.linkageKeys.map((key, index) => (
+                    <MatchKeyDisclosure key={index} summary={key} />
+                  ))}
+                </Stack>
+              </Collapse>
+            </div>
+          </Stack>
         </Stack>
-      </Stack>
 
-      {/* The legal agreement -- a cross-cutting GOVERNANCE frame, not a disclosure
+        {/* The legal agreement -- a cross-cutting GOVERNANCE frame, not a disclosure
           direction, so it carries its own labelled group. Placed last in the
           always-visible core, below the disclosure/result/mechanics tiers, as a
           pre-consent governance checkpoint: it must stay legible at the consent point
@@ -986,31 +1071,31 @@ export function InvitationTerms({
           All three values are pre-sanitized by summarizeInvitation, and the group's
           accessible name is the fixed "Legal agreement" aria-label, so no raw partner
           text enters the name. */}
-      {summary.legalAgreement !== undefined && (
-        <Stack role="group" aria-label="Legal agreement" gap={2}>
-          <Title order={tierHeadingOrder} fz="sm" fw={600}>
-            This invitation attaches a legal agreement.
-          </Title>
-          <Text size="sm">Reference: {summary.legalAgreement.reference}</Text>
-          {/* "Stated purpose", not "Purpose": the value is partner-authored free
+        {summary.legalAgreement !== undefined && (
+          <Stack role="group" aria-label="Legal agreement" gap={2}>
+            <Title order={tierHeadingOrder} fz="sm" fw={600}>
+              This invitation attaches a legal agreement.
+            </Title>
+            <Text size="sm">Reference: {summary.legalAgreement.reference}</Text>
+            {/* "Stated purpose", not "Purpose": the value is partner-authored free
               text, sanitized but never vetted by psilink (only byte-compared against
               the partner's own copy at exchange time), so the label marks it as
               partner-attested rather than an authorization psilink endorses -- the
               same provenance-marking the allowed-character constraint uses. */}
-          <Text size="sm">
-            Stated purpose: {summary.legalAgreement.purpose}
-          </Text>
-          {/* Name the subject ("Agreement valid through ...") rather than a bare
+            <Text size="sm">
+              Stated purpose: {summary.legalAgreement.purpose}
+            </Text>
+            {/* Name the subject ("Agreement valid through ...") rather than a bare
               "Valid through <date>": it sits on the same screen as the separate
               invitation-expiry line below, and at a glance the two same-weight dates
               are otherwise easy to conflate. */}
-          <Text size="xs" c="dimmed">
-            Agreement valid through {summary.legalAgreement.expirationDate}
-          </Text>
-        </Stack>
-      )}
+            <Text size="xs" c="dimmed">
+              Agreement valid through {summary.legalAgreement.expirationDate}
+            </Text>
+          </Stack>
+        )}
 
-      {/* A real disclosure: the toggle carries aria-expanded and aria-controls,
+        {/* A real disclosure: the toggle carries aria-expanded and aria-controls,
           and while closed Mantine's Collapse hides the panel from assistive tech
           and the tab order until opened -- with motion via aria-hidden + inert (and
           display:none), and under a reduced-motion preference via display:none on a
@@ -1026,97 +1111,122 @@ export function InvitationTerms({
           details" label. Other details always holds the personal-data and
           duplicate-match blocks, so the summary always renders and the reference
           never dangles. */}
-      <UnstyledButton
-        onClick={() => setDetailsOpen((open) => !open)}
-        aria-expanded={detailsOpen}
-        aria-controls={detailsId}
-        aria-describedby={detailsSummaryId}
-      >
-        <Group gap={4}>
-          <IconChevronRight
-            size={16}
-            aria-hidden
-            style={{
-              transform: detailsOpen ? "rotate(90deg)" : "rotate(0deg)",
-              transition: reduceMotion ? undefined : "transform 150ms ease",
-            }}
-          />
-          <Text size="sm" fw={500}>
-            Other details
-          </Text>
-        </Group>
-      </UnstyledButton>
-      {/* The self-describing summary: a fixed-copy, one-line enumeration of the
+        <UnstyledButton
+          onClick={() => setDetailsOpen((open) => !open)}
+          aria-expanded={detailsOpen}
+          aria-controls={detailsId}
+          aria-describedby={detailsSummaryId}
+        >
+          <Group gap={4}>
+            <IconChevronRight
+              size={16}
+              aria-hidden
+              style={{
+                transform: detailsOpen ? "rotate(90deg)" : "rotate(0deg)",
+                transition: reduceMotion ? undefined : "transform 150ms ease",
+              }}
+            />
+            <Text size="sm" fw={500}>
+              Other details
+            </Text>
+          </Group>
+        </UnstyledButton>
+        {/* The self-describing summary: a fixed-copy, one-line enumeration of the
           sections the disclosure contains, derived from what actually renders
           (otherDetailsContents). No partner text enters it -- the section names are
           fixed, and the payload-detail phrase is gated on showsPayloadDetail, the
           same predicate that renders the block. */}
-      <Text id={detailsSummaryId} size="xs" c="dimmed">
-        Contains {joinList(otherDetailsContents)}.
-      </Text>
+        <Text id={detailsSummaryId} size="xs" c="dimmed">
+          Contains {joinList(otherDetailsContents)}.
+        </Text>
 
-      <div id={detailsId}>
-        <Collapse expanded={detailsOpen}>
-          <Stack gap="sm">
-            <Term label="Personal data used">
-              <Stack gap="xs">
-                {summary.linkageFields.map((field, index) =>
-                  field.constraints.length > 0 ? (
-                    <Stack key={index} gap={2}>
-                      <Text size="sm">{field.label}</Text>
-                      {/* Each constraint as its own item rather than a joined
+        <div id={detailsId}>
+          <Collapse expanded={detailsOpen}>
+            <Stack gap="sm">
+              <Term label="Personal data used">
+                <Stack gap="xs">
+                  {summary.linkageFields.map((field, index) =>
+                    field.constraints.length > 0 ? (
+                      <Stack key={index} gap={2}>
+                        <Text size="sm">{field.label}</Text>
+                        {/* Each constraint as its own item rather than a joined
                         string: a partner-controlled allowedCharacters class may
                         contain the separator, which joined text would render as
                         spurious extra clauses. Keyed by index -- order is fixed
                         for a field. */}
-                      <List size="xs" withPadding listStyleType="circle">
-                        {field.constraints.map((constraint, ci) => (
-                          <List.Item key={ci}>
-                            <Text span size="xs" c="dimmed">
-                              {constraint}
-                            </Text>
-                          </List.Item>
-                        ))}
-                      </List>
-                    </Stack>
-                  ) : (
-                    <Text key={index} size="sm">
-                      {field.label}
-                    </Text>
-                  ),
-                )}
-              </Stack>
-            </Term>
+                        <List size="xs" withPadding listStyleType="circle">
+                          {field.constraints.map((constraint, ci) => (
+                            <List.Item key={ci}>
+                              <Text span size="xs" c="dimmed">
+                                {constraint}
+                              </Text>
+                            </List.Item>
+                          ))}
+                        </List>
+                      </Stack>
+                    ) : (
+                      <Text key={index} size="sm">
+                        {field.label}
+                      </Text>
+                    ),
+                  )}
+                </Stack>
+              </Term>
 
-            {/* Renders only when it has content: the acceptor's send list (hidden
+              {/* Renders only when it has content: the acceptor's send list (hidden
                 in the inviter's "proposing" preview, which shows its send as chips
                 above) or a declared receive (present even when empty). The guard is
                 showsPayloadDetail -- the same predicate the self-describing "Other
                 details" summary names this block by, so the summary lists exactly the
                 sections that actually render. */}
-            {showsPayloadDetail && summary.payload !== undefined && (
-              <Term label="Additional data for matched records">
-                {/* Viewer-centric, like Result sharing: the acceptor reads the
+              {showsPayloadDetail && summary.payload !== undefined && (
+                <Term label="Additional data for matched records">
+                  {/* Viewer-centric, like Result sharing: the acceptor reads the
                     inviter's send as the partner's ("Your partner will send"). The
                     inviter's own send is surfaced as chips above "Other details"
                     instead, so it is suppressed here under "proposing". */}
-                {/* Shown whenever the send set is a definite declaration --
+                  {/* Shown whenever the send set is a definite declaration --
                     including the empty set, rendered "(none)" so the strict
                     "receive nothing" lock-in is visible rather than inferred from a
                     missing line (the CLI's displayInvitation shows the same). A
                     lazy send (not declared) is omitted instead. */}
-                {summary.payload.sendDeclared &&
-                  perspective !== "proposing" && (
+                  {summary.payload.sendDeclared &&
+                    perspective !== "proposing" && (
+                      <Stack gap={2}>
+                        <Text size="sm">Your partner will send:</Text>
+                        {summary.payload.send.length > 0 ? (
+                          // One column per item rather than a joined string: a
+                          // partner-controlled column name may contain the separator,
+                          // which joined text would render as spurious extra columns.
+                          // Keyed by index -- column order is fixed and a sanitized
+                          // name is not unique.
+                          <List size="sm" withPadding listStyleType="circle">
+                            {summary.payload.send.map((column, index) => (
+                              <List.Item key={index}>{column}</List.Item>
+                            ))}
+                          </List>
+                        ) : (
+                          <Text size="sm" c="dimmed">
+                            (none) -- any payload column would abort the
+                            exchange
+                          </Text>
+                        )}
+                      </Stack>
+                    )}
+                  {/* Mirror of the send block: a declared receive is shown even
+                      when empty, rendered "(none)" so the strict "the acceptor
+                      sends nothing" assertion is visible rather than inferred from
+                      a missing line. A lazy (undeclared) receive is omitted. */}
+                  {summary.payload.receiveDeclared && (
                     <Stack gap={2}>
-                      <Text size="sm">Your partner will send:</Text>
-                      {summary.payload.send.length > 0 ? (
-                        // One column per item rather than a joined string: a
-                        // partner-controlled column name may contain the separator,
-                        // which joined text would render as spurious extra columns.
-                        // Keyed by index -- column order is fixed and a sanitized
-                        // name is not unique.
+                      <Text size="sm">
+                        {perspective === "proposing"
+                          ? "You request from your partner:"
+                          : "Your partner requests from you:"}
+                      </Text>
+                      {summary.payload.receive.length > 0 ? (
                         <List size="sm" withPadding listStyleType="circle">
-                          {summary.payload.send.map((column, index) => (
+                          {summary.payload.receive.map((column, index) => (
                             <List.Item key={index}>{column}</List.Item>
                           ))}
                         </List>
@@ -1127,68 +1237,46 @@ export function InvitationTerms({
                       )}
                     </Stack>
                   )}
-                {/* Mirror of the send block: a declared receive is shown even
-                      when empty, rendered "(none)" so the strict "the acceptor
-                      sends nothing" assertion is visible rather than inferred from
-                      a missing line. A lazy (undeclared) receive is omitted. */}
-                {summary.payload.receiveDeclared && (
-                  <Stack gap={2}>
-                    <Text size="sm">
-                      {perspective === "proposing"
-                        ? "You request from your partner:"
-                        : "Your partner requests from you:"}
-                    </Text>
-                    {summary.payload.receive.length > 0 ? (
-                      <List size="sm" withPadding listStyleType="circle">
-                        {summary.payload.receive.map((column, index) => (
-                          <List.Item key={index}>{column}</List.Item>
-                        ))}
-                      </List>
-                    ) : (
-                      <Text size="sm" c="dimmed">
-                        (none) -- any payload column would abort the exchange
-                      </Text>
-                    )}
-                  </Stack>
-                )}
-              </Term>
-            )}
+                </Term>
+              )}
 
-            <Term label="Duplicate matches">
-              <Text size="sm">
-                {summary.deduplicate
-                  ? "A record may match more than one of the partner's records."
-                  : "Each record matches at most one of the partner's records."}
-              </Text>
-              {/* Deduplicate changes match multiplicity, not what is disclosed, so
+              <Term label="Duplicate matches">
+                <Text size="sm">
+                  {summary.deduplicate
+                    ? "A record may match more than one of the partner's records."
+                    : "Each record matches at most one of the partner's records."}
+                </Text>
+                {/* Deduplicate changes match multiplicity, not what is disclosed, so
                 by the caveat-placement rule on {@link InvitationTerms} its caveat
                 sits here with its headline one expand down -- co-hidden with it, so
                 the line above never reads as in force while the caveat is hidden.
                 Not-applied is safe in the disclosure direction: the run matches at
                 most one, fewer matches than proposed, so no more is disclosed than
                 consented. */}
-              {summary.deduplicate && !summary.deduplicateApplied && (
-                <Text size="xs" c="dimmed">
-                  Your partner proposes this, but this version of the exchange
-                  does not yet apply it; each record still matches at most one.
-                </Text>
-              )}
-            </Term>
-          </Stack>
-        </Collapse>
-      </div>
+                {summary.deduplicate && !summary.deduplicateApplied && (
+                  <Text size="xs" c="dimmed">
+                    Your partner proposes this, but this version of the exchange
+                    does not yet apply it; each record still matches at most
+                    one.
+                  </Text>
+                )}
+              </Term>
+            </Stack>
+          </Collapse>
+        </div>
 
-      {summary.expires !== undefined && (
-        <Text size="xs" c="dimmed">
-          {/* Label the time zone: the expiry is one instant, but inviter and
+        {summary.expires !== undefined && (
+          <Text size="xs" c="dimmed">
+            {/* Label the time zone: the expiry is one instant, but inviter and
               acceptor may be in different zones, so a bare local wall-clock time
               would read as a different deadline on each end. */}
-          This invitation expires{" "}
-          {new Date(summary.expires).toLocaleString(undefined, {
-            timeZoneName: "short",
-          })}
-        </Text>
-      )}
+            This invitation expires{" "}
+            {new Date(summary.expires).toLocaleString(undefined, {
+              timeZoneName: "short",
+            })}
+          </Text>
+        )}
+      </CondensableDetails>
     </Stack>
   );
 }

--- a/apps/web/src/components/InvitePanel.tsx
+++ b/apps/web/src/components/InvitePanel.tsx
@@ -188,7 +188,10 @@ export function InvitePanel({ session, setSession, files }: InvitePanelProps) {
   };
 
   return (
-    <Paper>
+    // While composing, the home grid stretches the two panels to equal height, so
+    // this Paper fills its column beside the accept panel; in the takeover it sits in
+    // an auto-height Box where 100% resolves to content height (a no-op).
+    <Paper h={session === undefined ? "100%" : undefined}>
       <Title order={2}>Invite someone to join you in a data exchange</Title>
       {session === undefined ? (
         <Stack mt="md">

--- a/apps/web/src/components/LinkageTermsEditor.tsx
+++ b/apps/web/src/components/LinkageTermsEditor.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ActionIcon,
   Alert,
-  Badge,
   Box,
   Button,
   Checkbox,
@@ -826,7 +825,6 @@ export function LinkageTermsEditor({
                   style={{ listStyle: "none", padding: 0, margin: 0 }}
                 >
                   {draft.keys.map((entry, index) => {
-                    const satisfiable = keyIsSatisfiable(index);
                     // The key name is operator-authored but can be self-imported from
                     // a JSON/YAML document, so sanitize it for display and in
                     // accessible names -- the same discipline ExpertKeyEditor applies
@@ -845,26 +843,7 @@ export function LinkageTermsEditor({
                             onChange={(e) =>
                               toggleKey(index, e.currentTarget.checked)
                             }
-                            label={
-                              <Group gap="xs" wrap="nowrap">
-                                <Text size="sm">{keyLabel}</Text>
-                                <Badge
-                                  size="xs"
-                                  variant="light"
-                                  color={satisfiable ? "green" : "red"}
-                                  role="img"
-                                  aria-label={
-                                    satisfiable
-                                      ? "Your columns can satisfy this key"
-                                      : "Your columns cannot satisfy this key"
-                                  }
-                                >
-                                  {satisfiable
-                                    ? "satisfiable"
-                                    : "not satisfiable"}
-                                </Badge>
-                              </Group>
-                            }
+                            label={<Text size="sm">{keyLabel}</Text>}
                           />
                           <Group gap={4} wrap="nowrap">
                             <ActionIcon
@@ -1060,12 +1039,8 @@ export function LinkageTermsEditor({
                 icon={<IconInfoCircle aria-hidden />}
                 title="Fixed in this version"
               >
-                Matched identifiers are revealed (not just a count), and each
-                record matches at most one of your partner&apos;s. These are not
-                adjustable yet. Who receives the matched results is set above;
-                which of your columns are sent to your partner is set per column
-                under Your columns above. Turn on Expert authoring to build keys
-                directly or import and export the terms.
+                Turn on Expert authoring to build keys directly or import and
+                export the terms.
               </Alert>
             )}
           </Stack>
@@ -1086,6 +1061,11 @@ export function LinkageTermsEditor({
               linkageTerms={previewTerms}
               perspective="proposing"
               headingOrder={3}
+              // The author's own live preview: condensed so the pinned column stays
+              // compact. The disclose/produce facts track edits in the always-visible
+              // core; the lower tiers (how records are matched, legal, other details)
+              // fold behind one disclosure the author can open to check a key edit.
+              condensed
             />
           </Stack>
         </Grid.Col>

--- a/apps/web/src/components/PrepareData.tsx
+++ b/apps/web/src/components/PrepareData.tsx
@@ -635,6 +635,10 @@ export function PrepareData({
             perspective="accepted"
             headingOrder={3}
             sendColumns={disclosed}
+            // Post-consent reference (consent was given on the review screen), so the
+            // terms condense: the disclose/produce facts and this party's own outbound
+            // chips stay the standing last-look, and the lower tiers fold away.
+            condensed
           />
         </Grid.Col>
       </Grid>

--- a/apps/web/src/components/ShareBlock.tsx
+++ b/apps/web/src/components/ShareBlock.tsx
@@ -10,6 +10,8 @@ import {
 } from "@mantine/core";
 import { IconCheck, IconCopy } from "@tabler/icons-react";
 
+import type { Ref } from "react";
+
 /** A labelled, copy-to-clipboard view of one shareable artifact. It is only ever
  * rendered on the client -- behind the inviter exchange screen, which the compose
  * screen swaps in only from an event handler, so it is absent from the server
@@ -84,15 +86,23 @@ export function ShareBlock({
   deepLink,
   encoded,
   expires,
+  headingRef,
 }: {
   deepLink: string;
   encoded: string;
   /** The invitation's expiry instant (ISO 8601), if it carries one. */
   expires?: string;
+  /** Focus target for the heading. The inviter exchange screen leads with this
+   * block (sharing the link is the urgent post-generate task) and moves initial
+   * focus here on mount, so a keyboard/screen-reader user who pressed Generate lands
+   * on the link to copy rather than on the unmounted compose button. */
+  headingRef?: Ref<HTMLHeadingElement>;
 }) {
   return (
     <Stack gap="sm">
-      <Title order={3}>Share this invitation</Title>
+      <Title order={3} ref={headingRef} tabIndex={-1}>
+        Share this invitation
+      </Title>
       <Text size="sm" c="dimmed">
         Send one of these to your partner over a trusted channel (for example,
         secure email). It carries a one-time secret, so treat it as confidential

--- a/apps/web/test/browser/acceptInvitationTerms.test.ts
+++ b/apps/web/test/browser/acceptInvitationTerms.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
-import { userEvent } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
@@ -168,6 +168,42 @@ describe("accept screen: terms render from a decoded token", () => {
     expect(html).toContain("MOU-2025-0042");
     expect(html).toContain("risk_score");
     expect(html).toContain("program_outcome");
+  });
+
+  test("the review (consent) screen is never condensed -- every tier stays always-visible", async () => {
+    // The consent-integrity invariant: the acceptor's PRE-CONSENT review screen must
+    // render the FULL terms, never the condensed fold used on the post-consent
+    // reference surfaces. If AcceptInvitationPanel ever passed `condensed`, the lower
+    // tiers (how records are matched, legal, other details) would hide behind a "See
+    // the full terms" disclosure at the very screen where informed consent is given --
+    // and the renderHtml helper (which opens every toggle) would mask it. So this
+    // renders WITHOUT opening anything and asserts the fold is absent while a lower
+    // tier is present in the accessibility tree unaided.
+    flushSync(() =>
+      root!.render(
+        createElement(
+          MantineProvider,
+          null,
+          createElement(AcceptInvitationPanel, {
+            decode: { status: "ready", invitation: makeInvitation() },
+            consented: false,
+            onConsentedChange: () => {},
+            acceptorName: "",
+            onAcceptorNameChange: () => {},
+            onAcquireError: () => {},
+            onAcquired: () => {},
+          }),
+        ),
+      ),
+    );
+    // No condensing fold on the consent screen ...
+    expect(
+      page.getByRole("button", { name: "See the full terms" }).query(),
+    ).toBeNull();
+    // ... and a lower tier is always-visible without expanding anything.
+    await expect
+      .element(page.getByRole("heading", { name: "How records are matched" }))
+      .toBeInTheDocument();
   });
 
   test("renders the deduplicate setting as a duplicate-matches note", async () => {

--- a/apps/web/test/browser/exchangeView.test.ts
+++ b/apps/web/test/browser/exchangeView.test.ts
@@ -363,19 +363,40 @@ describe("ExchangeView focus throughline", () => {
     });
   });
 
-  test("moves focus to the exchange-summary heading on mount for the inviter", async () => {
-    // Both roles now lead with the exchange-summary heading (the left column); the
-    // inviter's share block moved below the columns. Entry focus lands on that
-    // heading -- taking a keyboard/screen-reader user who pressed Generate to the
-    // new screen rather than leaving focus on the unmounted compose button. The
-    // inviter's summary heading is "Exchange proposal" (the proposing perspective).
+  test("moves focus to the share-block heading on mount for the inviter", async () => {
+    // The inviter leads with the share block (above the columns): sharing the link is
+    // the urgent post-generate task, so entry focus lands on its heading -- taking a
+    // keyboard/screen-reader user who pressed Generate to the link to copy rather than
+    // leaving focus on the unmounted compose button. The heading is "Share this
+    // invitation".
     setOutcome("none");
     render(inviterConfig("secret-a"));
 
     await vi.waitFor(() => {
       const active = document.activeElement;
       expect(active?.tagName).toBe("H3");
-      expect(active?.textContent).toBe("Exchange proposal");
+      expect(active?.textContent).toBe("Share this invitation");
+    });
+  });
+
+  test("moves focus to the exchange-summary heading on mount for the acceptor", async () => {
+    // The acceptor renders no share block, so it leads with the terms summary heading
+    // (the inviter leads with the share block instead). Entry focus lands there on
+    // mount -- taking a keyboard/screen-reader user who pressed Accept to the terms
+    // rather than leaving focus on the unmounted button. The acceptor's summary
+    // heading is order 2, "Invitation from <identity>". Guards the role-divergent
+    // headingRef ternary: were it to drop the acceptor's ref, the inviter test above
+    // still passes (its focus comes from ShareBlock) while the acceptor silently loses
+    // entry focus to <body>.
+    setOutcome("none");
+    render(acceptorConfig("secret-a"));
+
+    await vi.waitFor(() => {
+      const active = document.activeElement;
+      expect(active?.tagName).toBe("H2");
+      expect(active?.textContent).toBe(
+        "Invitation from County Health Department",
+      );
     });
   });
 
@@ -383,11 +404,11 @@ describe("ExchangeView focus throughline", () => {
     setOutcome("none");
     render(inviterConfig("secret-a"));
 
-    // The inviter auto-starts; entry focus lands on the summary heading. Move it
-    // into the share block (onto the copy-link button the inviter would use while
-    // it waits), so the connect below orphans it.
+    // The inviter auto-starts; entry focus lands on the share-block heading. Move it
+    // onto the copy-link button (the inviter would use it while it waits), so the
+    // connect below orphans the focus when the share block unmounts.
     await vi.waitFor(() => {
-      expect(document.activeElement?.textContent).toBe("Exchange proposal");
+      expect(document.activeElement?.textContent).toBe("Share this invitation");
       expect(lifecycle.calls).toHaveLength(1);
     });
     const copyLink = page.getByRole("button", {
@@ -416,7 +437,7 @@ describe("ExchangeView focus throughline", () => {
     render(inviterConfig("secret-a"));
     await vi.waitFor(() => expect(lifecycle.calls).toHaveLength(1));
 
-    // Focus rests on the summary heading (the left column, which stays mounted
+    // Focus rests on the summary heading (the right column, which stays mounted
     // through the connect), so it is NOT orphaned when the share block unmounts.
     const terms = page.getByRole("heading", {
       name: "Exchange proposal",
@@ -445,6 +466,30 @@ describe("ExchangeView focus throughline", () => {
 
     await expect
       .element(page.getByText(/No columns are sent to your partner/))
+      .toBeInTheDocument();
+  });
+});
+
+describe("ExchangeView condenses the run-screen summary for both roles", () => {
+  // The run screen shows the terms as post-consent / authored reference, so both roles
+  // condense the summary behind the "See the full terms" fold. (The acceptor's
+  // PRE-CONSENT review screen is a different component and stays full -- guarded in
+  // acceptInvitationTerms.test.ts.) These guard against `condensed` being dropped from
+  // ExchangeView: the always-visible "No columns are sent" assertion above would still
+  // pass with the terms fully expanded, so it cannot catch a de-condense regression.
+  test("the inviter run screen condenses the summary", async () => {
+    setOutcome("none");
+    render(inviterConfig("secret-a"));
+    await expect
+      .element(page.getByRole("button", { name: "See the full terms" }))
+      .toBeInTheDocument();
+  });
+
+  test("the acceptor run screen condenses the summary", async () => {
+    setOutcome("none");
+    render(acceptorConfig("secret-a"));
+    await expect
+      .element(page.getByRole("button", { name: "See the full terms" }))
       .toBeInTheDocument();
   });
 });

--- a/apps/web/test/browser/invitationTerms.test.ts
+++ b/apps/web/test/browser/invitationTerms.test.ts
@@ -367,6 +367,101 @@ describe("InvitationTerms: per-key matching disclosures", () => {
   });
 });
 
+describe("InvitationTerms: the condensed reference view folds the lower tiers", () => {
+  // The post-consent / authored REFERENCE surfaces (both run screens, prepare-your-
+  // data, the inviter's live preview) render the summary condensed: the disclose/
+  // produce facts stay always-visible; the lower reference tiers (what you receive,
+  // how records are matched, the legal agreement, and "Other details") fold behind one
+  // "See the full terms" disclosure. The acceptor's PRE-CONSENT review screen never
+  // passes condensed -- guarded directly in acceptInvitationTerms.test.ts, and here by
+  // every other test rendering without it.
+  const FOLD = "See the full terms";
+  function renderCondensed(overrides?: Partial<LinkageTerms>) {
+    root!.render(
+      createElement(
+        MantineProvider,
+        null,
+        createElement(InvitationTerms, {
+          linkageTerms: { ...terms, ...overrides },
+          perspective: "proposing",
+          condensed: true,
+        }),
+      ),
+    );
+  }
+
+  test("the must-see facts stay always-visible; the lower tiers fold behind a collapsed disclosure", async () => {
+    renderCondensed();
+
+    // The fold toggle is present and collapsed by default.
+    const fold = toggle(FOLD);
+    await expect.element(fold).toBeInTheDocument();
+    expect(fold.element().getAttribute("aria-expanded")).toBe("false");
+
+    // It is a real disclosure held to the same contract as the others: while closed
+    // its panel is hidden from AT + the tab order (aria-hidden + inert), proving the
+    // tiers are present-but-hidden rather than merely absent.
+    const collapse = await readyCollapse(FOLD);
+    expect(collapse.getAttribute("aria-hidden")).toBe("true");
+    expect(collapse.hasAttribute("inert")).toBe(true);
+
+    // The must-see facts stay in the always-visible core: the viewer's own send
+    // ("What you disclose", chips) and the matching-method / result-sharing pair
+    // ("What the exchange produces").
+    const disclose = group("What you disclose");
+    await expect.element(disclose).toBeInTheDocument();
+    expect(disclose.element().textContent).toContain(
+      "Columns sent to your partner",
+    );
+    const produce = group("What the exchange produces");
+    await expect.element(produce).toBeInTheDocument();
+    expect(produce.element().textContent).toContain("Result sharing");
+
+    // The lower tiers are folded away. Gate on the fold panel having committed first
+    // (readyPanel), so a regression that leaked the tiers visible cannot pass on a
+    // not-yet-committed read: once committed, they are still out of the accessibility
+    // tree until the fold is opened.
+    await readyPanel(FOLD);
+    expect(group("How records are matched").query()).toBeNull();
+    expect(group("Legal agreement").query()).toBeNull();
+  });
+
+  test("opening the fold reveals the lower tiers -- nothing was removed, only folded", async () => {
+    renderCondensed();
+    await userEvent.click(toggle(FOLD));
+
+    // Once expanded, the matching mechanics and the legal-agreement governance frame
+    // are reachable again.
+    await expect.element(group("How records are matched")).toBeInTheDocument();
+    await expect.element(group("Legal agreement")).toBeInTheDocument();
+  });
+
+  test("folding never sweeps the disclosure-critical psi-c caveat out of the always-visible core", async () => {
+    // psi-c is a disclosure GUARANTEE (only the count is revealed). Its "not yet
+    // applied" caveat must stay in the always-visible "What the exchange produces"
+    // tier -- folding it would let a viewer read count-only as in force while the run
+    // still reveals matched identifiers. This is the one caveat that may never move
+    // below its headline, so it must never move behind the fold either.
+    renderCondensed({ algorithm: "psi-c" });
+    const produce = group("What the exchange produces");
+    await expect.element(produce).toBeInTheDocument();
+    expect(produce.element().textContent).toContain(
+      "matched records are still revealed",
+    );
+  });
+
+  test("the fold toggle is self-describing (perspective-neutral, so it fits agreed terms too)", async () => {
+    renderCondensed();
+    const fold = toggle(FOLD);
+    await expect.element(fold).toBeInTheDocument();
+    const describedById = fold.element().getAttribute("aria-describedby");
+    expect(describedById).toBeTruthy();
+    expect(document.getElementById(describedById!)?.textContent).toBe(
+      "Contains how records are matched and the other terms.",
+    );
+  });
+});
+
 describe("InvitationTerms: a key disclosure stays mounted but hidden under a reduced-motion preference", () => {
   // Since Mantine 9.4 a closed Collapse no longer unmounts its panel for a
   // reduced-motion user: it keeps the panel mounted inside a hidden React Activity
@@ -445,6 +540,40 @@ describe("InvitationTerms: a key disclosure stays mounted but hidden under a red
     await userEvent.click(toggle("Matching strategies"));
     for (const name of ["SSN + LN + DOB", "SSN + FN1"])
       await expectResolvableCollapsedWrapper(name);
+  });
+
+  test("the condensed fold's aria-controls wrapper survives collapse under reduced motion", async () => {
+    // The new "See the full terms" fold uses the same always-mounted-wrapper design.
+    // Under reduced motion Mantine may UNMOUNT the closed panel, so an id placed on
+    // the Collapse panel (instead of the outer wrapper) would dangle -- assert the
+    // wrapper stays present here, the invariant the other disclosures are held to.
+    root!.render(
+      createElement(
+        MantineProvider,
+        { theme: { respectReducedMotion: true } },
+        createElement(InvitationTerms, {
+          linkageTerms: terms,
+          perspective: "proposing",
+          condensed: true,
+        }),
+      ),
+    );
+    const fold = toggle("See the full terms");
+    await expect.element(fold).toBeInTheDocument();
+    expect(fold.element().getAttribute("aria-expanded")).toBe("false");
+    const id = fold.element().getAttribute("aria-controls");
+    expect(id).toBeTruthy();
+    // Wait for the reduced-motion effect to settle: the closed panel is then either
+    // gone (unmounted) or hidden (display:none).
+    await expect
+      .poll(() => {
+        const panel = document.getElementById(id!)
+          ?.firstElementChild as HTMLElement | null;
+        return panel === null || getComputedStyle(panel).display === "none";
+      })
+      .toBe(true);
+    // ... and through it all the wrapper stays present, so aria-controls resolves.
+    expect(document.getElementById(id!)).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

The web exchange-terms summary (`InvitationTerms`) grew tall enough that after generating an invitation the invitation link scrolled off the screen. This shortens it: the share block now leads the exchange screen (and takes initial focus), and a new condensed mode folds the lower reference tiers behind one default-collapsed disclosure on the post-consent and authoring screens. The acceptor's pre-consent review screen is unchanged and still shows every tier inline, so no consent-surfaced fact is hidden at the decision point. Presentation only -- nothing disclosed to a partner, sent on the wire, or written to disk changes. Bundled with small compose- and advanced-page polish requested in the same pass.

## Changes

- `apps/web` ExchangeView + ShareBlock: move the share block above the columns; the inviter leads with (and focuses) the share-block heading while the acceptor still leads with the summary heading; both run-screen roles pass `condensed`.
- `apps/web` InvitationTerms + ExchangeSummary: add a `condensed` prop and the `CondensableDetails` fold (lower tiers behind one default-collapsed disclosure reusing the existing disclosure idiom; the non-condensed render is byte-identical via a Fragment passthrough); perspective-neutral fold label.
- `apps/web` PrepareData + LinkageTermsEditor: render their post-consent / authoring reference summary condensed. `AcceptInvitationPanel` (the pre-consent review screen) is deliberately left full.
- `apps/web` HomePage + InvitePanel + AcceptForm: equal-height compose panels (`Grid align="stretch"` + `Paper h="100%"`).
- `apps/web` LinkageTermsEditor: drop the per-key satisfiability badge from the guided key list (it remains in the expert editor; the generate gate still enforces satisfiability); replace the fixed-in-this-version panel copy.
- `apps/web` tests: add/strengthen coverage (below).

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format`, `npx vitest run --project unit` (apps/web, 598 passing), `npx vitest run --project browser` (apps/web, 336 passing).
New tests cover: the condensed fold's a11y contract (collapsed = `aria-hidden` + `inert`, the `aria-controls` wrapper resolves under reduced motion), that folding keeps the outbound send chips and the psi-c count-only caveat always-visible, a regression guard that the acceptor's pre-consent review screen is never condensed, the acceptor's mount entry-focus on the summary heading (now divergent from the inviter's), and that both run screens render the fold.

## Background

The consent-surfaced tiers fold only on reference surfaces; the pre-consent review screen -- where informed consent is captured -- stays full, so no consent-critical fact is hidden at the decision point, and folding removes nothing (the full terms are one click away). The change was vetted by an independent four-lens review (correctness, accessibility, consent, tests); this PR includes the resulting fixes (stale docstrings corrected to the real invariant, a perspective-neutral fold label, and the added coverage above).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: web UI presentation only; no config, flag, wire, on-disk, or behavioral change, the set of disclosed facts is unchanged, and the pre-consent consent screen is untouched, so no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: presentation only; nothing an operator/deployer or security reviewer acts on across a release changes -- no change to what is disclosed to a partner, sent on the wire, written to disk, or revealed in the result, and the pre-consent consent screen is unchanged.
- [x] Security review -- Reviewed here by an independent consent/privacy pass, which verified the review screen is never condensed and that the outbound send chips, the psi-c count-only caveat, and the honest-helper membership note stay always-visible in the condensed views (nothing removed, only folded). Maintainer/security-reviewer sign-off obtained.