### PR TITLE
Encode the retro interventions in skills, conventions, and CI

### DIFF
--- a/.claude/commands/assess-review.md
+++ b/.claude/commands/assess-review.md
@@ -23,15 +23,31 @@ Start with the whole, not the parts:
 
 - **Soundness.** Comment on the overall approach and any patterns across the
   findings.
-- **Trajectory.** Reconstruct earlier rounds from the branch's commit history
-  (`git log staging..HEAD` -- prior review-fix commits show what past rounds
-  already addressed) and compare against the current findings. Is the
-  count net-decreasing (converging) or are fixes spawning fresh findings (churn)?
-- **Brittle areas.** When the same file or module keeps surfacing across rounds,
-  name it. A blind full-diff pass has diminishing returns there -- recommend
-  pivoting to a focused, independent assessment of just that area (point fresh
-  agents at it cold) rather than another whole-branch cold round. Say which areas,
-  and why they look brittle.
+- **Trajectory.** Read the `## Trajectory` section light-review wrote into
+  `review_findings.md`, and the rounds ledger at
+  `scratch/review-rounds/<branch>.jsonl` for the rounds before it (fall back to
+  reconstructing rounds from `git log staging..HEAD` review-fix commits if
+  either is missing). Converging is confirmed-new falling with repeats near
+  zero; churn is fixes spawning findings.
+
+Then check the **step-back triggers**. If ANY fires, do NOT proceed to
+fix-and-rerun: stop, and recommend a structural pivot instead -- a focused
+independent assessment of the churning area (fresh agents, cold) or a judge
+panel of alternative shapes -- presented to the owner in prose with options and
+a recommendation. Churn escalates to a different activity, never to another
+blind whole-branch round.
+
+1. The same file or area carries confirmed findings in three consecutive rounds
+   (two, for a diff under ~150 lines).
+2. This round confirmed as many findings as the previous round's fixes closed,
+   or more.
+3. Reviewers propose contradictory remedies for the same hunk, or the contested
+   list (high-severity, single-reviewer findings) grew from the previous round.
+4. Two or more reviewers voted that a materially simpler shape exists.
+5. A fix you are about to make would grow the branch's diff by roughly a third
+   or more.
+6. The driving board issue's **Affected areas** is in context and the diff has
+   spread well beyond it.
 
 ## Step 3 -- Triage and fix
 
@@ -40,6 +56,14 @@ hunks/files it names, not the whole diff), then decide.
 
 - **Default to fixing.** Drive-by corrections are welcome -- you do not need
   permission to fix something small and clearly right.
+- **Prose findings get a high bar.** Fix a finding that asks for a comment,
+  JSDoc, or doc paragraph only when the missing constraint is unrecoverable
+  from the code, names, types, and tests AND its absence enables a concrete
+  wrong edit you can name -- and prefer carrying it as a check, a test, or a
+  more explicit name over prose. Reviews here have a measured many-to-one bias
+  toward adding prose; do not ratchet. The same bar applies to prose you are
+  tempted to add defensively while triaging: pre-empting a re-raise is not a
+  reason.
 - **Autonomy boundary.** Settle implementation details yourself. STOP and ask the
   owner or PM before a fix that reaches beyond this change: public API / CLI /
   config-schema, protocol or wire format, security-relevant behavior, a
@@ -74,4 +98,5 @@ green. When it is ready, say so.
 
 ## Step 5 -- Clean up
 
-Delete `review_findings.md` from your working directory.
+Delete `review_findings.md` from your working directory. Leave
+`scratch/review-rounds/` in place -- it is the cross-round trajectory ledger.

--- a/.claude/commands/light-review.md
+++ b/.claude/commands/light-review.md
@@ -1,13 +1,11 @@
 ---
 name: light-review
-description: Multi-reviewer code review of the current branch (HEAD) against staging. Spawns three independent Sonnet reviewers, then a fourth Sonnet agent that clusters and verifies their findings, and writes the consolidated result to review_findings.md in the working directory. Takes an optional list of documentation files the reviewers and consolidator should consult for design justification. Pure orchestration -- it does not review the code itself.
+description: Multi-reviewer code review of the current branch (HEAD) against staging. Runs three independent schema-forced Sonnet reviewers and a Sonnet consolidator through one Workflow, computes the round's trajectory against prior rounds, and writes review_findings.md in the working directory. Takes an optional list of documentation files the reviewers and consolidator should consult for design justification. Pure orchestration -- it does not review the code itself.
 ---
 
-You are ORCHESTRATING a code review. You do not review the code yourself and you do not
-explore the codebase -- you spawn agents, collect their output, and write a file.
-
-Spawn every agent below with the Agent tool: the general-purpose subagent type, model
-`sonnet`. They need Bash (to run `git diff`) and Read (for docs and verification).
+You are ORCHESTRATING a code review. You do not review the code yourself and you
+do not explore the codebase -- you run one Workflow, compute the round's
+trajectory, and write a file.
 
 ## Input
 
@@ -27,85 +25,132 @@ with staging", i.e. PR semantics -- it ignores commits staging gained after the 
 forked. Every agent below uses the same three-dot form. Only this `--stat` runs in the
 main thread, so the full diff never enters this conversation's context.
 
-## Step 2 -- Three independent reviewers
+## Step 2 -- Run the review Workflow
 
-Spawn exactly three Sonnet agents in ONE message so they run in parallel, never see each
-other's output, and never see these orchestration instructions. Send all three the SAME
-prompt below. Resolve the bracketed DOCS clause before sending: include it only if DOCS
-is non-empty, substituting the actual paths for `<DOCS>`.
+Invoke the Workflow tool with `args` set to `{"docs": [<the DOCS list, possibly empty>]}`
+and the script below VERBATIM -- do not paraphrase it, and do not spawn the reviewers
+with the Agent tool instead: plain agents cannot have their output format enforced, and
+the schema is the point (prompt-side "return only JSON" instructions have a long failure
+record here).
 
---- reviewer prompt ---
-You are a senior software engineer reviewing the current branch (HEAD) of this repository.
-Generate the diff yourself with `git diff "staging...HEAD"` -- the three-dot form is
-deliberate and non-negotiable: it shows ONLY what this branch added since it forked from
-`staging`, and it excludes every commit `staging` gained after the fork. That diff is the
-complete and exclusive scope of your review. Never widen it: do not run a two-dot
-`git diff staging HEAD`, do not diff against `HEAD~N`, the tip of `staging`, or any other
-base.
+```js
+export const meta = {
+  name: 'light-review',
+  description: 'Three schema-forced reviewers over the branch diff, then a consolidator that clusters and verifies',
+  phases: [{ title: 'Review' }, { title: 'Consolidate' }],
+}
 
-Review the branch's own changes and nothing else. Anything attributable to `staging`
-advancing since the branch forked -- the branch's base or starting point moving, the
-"root" of the branch changing, upstream commits the branch has not yet absorbed -- is OUT
-OF SCOPE and not this branch's responsibility. Do not flag it, describe it, or even
-mention that the base moved; treat such material as invisible. If a hunk merely re-states
-upstream `staging` work rather than introducing new behavior authored on this branch,
-ignore it. Open another file only if a hunk cannot be judged without it.
+const FINDING = {
+  type: 'object',
+  required: ['name', 'description', 'severity', 'file'],
+  properties: {
+    name: { type: 'string' },
+    description: { type: 'string' },
+    severity: { type: 'string', enum: ['critical', 'major', 'minor', 'nit'] },
+    file: { type: 'string' },
+  },
+}
+const REVIEWER_SCHEMA = {
+  type: 'object',
+  required: ['findings', 'simplerShape'],
+  properties: {
+    findings: { type: 'array', items: FINDING },
+    simplerShape: {
+      type: 'object',
+      required: ['simpler', 'reason'],
+      properties: { simpler: { type: 'boolean' }, reason: { type: 'string' } },
+    },
+  },
+}
+const CONSOLIDATOR_SCHEMA = {
+  type: 'object',
+  required: ['clusters'],
+  properties: {
+    clusters: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['name', 'description', 'severity', 'file', 'flaggedBy', 'verification', 'verificationNote'],
+        properties: {
+          name: { type: 'string' },
+          description: { type: 'string' },
+          severity: { type: 'string', enum: ['critical', 'major', 'minor', 'nit'] },
+          file: { type: 'string' },
+          flaggedBy: { type: 'number' },
+          verification: { type: 'string', enum: ['confirmed', 'refuted', 'unverifiable'] },
+          verificationNote: { type: 'string' },
+        },
+      },
+    },
+  },
+}
 
-[IF DOCS NON-EMPTY: First read these docs for design context: <DOCS>. When an issue could
-be a deliberate design decision, check whether these docs justify it before flagging it.]
+const docsClause = args.docs && args.docs.length
+  ? 'First read these docs for design context: ' + args.docs.join(', ') + '. When an issue could be a deliberate design decision, check whether these docs justify it before flagging it.\n\n'
+  : ''
 
-Review for: correctness bugs, logic errors, security issues, missing error handling at
-system boundaries, type-safety issues, API-contract violations, documentation-tier
-placement (spec-level detail -- a constant value, byte/wire layout, an HKDF info string or other algorithm step, or
-"would only need revisiting if..." rationale -- written into a `docs/` overview doc rather
-than `docs/spec/`), and anything else that looks wrong.
+const reviewerPrompt = `You are a senior software engineer reviewing the current branch (HEAD) of this repository.
+Generate the diff yourself with git diff "staging...HEAD" -- the three-dot form is deliberate and non-negotiable: it shows ONLY what this branch added since it forked from staging, and it excludes every commit staging gained after the fork. That diff is the complete and exclusive scope of your review. Never widen it: do not run a two-dot git diff staging HEAD, do not diff against HEAD~N, the tip of staging, or any other base.
 
-Return ONLY a JSON array, no other text. Each element:
-- "name": short title (5 words max)
-- "description": 1-2 sentence explanation of the issue
-- "severity": one of "critical", "major", "minor", "nit"
-- "file": file path where the issue occurs, or "general" if not file-specific
+Review the branch's own changes and nothing else. Anything attributable to staging advancing since the branch forked -- the branch's base or starting point moving, the "root" of the branch changing, upstream commits the branch has not yet absorbed -- is OUT OF SCOPE and not this branch's responsibility. Do not flag it, describe it, or even mention that the base moved; treat such material as invisible. If a hunk merely re-states upstream staging work rather than introducing new behavior authored on this branch, ignore it. Open another file only if a hunk cannot be judged without it.
 
-Example: [{"name": "...", "description": "...", "severity": "major", "file": "src/foo.ts"}]
-If you find no issues, return an empty array [].
---- end reviewer prompt ---
+${docsClause}Review for: correctness bugs, logic errors, security issues, missing error handling at system boundaries, type-safety issues, API-contract violations, documentation-tier placement (spec-level detail -- a constant value, byte/wire layout, an HKDF info string or other algorithm step, or "would only need revisiting if..." rationale -- written into a docs/ overview doc rather than docs/spec/), excess prose (a comment that restates the adjacent code, narrates change history -- "now", "previously", "was moved" -- duplicates a JSDoc, or cites a board item id; name such findings "excess prose: ..."), and anything else that looks wrong.
 
-## Step 3 -- Collect
+Do NOT flag missing comments or ask for more explanatory prose unless a genuinely non-obvious constraint is uncarried by the code, names, types, and tests -- this codebase treats prose as a last resort and a check, test, or rename as the preferred carrier.
 
-Gather the three JSON arrays verbatim, each block labeled "Reviewer 1", "Reviewer 2",
-"Reviewer 3". Do not edit, merge, or drop anything. If a reviewer returns prose, a fenced
-code block, or malformed JSON instead of a clean array, pass it through labeled and
-unaltered -- do not try to repair it.
+Separately from the findings, answer the shape question: is there a materially simpler shape for this branch's change -- a different factoring, an existing mechanism it should have reused, a smaller surface? Set simpler=true ONLY if you can name the shape in one sentence (put it in reason); otherwise simpler=false with a short reason. Do not force it.`
 
-## Step 4 -- Consolidate and verify (one Sonnet agent, single pass)
+const reviews = (await parallel([1, 2, 3].map((n) => () =>
+  agent(reviewerPrompt, { label: `reviewer-${n}`, phase: 'Review', schema: REVIEWER_SCHEMA, model: 'sonnet' }),
+))).filter(Boolean)
 
-Spawn a fourth Sonnet agent. Give it: the three labeled arrays from Step 3, and
-instructions to run `git diff "staging...HEAD"` [IF DOCS NON-EMPTY: and read <DOCS>] in
-order to verify. If any reviewer's block was not parseable JSON (see Step 3), tell it to
-salvage what findings it can and note which reviewer's output could not be parsed. In a
-single response -- no sub-agents, no iteration -- it must:
+const consolidatorPrompt = `You are consolidating a code review of the current branch. ${reviews.length} independent reviewers examined git diff "staging...HEAD" (three-dot; the branch's own changes only -- never widen the diff). Their findings:
+${JSON.stringify(reviews.map((r, i) => ({ reviewer: i + 1, findings: r.findings })), null, 1)}
 
-1. Drop any finding that is not about the current branch's own changes. The three-dot diff
-   scopes the review to what this branch authored since it forked from `staging`; any
-   finding describing the branch's base/root moving, or `staging`'s progress since the
-   fork, is out of scope and must NOT appear in the output -- discard it before clustering,
-   do not even list it as refuted.
-2. Cluster the remaining findings that describe the same underlying issue across reviewers.
-3. Verify each cluster's core claim by reading only the specific hunks or files that
-   cluster names -- not the whole diff -- and mark it Confirmed / Refuted / Unverifiable
-   with a one-line reason.
+${docsClause}In a single pass -- no sub-agents, no iteration:
+1. Drop any finding that is not about the current branch's own changes (anything describing the branch's base moving, or staging's progress since the fork) -- discard it before clustering, do not even list it as refuted.
+2. Cluster findings that describe the same underlying issue across reviewers; flaggedBy is the number of distinct reviewers in the cluster.
+3. Verify each cluster's core claim by reading only the specific hunks or files it names -- not the whole diff -- and set verification confirmed/refuted/unverifiable with a one-line verificationNote.`
 
-It outputs one markdown document, clusters sorted by severity (critical first) then by
-reviewer count (descending). Each cluster is a row with: issue number, name, description,
-severity, file, "flagged by N of 3", and the verification outcome.
+const consolidated = await agent(consolidatorPrompt, {
+  label: 'consolidator', phase: 'Consolidate', schema: CONSOLIDATOR_SCHEMA, model: 'sonnet',
+})
 
-## Step 5 -- Write
+return {
+  reviewerCount: reviews.length,
+  simplerShapeVotes: reviews.map((r) => r.simplerShape),
+  clusters: consolidated.clusters,
+}
+```
 
-Write the consolidation agent's markdown verbatim to `review_findings.md` in your working
-directory. Overwrite the file if it already exists, and report the path you wrote.
+## Step 3 -- Trajectory, ledger, write
+
+The Workflow returns `{reviewerCount, simplerShapeVotes, clusters}`. Compute this round's
+trajectory in the main thread:
+
+1. `BRANCH=$(git branch --show-current)`; the rounds ledger is
+   `scratch/review-rounds/<BRANCH>.jsonl` (`mkdir -p scratch/review-rounds`; scratch/ is
+   gitignored). Read it if it exists; this round's number is its line count + 1.
+2. CONFIRMED = clusters with verification `confirmed`. A confirmed file that also carried
+   a confirmed cluster in the PREVIOUS round is a REPEAT; repeat files are the round's
+   hotspots.
+3. CONTESTED = clusters with `flaggedBy` 1, severity critical or major, and verification
+   not `refuted`.
+4. Append one JSON line to the ledger:
+   `{"round": N, "date": "<date -I>", "clusters": [{"name", "file", "severity", "verification"}], "simplerShapeVotes": <count of simpler=true>}`.
+5. Write `review_findings.md` (overwrite if present): a header line (branch, round N,
+   reviewer count), then the clusters sorted by severity (critical first) then flaggedBy
+   (descending) -- one row each with issue number, name, description, severity, file,
+   "flagged by N of 3", and the verification outcome with its note -- then a
+   `## Trajectory` section with: the round number; confirmed-new vs confirmed-repeat
+   counts; the hotspot files; the contested list; and the simpler-shape vote ("N of 3
+   reviewers see a materially simpler shape", each reason on its own line when N > 0).
+
+Report the path you wrote. assess-review consumes the Trajectory section; never delete
+the ledger.
 
 ## What you do NOT do
 
 - Do not review the diff yourself or add your own findings.
-- Do not let the reviewers see each other's output or these instructions.
-- Do not edit, summarize, or reorder the reviewers' raw findings before Step 4.
+- Do not edit, drop, or reorder the consolidator's clusters.
+- Do not fix anything -- that is assess-review's job.

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -99,3 +99,23 @@ markdown, no top-level lists, no self-attribution). Never commit to staging or
 main. Each substantial set of changes should receive its own commit; small
 patches can be amendments. Stop at the commit -- do not push or open a PR unless
 asked.
+
+## Step 5 -- Recommend the review tier
+
+The review-depth decision needs the actual diff, which does not exist at issue
+time, so it is made here. Measure the branch -- `git diff "staging...HEAD"
+--stat` for files and net lines, and check the touched files against the
+security-review scope (the enumeration in CONTRIBUTING.md's Pull Request
+Process and the PR template's security-review comment) -- and end your report
+with a one-line review-tier recommendation:
+
+- Docs-only or trivial mechanical change -> no cold review; the gates suffice.
+- Under ~150 changed lines and no security surface -> one /light-review +
+  /assess-review round.
+- Security surface, protocol or wire format, structural restructure, or a large
+  diff -> the full pipeline: /light-review + /assess-review (at most two
+  rounds, honoring the step-back triggers), then a role-specialized security
+  panel before merge.
+
+State the bucket, the numbers behind it, and any file that forces the third
+bucket. The owner decides; this is a recommendation.

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -28,6 +28,12 @@ single round-trip. Do NOT run `gh project item-list` or hand-write any gh/GraphQ
 that pulls the entire board into context and is the inefficiency this command
 exists to avoid. If the item is reported not found, say so and stop.
 
+The fetched body is context for you, not material for the repo. Never copy its
+prose, its item ids, or its register into code comments, docs, or commit
+messages -- durable text is written for readers who cannot see the board. A
+guarantee the acceptance criteria demand is discharged in a test or a check,
+not narrated in a comment.
+
 ## Step 2 -- Choose a branch name
 
 Slugify the issue title to lowercase letters, digits, and hyphens (so it is a
@@ -82,8 +88,11 @@ Know when to decide and when to ask:
 Implement on the branch, following CONTRIBUTING.md. Verify before you commit:
 rebuild core (`npm run build -w packages/core`) if you touched it -- it was built
 at issue start, so this only picks up changes you made. Then `npm run typecheck &&
-npm run lint`, and run the tests covering what you changed. Report what you ran
-and the result; do not commit on red without saying so.
+npm run lint`, and run the tests covering what you changed. Then sweep your own
+diff (`git diff`): delete every comment that restates the code, narrates the
+change, or cites a board id, and move any "this cannot happen" claim into a
+check. Report what you ran and the result; do not commit on red without saying
+so.
 
 Commit to the new branch following CONTRIBUTING.md's commit conventions (no
 markdown, no top-level lists, no self-attribution). Never commit to staging or

--- a/.claude/pm/ruleset.md
+++ b/.claude/pm/ruleset.md
@@ -57,6 +57,8 @@ Free-form. Capture non-obvious context a contributor would otherwise have to red
 - Known gotchas from the codebase or prior PRs.
 - Pointers to relevant existing patterns (e.g. "follow the FileSyncConnection injection pattern").
 
+Point rather than narrate: reference the mechanism's code or doc home ("see FILE_SYNC.md, Disclosed-columns subset on the token") instead of re-explaining it inline. Implementing agents measurably transcribe issue prose into durable comments and docs; a pointer can only be followed.
+
 When the input already contains an analysis -- options with trade-offs, a problem statement, a scope estimate -- carry that substance forward into the task. You may evaluate it: note risks or gaps in specific approaches, add context the submitter missed, critique assumptions. But do not select an implementation approach on the submitter's behalf when they have not selected one.
 
 Pay particular attention to statements that constrain the solution space: root cause conclusions, architectural invariants, and "any fix must ..." claims. These often appear as framing prose around an options table rather than in a named section, and they are easy to drop when compressing an analysis. Preserve them explicitly -- a contributor who misses a constraint may pursue an approach that cannot satisfy the requirement. Unresolved design decisions belong in **Open questions**, stated clearly so whoever picks up the task knows a decision is still needed. A task that reaches the board with open design choices is not incomplete; it is honest.

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -55,6 +55,12 @@ jobs:
       # docs/spec/DEPENDENCY_PINS.md or docs/TESTING.md) crept back in.
       - name: CONTRIBUTING scope
         run: npm run check:contributing
+      # Encodes the CLI command inventory as a check: every subcommand
+      # registered in apps/cli/src/cliParser.ts must be mentioned in
+      # docs/DESIGN.md and docs/CLI.md, so a shipped command cannot leave the
+      # overview enumerations silently stale.
+      - name: Command inventory
+        run: npm run check:command-inventory
       # Scripts project (.claude/scripts/*.mjs) has its own vitest suite. Plain
       # .mjs with no server or Docker dependency, so a stock runner suffices. This
       # is the repo-wide non-path-filtered gate that guarantees the suite is always

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,14 @@ Beyond the conventions in `CONTRIBUTING.md`:
 - Typecheck, lint, and format are CI checks.
 - Project state belongs in the GitHub project and docs/, not agent memory.
 - Encode a "does not happen at runtime" claim (a line that never fires, an unreachable branch) as a check, never a comment or doc note -- prose asserting a runtime fact rots silently; a check cannot lie. Full rule and the Global-listener cautionary example: `CONTRIBUTING.md`, Code Conventions.
+- Before committing, sweep your own diff: delete every comment that restates the code, narrates change history ("now", "previously", "moved here"), or cites a board item id. Thoroughness is demonstrated in tests and checks, not prose.
+- Board content is working context, never repo material: item ids and issue-body prose stay out of code, comments, docs, and commit messages.
 - Prettier ignores markdown.
 - Branch names shouldn't use '/'.
+- Rebase and merge in a detached /tmp worktree (`git worktree add --detach`), never in /workspace: the IDE formatter/LSP races the working tree. Afterwards `git reset --hard` the branch in /workspace and remove the worktree.
+- The Bash tool runs zsh: unquoted `$var` does not word-split, bare `grep` is ugrep, and an unmatched glob is an error -- quote globs, and use arrays or `xargs` for multi-file commands.
+- `vitest -w` is watch mode and hangs a non-interactive session; use `npx vitest run` or `npm test -w <workspace>`.
+- Dev containers are firewall-blocked: never give subagents web-search or web-fetch tasks.
 - Don't use chip to raise issues -- ask directly.
 - When you document a change, route the detail by tier: spec-level detail (constant values, byte/wire layout, HKDF info strings, algorithm steps) belongs in `docs/spec/`; overview docs (`docs/`) stay conceptual and operational -- regardless of which doc you currently have open. Full rule: `CONTRIBUTING.md`, Documentation.
 - `CONTRIBUTING.md` is a pre-contribution quickstart, not a reference: do not add dependency-internal premises, upgrade runbooks, test-infra internals, coverage rationale, or design rationale to it -- route per its "Scope of this document" section. A CI backstop (`npm run check:contributing`) fails the build on the two mechanical tells -- a new `##`/`###` section outside its quickstart allowlist, or a `node_modules/` source-path citation -- but doc-tier placement is otherwise a review call, so keep deep material out even when it would pass.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ Beyond the conventions in `CONTRIBUTING.md`:
 - Project state belongs in the GitHub project and docs/, not agent memory.
 - Encode a "does not happen at runtime" claim (a line that never fires, an unreachable branch) as a check, never a comment or doc note -- prose asserting a runtime fact rots silently; a check cannot lie. Full rule and the Global-listener cautionary example: `CONTRIBUTING.md`, Code Conventions.
 - Before committing, sweep your own diff: delete every comment that restates the code, narrates change history ("now", "previously", "moved here"), or cites a board item id. Thoroughness is demonstrated in tests and checks, not prose.
+- When you finish implementing a branch, end your report with a review-tier recommendation sized from the actual diff (`git diff "staging...HEAD" --stat` plus a security-surface check), not from the issue -- tiers and rule: `.claude/commands/start-issue.md`, Step 5.
 - Board content is working context, never repo material: item ids and issue-body prose stay out of code, comments, docs, and commit messages.
 - Prettier ignores markdown.
 - Branch names shouldn't use '/'.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,8 @@ When behavior changes, update the matching tier:
 
 If you are writing a constant value, a byte/wire layout, an HKDF info string or other algorithm step, or the "would only need revisiting if..." rationale behind one of those, it belongs in `docs/spec/` - regardless of which doc you currently have open. Overview docs (`docs/`) stay conceptual and operational, including operational rationale such as the coverage-gate decision.
 
+Overview docs must stay scannable: no multi-hundred-word paragraphs -- use subheadings and lists. When an edit lands in a section that is already a wall of text, restructure the section rather than growing a sentence in place.
+
 Documentation-tier placement is in scope for code review: a reviewer flags spec-level detail written into a `docs/` overview doc.
 
 ## Changelog

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "formatcheck": "prettier --list-different .",
     "linkcheck": "node scripts/check-doc-links.mjs",
     "check:contributing": "node scripts/check-contributing-scope.mjs",
+    "check:command-inventory": "node scripts/check-command-inventory.mjs",
     "typecheck": "tsc -p packages/core/tsconfig.json --noEmit && tsc -p apps/cli/tsconfig.test.json && tsc -p apps/web/tsconfig.json",
     "test": "npm run test -w packages/core -w apps/cli -w apps/web",
     "test:scripts": "vitest run --project scripts --project repo-scripts",

--- a/scripts/check-command-inventory.mjs
+++ b/scripts/check-command-inventory.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// CLI command inventory check, run by static_checks.yaml on every PR.
+//
+// docs/DESIGN.md and docs/CLI.md enumerate the CLI's subcommands; the registry
+// lives in apps/cli/src/cliParser.ts. The enumerations drift when a command
+// ships without the overview docs being revisited (verify-receipt shipped and
+// DESIGN.md said "five subcommands" until a later sweep caught it). Prose
+// cannot assert a code fact reliably, so the claim is encoded as a check:
+// every registered command name must appear in both docs.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PARSER = "apps/cli/src/cliParser.ts";
+const DOCS = ["docs/DESIGN.md", "docs/CLI.md"];
+
+/** Extract registered subcommand names from cliParser source (skips `$0`). */
+export function registeredCommands(parserSource) {
+  return [...parserSource.matchAll(/\.command\(\s*"([^"$][^"\s]*)/g)].map(
+    (m) => m[1],
+  );
+}
+
+/** Return `{doc, command}` pairs where a registered command is never mentioned. */
+export function missingMentions(commands, docTexts) {
+  const missing = [];
+  for (const [doc, text] of Object.entries(docTexts)) {
+    for (const command of commands) {
+      if (!text.includes(command)) missing.push({ doc, command });
+    }
+  }
+  return missing;
+}
+
+// CLI entry: only runs when invoked directly, so the test can import the pure
+// functions without the process.exit.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const commands = registeredCommands(
+    readFileSync(resolve(root, PARSER), "utf8"),
+  );
+  if (commands.length === 0) {
+    console.error(
+      `${PARSER}: no .command("...") registrations matched -- the extraction pattern rotted; fix scripts/check-command-inventory.mjs`,
+    );
+    process.exit(1);
+  }
+  const docTexts = Object.fromEntries(
+    DOCS.map((d) => [d, readFileSync(resolve(root, d), "utf8")]),
+  );
+  const missing = missingMentions(commands, docTexts);
+  if (missing.length > 0) {
+    for (const { doc, command } of missing) {
+      console.error(
+        `${doc}: registered command "${command}" is never mentioned -- update the command enumeration.`,
+      );
+    }
+    process.exit(1);
+  }
+  console.log(
+    `Command inventory check passed: ${commands.length} commands (${commands.join(", ")}) mentioned in ${DOCS.join(", ")}.`,
+  );
+}

--- a/scripts/check-command-inventory.test.mjs
+++ b/scripts/check-command-inventory.test.mjs
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  missingMentions,
+  registeredCommands,
+} from "./check-command-inventory.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "..");
+
+describe("command inventory check", () => {
+  it("extracts every registered command from the real cliParser and skips $0", () => {
+    const source = readFileSync(
+      resolve(root, "apps/cli/src/cliParser.ts"),
+      "utf8",
+    );
+    const commands = registeredCommands(source);
+    expect(commands).toContain("init");
+    expect(commands).toContain("verify-receipt");
+    expect(commands).not.toContain("$0");
+    expect(commands.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("passes on the real docs", () => {
+    const source = readFileSync(
+      resolve(root, "apps/cli/src/cliParser.ts"),
+      "utf8",
+    );
+    const docTexts = Object.fromEntries(
+      ["docs/DESIGN.md", "docs/CLI.md"].map((d) => [
+        d,
+        readFileSync(resolve(root, d), "utf8"),
+      ]),
+    );
+    expect(missingMentions(registeredCommands(source), docTexts)).toEqual([]);
+  });
+
+  it("takes only the first token of a positional command signature", () => {
+    const source = '.command(\n  "verify-receipt <record> [input-file]",\n)';
+    expect(registeredCommands(source)).toEqual(["verify-receipt"]);
+  });
+
+  it("flags a command missing from a doc", () => {
+    const missing = missingMentions(["init", "verify-receipt"], {
+      "docs/DESIGN.md": "init only here",
+    });
+    expect(missing).toEqual([
+      { doc: "docs/DESIGN.md", command: "verify-receipt" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

A retrospective over the recent agent-built sessions traced the repo's prose bloat to three mechanisms: excess comments are authored at initial implementation even with the style rule in context, review rounds add prose at a many-to-one rate versus removing it, and board issue bodies leak their ids and register into durable text. It also found reviewer output-format failures endemic and environment lessons trapped in per-container memory. This PR encodes the countermeasures: the style bar becomes a procedural pre-commit diff sweep, the review skills gain schema-forced output, an excess-prose dimension, a per-round trajectory ledger with explicit step-back triggers, and a post-implementation review-tier recommendation, and the CLI command inventory becomes a CI check so overview docs cannot silently omit a shipped command.

## Changes

- CLAUDE.md: pre-commit comment-sweep rule; board content declared context-only; environment quirks (worktree rebase, zsh behavior, vitest watch flag, firewalled subagents) moved from per-container agent memory into the checked-in file; review-tier reporting rule.
- .claude/commands/light-review.md: reviewers and consolidator now run through one Workflow with schema-forced JSON output (prompt-side "only JSON" instructions failed routinely); the rubric gains an excess-prose dimension and a per-reviewer simpler-shape vote; each round appends to a gitignored trajectory ledger and writes a Trajectory section into review_findings.md.
- .claude/commands/assess-review.md: trajectory is read from the ledger; six explicit step-back triggers escalate churn to a structural pivot instead of another blind round; prose-adding fixes are held to a high bar.
- .claude/commands/start-issue.md: issue bodies declared context-not-material for the repo; the pre-commit sweep folded into the verify step; a new Step 5 recommends the review tier from the measured diff, since the tier decision needs data that does not exist at issue time.
- .claude/pm/ruleset.md: implementation notes prefer pointers to a mechanism's code or doc home over re-narrating it inline.
- CONTRIBUTING.md: overview docs must stay scannable -- no multi-hundred-word paragraphs; restructure a wall-of-text section rather than growing a sentence in place.
- scripts/check-command-inventory.mjs (+ test), package.json, .github/workflows/static_checks.yaml: new CI check asserting every subcommand registered in apps/cli/src/cliParser.ts is mentioned in docs/DESIGN.md and docs/CLI.md.

## Test plan

Ran: `node scripts/check-command-inventory.mjs` (passes, 6 commands found), `npm run test:scripts` (31 passed, including the 4 new inventory tests), lint, formatcheck, linkcheck, check:contributing.
New tests cover: command extraction from the real cliParser (skips `$0`, takes the first token of a positional signature), a pass over the real docs, and the missing-mention failure path.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented product behavior changed; the diff itself edits the contributor-facing conventions (CONTRIBUTING.md, CLAUDE.md, skills)
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: process, skills, and CI tooling only; nothing operator- or security-reviewer-visible changed in the product
- [x] Security review -- n/a: none of the enumerated surfaces touched; the diff is skills, contributor docs, and a docs-inventory CI script
