### PR TITLE
Add inviter spine: Your file and Matching & sharing

### DIFF
--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -1,0 +1,264 @@
+import { Fragment, useEffect, useRef, useState } from "react";
+
+import { Alert, Anchor } from "@mantine/core";
+import { Link } from "@tanstack/react-router";
+
+import { sanitizeErrorForDisplay } from "@psilink/core";
+
+import { emptyColumnPositions, unnameableColumnsAlert } from "@psi/columnNames";
+import { loadCSVFileOffMainThread } from "@psi/csvParseController";
+
+import { Rail, RailFacts, RailGroup, RailProblems, RailSteps } from "./Rail";
+import {
+  editorFromCsv,
+  editorWithColumnDisclosure,
+  editorWithColumnType,
+  editorWithIdentity,
+  identifierProblem,
+  inviterLedgerRows,
+  inviterRailFacts,
+} from "./inviterModel";
+import { BenchShell } from "./BenchShell";
+import { Ledger } from "./Ledger";
+import { MatchingSharingSection } from "./MatchingSharingSection";
+import { YourFileSection } from "./YourFileSection";
+import styles from "./bench.module.css";
+
+import type { AcquiredCsv, InviterEditor } from "./inviterModel";
+import type { DisclosureChoice } from "@psi/metadataEditing";
+import type { IntakeAlert } from "./YourFileSection";
+import type { RailStep } from "./Rail";
+import type { SemanticType } from "@psilink/core";
+
+type SpineSection = "file" | "columns" | "review";
+
+const SPINE_LABELS: Record<SpineSection, string> = {
+  file: "Your file",
+  columns: "Matching & sharing",
+  review: "Review & create",
+};
+
+const SPINE_ORDER: ReadonlyArray<SpineSection> = ["file", "columns", "review"];
+
+function demotionNotice(demoted: ReadonlyArray<string>): string {
+  if (demoted.length === 0) return "";
+  return `${demoted.join(", ")} changed to Ignored - only one column can be the row identifier.`;
+}
+
+/**
+ * The inviter's working surface: one bench whose rail walks the three-step
+ * required spine while the work column swaps sections in place. The draft
+ * seeds from the file the moment it is read (step 1) and every step-2 edit
+ * flows through the shared draft model, so the rail facts and the disclosure
+ * ledger track live. Step 3 is not built yet and says so.
+ */
+export function InviterBench() {
+  const [name, setName] = useState("");
+  const [section, setSection] = useState<SpineSection>("file");
+  const [acquired, setAcquired] = useState<AcquiredCsv>();
+  const [editor, setEditor] = useState<InviterEditor>();
+  const [intakeAlert, setIntakeAlert] = useState<IntakeAlert>();
+  const [reading, setReading] = useState(false);
+  const [announcement, setAnnouncement] = useState("");
+
+  // A parse may still be in flight when the surface unmounts or a newer file
+  // is dropped; the id lets the stale resolution fall on the floor instead of
+  // clobbering current state (the FileAcquire pattern).
+  const parseId = useRef(0);
+  useEffect(
+    () => () => {
+      parseId.current += 1;
+    },
+    [],
+  );
+
+  // Moving between sections replaces the whole work column, so focus is sent
+  // to the incoming h1 (they carry tabIndex -1) or a screen-reader user is
+  // left on a control that no longer exists. Skipped on mount: initial focus
+  // stays at the top of the document.
+  const headingRef = useRef<HTMLDivElement>(null);
+  const mounted = useRef(false);
+  useEffect(() => {
+    if (mounted.current) headingRef.current?.querySelector("h1")?.focus();
+    mounted.current = true;
+  }, [section]);
+
+  async function readFile(file: File) {
+    const id = ++parseId.current;
+    setReading(true);
+    setIntakeAlert(undefined);
+    try {
+      const result = await loadCSVFileOffMainThread(file);
+      if (id !== parseId.current) return;
+      const columns = result.meta.fields ?? [];
+      const emptyPositions = emptyColumnPositions(columns);
+      if (emptyPositions.length > 0) {
+        setIntakeAlert(unnameableColumnsAlert(emptyPositions));
+        return;
+      }
+      const csv: AcquiredCsv = {
+        fileName: file.name,
+        sizeBytes: file.size,
+        rawRows: result.data,
+        columns,
+      };
+      const seeded = editorFromCsv(name, csv);
+      setAcquired(csv);
+      setEditor(seeded);
+      if (seeded.draft.keys.length === 0)
+        setIntakeAlert({
+          title: "This file cannot be matched",
+          message:
+            "None of the matching keys can be built from this file's columns. Matching needs columns like name, date of birth, Social Security number, ZIP code, phone, or email.",
+        });
+    } catch (error) {
+      if (id !== parseId.current) return;
+      setIntakeAlert({
+        title: "The file could not be read",
+        message: sanitizeErrorForDisplay(error),
+      });
+    } finally {
+      if (id === parseId.current) setReading(false);
+    }
+  }
+
+  function updateName(next: string) {
+    setName(next);
+    setEditor((current) =>
+      current === undefined ? current : editorWithIdentity(current, next),
+    );
+  }
+
+  function applyColumnEdit(result: {
+    editor: InviterEditor;
+    demotedIdentifiers: Array<string>;
+  }) {
+    setEditor(result.editor);
+    setAnnouncement(demotionNotice(result.demotedIdentifiers));
+  }
+
+  const linkable = editor !== undefined && editor.draft.keys.length > 0;
+  const fileReady = name.trim().length > 0 && linkable;
+
+  const currentPosition = SPINE_ORDER.indexOf(section);
+  const steps: Array<RailStep> = SPINE_ORDER.map((step, position) => {
+    const state =
+      step === section
+        ? "current"
+        : position < currentPosition
+          ? "done"
+          : "pending";
+    return {
+      label: SPINE_LABELS[step],
+      state,
+      onSelect: state === "done" ? () => setSection(step) : undefined,
+    };
+  });
+
+  const problems =
+    editor !== undefined && identifierProblem(editor.draft)
+      ? [
+          {
+            label: "Choose a single row identifier",
+            onSelect: () => setSection("columns"),
+          },
+        ]
+      : [];
+
+  return (
+    <BenchShell
+      rail={
+        <Rail label="Exchange setup">
+          <RailGroup label="Set up">
+            <RailSteps steps={steps} />
+          </RailGroup>
+          <RailGroup label="Customize" note="Filled in from your file.">
+            <RailFacts facts={inviterRailFacts(editor)} />
+          </RailGroup>
+          <RailProblems problems={problems} />
+        </Rail>
+      }
+      ledger={
+        <Ledger
+          rows={inviterLedgerRows(editor).map((row) => ({
+            label: row.label,
+            reference: row.reference,
+            muted: row.muted,
+            value: Array.isArray(row.value) ? (
+              <>
+                {row.value.map((line, index) => (
+                  <Fragment key={line}>
+                    {index > 0 && <br />}
+                    {line}
+                  </Fragment>
+                ))}
+              </>
+            ) : (
+              row.value
+            ),
+          }))}
+          footer="Your file stays in this browser. Nothing is uploaded; your partner receives only what this ledger names."
+        />
+      }
+    >
+      <div ref={headingRef}>
+        {section === "file" && (
+          <YourFileSection
+            name={name}
+            onNameChange={updateName}
+            onFile={(file) => void readFile(file)}
+            reading={reading}
+            acquired={acquired}
+            linkable={linkable}
+            alert={intakeAlert}
+            onContinue={() => {
+              if (fileReady) setSection("columns");
+            }}
+          />
+        )}
+        {section === "columns" &&
+          editor !== undefined &&
+          acquired !== undefined && (
+            <MatchingSharingSection
+              metadata={editor.draft.metadata}
+              onColumnType={(columnName: string, type: SemanticType) =>
+                applyColumnEdit(
+                  editorWithColumnType(editor, acquired, columnName, type),
+                )
+              }
+              onColumnDisclosure={(
+                columnName: string,
+                choice: DisclosureChoice,
+              ) =>
+                applyColumnEdit(
+                  editorWithColumnDisclosure(
+                    editor,
+                    acquired,
+                    columnName,
+                    choice,
+                  ),
+                )
+              }
+              announcement={announcement}
+              onContinue={() => setSection("review")}
+            />
+          )}
+        {section === "review" && (
+          <>
+            <p className={styles.eyebrow}>Step 3 of 3</p>
+            <h1 tabIndex={-1}>Review &amp; create</h1>
+            <Alert color="yellow" title="Under construction" mt="md">
+              This step is not built yet: the check-your-answers review, the
+              transport choice, and the create action arrive with the next bench
+              screens. To run an exchange today, use the{" "}
+              <Anchor component={Link} to="/">
+                current app
+              </Anchor>
+              .
+            </Alert>
+          </>
+        )}
+      </div>
+    </BenchShell>
+  );
+}

--- a/apps/web/src/bench/Ledger.tsx
+++ b/apps/web/src/bench/Ledger.tsx
@@ -5,12 +5,14 @@ import type { ReactNode } from "react";
 /**
  * One row of the disclosure ledger: an uppercase label, the value in the
  * bench's monospace data voice, and an optional reference to the spine step
- * that owns the value ("Step 2"). An absent value renders as a muted em-dash,
- * the ledger's "not decided yet" mark.
+ * that owns the value ("Step 2"). `muted` is the named empty state ("None",
+ * "Nothing - matching only"), rendered in the placeholder voice; with neither
+ * the row shows the em-dash "not decided yet" mark.
  */
 export interface LedgerRow {
   label: string;
   value?: ReactNode;
+  muted?: string;
   reference?: string;
 }
 
@@ -41,7 +43,9 @@ export function Ledger({
               )}
             </dt>
             <dd>
-              {row.value ?? <span className={styles.dash}>{"\u2014"}</span>}
+              {row.value ?? (
+                <span className={styles.dash}>{row.muted ?? "\u2014"}</span>
+              )}
             </dd>
           </div>
         ))}

--- a/apps/web/src/bench/MatchingSharingSection.tsx
+++ b/apps/web/src/bench/MatchingSharingSection.tsx
@@ -1,0 +1,158 @@
+import { Button, NativeSelect } from "@mantine/core";
+
+import {
+  DISCLOSURE_LABELS,
+  SEMANTIC_TYPE_LABELS,
+  disclosureChoicesForType,
+  disclosureOf,
+} from "@psi/metadataEditing";
+
+import { disclosedColumnNames } from "@psilink/core";
+
+import styles from "./bench.module.css";
+
+import type { Metadata, SemanticType } from "@psilink/core";
+import type { DisclosureChoice } from "@psi/metadataEditing";
+
+const SEMANTIC_TYPES = Object.keys(SEMANTIC_TYPE_LABELS) as Array<SemanticType>;
+
+/**
+ * Step 2 of the inviter spine -- the one mandatory review: what each column is
+ * and what it is used for, which together decide exactly what the partner can
+ * ever see. Presentational over the host's metadata; edits go up through the
+ * two callbacks and the single-identifier rule's demotions come back down as
+ * `announcement`.
+ */
+export function MatchingSharingSection({
+  metadata,
+  onColumnType,
+  onColumnDisclosure,
+  announcement,
+  onContinue,
+}: {
+  metadata: Metadata;
+  onColumnType: (columnName: string, type: SemanticType) => void;
+  onColumnDisclosure: (columnName: string, choice: DisclosureChoice) => void;
+  /** The demotion notice from the last edit, announced politely and rendered
+   * under the table; empty when the last edit displaced nothing. */
+  announcement: string;
+  onContinue: () => void;
+}) {
+  const sent = disclosedColumnNames(metadata);
+  return (
+    <>
+      <p className={styles.eyebrow}>Step 2 of 3</p>
+      <h1 tabIndex={-1}>Matching &amp; sharing</h1>
+      <p>
+        Confirm what each column is and what it is used for. This is the one
+        review every exchange needs: it decides exactly what your partner can
+        ever see.
+      </p>
+      <div className={styles.tableScroll}>
+        <table className={styles.benchTable}>
+          <caption className={styles.visuallyHidden}>
+            Your columns: type and use
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col">Column</th>
+              <th scope="col">Type</th>
+              <th scope="col">How it is used</th>
+            </tr>
+          </thead>
+          <tbody>
+            {metadata.map((column) => (
+              <tr key={column.name}>
+                <td className={styles.mono}>{column.name}</td>
+                <td>
+                  <NativeSelect
+                    aria-label={`Type for ${column.name}`}
+                    value={column.type}
+                    data={SEMANTIC_TYPES.map((type) => ({
+                      value: type,
+                      label: SEMANTIC_TYPE_LABELS[type],
+                    }))}
+                    onChange={(event) =>
+                      onColumnType(
+                        column.name,
+                        event.currentTarget.value as SemanticType,
+                      )
+                    }
+                  />
+                </td>
+                <td>
+                  <NativeSelect
+                    aria-label={`How ${column.name} is used`}
+                    value={disclosureOf(column)}
+                    data={disclosureChoicesForType(column.type).map(
+                      (choice) => ({
+                        value: choice,
+                        label: DISCLOSURE_LABELS[choice],
+                      }),
+                    )}
+                    onChange={(event) =>
+                      onColumnDisclosure(
+                        column.name,
+                        event.currentTarget.value as DisclosureChoice,
+                      )
+                    }
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className={`${styles.small} ${styles.sub}`} aria-live="polite">
+        {announcement !== ""
+          ? announcement
+          : "Only one column can be the row identifier. Choose a single identifier."}
+      </p>
+      <h2>Extra data for matched records</h2>
+      <p className={styles.small}>
+        <strong>You will send:</strong>{" "}
+        {sent.length > 0 ? (
+          <span className={styles.mono}>{sent.join(", ")}</span>
+        ) : (
+          "nothing"
+        )}
+        <br />
+        <strong>You will receive:</strong> the columns your partner marks as
+        sent, for each matched row.
+      </p>
+      {sent.length > 0 ? (
+        <>
+          <p>
+            For each row in your file that matches, you will send your partner
+            these elements:
+          </p>
+          <ul className={styles.columnChips}>
+            {sent.map((column) => (
+              <li key={column} className={styles.mono}>
+                {column}
+              </li>
+            ))}
+          </ul>
+          <p className={`${styles.small} ${styles.sub}`}>
+            You can change these with the &quot;How it is used&quot; selects
+            above. Your partner never receives the values in your non-matching
+            rows.
+          </p>
+        </>
+      ) : (
+        <div className={styles.stateInset}>
+          <p className={styles.stateLabel}>
+            No columns marked &quot;sent to your partner&quot;
+          </p>
+          <p className={styles.small} style={{ margin: 0 }}>
+            No values will be sent to your partner. Your file&apos;s columns are
+            used only to find matches.
+          </p>
+        </div>
+      )}
+      <div className={styles.workFoot}>
+        <Button onClick={onContinue}>Continue to review &amp; create</Button>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/bench/MatchingSharingSection.tsx
+++ b/apps/web/src/bench/MatchingSharingSection.tsx
@@ -103,10 +103,18 @@ export function MatchingSharingSection({
           </tbody>
         </table>
       </div>
-      <p className={`${styles.small} ${styles.sub}`} aria-live="polite">
-        {announcement !== ""
-          ? announcement
-          : "Only one column can be the row identifier. Choose a single identifier."}
+      <p className={`${styles.small} ${styles.sub}`}>
+        Only one column can be the row identifier. Choose a single identifier.
+      </p>
+      {/* Always mounted so assistive tech observes content changes; kept
+          separate from the hint above so clearing a notice never re-announces
+          the hint. */}
+      <p
+        className={`${styles.small} ${styles.sub}`}
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {announcement}
       </p>
       <h2>Extra data for matched records</h2>
       <p className={styles.small}>

--- a/apps/web/src/bench/Rail.tsx
+++ b/apps/web/src/bench/Rail.tsx
@@ -9,10 +9,14 @@ import type { ReactNode } from "react";
  */
 export type RailStepState = "done" | "current" | "pending";
 
-/** One entry in a {@link RailSteps} spine or timeline list. */
+/** One entry in a {@link RailSteps} spine or timeline list. A completed step
+ * with `onSelect` renders as a link back to that step, per the mockup's
+ * done-steps-are-links rule; the current and pending steps are not
+ * navigable. */
 export interface RailStep {
   label: string;
   state: RailStepState;
+  onSelect?: () => void;
 }
 
 /**
@@ -85,12 +89,63 @@ export function RailSteps({ steps }: { steps: ReadonlyArray<RailStep> }) {
     <ol className={styles.railSteps}>
       {steps.map((step) => (
         <li key={step.label} className={STEP_STATE_CLASS[step.state]}>
-          <span aria-current={step.state === "current" ? "step" : undefined}>
-            {step.label}
-          </span>
+          {step.state === "done" && step.onSelect !== undefined ? (
+            <button
+              type="button"
+              className={styles.stepLink}
+              onClick={step.onSelect}
+            >
+              {step.label}
+            </button>
+          ) : (
+            <span aria-current={step.state === "current" ? "step" : undefined}>
+              {step.label}
+            </span>
+          )}
         </li>
       ))}
     </ol>
+  );
+}
+
+/** One entry in the rail's {@link RailProblems} block. */
+export interface RailProblem {
+  label: string;
+  onSelect?: () => void;
+}
+
+/**
+ * The rail's Problems block -- the design's error summary: it appears only
+ * when something actually needs attention, and each entry links into the
+ * surface that can fix it.
+ */
+export function RailProblems({
+  problems,
+}: {
+  problems: ReadonlyArray<RailProblem>;
+}) {
+  if (problems.length === 0) return null;
+  return (
+    <section className={styles.problems} aria-label="Problems">
+      <h2>Problems</h2>
+      <ul>
+        {problems.map((problem) => (
+          <li key={problem.label}>
+            {problem.onSelect !== undefined ? (
+              <button
+                type="button"
+                className={styles.stepLink}
+                onClick={problem.onSelect}
+              >
+                {problem.label}
+              </button>
+            ) : (
+              problem.label
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }
 

--- a/apps/web/src/bench/YourFileSection.tsx
+++ b/apps/web/src/bench/YourFileSection.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef } from "react";
+
+import { Alert, Button, TextInput } from "@mantine/core";
+import { Dropzone } from "@mantine/dropzone";
+
+import { MAX_CSV_FILE_BYTES } from "@components/csvIntake";
+
+import { fileCardMeta } from "./inviterModel";
+import styles from "./bench.module.css";
+
+import type { AcquiredCsv } from "./inviterModel";
+
+/** A titled alert for a failed or unusable read, focused when it appears so
+ * the failure is announced without clearing the operator's input. */
+export interface IntakeAlert {
+  title: string;
+  message: string;
+}
+
+/**
+ * Step 1 of the inviter spine: the inviter's name and file. Presentational --
+ * the host owns the parse and the draft; this section renders the intake
+ * surface (dropzone always available, file card once read, recommended-terms
+ * callout when the file can back an exchange) and gates Continue on a name
+ * and a linkable file.
+ */
+export function YourFileSection({
+  name,
+  onNameChange,
+  onFile,
+  reading,
+  acquired,
+  linkable,
+  alert,
+  onContinue,
+}: {
+  name: string;
+  onNameChange: (name: string) => void;
+  /** The dropped or selected file; the host parses it. */
+  onFile: (file: File) => void;
+  reading: boolean;
+  acquired: AcquiredCsv | undefined;
+  /** Whether the read file can back at least one matching key. */
+  linkable: boolean;
+  alert: IntakeAlert | undefined;
+  onContinue: () => void;
+}) {
+  const alertRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (alert !== undefined) alertRef.current?.focus();
+  }, [alert]);
+
+  const ready = name.trim().length > 0 && acquired !== undefined && linkable;
+  return (
+    <>
+      <p className={styles.eyebrow}>Step 1 of 3</p>
+      <h1 tabIndex={-1}>Your file</h1>
+      <TextInput
+        label="Your name"
+        description="Recorded in the invitation's linkage terms so your partner can identify you"
+        value={name}
+        maxLength={200}
+        onChange={(event) => onNameChange(event.currentTarget.value)}
+      />
+      <Dropzone
+        className={styles.dropzone}
+        onDrop={(files) => {
+          const file = files.at(0);
+          if (file !== undefined) onFile(file);
+        }}
+        accept={["text/plain", "text/csv", "application/vnd.ms-excel"]}
+        maxSize={MAX_CSV_FILE_BYTES}
+        multiple={false}
+        loading={reading}
+        aria-label="Your data file"
+        mt="md"
+      >
+        <p>
+          <strong>Drag your CSV here or click to select</strong>
+        </p>
+        <p className={styles.dropzoneMax}>
+          (Max file size: {MAX_CSV_FILE_BYTES / 1024 ** 2} MB)
+        </p>
+      </Dropzone>
+      {acquired !== undefined && (
+        <div className={styles.fileCard}>
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            aria-hidden="true"
+          >
+            <path d="M13 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V9z" />
+            <path d="M13 3v6h6" />
+          </svg>
+          <div>
+            <div className={`${styles.fileName} ${styles.mono}`}>
+              {acquired.fileName}
+            </div>
+            <div className={`${styles.fileMeta} ${styles.mono}`}>
+              {fileCardMeta(acquired.rawRows.length, acquired.sizeBytes)}
+            </div>
+          </div>
+        </div>
+      )}
+      <p className={`${styles.small} ${styles.sub}`}>
+        Your file is processed entirely in your browser and it is never uploaded
+        to our server.
+      </p>
+      {alert !== undefined && (
+        <Alert
+          color="red"
+          title={alert.title}
+          mt="md"
+          ref={alertRef}
+          tabIndex={-1}
+        >
+          {alert.message}
+        </Alert>
+      )}
+      {acquired !== undefined && linkable && (
+        <div className={styles.callout}>
+          <p className={styles.calloutLead}>
+            Recommended terms are ready. Most exchanges need nothing more.
+          </p>
+          <p className={styles.small}>
+            Cleaning, matching keys, and the option of a legal agreement were
+            set from your file&apos;s columns. Customize any of them any time
+            before you create the invitation.
+          </p>
+        </div>
+      )}
+      <div className={styles.workFoot}>
+        <Button disabled={!ready} onClick={onContinue}>
+          Continue to matching &amp; sharing
+        </Button>
+        <p
+          className={
+            ready
+              ? `${styles.statusLine} ${styles.statusLineOk}`
+              : styles.statusLine
+          }
+        >
+          {ready
+            ? "Ready to continue."
+            : "A name and a file are needed to proceed."}
+        </p>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/bench/bench.module.css
+++ b/apps/web/src/bench/bench.module.css
@@ -20,6 +20,15 @@
   margin: 0 0 0.6rem 0;
 }
 
+.page h1:focus {
+  outline: none;
+}
+
+.page h1:focus-visible {
+  outline: 3px solid var(--bench-accent);
+  outline-offset: 4px;
+}
+
 .page h2 {
   font-size: 1.18rem;
   font-weight: 650;
@@ -39,6 +48,15 @@
 
 .page a {
   color: var(--bench-accent);
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
 }
 
 .mono {
@@ -210,6 +228,39 @@
   box-shadow: 0 0 0 3px var(--bench-accent-glow);
 }
 
+.stepLink {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+}
+
+.problems {
+  margin-top: 20px;
+  border: 2px solid var(--bench-danger);
+  background: var(--bench-danger-bg);
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
+.problems h2 {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 6px 0;
+  color: var(--bench-danger);
+}
+
+.problems ul {
+  margin: 0;
+  padding: 0 0 0 1.1em;
+  font-size: 13.5px;
+}
+
 .railFacts li {
   display: flex;
   justify-content: space-between;
@@ -304,6 +355,155 @@
   border-top: 2px solid var(--bench-rule);
   font-size: 13px;
   color: var(--bench-secondary);
+}
+
+/* ---------- work-column furniture ---------- */
+
+.workFoot {
+  margin-top: 2rem;
+  padding-top: 1.2rem;
+  border-top: 1px solid var(--bench-rule);
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.statusLine {
+  font-weight: 600;
+  margin: 0;
+  color: var(--bench-secondary);
+  font-size: 14px;
+}
+
+.statusLineOk {
+  color: var(--bench-ok);
+}
+
+.dropzone {
+  border: 2px dashed var(--bench-field-border);
+  border-radius: 8px;
+  background: var(--bench-field-bg);
+  padding: 22px 24px;
+  text-align: center;
+  max-width: 640px;
+  cursor: pointer;
+}
+
+.dropzone p {
+  margin: 2px auto;
+}
+
+.dropzoneMax {
+  color: var(--bench-secondary);
+  font-size: 14px;
+}
+
+.fileCard {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: var(--bench-code-bg);
+  border: 1px solid var(--bench-rule);
+  border-radius: 8px;
+  padding: 12px 16px;
+  max-width: 640px;
+  margin: 12px 0;
+}
+
+.fileCard svg {
+  flex: none;
+  width: 22px;
+  height: 22px;
+  color: var(--bench-accent);
+}
+
+.fileName {
+  font-weight: 650;
+}
+
+.fileMeta {
+  color: var(--bench-secondary);
+  font-size: 14px;
+}
+
+.callout {
+  background: var(--bench-accent-bg);
+  border: 1px solid var(--bench-accent);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin: 1.1rem 0;
+  max-width: 640px;
+}
+
+.callout p {
+  margin: 3px 0;
+}
+
+.calloutLead {
+  font-weight: 650;
+}
+
+.stateInset {
+  border: 1px dashed var(--bench-faint);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin: 1.4rem 0;
+  max-width: 640px;
+}
+
+.stateLabel {
+  font-size: 11.5px;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--bench-faint);
+  margin: 0 0 8px 0;
+}
+
+.tableScroll {
+  overflow-x: auto;
+  max-width: 640px;
+}
+
+.benchTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+.benchTable th {
+  font-size: 12px;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--bench-secondary);
+  text-align: left;
+  padding: 6px 12px 6px 0;
+  border-bottom: 2px solid var(--bench-rule);
+}
+
+.benchTable td {
+  padding: 9px 12px 9px 0;
+  border-bottom: 1px solid var(--bench-rule-soft);
+  vertical-align: middle;
+}
+
+.columnChips {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 0.6rem 0;
+  padding: 0;
+  list-style: none;
+}
+
+.columnChips li {
+  background: var(--bench-code-bg);
+  border: 1px solid var(--bench-rule);
+  border-radius: 999px;
+  padding: 3px 12px;
+  font-weight: 600;
 }
 
 /* ---------- lobby ---------- */

--- a/apps/web/src/bench/inviterModel.ts
+++ b/apps/web/src/bench/inviterModel.ts
@@ -1,0 +1,261 @@
+import { disclosedColumnNames } from "@psilink/core";
+
+import {
+  hasMultipleIdentifiers,
+  setColumnDisclosure,
+  setColumnType,
+} from "@psi/metadataEditing";
+import { seedAdvancedInvite, setDraftMetadata } from "@psi/advancedInvite";
+
+import type {
+  AdvancedInviteDraft,
+  AdvancedInviteSeed,
+  OutputDirection,
+} from "@psi/advancedInvite";
+import type { CSVRow, LinkageKey, SemanticType } from "@psilink/core";
+import type { DisclosureChoice } from "@psi/metadataEditing";
+
+/**
+ * The pure model behind the inviter bench's required spine: seeding the draft
+ * from the read file, applying the two column edits step 2 offers, and the
+ * view-model builders the rail facts and the disclosure ledger render from.
+ * No React, no I/O -- the tested boundary for "default terms derive from the
+ * file" and "the ledger tracks term edits". The draft itself is the Advanced
+ * editor's ({@link AdvancedInviteDraft}); the bench re-surfaces that model, so
+ * every derivation and edit goes through the same seed/reconcile helpers the
+ * old editor is tested on.
+ */
+
+/** The read file the spine works over: identity for the file card plus the
+ * parsed rows and columns every derivation binds to. */
+export interface AcquiredCsv {
+  fileName: string;
+  sizeBytes: number;
+  rawRows: Array<CSVRow>;
+  columns: Array<string>;
+}
+
+/** An editing session over the read file: the live draft and the fixed seed it
+ * derived from ({@link seedAdvancedInvite}). */
+export interface InviterEditor {
+  draft: AdvancedInviteDraft;
+  seed: AdvancedInviteSeed;
+}
+
+/** Seed the editing session from the read file -- the "default terms derive
+ * from the file the moment it is read" moment of the design. */
+export function editorFromCsv(
+  inviterName: string,
+  csv: AcquiredCsv,
+): InviterEditor {
+  return seedAdvancedInvite(inviterName, csv.columns, csv.rawRows);
+}
+
+/** Carry a later name edit into the draft without disturbing the derived
+ * terms; the identity only labels the terms, it never changes which keys the
+ * columns can produce. */
+export function editorWithIdentity(
+  editor: InviterEditor,
+  identity: string,
+): InviterEditor {
+  return { ...editor, draft: { ...editor.draft, identity } };
+}
+
+/** The result of a step-2 column edit: the reconciled session plus any
+ * identifier columns the single-identifier rule demoted, for the caller to
+ * announce. */
+export interface ColumnEditResult {
+  editor: InviterEditor;
+  demotedIdentifiers: Array<string>;
+}
+
+function withMetadata(
+  editor: InviterEditor,
+  csv: AcquiredCsv,
+  metadata: AdvancedInviteDraft["metadata"],
+  demotedIdentifiers: Array<string>,
+): ColumnEditResult {
+  return {
+    editor: {
+      ...editor,
+      draft: setDraftMetadata(editor.draft, metadata, csv.rawRows),
+    },
+    demotedIdentifiers,
+  };
+}
+
+/** Apply the "Type" select: retype a column, letting the draft reconcile its
+ * offerable keys and cleaning against the new metadata. */
+export function editorWithColumnType(
+  editor: InviterEditor,
+  csv: AcquiredCsv,
+  columnName: string,
+  type: SemanticType,
+): ColumnEditResult {
+  const { metadata, demotedIdentifiers } = setColumnType(
+    editor.draft.metadata,
+    columnName,
+    type,
+  );
+  return withMetadata(editor, csv, metadata, demotedIdentifiers);
+}
+
+/** Apply the "How it is used" select: change a column's disclosure choice. */
+export function editorWithColumnDisclosure(
+  editor: InviterEditor,
+  csv: AcquiredCsv,
+  columnName: string,
+  choice: DisclosureChoice,
+): ColumnEditResult {
+  const { metadata, demotedIdentifiers } = setColumnDisclosure(
+    editor.draft.metadata,
+    columnName,
+    choice,
+  );
+  return withMetadata(editor, csv, metadata, demotedIdentifiers);
+}
+
+/** The linkage keys the draft currently authors, in order. */
+export function enabledKeys(draft: AdvancedInviteDraft): Array<LinkageKey> {
+  return draft.keys.filter((entry) => entry.enabled).map((entry) => entry.key);
+}
+
+/** Whether the metadata sits in the two-identifier state the single-identifier
+ * rule forbids -- the rail's Problems entry for step 2. */
+export function identifierProblem(draft: AdvancedInviteDraft): boolean {
+  return hasMultipleIdentifiers(draft.metadata);
+}
+
+/** The file card's metadata line, e.g. `12,408 rows - 8.4 MB`. */
+export function fileCardMeta(rowCount: number, sizeBytes: number): string {
+  const rows = new Intl.NumberFormat("en-US").format(rowCount);
+  const size =
+    sizeBytes >= 1024 ** 2
+      ? `${(sizeBytes / 1024 ** 2).toFixed(1)} MB`
+      : `${Math.max(1, Math.round(sizeBytes / 1024))} KB`;
+  return `${rows} rows - ${size}`;
+}
+
+/** The ledger's Expires phrasing for a draft lifetime, e.g. `1 hour after you
+ * share`. Whole days/hours/minutes cover every value step 3's control will
+ * offer; anything else falls back to minutes. */
+export function lifetimeLabel(seconds: number): string {
+  const unit = (count: number, noun: string) =>
+    `${count} ${noun}${count === 1 ? "" : "s"} after you share`;
+  if (seconds % 86400 === 0) return unit(seconds / 86400, "day");
+  if (seconds % 3600 === 0) return unit(seconds / 3600, "hour");
+  return unit(Math.max(1, Math.round(seconds / 60)), "minute");
+}
+
+/** Ledger phrasing for who receives the matched results. */
+export const RESULTS_DIRECTION_LABELS: Record<OutputDirection, string> = {
+  both: "You and your partner",
+  inviter: "Only you",
+  partner: "Only your partner",
+};
+
+/** One disclosure-ledger row: `value` renders in the data voice, `muted`
+ * renders in the empty-state voice ("None", "Nothing"), neither renders the
+ * em-dash placeholder. */
+export interface InviterLedgerRow {
+  label: string;
+  reference?: string;
+  value?: string | ReadonlyArray<string>;
+  muted?: string;
+}
+
+/**
+ * The disclosure ledger for the spine, filling in as the exchange takes shape:
+ * before a file is read every value is the em-dash placeholder; once a session
+ * exists the send list, matched-on keys, expiry, and result direction are read
+ * live from the draft.
+ */
+export function inviterLedgerRows(
+  editor: InviterEditor | undefined,
+): Array<InviterLedgerRow> {
+  if (editor === undefined) {
+    return [
+      { label: "You will send", reference: "Step 2" },
+      { label: "You will receive", reference: "Step 2" },
+      { label: "Matched on", reference: "Step 2" },
+      { label: "Expires", reference: "Step 3" },
+      { label: "Results go to", reference: "Step 3" },
+      { label: "Agreement" },
+      { label: "Transport", reference: "Step 3" },
+    ];
+  }
+  const sent = disclosedColumnNames(editor.draft.metadata);
+  const keys = enabledKeys(editor.draft);
+  return [
+    sent.length > 0
+      ? { label: "You will send", reference: "Step 2", value: sent.join(", ") }
+      : {
+          label: "You will send",
+          reference: "Step 2",
+          muted: "Nothing - matching only",
+        },
+    {
+      label: "You will receive",
+      reference: "Step 2",
+      value: "Matched rows + your partner's shared columns",
+    },
+    keys.length > 0
+      ? {
+          label: "Matched on",
+          reference: "Step 2",
+          value: keys.map((key, index) => `${index + 1}. ${key.name}`),
+        }
+      : { label: "Matched on", reference: "Step 2", muted: "No keys" },
+    {
+      label: "Expires",
+      reference: "Step 3",
+      value: lifetimeLabel(editor.draft.lifetimeSeconds),
+    },
+    {
+      label: "Results go to",
+      reference: "Step 3",
+      value: RESULTS_DIRECTION_LABELS[editor.draft.outputDirection],
+    },
+    editor.draft.legalAgreement?.reference !== undefined &&
+    editor.draft.legalAgreement.reference !== ""
+      ? { label: "Agreement", value: editor.draft.legalAgreement.reference }
+      : { label: "Agreement", muted: "None" },
+    { label: "Transport", reference: "Step 3", value: "Browser" },
+  ];
+}
+
+/** One rail quiet fact for the Customize group. */
+export interface InviterRailFact {
+  label: string;
+  fact?: string;
+}
+
+/** The Customize group's quiet facts, read live from the draft: cleaning
+ * pipeline count, authored key count, and the agreement reference. Undefined
+ * facts render as the em-dash "nothing yet" mark. */
+export function inviterRailFacts(
+  editor: InviterEditor | undefined,
+): Array<InviterRailFact> {
+  const plural = (count: number, noun: string) =>
+    `${count} ${noun}${count === 1 ? "" : "s"}`;
+  return [
+    {
+      label: "Cleaning",
+      fact:
+        editor === undefined
+          ? undefined
+          : plural(editor.draft.standardization.length, "field"),
+    },
+    {
+      label: "Matching keys",
+      fact:
+        editor === undefined
+          ? undefined
+          : plural(enabledKeys(editor.draft).length, "key"),
+    },
+    {
+      label: "Legal agreement",
+      fact: editor?.draft.legalAgreement?.reference,
+    },
+  ];
+}

--- a/apps/web/src/bench/placeholders.tsx
+++ b/apps/web/src/bench/placeholders.tsx
@@ -1,10 +1,7 @@
 import { Alert, Anchor } from "@mantine/core";
 import { Link } from "@tanstack/react-router";
 
-import { Rail, RailFacts, RailGroup, RailSteps } from "./Rail";
 import { BenchShell } from "./BenchShell";
-import { Ledger } from "./Ledger";
-import styles from "./bench.module.css";
 
 /**
  * Temporary bench screens shown while the real flows are built out, screen by
@@ -13,77 +10,20 @@ import styles from "./bench.module.css";
  * is never presented as in force. Deleted as the real screens land.
  */
 
-function UnderConstructionNotice({ flow }: { flow: string }) {
-  return (
-    <Alert color="yellow" title="Under construction" mt="md">
-      The bench is the next version of psilink and this screen is not built yet:{" "}
-      {flow} To run an exchange today, use the{" "}
-      <Anchor component={Link} to="/">
-        current app
-      </Anchor>
-      .
-    </Alert>
-  );
-}
-
-/**
- * Stand-in for the inviter flow's first spine screen. Renders the real rail
- * and ledger so the bench's three-region surface is exercised end to end
- * before the work column has content.
- */
-export function ExchangeUnderConstruction() {
-  return (
-    <BenchShell
-      rail={
-        <Rail label="Exchange setup">
-          <RailGroup label="Set up">
-            <RailSteps
-              steps={[
-                { label: "Your file", state: "current" },
-                { label: "Matching & sharing", state: "pending" },
-                { label: "Review & create", state: "pending" },
-              ]}
-            />
-          </RailGroup>
-          <RailGroup label="Customize" note="Filled in from your file.">
-            <RailFacts
-              facts={[
-                { label: "Cleaning" },
-                { label: "Matching keys" },
-                { label: "Legal agreement" },
-              ]}
-            />
-          </RailGroup>
-        </Rail>
-      }
-      ledger={
-        <Ledger
-          rows={[
-            { label: "You will send", reference: "Step 2" },
-            { label: "You will receive" },
-            { label: "Matched on", reference: "Step 2" },
-            { label: "Expires", reference: "Step 3" },
-            { label: "Results go to", reference: "Step 3" },
-            { label: "Agreement" },
-            { label: "Transport", reference: "Step 3" },
-          ]}
-          footer="Fills in as the exchange takes shape - the standing answer to what leaves this machine."
-        />
-      }
-    >
-      <p className={styles.eyebrow}>Step 1 of 3</p>
-      <h1>Your file</h1>
-      <UnderConstructionNotice flow="the inviter flow arrives with the bench's spine screens." />
-    </BenchShell>
-  );
-}
-
 /** Stand-in for the acceptor path's entry screen. */
 export function AcceptUnderConstruction() {
   return (
     <BenchShell>
       <h1>Accept an invitation</h1>
-      <UnderConstructionNotice flow="the acceptor path arrives after the inviter flow." />
+      <Alert color="yellow" title="Under construction" mt="md">
+        The bench is the next version of psilink and this screen is not built
+        yet: the acceptor path arrives after the inviter flow. To run an
+        exchange today, use the{" "}
+        <Anchor component={Link} to="/">
+          current app
+        </Anchor>
+        .
+      </Alert>
     </BenchShell>
   );
 }

--- a/apps/web/src/routes/bench/exchange.tsx
+++ b/apps/web/src/routes/bench/exchange.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { ExchangeUnderConstruction } from "@bench/placeholders";
+import { InviterBench } from "@bench/InviterBench";
 
 export const Route = createFileRoute("/bench/exchange")({
-  component: ExchangeUnderConstruction,
+  component: InviterBench,
 });

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -2,18 +2,16 @@
 
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { page } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
 import { MantineProvider } from "@mantine/core";
 
-import {
-  AcceptUnderConstruction,
-  ExchangeUnderConstruction,
-} from "@bench/placeholders";
+import { AcceptUnderConstruction } from "@bench/placeholders";
 import { BenchLobby } from "@bench/BenchLobby";
+import { InviterBench } from "@bench/InviterBench";
 import styles from "@bench/bench.module.css";
 
 import type { ReactNode } from "react";
@@ -116,9 +114,9 @@ describe("bench lobby", () => {
   });
 });
 
-describe("bench shell", () => {
-  test("renders rail, work, and ledger as labeled landmarks", async () => {
-    mount(createElement(ExchangeUnderConstruction));
+describe("inviter bench", () => {
+  test("renders the empty spine: landmarks, placeholder ledger, quiet facts", async () => {
+    mount(createElement(InviterBench));
 
     await expect
       .element(page.getByRole("heading", { level: 1 }))
@@ -134,7 +132,7 @@ describe("bench shell", () => {
     );
     expect(currentSteps.map((step) => step.textContent)).toEqual(["Your file"]);
 
-    // Customize facts with no state yet render the em-dash quiet fact.
+    // Customize facts with no file yet render the em-dash quiet fact.
     const facts = Array.from(
       (rail as Element).querySelectorAll(`.${styles.val}`),
     );
@@ -160,22 +158,92 @@ describe("bench shell", () => {
       "Transport",
     ]);
 
-    const references = Array.from(
-      (ledger as Element).querySelectorAll(`.${styles.ledgerRef}`),
-    ).map((reference) => reference.textContent);
-    expect(references).toEqual([
-      "Step 2",
-      "Step 2",
-      "Step 3",
-      "Step 3",
-      "Step 3",
-    ]);
-
     // Every undecided ledger value is the muted em-dash mark.
     const values = Array.from((ledger as Element).querySelectorAll("dd")).map(
       (value) => value.textContent,
     );
     expect(values).toEqual(Array.from({ length: 7 }, () => EM_DASH));
+  });
+
+  test("derives terms on read and tracks step-2 edits in the ledger", async () => {
+    mount(createElement(InviterBench));
+
+    await expect.element(page.getByLabelText("Your name")).toBeInTheDocument();
+    await userEvent.fill(page.getByLabelText("Your name"), "Dana Okafor");
+
+    const fileInput = document.querySelector('input[type="file"]');
+    expect(fileInput).not.toBeNull();
+    await userEvent.upload(
+      page.elementLocator(fileInput as HTMLElement),
+      new File(
+        [
+          "client_id,first_name,last_name,dob,program_code\n" +
+            "1,Ann,Lee,01/02/1990,A\n2,Bo,Ray,03/04/1985,B\n",
+        ],
+        "clients.csv",
+        { type: "text/csv" },
+      ),
+    );
+
+    // The file card and the recommended-terms callout appear on read, and the
+    // ledger fills in while still on step 1: derivation happens at read time.
+    await expect.element(page.getByText("clients.csv")).toBeInTheDocument();
+    await expect
+      .element(page.getByText("Recommended terms are ready", { exact: false }))
+      .toBeInTheDocument();
+
+    const ledger = () =>
+      document.querySelector('aside[aria-label="This exchange"]') as Element;
+    const ledgerRow = (label: string) =>
+      Array.from(ledger().querySelectorAll(`.${styles.ledgerRow}`)).find(
+        (row) => row.querySelector("dt")?.childNodes[0].textContent === label,
+      );
+    expect(ledgerRow("You will send")?.querySelector("dd")?.textContent).toBe(
+      "program_code",
+    );
+    expect(ledgerRow("Expires")?.querySelector("dd")?.textContent).toBe(
+      "1 hour after you share",
+    );
+
+    await page
+      .getByRole("button", { name: "Continue to matching & sharing" })
+      .click();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Matching & sharing");
+
+    // Undiscloses the only sent column: the ledger and the empty-state inset
+    // track the edit.
+    await page
+      .getByLabelText("How program_code is used")
+      .selectOptions("ignored");
+    await expect
+      .element(page.getByText("Nothing - matching only"))
+      .toBeInTheDocument();
+    await expect
+      .element(
+        page.getByText("No values will be sent to your partner", {
+          exact: false,
+        }),
+      )
+      .toBeInTheDocument();
+
+    // Retyping the ignored column to the row identifier displaces the inferred
+    // one; the displacement is announced.
+    await page
+      .getByLabelText("Type for program_code")
+      .selectOptions("identifier");
+    await expect
+      .element(
+        page.getByText(
+          "client_id changed to Ignored - only one column can be the row identifier.",
+        ),
+      )
+      .toBeInTheDocument();
+
+    // The layout holds at 400px: no horizontal document overflow.
+    await page.viewport(400, 800);
+    expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(400);
   });
 
   test("collapses to the single-column layout without rail and ledger", async () => {

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -246,6 +246,41 @@ describe("inviter bench", () => {
     expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(400);
   });
 
+  test("surfaces a two-identifier file in the rail's Problems block", async () => {
+    mount(createElement(InviterBench));
+
+    await expect.element(page.getByLabelText("Your name")).toBeInTheDocument();
+    await userEvent.fill(page.getByLabelText("Your name"), "Dana");
+
+    const fileInput = document.querySelector('input[type="file"]');
+    await userEvent.upload(
+      page.elementLocator(fileInput as HTMLElement),
+      new File(
+        ["id,identifier,last_name,dob\n1,2,Lee,01/02/1990\n"],
+        "twoids.csv",
+        { type: "text/csv" },
+      ),
+    );
+    await expect.element(page.getByText("twoids.csv")).toBeInTheDocument();
+
+    // The inferred two-identifier conflict is a rail problem from the moment
+    // the file is read, and its entry navigates into step 2 to fix it.
+    await page
+      .getByRole("button", { name: "Choose a single row identifier" })
+      .click();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Matching & sharing");
+
+    await page
+      .getByLabelText("How identifier is used")
+      .selectOptions("ignored");
+    await expect
+      .element(page.getByLabelText("How identifier is used"))
+      .toHaveValue("ignored");
+    expect(document.querySelector('section[aria-label="Problems"]')).toBeNull();
+  });
+
   test("collapses to the single-column layout without rail and ledger", async () => {
     mount(createElement(AcceptUnderConstruction));
 

--- a/apps/web/test/unit/benchInviterModel.test.ts
+++ b/apps/web/test/unit/benchInviterModel.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  editorFromCsv,
+  editorWithColumnDisclosure,
+  editorWithColumnType,
+  editorWithIdentity,
+  enabledKeys,
+  fileCardMeta,
+  identifierProblem,
+  inviterLedgerRows,
+  inviterRailFacts,
+  lifetimeLabel,
+} from "@bench/inviterModel";
+
+import type { AcquiredCsv } from "@bench/inviterModel";
+
+// Headers chosen from inferMetadata's exact-match alias table: four linkage
+// types (enough to back several default keys), one _id-suffixed identifier,
+// and one unrecognized column, which infers to a sent payload column.
+const csv: AcquiredCsv = {
+  fileName: "clients.csv",
+  sizeBytes: Math.round(8.4 * 1024 ** 2),
+  rawRows: [
+    {
+      client_id: "1",
+      first_name: "Ann",
+      last_name: "Lee",
+      dob: "01/02/1990",
+      ssn4: "1234",
+      program_code: "A",
+    },
+  ],
+  columns: [
+    "client_id",
+    "first_name",
+    "last_name",
+    "dob",
+    "ssn4",
+    "program_code",
+  ],
+};
+
+function ledgerValue(editor: ReturnType<typeof editorFromCsv>, label: string) {
+  const row = inviterLedgerRows(editor).find((entry) => entry.label === label);
+  if (row === undefined) throw new Error(`no ledger row labeled ${label}`);
+  return row;
+}
+
+describe("spine derivation from the read file", () => {
+  test("seeding derives default keys and a disclosed send set", () => {
+    const editor = editorFromCsv("Dana Okafor", csv);
+    expect(enabledKeys(editor.draft).length).toBeGreaterThan(0);
+    expect(editor.draft.identity).toBe("Dana Okafor");
+
+    const send = ledgerValue(editor, "You will send");
+    expect(send.value).toBe("program_code");
+
+    const matchedOn = ledgerValue(editor, "Matched on");
+    expect(Array.isArray(matchedOn.value)).toBe(true);
+    expect((matchedOn.value as ReadonlyArray<string>)[0]).toMatch(/^1\. /);
+
+    expect(ledgerValue(editor, "Expires").value).toBe("1 hour after you share");
+    expect(ledgerValue(editor, "Results go to").value).toBe(
+      "You and your partner",
+    );
+    expect(ledgerValue(editor, "Agreement").muted).toBe("None");
+    expect(ledgerValue(editor, "Transport").value).toBe("Browser");
+  });
+
+  test("an unmatchable file derives zero keys", () => {
+    const unmatchable: AcquiredCsv = {
+      ...csv,
+      columns: ["program_code", "notes"],
+      rawRows: [{ program_code: "A", notes: "x" }],
+    };
+    const editor = editorFromCsv("Dana", unmatchable);
+    expect(enabledKeys(editor.draft)).toEqual([]);
+    expect(ledgerValue(editor, "Matched on").muted).toBe("No keys");
+  });
+
+  test("before a file is read, every ledger row is the placeholder", () => {
+    for (const row of inviterLedgerRows(undefined)) {
+      expect(row.value).toBeUndefined();
+      expect(row.muted).toBeUndefined();
+    }
+    for (const fact of inviterRailFacts(undefined)) {
+      expect(fact.fact).toBeUndefined();
+    }
+  });
+
+  test("rail facts count the derived cleaning and keys", () => {
+    const editor = editorFromCsv("Dana", csv);
+    const facts = inviterRailFacts(editor);
+    expect(facts[0].label).toBe("Cleaning");
+    expect(facts[0].fact).toMatch(/^\d+ fields?$/);
+    expect(facts[1].fact).toBe(`${enabledKeys(editor.draft).length} keys`);
+    expect(facts[2].fact).toBeUndefined();
+  });
+});
+
+describe("ledger tracks step-2 edits", () => {
+  test("undisclosing the sent column empties the send row", () => {
+    const seeded = editorFromCsv("Dana", csv);
+    const { editor } = editorWithColumnDisclosure(
+      seeded,
+      csv,
+      "program_code",
+      "ignored",
+    );
+    const send = ledgerValue(editor, "You will send");
+    expect(send.value).toBeUndefined();
+    expect(send.muted).toBe("Nothing - matching only");
+  });
+
+  test("retyping a matched column reconciles the key set", () => {
+    const seeded = editorFromCsv("Dana", csv);
+    const before = enabledKeys(seeded.draft).length;
+    const { editor } = editorWithColumnType(seeded, csv, "ssn4", "other");
+    const after = enabledKeys(editor.draft).length;
+    expect(after).toBeGreaterThan(0);
+    expect(after).toBeLessThan(before);
+    expect(ledgerValue(editor, "Matched on").value).toHaveLength(after);
+    expect(inviterRailFacts(editor)[1].fact).toBe(`${after} keys`);
+  });
+
+  test("choosing an identifier demotes the previous one and reports it", () => {
+    const twoIds: AcquiredCsv = {
+      ...csv,
+      columns: ["id", "identifier", "last_name", "dob"],
+      rawRows: [{ id: "1", identifier: "2", last_name: "Lee", dob: "x" }],
+    };
+    const seeded = editorFromCsv("Dana", twoIds);
+    expect(identifierProblem(seeded.draft)).toBe(true);
+
+    const { editor, demotedIdentifiers } = editorWithColumnDisclosure(
+      seeded,
+      twoIds,
+      "id",
+      "identifier",
+    );
+    expect(demotedIdentifiers).toEqual(["identifier"]);
+    expect(identifierProblem(editor.draft)).toBe(false);
+  });
+
+  test("a name edit relabels the identity without touching the keys", () => {
+    const seeded = editorFromCsv("Dana", csv);
+    const renamed = editorWithIdentity(seeded, "Riverbend County");
+    expect(renamed.draft.identity).toBe("Riverbend County");
+    expect(enabledKeys(renamed.draft)).toEqual(enabledKeys(seeded.draft));
+  });
+});
+
+describe("display helpers", () => {
+  test("lifetimeLabel phrases whole units", () => {
+    expect(lifetimeLabel(3600)).toBe("1 hour after you share");
+    expect(lifetimeLabel(7200)).toBe("2 hours after you share");
+    expect(lifetimeLabel(86400)).toBe("1 day after you share");
+    expect(lifetimeLabel(900)).toBe("15 minutes after you share");
+  });
+
+  test("fileCardMeta formats rows and size", () => {
+    expect(fileCardMeta(12408, Math.round(8.4 * 1024 ** 2))).toBe(
+      "12,408 rows - 8.4 MB",
+    );
+    expect(fileCardMeta(3, 2048)).toBe("3 rows - 2 KB");
+  });
+});


### PR DESCRIPTION
## Summary

The first two required-spine screens of the inviter bench: Your file (name + CSV intake) and Matching & sharing (the one mandatory review - what each column is and what it is used for). Default exchange terms derive from the file the moment it is read, and the standing disclosure ledger and rail facts fill in live as terms take shape. The surface is new; the domain logic is not: the bench drives the Advanced editor's tested draft model, so derivation, key/cleaning reconciliation, and the single-identifier rule behave exactly as the old editor's tested seams define them. Step 3 remains an honest under-construction notice.

Implements [211235774](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=211235774).

## Changes

- apps/web/src/bench/inviterModel.ts: the pure spine model - seeding from the read file (`seedAdvancedInvite`), the two step-2 column edits (wrapping `setColumnType`/`setColumnDisclosure` + `setDraftMetadata`), and the ledger/rail-fact view models. The tested boundary for derivation and ledger updates.
- apps/web/src/bench/InviterBench.tsx: the working surface - one route, sections swapped in place with focus sent to the incoming h1; owns the off-main-thread CSV parse with stale-parse protection, intake gates (unnamed columns, unreadable file, unmatchable file), and the rail Problems entry for an inferred two-identifier file.
- apps/web/src/bench/YourFileSection.tsx, MatchingSharingSection.tsx: the two screens per the mockup - dropzone + file card + recommended-terms callout with continue gated on name and a linkable file; the column table (Type / How it is used selects over the shared vocabulary), single-identifier hint plus a separate atomic live region for demotion notices, extra-data chips with the designed empty-state inset.
- apps/web/src/bench/Rail.tsx, Ledger.tsx, bench.module.css: done steps become links, the Problems block lands, ledger rows gain a named muted state ("None", "Nothing - matching only"), and the mockup's form/table/state CSS is translated onto the tokens.
- apps/web/test/unit/benchInviterModel.test.ts: derivation from a read file, ledger updates on disclosure/type edits, identifier demotion, display helpers (10 tests).
- apps/web/test/browser/bench.test.ts: the real flow in Chromium - upload, derivation at read time, ledger tracking through step-2 edits, the demotion announcement, the Problems-block navigate-and-clear path, and a 400px no-overflow check.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run formatcheck`, `npm run test:unit -w apps/web` (611 passed), `npm run test:browser -w apps/web` (342 passed, real Chromium), `npm run build -w apps/web`.
New tests cover: default-terms derivation from a read file and ledger updates in response to term edits (the issue's named criteria), plus intake gates, the single-identifier rule end to end, and the 400px layout hold.

## Background

A light-review round (3 reviewers, 3 confirmed minors, 0 simpler-shape votes) drove two fixes: the split hint/live-region and the Problems-block test. The third finding - step 2's Continue is not disabled while the two-identifier problem stands - is deliberate: the mockup's own Review & create screen carries the rail Problems block, so the design routes an unresolved problem to the create gate, which lands with the Review & create slice; the Problems entry persists across sections meanwhile.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed; the bench remains a parallel preview and the docs rewrite is scheduled with the cutover item
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: preview routes on the continuously deployed web app; no operator- or reviewer-actionable change
- [x] Security review -- n/a: no enumerated surface touched; the disclosure summaries render through core's unchanged `disclosedColumnNames` predicate, no exchange is wired, and nothing new is sent, stored, or logged
