### PR TITLE
Add inviter Review & create screen

### DIFF
--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -6,6 +6,8 @@ import { Link } from "@tanstack/react-router";
 import { sanitizeErrorForDisplay } from "@psilink/core";
 
 import { emptyColumnPositions, unnameableColumnsAlert } from "@psi/columnNames";
+import { generateInvitation } from "@psi/invitation";
+import { invitationLocation } from "@psi/invitationLocation";
 import { loadCSVFileOffMainThread } from "@psi/csvParseController";
 
 import { Rail, RailFacts, RailGroup, RailProblems, RailSteps } from "./Rail";
@@ -14,31 +16,41 @@ import {
   editorWithColumnDisclosure,
   editorWithColumnType,
   editorWithIdentity,
-  identifierProblem,
+  editorWithLifetime,
+  editorWithOutputDirection,
   inviterLedgerRows,
   inviterRailFacts,
+  resetToRecommended,
+  reviewValidation,
+  sealEditor,
+  spineProblems,
 } from "./inviterModel";
 import { BenchShell } from "./BenchShell";
 import { Ledger } from "./Ledger";
 import { MatchingSharingSection } from "./MatchingSharingSection";
+import { ReviewCreateSection } from "./ReviewCreateSection";
 import { YourFileSection } from "./YourFileSection";
-import styles from "./bench.module.css";
 
 import type { AcquiredCsv, InviterEditor } from "./inviterModel";
 import type { DisclosureChoice } from "@psi/metadataEditing";
+import type { GeneratedInvitation } from "@psi/invitation";
 import type { IntakeAlert } from "./YourFileSection";
 import type { RailStep } from "./Rail";
 import type { SemanticType } from "@psilink/core";
 
-type SpineSection = "file" | "columns" | "review";
+type SpineSection = "file" | "columns" | "review" | "share";
 
-const SPINE_LABELS: Record<SpineSection, string> = {
+const SPINE_LABELS: Record<Exclude<SpineSection, "share">, string> = {
   file: "Your file",
   columns: "Matching & sharing",
   review: "Review & create",
 };
 
-const SPINE_ORDER: ReadonlyArray<SpineSection> = ["file", "columns", "review"];
+const SPINE_ORDER: ReadonlyArray<Exclude<SpineSection, "share">> = [
+  "file",
+  "columns",
+  "review",
+];
 
 function demotionNotice(demoted: ReadonlyArray<string>): string {
   if (demoted.length === 0) return "";
@@ -56,10 +68,14 @@ export function InviterBench() {
   const [name, setName] = useState("");
   const [section, setSection] = useState<SpineSection>("file");
   const [acquired, setAcquired] = useState<AcquiredCsv>();
+  const [sourceFile, setSourceFile] = useState<File>();
   const [editor, setEditor] = useState<InviterEditor>();
   const [intakeAlert, setIntakeAlert] = useState<IntakeAlert>();
   const [reading, setReading] = useState(false);
   const [announcement, setAnnouncement] = useState("");
+  const [invitation, setInvitation] = useState<GeneratedInvitation>();
+  const [minting, setMinting] = useState(false);
+  const [createAlert, setCreateAlert] = useState<IntakeAlert>();
 
   // A parse may still be in flight when the surface unmounts or a newer file
   // is dropped; the id lets the stale resolution fall on the floor instead of
@@ -104,6 +120,7 @@ export function InviterBench() {
       };
       const seeded = editorFromCsv(name, csv);
       setAcquired(csv);
+      setSourceFile(file);
       setEditor(seeded);
       if (seeded.draft.keys.length === 0)
         setIntakeAlert({
@@ -137,50 +154,103 @@ export function InviterBench() {
     setAnnouncement(demotionNotice(result.demotedIdentifiers));
   }
 
+  // Minting re-parses the retained source file through generateInvitation --
+  // the same fail-closed parse boundary the current app mints at -- so the
+  // embedded terms, the returned rows, and the satisfiability re-check all
+  // bind to one read of the file.
+  async function createInvitation() {
+    if (editor === undefined || sourceFile === undefined) return;
+    const validation = reviewValidation(editor);
+    if (!validation.canGenerate || validation.terms === undefined) return;
+    setMinting(true);
+    setCreateAlert(undefined);
+    try {
+      const minted = await generateInvitation({
+        inviterName: editor.draft.identity,
+        file: sourceFile,
+        location: invitationLocation(),
+        lifetimeSeconds: editor.draft.lifetimeSeconds,
+        linkageTerms: validation.terms,
+        metadata: editor.draft.metadata,
+        standardization: editor.draft.standardization,
+      });
+      setEditor(sealEditor(editor));
+      setInvitation(minted);
+      setSection("share");
+    } catch {
+      // Everything user-actionable was validated before the button armed, so
+      // a failure here is internal; a fixed message avoids echoing internals
+      // into a secret-bearing flow (the InvitePanel rule).
+      setCreateAlert({
+        title: "Could not create the invitation",
+        message:
+          "Something went wrong while creating the invitation. Your terms are unchanged - try again.",
+      });
+    } finally {
+      setMinting(false);
+    }
+  }
+
   const linkable = editor !== undefined && editor.draft.keys.length > 0;
   const fileReady = name.trim().length > 0 && linkable;
+  const sealed = editor?.sealed === true;
 
-  const currentPosition = SPINE_ORDER.indexOf(section);
-  const steps: Array<RailStep> = SPINE_ORDER.map((step, position) => {
-    const state =
-      step === section
-        ? "current"
-        : position < currentPosition
-          ? "done"
-          : "pending";
-    return {
-      label: SPINE_LABELS[step],
-      state,
-      onSelect: state === "done" ? () => setSection(step) : undefined,
-    };
-  });
-
-  const problems =
-    editor !== undefined && identifierProblem(editor.draft)
+  const currentPosition = SPINE_ORDER.indexOf(
+    section === "share" ? "review" : section,
+  );
+  const steps: Array<RailStep> =
+    section === "share"
       ? [
-          {
-            label: "Choose a single row identifier",
-            onSelect: () => setSection("columns"),
-          },
+          { label: "Share", state: "current" },
+          { label: "Partner accepts", state: "pending" },
+          { label: "Exchange runs", state: "pending" },
+          { label: "Results", state: "pending" },
         ]
-      : [];
+      : SPINE_ORDER.map((step, position) => {
+          const state =
+            step === section
+              ? "current"
+              : position < currentPosition
+                ? "done"
+                : "pending";
+          return {
+            label: SPINE_LABELS[step],
+            state,
+            onSelect: state === "done" ? () => setSection(step) : undefined,
+          };
+        });
+
+  const problems = sealed
+    ? []
+    : spineProblems(editor).map((problem) => ({
+        label: problem.message,
+        onSelect: () => setSection(problem.target),
+      }));
 
   return (
     <BenchShell
       rail={
-        <Rail label="Exchange setup">
-          <RailGroup label="Set up">
-            <RailSteps steps={steps} />
-          </RailGroup>
-          <RailGroup label="Customize" note="Filled in from your file.">
-            <RailFacts facts={inviterRailFacts(editor)} />
-          </RailGroup>
-          <RailProblems problems={problems} />
-        </Rail>
+        section === "share" ? (
+          <Rail label="Exchange progress">
+            <RailGroup label="This exchange" note="Browser">
+              <RailSteps steps={steps} />
+            </RailGroup>
+          </Rail>
+        ) : (
+          <Rail label="Exchange setup">
+            <RailGroup label="Set up">
+              <RailSteps steps={steps} />
+            </RailGroup>
+            <RailGroup label="Customize" note="Filled in from your file.">
+              <RailFacts facts={inviterRailFacts(editor)} />
+            </RailGroup>
+            <RailProblems problems={problems} />
+          </Rail>
+        )
       }
       ledger={
         <Ledger
-          rows={inviterLedgerRows(editor).map((row) => ({
+          rows={inviterLedgerRows(editor, invitation?.expires).map((row) => ({
             label: row.label,
             reference: row.reference,
             muted: row.muted,
@@ -243,14 +313,44 @@ export function InviterBench() {
               onContinue={() => setSection("review")}
             />
           )}
-        {section === "review" && (
+        {section === "review" &&
+          editor !== undefined &&
+          acquired !== undefined && (
+            <>
+              <ReviewCreateSection
+                editor={editor}
+                csv={acquired}
+                problems={spineProblems(editor)}
+                minting={minting}
+                onLifetime={(seconds) =>
+                  setEditor(editorWithLifetime(editor, seconds))
+                }
+                onDirection={(direction) =>
+                  setEditor(editorWithOutputDirection(editor, direction))
+                }
+                onReset={() => setEditor(resetToRecommended(editor, acquired))}
+                onCreate={() => void createInvitation()}
+                onNavigate={setSection}
+              />
+              {createAlert !== undefined && (
+                <Alert color="red" title={createAlert.title} mt="md">
+                  {createAlert.message}
+                </Alert>
+              )}
+            </>
+          )}
+        {section === "share" && (
           <>
-            <p className={styles.eyebrow}>Step 3 of 3</p>
-            <h1 tabIndex={-1}>Review &amp; create</h1>
+            <h1 tabIndex={-1}>Your invitation is ready</h1>
+            <p>
+              The terms are sealed: the invitation your partner consents to is
+              exactly the proposal you just reviewed.
+            </p>
             <Alert color="yellow" title="Under construction" mt="md">
-              This step is not built yet: the check-your-answers review, the
-              transport choice, and the create action arrive with the next bench
-              screens. To run an exchange today, use the{" "}
+              The share screen - the invitation link and code with their copy
+              actions - arrives with the next bench screens. Nothing has been
+              shared: the invitation exists only in this browser and expires on
+              its own. To run an exchange today, use the{" "}
               <Anchor component={Link} to="/">
                 current app
               </Anchor>

--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -5,10 +5,14 @@ import { Link } from "@tanstack/react-router";
 
 import { sanitizeErrorForDisplay } from "@psilink/core";
 
+import { InvitationFileError, generateInvitation } from "@psi/invitation";
 import { emptyColumnPositions, unnameableColumnsAlert } from "@psi/columnNames";
-import { generateInvitation } from "@psi/invitation";
 import { invitationLocation } from "@psi/invitationLocation";
 import { loadCSVFileOffMainThread } from "@psi/csvParseController";
+
+import { whenDiagnostic } from "@utils/diagnostics";
+
+import { unlinkableFileAlert } from "@components/UnlinkableFileAlert";
 
 import { Rail, RailFacts, RailGroup, RailProblems, RailSteps } from "./Rail";
 import {
@@ -177,15 +181,40 @@ export function InviterBench() {
       setEditor(sealEditor(editor));
       setInvitation(minted);
       setSection("share");
-    } catch {
-      // Everything user-actionable was validated before the button armed, so
-      // a failure here is internal; a fixed message avoids echoing internals
-      // into a secret-bearing flow (the InvitePanel rule).
-      setCreateAlert({
-        title: "Could not create the invitation",
-        message:
-          "Something went wrong while creating the invitation. Your terms are unchanged - try again.",
-      });
+    } catch (error) {
+      if (error instanceof InvitationFileError) {
+        // The mint re-parses the retained file, so it can fail in the same
+        // user-actionable ways step 1 gates on (the file changed on disk, or
+        // its satisfiability shifted with the edited terms); surface the same
+        // shared alerts rather than a generic failure.
+        setCreateAlert(
+          error.failure.kind === "unreadable"
+            ? {
+                title: "Could not read your file",
+                message: sanitizeErrorForDisplay(error.failure.cause),
+              }
+            : error.failure.kind === "unnameable"
+              ? unnameableColumnsAlert(error.failure.positions)
+              : unlinkableFileAlert(error.failure.unsatisfied),
+        );
+      } else {
+        // Internal and non-user-actionable: a fixed message avoids echoing
+        // internals into a secret-bearing flow, the default log carries only
+        // the error type, and the detail reaches the console only under
+        // diagnostic mode -- the InvitePanel rule, applied literally.
+        console.error(
+          "invitation creation failed:",
+          error instanceof Error ? error.name : typeof error,
+        );
+        whenDiagnostic(() =>
+          console.error("invitation creation failed (detail):", error),
+        );
+        setCreateAlert({
+          title: "Could not create the invitation",
+          message:
+            "Something went wrong while creating the invitation. Your terms are unchanged - try again.",
+        });
+      }
     } finally {
       setMinting(false);
     }

--- a/apps/web/src/bench/ReviewCreateSection.tsx
+++ b/apps/web/src/bench/ReviewCreateSection.tsx
@@ -1,0 +1,200 @@
+import { Button, NativeSelect, Radio } from "@mantine/core";
+
+import {
+  LIFETIME_CHOICES,
+  RESULTS_DIRECTION_LABELS,
+  answersRows,
+  expiryLabel,
+} from "./inviterModel";
+import styles from "./bench.module.css";
+
+import type {
+  AcquiredCsv,
+  InviterEditor,
+  SpineProblem,
+  SpineTarget,
+} from "./inviterModel";
+import type { OutputDirection } from "@psi/advancedInvite";
+
+const DIRECTION_CHOICES: ReadonlyArray<{
+  value: OutputDirection;
+  label: string;
+}> = [
+  { value: "both", label: `${RESULTS_DIRECTION_LABELS.both} (recommended)` },
+  { value: "inviter", label: RESULTS_DIRECTION_LABELS.inviter },
+  { value: "partner", label: RESULTS_DIRECTION_LABELS.partner },
+];
+
+/**
+ * Step 3 of the inviter spine: the review-time decisions (lifetime, result
+ * direction, transport), the check-your-answers restatement of the whole
+ * proposal, and the create action -- the point of no return whose copy says
+ * so. The transport cards for SFTP and a shared directory are present but
+ * disabled until exchange-file download ships; their copy carries the
+ * channel-capability rule (browsers run live WebRTC exchanges; SFTP and
+ * shared-directory exchanges run in the command-line tool).
+ */
+export function ReviewCreateSection({
+  editor,
+  csv,
+  problems,
+  minting,
+  onLifetime,
+  onDirection,
+  onReset,
+  onCreate,
+  onNavigate,
+}: {
+  editor: InviterEditor;
+  csv: AcquiredCsv;
+  problems: ReadonlyArray<SpineProblem>;
+  minting: boolean;
+  onLifetime: (seconds: number) => void;
+  onDirection: (direction: OutputDirection) => void;
+  onReset: () => void;
+  onCreate: () => void;
+  onNavigate: (target: SpineTarget) => void;
+}) {
+  const canCreate = problems.length === 0 && !minting;
+  return (
+    <>
+      <p className={styles.eyebrow}>Step 3 of 3</p>
+      <h1 tabIndex={-1}>Review &amp; create</h1>
+      <NativeSelect
+        label="Invitation lifetime"
+        description="How long this invitation can be accepted before it expires."
+        value={String(editor.draft.lifetimeSeconds)}
+        data={LIFETIME_CHOICES.map((choice) => ({
+          value: String(choice.seconds),
+          label: choice.label,
+        }))}
+        onChange={(event) => onLifetime(Number(event.currentTarget.value))}
+      />
+      <p className={`${styles.small} ${styles.sub}`}>
+        Shared now, it expires{" "}
+        <span className={styles.mono}>
+          {expiryLabel(editor.draft.lifetimeSeconds, new Date())}
+        </span>
+        .
+      </p>
+      <NativeSelect
+        label="Who receives the matched results"
+        description="The party who receives no results still contributes records to the match."
+        value={editor.draft.outputDirection}
+        data={DIRECTION_CHOICES.map((choice) => ({
+          value: choice.value,
+          label: choice.label,
+        }))}
+        onChange={(event) =>
+          onDirection(event.currentTarget.value as OutputDirection)
+        }
+        mt="md"
+      />
+      <fieldset className={styles.fieldset}>
+        <legend>How will this exchange run?</legend>
+        <div className={`${styles.radioCard} ${styles.radioCardSelected}`}>
+          <Radio
+            checked
+            readOnly
+            label="Live, in this browser (recommended)"
+            description="Your browsers connect directly. You get an invitation link and code to share; keep this tab open while your partner accepts."
+          />
+        </div>
+        <div className={styles.radioCard}>
+          <Radio
+            disabled
+            checked={false}
+            readOnly
+            label={
+              <>
+                Over SFTP, run by the psilink command-line tool
+                <span className={styles.tagRoadmap}>On the roadmap</span>
+              </>
+            }
+            description="Will save an exchange file that automates the command-line tool over your SFTP server. Your partner accepts with the same invitation code."
+          />
+        </div>
+        <div className={styles.radioCard}>
+          <Radio
+            disabled
+            checked={false}
+            readOnly
+            label={
+              <>
+                Over a shared directory, run by the command-line tool
+                <span className={styles.tagRoadmap}>On the roadmap</span>
+              </>
+            }
+            description="Will save an exchange file the command-line tool runs against a directory both parties can reach."
+          />
+        </div>
+        <p className={`${styles.small} ${styles.sub}`}>
+          This browser runs live exchanges only; SFTP and shared-directory
+          exchanges run in the psilink command-line tool.
+        </p>
+      </fieldset>
+      <h2>Exchange proposal</h2>
+      <p className={`${styles.small} ${styles.sub}`}>
+        Check every term before you create the invitation. Creating it seals the
+        terms.
+      </p>
+      <div className={styles.tableScroll}>
+        <table className={`${styles.benchTable} ${styles.answers}`}>
+          <caption className={styles.visuallyHidden}>
+            Check your answers before creating the invitation
+          </caption>
+          <tbody>
+            {answersRows(editor, csv).map((row) => (
+              <tr key={row.label}>
+                <th scope="row">{row.label}</th>
+                <td className={row.mono === true ? styles.mono : undefined}>
+                  {row.value}
+                </td>
+                <td className={styles.answersChange}>
+                  {row.changeTarget !== undefined ? (
+                    <button
+                      type="button"
+                      className={styles.stepLink}
+                      onClick={() =>
+                        onNavigate(row.changeTarget as SpineTarget)
+                      }
+                    >
+                      Change
+                      <span className={styles.visuallyHidden}>
+                        {" "}
+                        {row.label.toLowerCase()}
+                      </span>
+                    </button>
+                  ) : row.setAbove === true ? (
+                    <span className={styles.setAbove}>
+                      Set above on this step
+                    </span>
+                  ) : null}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className={styles.workFoot}>
+        <Button disabled={!canCreate} loading={minting} onClick={onCreate}>
+          Create the invitation
+        </Button>
+        <Button variant="default" disabled={minting} onClick={onReset}>
+          Reset to recommended
+        </Button>
+        <p
+          className={
+            problems.length === 0
+              ? `${styles.statusLine} ${styles.statusLineOk}`
+              : `${styles.statusLine} ${styles.statusLineDanger}`
+          }
+        >
+          {problems.length === 0
+            ? "Ready to create."
+            : `Resolve ${problems.length === 1 ? "the problem" : `the ${problems.length} problems`} in the rail to continue.`}
+        </p>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/bench/bench.module.css
+++ b/apps/web/src/bench/bench.module.css
@@ -489,6 +489,72 @@
   vertical-align: middle;
 }
 
+.statusLineDanger {
+  color: var(--bench-danger);
+}
+
+.radioCard {
+  border: 2px solid var(--bench-rule);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin: 10px 0;
+  max-width: 640px;
+}
+
+.radioCardSelected {
+  border-color: var(--bench-accent);
+  background: var(--bench-accent-bg);
+}
+
+.tagRoadmap {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--bench-warn);
+  border: 1px solid var(--bench-warn);
+  border-radius: 999px;
+  padding: 1px 8px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
+.answers th[scope="row"] {
+  font-size: 15px;
+  font-weight: 650;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--bench-ink);
+  border-bottom: 1px solid var(--bench-rule-soft);
+  padding: 10px 16px 10px 0;
+  width: 34%;
+  vertical-align: top;
+}
+
+.answersChange {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.setAbove {
+  color: var(--bench-faint);
+  font-size: 13px;
+}
+
+.fieldset {
+  border: 0;
+  padding: 0;
+  margin: 1.2rem 0;
+  max-width: 640px;
+}
+
+.fieldset legend {
+  font-weight: 650;
+  padding: 0;
+  margin-bottom: 4px;
+}
+
 .columnChips {
   display: flex;
   gap: 8px;

--- a/apps/web/src/bench/inviterModel.ts
+++ b/apps/web/src/bench/inviterModel.ts
@@ -215,9 +215,9 @@ export const LIFETIME_CHOICES: ReadonlyArray<{
   { seconds: MAX_INVITATION_LIFETIME_SECONDS, label: "1 year" },
 ];
 
-/** The absolute moment an invitation shared `now` would expire, phrased for
- * the live expiry hint, e.g. `July 8, 2026, 3:32 PM EDT`. */
-export function expiryLabel(lifetimeSeconds: number, now: Date): string {
+/** An absolute moment phrased for display, e.g. `July 8, 2026, 3:32 PM EDT`
+ * -- the minted expiry in the ledger. */
+export function dateTimeLabel(moment: Date): string {
   return new Intl.DateTimeFormat("en-US", {
     month: "long",
     day: "numeric",
@@ -225,7 +225,13 @@ export function expiryLabel(lifetimeSeconds: number, now: Date): string {
     hour: "numeric",
     minute: "2-digit",
     timeZoneName: "short",
-  }).format(new Date(now.getTime() + lifetimeSeconds * 1000));
+  }).format(moment);
+}
+
+/** The absolute moment an invitation shared `now` would expire, phrased for
+ * the live expiry hint. */
+export function expiryLabel(lifetimeSeconds: number, now: Date): string {
+  return dateTimeLabel(new Date(now.getTime() + lifetimeSeconds * 1000));
 }
 
 /** Ledger phrasing for who receives the matched results. */
@@ -294,7 +300,7 @@ export function inviterLedgerRows(
       reference: "Step 3",
       value:
         expiresIso !== undefined
-          ? expiryLabel(0, new Date(expiresIso))
+          ? dateTimeLabel(new Date(expiresIso))
           : lifetimeLabel(editor.draft.lifetimeSeconds),
     },
     {
@@ -316,28 +322,36 @@ export interface InviterRailFact {
   fact?: string;
 }
 
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/** The cleaning summary ("3 fields") shared by the rail fact and the
+ * check-your-answers row, so the two surfaces cannot disagree. */
+export function cleaningFact(draft: AdvancedInviteDraft): string {
+  return plural(draft.standardization.length, "field");
+}
+
+/** The key-count summary ("2 keys") shared by the rail fact and the
+ * check-your-answers row. */
+export function keysFact(draft: AdvancedInviteDraft): string {
+  return plural(enabledKeys(draft).length, "key");
+}
+
 /** The Customize group's quiet facts, read live from the draft: cleaning
  * pipeline count, authored key count, and the agreement reference. Undefined
  * facts render as the em-dash "nothing yet" mark. */
 export function inviterRailFacts(
   editor: InviterEditor | undefined,
 ): Array<InviterRailFact> {
-  const plural = (count: number, noun: string) =>
-    `${count} ${noun}${count === 1 ? "" : "s"}`;
   return [
     {
       label: "Cleaning",
-      fact:
-        editor === undefined
-          ? undefined
-          : plural(editor.draft.standardization.length, "field"),
+      fact: editor === undefined ? undefined : cleaningFact(editor.draft),
     },
     {
       label: "Matching keys",
-      fact:
-        editor === undefined
-          ? undefined
-          : plural(enabledKeys(editor.draft).length, "key"),
+      fact: editor === undefined ? undefined : keysFact(editor.draft),
     },
     {
       label: "Legal agreement",
@@ -391,7 +405,7 @@ export function spineProblems(
 ): Array<SpineProblem> {
   if (editor === undefined) return [];
   const problems: Array<SpineProblem> = [];
-  if (hasMultipleIdentifiers(editor.draft.metadata))
+  if (identifierProblem(editor.draft))
     problems.push({
       message: "Choose a single row identifier",
       target: "columns",
@@ -442,11 +456,11 @@ export function answersRows(
     },
     {
       label: "Cleaning",
-      value: `${inviterRailFacts(editor)[0].fact ?? ""}, filled in from your file`,
+      value: `${cleaningFact(editor.draft)}, filled in from your file`,
     },
     {
       label: "Matching keys",
-      value: `${inviterRailFacts(editor)[1].fact ?? ""}, recommended order`,
+      value: `${keysFact(editor.draft)}, recommended order`,
     },
     {
       label: "Legal agreement",

--- a/apps/web/src/bench/inviterModel.ts
+++ b/apps/web/src/bench/inviterModel.ts
@@ -1,15 +1,24 @@
-import { disclosedColumnNames } from "@psilink/core";
+import {
+  MAX_INVITATION_LIFETIME_SECONDS,
+  disclosedColumnNames,
+} from "@psilink/core";
 
 import {
   hasMultipleIdentifiers,
   setColumnDisclosure,
   setColumnType,
 } from "@psi/metadataEditing";
-import { seedAdvancedInvite, setDraftMetadata } from "@psi/advancedInvite";
+import {
+  seedAdvancedInvite,
+  setDraftMetadata,
+  validateAdvancedInvite,
+} from "@psi/advancedInvite";
 
 import type {
+  AdvancedField,
   AdvancedInviteDraft,
   AdvancedInviteSeed,
+  AdvancedValidation,
   OutputDirection,
 } from "@psi/advancedInvite";
 import type { CSVRow, LinkageKey, SemanticType } from "@psilink/core";
@@ -36,10 +45,18 @@ export interface AcquiredCsv {
 }
 
 /** An editing session over the read file: the live draft and the fixed seed it
- * derived from ({@link seedAdvancedInvite}). */
+ * derived from ({@link seedAdvancedInvite}). Once `sealed` (the invitation was
+ * created), every mutator in this module returns the session unchanged -- the
+ * terms a partner is consenting to can never drift from what was minted. */
 export interface InviterEditor {
   draft: AdvancedInviteDraft;
   seed: AdvancedInviteSeed;
+  sealed?: boolean;
+}
+
+/** Seal the session at create time; see {@link InviterEditor.sealed}. */
+export function sealEditor(editor: InviterEditor): InviterEditor {
+  return { ...editor, sealed: true };
 }
 
 /** Seed the editing session from the read file -- the "default terms derive
@@ -58,7 +75,36 @@ export function editorWithIdentity(
   editor: InviterEditor,
   identity: string,
 ): InviterEditor {
+  if (editor.sealed === true) return editor;
   return { ...editor, draft: { ...editor.draft, identity } };
+}
+
+/** Set the invitation lifetime step 3 offers ({@link LIFETIME_CHOICES}). */
+export function editorWithLifetime(
+  editor: InviterEditor,
+  lifetimeSeconds: number,
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return { ...editor, draft: { ...editor.draft, lifetimeSeconds } };
+}
+
+/** Set who receives the matched results. */
+export function editorWithOutputDirection(
+  editor: InviterEditor,
+  outputDirection: OutputDirection,
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return { ...editor, draft: { ...editor.draft, outputDirection } };
+}
+
+/** Discard every edit and re-derive the recommended draft from the file,
+ * keeping only the inviter's name -- step 3's "Reset to recommended". */
+export function resetToRecommended(
+  editor: InviterEditor,
+  csv: AcquiredCsv,
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return editorFromCsv(editor.draft.identity, csv);
 }
 
 /** The result of a step-2 column edit: the reconciled session plus any
@@ -92,6 +138,7 @@ export function editorWithColumnType(
   columnName: string,
   type: SemanticType,
 ): ColumnEditResult {
+  if (editor.sealed === true) return { editor, demotedIdentifiers: [] };
   const { metadata, demotedIdentifiers } = setColumnType(
     editor.draft.metadata,
     columnName,
@@ -107,6 +154,7 @@ export function editorWithColumnDisclosure(
   columnName: string,
   choice: DisclosureChoice,
 ): ColumnEditResult {
+  if (editor.sealed === true) return { editor, demotedIdentifiers: [] };
   const { metadata, demotedIdentifiers } = setColumnDisclosure(
     editor.draft.metadata,
     columnName,
@@ -136,15 +184,48 @@ export function fileCardMeta(rowCount: number, sizeBytes: number): string {
   return `${rows} rows - ${size}`;
 }
 
-/** The ledger's Expires phrasing for a draft lifetime, e.g. `1 hour after you
- * share`. Whole days/hours/minutes cover every value step 3's control will
- * offer; anything else falls back to minutes. */
-export function lifetimeLabel(seconds: number): string {
+/** A lifetime as a plain duration phrase, e.g. `1 hour`, `7 days`. Whole
+ * days/hours cover every {@link LIFETIME_CHOICES} value; anything else falls
+ * back to minutes. */
+export function lifetimeNoun(seconds: number): string {
   const unit = (count: number, noun: string) =>
-    `${count} ${noun}${count === 1 ? "" : "s"} after you share`;
+    `${count} ${noun}${count === 1 ? "" : "s"}`;
   if (seconds % 86400 === 0) return unit(seconds / 86400, "day");
   if (seconds % 3600 === 0) return unit(seconds / 3600, "hour");
   return unit(Math.max(1, Math.round(seconds / 60)), "minute");
+}
+
+/** The ledger's Expires phrasing for a draft lifetime, e.g. `1 hour after you
+ * share`. */
+export function lifetimeLabel(seconds: number): string {
+  return `${lifetimeNoun(seconds)} after you share`;
+}
+
+/** The lifetimes step 3 offers, from the recommended hour up to the bounded
+ * maximum ({@link MAX_INVITATION_LIFETIME_SECONDS}, one year). */
+export const LIFETIME_CHOICES: ReadonlyArray<{
+  seconds: number;
+  label: string;
+}> = [
+  { seconds: 3600, label: "1 hour (recommended)" },
+  { seconds: 6 * 3600, label: "6 hours" },
+  { seconds: 86400, label: "1 day" },
+  { seconds: 7 * 86400, label: "7 days" },
+  { seconds: 30 * 86400, label: "30 days" },
+  { seconds: MAX_INVITATION_LIFETIME_SECONDS, label: "1 year" },
+];
+
+/** The absolute moment an invitation shared `now` would expire, phrased for
+ * the live expiry hint, e.g. `July 8, 2026, 3:32 PM EDT`. */
+export function expiryLabel(lifetimeSeconds: number, now: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  }).format(new Date(now.getTime() + lifetimeSeconds * 1000));
 }
 
 /** Ledger phrasing for who receives the matched results. */
@@ -168,10 +249,12 @@ export interface InviterLedgerRow {
  * The disclosure ledger for the spine, filling in as the exchange takes shape:
  * before a file is read every value is the em-dash placeholder; once a session
  * exists the send list, matched-on keys, expiry, and result direction are read
- * live from the draft.
+ * live from the draft. Once the invitation is minted its absolute `expires`
+ * moment replaces the relative lifetime phrase.
  */
 export function inviterLedgerRows(
   editor: InviterEditor | undefined,
+  expiresIso?: string,
 ): Array<InviterLedgerRow> {
   if (editor === undefined) {
     return [
@@ -209,7 +292,10 @@ export function inviterLedgerRows(
     {
       label: "Expires",
       reference: "Step 3",
-      value: lifetimeLabel(editor.draft.lifetimeSeconds),
+      value:
+        expiresIso !== undefined
+          ? expiryLabel(0, new Date(expiresIso))
+          : lifetimeLabel(editor.draft.lifetimeSeconds),
     },
     {
       label: "Results go to",
@@ -256,6 +342,131 @@ export function inviterRailFacts(
     {
       label: "Legal agreement",
       fact: editor?.draft.legalAgreement?.reference,
+    },
+  ];
+}
+
+/** A bench section a Problems entry or a Change link can navigate to. */
+export type SpineTarget = "file" | "columns" | "review";
+
+/** The section that owns each validation field, so a Problems entry can link
+ * to where the fix lives. Key, cleaning, and agreement fields point at step 2
+ * until their Customize tabs exist -- the column table is where those terms
+ * are shaped today. */
+const FIELD_TARGETS: Record<AdvancedField, SpineTarget> = {
+  identity: "file",
+  payload: "columns",
+  keys: "columns",
+  standardization: "columns",
+  lifetime: "review",
+  legalReference: "review",
+  legalPurpose: "review",
+  legalExpiration: "review",
+};
+
+/** One entry in the rail's Problems block: the message and the section that
+ * can resolve it. */
+export interface SpineProblem {
+  message: string;
+  target: SpineTarget;
+}
+
+/** Validate the draft for the create gate -- the Advanced editor's own
+ * validation over the bench's session. */
+export function reviewValidation(
+  editor: InviterEditor,
+  now: Date = new Date(),
+): AdvancedValidation {
+  return validateAdvancedInvite(editor.draft, editor.seed, now);
+}
+
+/**
+ * The rail's Problems block as an error summary: the single-identifier
+ * conflict (which only inference can seed) plus every validation error, each
+ * pointing at the section that owns the fix. Empty when the draft can mint.
+ */
+export function spineProblems(
+  editor: InviterEditor | undefined,
+  now: Date = new Date(),
+): Array<SpineProblem> {
+  if (editor === undefined) return [];
+  const problems: Array<SpineProblem> = [];
+  if (hasMultipleIdentifiers(editor.draft.metadata))
+    problems.push({
+      message: "Choose a single row identifier",
+      target: "columns",
+    });
+  const { errors } = reviewValidation(editor, now);
+  for (const [field, message] of Object.entries(errors)) {
+    problems.push({ message, target: FIELD_TARGETS[field as AdvancedField] });
+  }
+  return problems;
+}
+
+/** One check-your-answers row: the term, its display value, and either the
+ * section its Change link navigates to or the "set above" mark for the terms
+ * owned by step 3 itself. */
+export interface AnswersRow {
+  label: string;
+  value: string;
+  mono?: boolean;
+  changeTarget?: SpineTarget;
+  setAbove?: boolean;
+}
+
+/** The check-your-answers table: the full proposal restated before the point
+ * of no return. Cleaning, key, and agreement rows carry no Change link until
+ * their Customize tabs exist. */
+export function answersRows(
+  editor: InviterEditor,
+  csv: AcquiredCsv,
+): Array<AnswersRow> {
+  const sent = disclosedColumnNames(editor.draft.metadata);
+  return [
+    {
+      label: "Your name",
+      value: editor.draft.identity,
+      changeTarget: "file",
+    },
+    {
+      label: "Your file",
+      value: `${csv.fileName} - ${new Intl.NumberFormat("en-US").format(csv.rawRows.length)} rows`,
+      mono: true,
+      changeTarget: "file",
+    },
+    {
+      label: "Columns shared",
+      value: sent.length > 0 ? sent.join(", ") : "None",
+      mono: sent.length > 0,
+      changeTarget: "columns",
+    },
+    {
+      label: "Cleaning",
+      value: `${inviterRailFacts(editor)[0].fact ?? ""}, filled in from your file`,
+    },
+    {
+      label: "Matching keys",
+      value: `${inviterRailFacts(editor)[1].fact ?? ""}, recommended order`,
+    },
+    {
+      label: "Legal agreement",
+      value: editor.draft.legalAgreement?.reference ?? "None",
+      mono: editor.draft.legalAgreement?.reference !== undefined,
+    },
+    {
+      label: "Invitation lifetime",
+      value: lifetimeNoun(editor.draft.lifetimeSeconds),
+      setAbove: true,
+    },
+    {
+      label: "Results go to",
+      value: RESULTS_DIRECTION_LABELS[editor.draft.outputDirection],
+      setAbove: true,
+    },
+    {
+      label: "Transport",
+      value: "Live, in this browser",
+      setAbove: true,
     },
   ];
 }

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -256,7 +256,7 @@ describe("inviter bench", () => {
     await userEvent.upload(
       page.elementLocator(fileInput as HTMLElement),
       new File(
-        ["id,identifier,last_name,dob\n1,2,Lee,01/02/1990\n"],
+        ["id,identifier,first_name,last_name,dob\n1,2,Ann,Lee,01/02/1990\n"],
         "twoids.csv",
         { type: "text/csv" },
       ),
@@ -279,6 +279,98 @@ describe("inviter bench", () => {
       .element(page.getByLabelText("How identifier is used"))
       .toHaveValue("ignored");
     expect(document.querySelector('section[aria-label="Problems"]')).toBeNull();
+  });
+
+  test("review restates the proposal, gates on problems, and create seals", async () => {
+    mount(createElement(InviterBench));
+
+    await expect.element(page.getByLabelText("Your name")).toBeInTheDocument();
+    await userEvent.fill(page.getByLabelText("Your name"), "Dana Okafor");
+    const fileInput = document.querySelector('input[type="file"]');
+    await userEvent.upload(
+      page.elementLocator(fileInput as HTMLElement),
+      new File(
+        [
+          "client_id,first_name,last_name,dob,program_code\n" +
+            "1,Ann,Lee,01/02/1990,A\n2,Bo,Ray,03/04/1985,B\n",
+        ],
+        "clients.csv",
+        { type: "text/csv" },
+      ),
+    );
+    await expect.element(page.getByText("clients.csv")).toBeInTheDocument();
+    await page
+      .getByRole("button", { name: "Continue to matching & sharing" })
+      .click();
+    await page
+      .getByRole("button", { name: "Continue to review & create" })
+      .click();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Review & create");
+
+    // The check-your-answers table restates the proposal, and the CLI
+    // transports are present but disabled with the roadmap tag.
+    await expect
+      .element(page.getByText("clients.csv - 2 rows"))
+      .toBeInTheDocument();
+    const radios = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="radio"]'),
+    );
+    expect(radios).toHaveLength(3);
+    expect(radios[0].checked).toBe(true);
+    expect(radios[0].disabled).toBe(false);
+    expect(radios[1].disabled).toBe(true);
+    expect(radios[2].disabled).toBe(true);
+    expect(document.querySelectorAll(`.${styles.tagRoadmap}`)).toHaveLength(2);
+
+    // An incoherent direction (payload to a partner receiving no results)
+    // surfaces in the rail and refuses to arm the create button.
+    await page
+      .getByLabelText("Who receives the matched results")
+      .selectOptions("inviter");
+    await expect
+      .element(page.getByText("Resolve the problem in the rail to continue."))
+      .toBeInTheDocument();
+    expect(
+      document.querySelector('section[aria-label="Problems"]'),
+    ).not.toBeNull();
+    const createButton = page.getByRole("button", {
+      name: "Create the invitation",
+    });
+    await expect.element(createButton).toBeDisabled();
+
+    await page
+      .getByLabelText("Who receives the matched results")
+      .selectOptions("both");
+    await expect
+      .element(page.getByText("Ready to create."))
+      .toBeInTheDocument();
+
+    // Create mints the real invitation and seals the terms: the rail becomes
+    // the protocol timeline (no step links back into editing) and the
+    // ledger's expiry turns absolute.
+    await createButton.click();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Your invitation is ready");
+
+    const rail = document.querySelector('nav[aria-label="Exchange progress"]');
+    expect(rail).not.toBeNull();
+    const current = (rail as Element).querySelector('[aria-current="step"]');
+    expect(current?.textContent).toBe("Share");
+    expect((rail as Element).querySelectorAll("button")).toHaveLength(0);
+
+    const ledger = document.querySelector('aside[aria-label="This exchange"]');
+    const expiresRow = Array.from(
+      (ledger as Element).querySelectorAll(`.${styles.ledgerRow}`),
+    ).find(
+      (row) => row.querySelector("dt")?.childNodes[0].textContent === "Expires",
+    );
+    expect(expiresRow?.querySelector("dd")?.textContent).not.toBe(
+      "1 hour after you share",
+    );
+    expect(expiresRow?.querySelector("dd")?.textContent).toMatch(/20\d\d/);
   });
 
   test("collapses to the single-column layout without rail and ledger", async () => {

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -11,6 +11,7 @@ import { MantineProvider } from "@mantine/core";
 
 import { AcceptUnderConstruction } from "@bench/placeholders";
 import { BenchLobby } from "@bench/BenchLobby";
+import { InvitationFileError } from "@psi/invitation";
 import { InviterBench } from "@bench/InviterBench";
 import styles from "@bench/bench.module.css";
 
@@ -39,6 +40,27 @@ vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => () => undefined,
 }));
 
+// Swap the mint per-test to drive the create action's failure paths, which a
+// real (validated-before-arming) mint cannot reach deterministically. With
+// `fail` unset it delegates to the real generateInvitation, so the happy-path
+// create below runs against the real mint boundary (the csvLoad pattern from
+// fileAcquire.test.ts).
+const mintHarness = vi.hoisted(() => ({
+  fail: undefined as Error | undefined,
+}));
+vi.mock("@psi/invitation", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    generateInvitation: (params: unknown) =>
+      mintHarness.fail !== undefined
+        ? Promise.reject(mintHarness.fail)
+        : (actual.generateInvitation as (p: unknown) => Promise<unknown>)(
+            params,
+          ),
+  };
+});
+
 const EM_DASH = "\u2014";
 
 let container: HTMLElement | undefined;
@@ -56,6 +78,7 @@ afterEach(() => {
   container?.remove();
   root = undefined;
   container = undefined;
+  mintHarness.fail = undefined;
 });
 
 describe("bench lobby", () => {
@@ -371,6 +394,64 @@ describe("inviter bench", () => {
       "1 hour after you share",
     );
     expect(expiresRow?.querySelector("dd")?.textContent).toMatch(/20\d\d/);
+  });
+
+  test("a failed mint leaves the terms editable and create retryable", async () => {
+    mount(createElement(InviterBench));
+
+    await expect.element(page.getByLabelText("Your name")).toBeInTheDocument();
+    await userEvent.fill(page.getByLabelText("Your name"), "Dana");
+    const fileInput = document.querySelector('input[type="file"]');
+    await userEvent.upload(
+      page.elementLocator(fileInput as HTMLElement),
+      new File(
+        ["first_name,last_name,dob\nAnn,Lee,01/02/1990\n"],
+        "clients.csv",
+        { type: "text/csv" },
+      ),
+    );
+    await expect.element(page.getByText("clients.csv")).toBeInTheDocument();
+    await page
+      .getByRole("button", { name: "Continue to matching & sharing" })
+      .click();
+    await page
+      .getByRole("button", { name: "Continue to review & create" })
+      .click();
+
+    // An internal mint failure shows the fixed message (no internals echoed
+    // into a secret-bearing flow) and seals nothing: the spine rail survives,
+    // so every term is still editable.
+    mintHarness.fail = new Error("internal mint failure");
+    const createButton = page.getByRole("button", {
+      name: "Create the invitation",
+    });
+    await createButton.click();
+    await expect
+      .element(page.getByText("Could not create the invitation"))
+      .toBeInTheDocument();
+    expect(
+      document.querySelector('nav[aria-label="Exchange setup"]'),
+    ).not.toBeNull();
+    expect(
+      document.querySelector('nav[aria-label="Exchange progress"]'),
+    ).toBeNull();
+
+    // A mint-time file error surfaces the shared user-actionable alert.
+    mintHarness.fail = new InvitationFileError({
+      kind: "unreadable",
+      cause: new Error("gone"),
+    });
+    await createButton.click();
+    await expect
+      .element(page.getByText("Could not read your file"))
+      .toBeInTheDocument();
+
+    // Clearing the failure retries cleanly: the terms were never sealed.
+    mintHarness.fail = undefined;
+    await createButton.click();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Your invitation is ready");
   });
 
   test("collapses to the single-column layout without rail and ledger", async () => {

--- a/apps/web/test/unit/benchInviterModel.test.ts
+++ b/apps/web/test/unit/benchInviterModel.test.ts
@@ -1,16 +1,23 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  answersRows,
   editorFromCsv,
   editorWithColumnDisclosure,
   editorWithColumnType,
   editorWithIdentity,
+  editorWithLifetime,
+  editorWithOutputDirection,
   enabledKeys,
   fileCardMeta,
   identifierProblem,
   inviterLedgerRows,
   inviterRailFacts,
   lifetimeLabel,
+  resetToRecommended,
+  reviewValidation,
+  sealEditor,
+  spineProblems,
 } from "@bench/inviterModel";
 
 import type { AcquiredCsv } from "@bench/inviterModel";
@@ -164,5 +171,85 @@ describe("display helpers", () => {
       "12,408 rows - 8.4 MB",
     );
     expect(fileCardMeta(3, 2048)).toBe("3 rows - 2 KB");
+  });
+});
+
+describe("review and create", () => {
+  test("a fresh seed has no problems and can mint", () => {
+    const editor = editorFromCsv("Dana", csv);
+    expect(spineProblems(editor)).toEqual([]);
+    const validation = reviewValidation(editor);
+    expect(validation.canGenerate).toBe(true);
+    expect(validation.terms).toBeDefined();
+  });
+
+  test("an invalid term surfaces a problem that targets its source", () => {
+    const seeded = editorFromCsv("Dana", csv);
+    // Sending a column to a partner that receives no results is the
+    // incoherent pair validateAdvancedInvite refuses; the column table owns
+    // the disclosed set, so the problem points at step 2.
+    const editor = editorWithOutputDirection(seeded, "inviter");
+    const problems = spineProblems(editor);
+    expect(problems.length).toBeGreaterThan(0);
+    expect(problems[0].target).toBe("columns");
+    expect(reviewValidation(editor).canGenerate).toBe(false);
+
+    const resolved = editorWithOutputDirection(editor, "both");
+    expect(spineProblems(resolved)).toEqual([]);
+  });
+
+  test("the two-identifier conflict is a problem targeting step 2", () => {
+    const twoIds: AcquiredCsv = {
+      ...csv,
+      columns: ["id", "identifier", "last_name", "dob"],
+      rawRows: [{ id: "1", identifier: "2", last_name: "Lee", dob: "x" }],
+    };
+    const problems = spineProblems(editorFromCsv("Dana", twoIds));
+    expect(
+      problems.some(
+        (problem) =>
+          problem.message === "Choose a single row identifier" &&
+          problem.target === "columns",
+      ),
+    ).toBe(true);
+  });
+
+  test("terms are immutable after create seals the session", () => {
+    const sealedEditor = sealEditor(editorFromCsv("Dana", csv));
+    expect(
+      editorWithColumnDisclosure(sealedEditor, csv, "program_code", "ignored")
+        .editor,
+    ).toBe(sealedEditor);
+    expect(editorWithColumnType(sealedEditor, csv, "dob", "other").editor).toBe(
+      sealedEditor,
+    );
+    expect(editorWithIdentity(sealedEditor, "Other")).toBe(sealedEditor);
+    expect(editorWithLifetime(sealedEditor, 86400)).toBe(sealedEditor);
+    expect(editorWithOutputDirection(sealedEditor, "inviter")).toBe(
+      sealedEditor,
+    );
+    expect(resetToRecommended(sealedEditor, csv)).toBe(sealedEditor);
+  });
+
+  test("check-your-answers restates the proposal with change targets", () => {
+    const editor = editorWithLifetime(editorFromCsv("Dana Okafor", csv), 86400);
+    const rows = answersRows(editor, csv);
+    const byLabel = new Map(rows.map((row) => [row.label, row]));
+    expect(byLabel.get("Your name")?.value).toBe("Dana Okafor");
+    expect(byLabel.get("Your name")?.changeTarget).toBe("file");
+    expect(byLabel.get("Your file")?.value).toBe("clients.csv - 1 rows");
+    expect(byLabel.get("Columns shared")?.value).toBe("program_code");
+    expect(byLabel.get("Columns shared")?.changeTarget).toBe("columns");
+    expect(byLabel.get("Invitation lifetime")?.value).toBe("1 day");
+    expect(byLabel.get("Invitation lifetime")?.setAbove).toBe(true);
+    expect(byLabel.get("Results go to")?.value).toBe("You and your partner");
+    expect(byLabel.get("Transport")?.value).toBe("Live, in this browser");
+  });
+
+  test("a minted expiry replaces the relative lifetime in the ledger", () => {
+    const editor = editorFromCsv("Dana", csv);
+    const rows = inviterLedgerRows(editor, "2026-07-08T19:32:00.000Z");
+    const expires = rows.find((row) => row.label === "Expires");
+    expect(expires?.value).toContain("July 8, 2026");
   });
 });

--- a/apps/web/test/unit/benchInviterModel.test.ts
+++ b/apps/web/test/unit/benchInviterModel.test.ts
@@ -240,6 +240,12 @@ describe("review and create", () => {
     expect(byLabel.get("Your file")?.value).toBe("clients.csv - 1 rows");
     expect(byLabel.get("Columns shared")?.value).toBe("program_code");
     expect(byLabel.get("Columns shared")?.changeTarget).toBe("columns");
+    expect(byLabel.get("Cleaning")?.value).toMatch(
+      /^\d+ fields?, filled in from your file$/,
+    );
+    expect(byLabel.get("Matching keys")?.value).toMatch(
+      /^\d+ keys?, recommended order$/,
+    );
     expect(byLabel.get("Invitation lifetime")?.value).toBe("1 day");
     expect(byLabel.get("Invitation lifetime")?.setAbove).toBe(true);
     expect(byLabel.get("Results go to")?.value).toBe("You and your partner");


### PR DESCRIPTION
## Summary

The inviter spine is complete: Review & create restates the whole proposal in a check-your-answers table with Change links, holds the review-time decisions (invitation lifetime with a live absolute-expiry hint, results direction), renders the three-transport chooser with the roadmap-honesty pattern, and arms the create action only when the rail's Problems block - now a real error summary driven by the Advanced editor's own validation - is empty. Create mints the invitation through the existing fail-closed boundary and seals the terms: every model mutator refuses a sealed session, the rail becomes the protocol timeline, and the ledger's expiry turns absolute. The share surface itself is the next epic item and the post-create screen says so.

Implements [211235786](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=211235786).

## Changes

- apps/web/src/bench/ReviewCreateSection.tsx: the step-3 surface - lifetime and results-direction selects, the transport radio cards (live-in-browser selected; SFTP and shared-directory present but disabled with the "On the roadmap" tag and the capability rule spelled out: browsers run live exchanges only, the CLI runs SFTP/filedrop), the check-your-answers table, and the create/reset footer with the ok/danger status line.
- apps/web/src/bench/inviterModel.ts: sealed sessions (every mutator returns a sealed session unchanged), lifetime/direction/reset mutators, `spineProblems` (the single-identifier conflict plus every validation error, each targeting the section that owns the fix), `answersRows`, `LIFETIME_CHOICES` up to the bounded one-year maximum, and shared fact/date helpers so the answers rows, rail facts, and expiry displays cannot drift apart.
- apps/web/src/bench/InviterBench.tsx: retains the source `File` so create re-parses through `generateInvitation` - the same mint boundary the current app uses, so the embedded terms and its internal satisfiability/payload backstops bind to one read; on success seals, stores the invitation, and swaps the rail to the timeline. The mint's error handling applies the InvitePanel rule: shared user-actionable alerts for an `InvitationFileError`, type-only logging with detail under diagnostic mode for anything internal.
- apps/web/src/bench/bench.module.css: radio cards, roadmap tag, answers-table styling, danger status line.
- Tests: unit (22 total) pin the acceptance criteria - an invalid term surfaces a Problems entry that navigates to its source, and terms are immutable after create - plus answers-row content and the ledger's absolute expiry; the browser suite drives review, problem gating, and the sealed post-create state end to end in Chromium against a real mint.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run formatcheck`, `npm run test:unit -w apps/web` (617 passed), `npm run test:browser -w apps/web` (343 passed), `npm run build -w apps/web`.
New tests cover: the two named acceptance criteria (problem-navigates-to-source, immutability after create), a fresh seed minting cleanly, the two-identifier problem targeting step 2, check-your-answers content including the shared cleaning/key summaries, and the browser flow through gating, create, and the sealed timeline rail.

## Background

Minting adds a new caller of `generateInvitation`'s documented authored-terms path; the boundary's own fail-closed checks (satisfiability re-check, `assertPayloadSendDisclosed`) run unchanged inside it, and no token-generation or disclosure code is modified. A light-review round (3 reviewers, 4 confirmed findings, 0 simpler-shape votes) drove fixes for all four: restored mint diagnostics per the InvitePanel rule, label-safe answers rows, a dedicated absolute-date helper, and the identifier predicate deduplicated.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed; the bench remains a parallel preview and the docs rewrite is scheduled with the cutover item
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: preview routes on the continuously deployed web app; no operator- or reviewer-actionable change
- [x] Security review -- n/a: no enumerated surface modified; create calls the existing mint boundary through its documented contract with its internal fail-closed checks unchanged, and nothing new is sent, stored, or logged (internal mint errors log type-only, detail gated behind diagnostic mode)
