### PR TITLE
Require a test for review fixes that add behavior

### DIFF
--- a/.claude/commands/assess-review.md
+++ b/.claude/commands/assess-review.md
@@ -56,6 +56,10 @@ hunks/files it names, not the whole diff), then decide.
 
 - **Default to fixing.** Drive-by corrections are welcome -- you do not need
   permission to fix something small and clearly right.
+- **A fix that adds behavior gets a test.** When a fix introduces new branching
+  or a new code path (error handling, a guard, a fallback), pin its guarantees
+  with a test in the same pass. No later round re-reviews a fix: another round
+  exists only for the step-back triggers.
 - **Prose findings get a high bar.** Fix a finding that asks for a comment,
   JSDoc, or doc paragraph only when the missing constraint is unrecoverable
   from the code, names, types, and tests AND its absence enables a concrete


### PR DESCRIPTION
## Summary

Add one triage rule to the assess-review skill: a review fix that introduces new branching or a new code path pins its guarantees with a test in the same pass. Review rounds verify trajectory, not fixes, so a fix's correctness is never left to a later round's prose.

## Changes

- .claude/commands/assess-review.md: new bullet in Step 3's triage list, between the default-to-fixing and prose-findings rules.

## Test plan

Ran: `npm run lint`, `npm run formatcheck`, `npm run linkcheck`.
New tests cover: n/a - contributor-process text only.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: agent skill text, not product documentation
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: process text only, nothing operator- or reviewer-visible
- [x] Security review -- n/a: no code touched
