### PR TITLE
Add Customize tabs: cleaning, keys, agreement

### DIFF
--- a/apps/web/src/bench/AgreementTab.tsx
+++ b/apps/web/src/bench/AgreementTab.tsx
@@ -1,4 +1,8 @@
+import { useEffect, useRef } from "react";
+
 import { Alert, Checkbox, TextInput } from "@mantine/core";
+
+import { MAX_NAME_LENGTH, MAX_TEXT_LENGTH } from "@psilink/core";
 
 import styles from "./bench.module.css";
 
@@ -31,8 +35,23 @@ export function AgreementTab({
   onBack: () => void;
 }) {
   const agreement = editor.draft.legalAgreement;
-  const set = (patch: Partial<DraftLegalAgreement>) =>
-    onAgreement({ ...(agreement ?? EMPTY_AGREEMENT), ...patch });
+  // No-op when the block is detached (the fields unmount with it), so a
+  // batched field patch can never silently re-attach an emptied agreement.
+  const set = (patch: Partial<DraftLegalAgreement>) => {
+    if (agreement === undefined) return;
+    onAgreement({ ...agreement, ...patch });
+  };
+
+  // Checking "Attach" reveals the three fields below the checkbox; send a
+  // keyboard user into the first one rather than leaving them on the checkbox
+  // with no cue the block opened.
+  const referenceRef = useRef<HTMLInputElement>(null);
+  const wasAttached = useRef(agreement !== undefined);
+  useEffect(() => {
+    if (!wasAttached.current && agreement !== undefined)
+      referenceRef.current?.focus();
+    wasAttached.current = agreement !== undefined;
+  }, [agreement]);
   return (
     <>
       <button type="button" className={styles.backlink} onClick={onBack}>
@@ -57,10 +76,13 @@ export function AgreementTab({
             wording from your signed agreement.
           </Alert>
           <TextInput
+            ref={referenceRef}
             label="Agreement reference"
             placeholder="MOU-2025-0042"
             value={agreement.reference}
+            maxLength={MAX_NAME_LENGTH}
             error={validation.errors.legalReference}
+            errorProps={{ role: "alert" }}
             onChange={(event) => set({ reference: event.currentTarget.value })}
             mt="md"
           />
@@ -68,15 +90,19 @@ export function AgreementTab({
             label="Purpose of the disclosure"
             placeholder="Program evaluation"
             value={agreement.purpose}
+            maxLength={MAX_TEXT_LENGTH}
             error={validation.errors.legalPurpose}
+            errorProps={{ role: "alert" }}
             onChange={(event) => set({ purpose: event.currentTarget.value })}
             mt="md"
           />
           <TextInput
+            type="date"
             label="Expiration date"
             placeholder="YYYY-MM-DD"
             value={agreement.expirationDate}
             error={validation.errors.legalExpiration}
+            errorProps={{ role: "alert" }}
             onChange={(event) =>
               set({ expirationDate: event.currentTarget.value })
             }

--- a/apps/web/src/bench/AgreementTab.tsx
+++ b/apps/web/src/bench/AgreementTab.tsx
@@ -1,0 +1,90 @@
+import { Alert, Checkbox, TextInput } from "@mantine/core";
+
+import styles from "./bench.module.css";
+
+import type {
+  AdvancedValidation,
+  DraftLegalAgreement,
+} from "@psi/advancedInvite";
+import type { InviterEditor } from "./inviterModel";
+
+const EMPTY_AGREEMENT: DraftLegalAgreement = {
+  reference: "",
+  purpose: "",
+  expirationDate: "",
+};
+
+/**
+ * The Legal agreement tab: attach or detach the optional agreement block and
+ * author the three values the partner must enter identically at accept time.
+ * Validation errors surface inline on the owning field.
+ */
+export function AgreementTab({
+  editor,
+  validation,
+  onAgreement,
+  onBack,
+}: {
+  editor: InviterEditor;
+  validation: AdvancedValidation;
+  onAgreement: (agreement: DraftLegalAgreement | undefined) => void;
+  onBack: () => void;
+}) {
+  const agreement = editor.draft.legalAgreement;
+  const set = (patch: Partial<DraftLegalAgreement>) =>
+    onAgreement({ ...(agreement ?? EMPTY_AGREEMENT), ...patch });
+  return (
+    <>
+      <button type="button" className={styles.backlink} onClick={onBack}>
+        {"\u2190"} Back to Review &amp; create
+      </button>
+      <p className={styles.eyebrow}>Customize</p>
+      <h1 tabIndex={-1}>Legal agreement</h1>
+      <Checkbox
+        label="Attach a legal agreement"
+        description="Reference, purpose, and expiry your partner must enter identically."
+        checked={agreement !== undefined}
+        onChange={(event) =>
+          onAgreement(event.currentTarget.checked ? EMPTY_AGREEMENT : undefined)
+        }
+        mt="sm"
+      />
+      {agreement !== undefined && (
+        <>
+          <Alert variant="light" mt="md">
+            Your partner must enter these three values exactly as written here
+            before they can accept. A mismatch stops the exchange - use the
+            wording from your signed agreement.
+          </Alert>
+          <TextInput
+            label="Agreement reference"
+            placeholder="MOU-2025-0042"
+            value={agreement.reference}
+            error={validation.errors.legalReference}
+            onChange={(event) => set({ reference: event.currentTarget.value })}
+            mt="md"
+          />
+          <TextInput
+            label="Purpose of the disclosure"
+            placeholder="Program evaluation"
+            value={agreement.purpose}
+            error={validation.errors.legalPurpose}
+            onChange={(event) => set({ purpose: event.currentTarget.value })}
+            mt="md"
+          />
+          <TextInput
+            label="Expiration date"
+            placeholder="YYYY-MM-DD"
+            value={agreement.expirationDate}
+            error={validation.errors.legalExpiration}
+            onChange={(event) =>
+              set({ expirationDate: event.currentTarget.value })
+            }
+            mt="md"
+            maw={220}
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/bench/CleaningTab.tsx
+++ b/apps/web/src/bench/CleaningTab.tsx
@@ -1,5 +1,8 @@
 import { useMemo } from "react";
 
+import { VisuallyHidden } from "@mantine/core";
+
+import { SEMANTIC_TYPE_LABELS } from "@psi/metadataEditing";
 import { isSilentEmpty } from "@psi/nonEmptyAggregate";
 
 import { CleaningErrorBoundary } from "@components/CleaningErrorBoundary";
@@ -28,6 +31,7 @@ export function CleaningTab({
   onFieldAdded,
   onFieldRemoved,
   onResetCleaning,
+  cleaningError,
   onBack,
 }: {
   editor: InviterEditor;
@@ -38,6 +42,9 @@ export function CleaningTab({
   onFieldAdded: (type: LinkageField["type"]) => void;
   onFieldRemoved: (output: string) => void;
   onResetCleaning: () => void;
+  /** The validation message for the cleaning, rendered inline (the rail's
+   * Problems block carries it too). */
+  cleaningError: string | undefined;
   onBack: () => void;
 }) {
   const declaredFields = useMemo(
@@ -51,6 +58,33 @@ export function CleaningTab({
   const resetKey = editor.draft.standardization
     .map((transformation) => `${transformation.output}=${transformation.input}`)
     .join(",");
+
+  // The per-card coverage alarm is presentational by contract (FieldCoverage
+  // announces nothing itself); this region makes the one editor-wide
+  // announcement it defers to. Safe type labels, never the partner-controlled
+  // field names.
+  const fieldTypeByName = useMemo(
+    () => new Map(declaredFields.map((field) => [field.name, field.type])),
+    [declaredFields],
+  );
+  const silentEmptyLabels = useMemo(() => {
+    if (rates === null) return [];
+    const labels = new Set<string>();
+    for (const transformation of editor.draft.standardization) {
+      const rate = rates.get(transformation.output);
+      if (rate !== undefined && isSilentEmpty(rate)) {
+        const type = fieldTypeByName.get(transformation.output);
+        if (type !== undefined) labels.add(SEMANTIC_TYPE_LABELS[type]);
+      }
+    }
+    return [...labels];
+  }, [rates, editor.draft.standardization, fieldTypeByName]);
+  const coverageAnnouncement =
+    silentEmptyLabels.length === 0
+      ? ""
+      : `Coverage warning: ${silentEmptyLabels.join(", ")} ${
+          silentEmptyLabels.length === 1 ? "produces" : "produce"
+        } no value for any row and cannot match. Check the cleaning steps.`;
   return (
     <>
       <button type="button" className={styles.backlink} onClick={onBack}>
@@ -63,6 +97,19 @@ export function CleaningTab({
         spacing, case, accents, date styles - do not hide a match. These steps
         came from your file; change them only if you know your data needs it.
       </p>
+      {cleaningError !== undefined && (
+        <p
+          role="alert"
+          className={`${styles.small} ${styles.statusLine} ${styles.statusLineDanger}`}
+        >
+          {cleaningError}
+        </p>
+      )}
+      <VisuallyHidden>
+        <p role="status" aria-live="polite" aria-atomic="true">
+          {coverageAnnouncement}
+        </p>
+      </VisuallyHidden>
       <CleaningErrorBoundary onReset={onResetCleaning} resetKey={resetKey}>
         <StandardizationCards
           standardization={editor.draft.standardization}

--- a/apps/web/src/bench/CleaningTab.tsx
+++ b/apps/web/src/bench/CleaningTab.tsx
@@ -1,0 +1,91 @@
+import { useMemo } from "react";
+
+import { isSilentEmpty } from "@psi/nonEmptyAggregate";
+
+import { CleaningErrorBoundary } from "@components/CleaningErrorBoundary";
+import { FieldCoverage } from "@components/FieldCoverage";
+import { StandardizationCards } from "@components/StandardizationCards";
+import { useNonEmptyRates } from "@components/useNonEmptyRates";
+
+import { declaredFieldsFor } from "./inviterModel";
+import styles from "./bench.module.css";
+
+import type { AcquiredCsv, InviterEditor } from "./inviterModel";
+import type { LinkageField, StandardizationStep } from "@psilink/core";
+
+/**
+ * The Cleaning tab: per-field pipelines with previews and whole-file coverage,
+ * mounted from the shared standardization workbench over the bench's draft.
+ * Add/remove same-typed fields is the expert affordance, gated with the keys
+ * tab's expert switch.
+ */
+export function CleaningTab({
+  editor,
+  csv,
+  expertMode,
+  onFieldSteps,
+  onFieldInput,
+  onFieldAdded,
+  onFieldRemoved,
+  onResetCleaning,
+  onBack,
+}: {
+  editor: InviterEditor;
+  csv: AcquiredCsv;
+  expertMode: boolean;
+  onFieldSteps: (output: string, steps: Array<StandardizationStep>) => void;
+  onFieldInput: (output: string, input: string) => void;
+  onFieldAdded: (type: LinkageField["type"]) => void;
+  onFieldRemoved: (output: string) => void;
+  onResetCleaning: () => void;
+  onBack: () => void;
+}) {
+  const declaredFields = useMemo(
+    () => declaredFieldsFor(editor.draft),
+    [editor.draft],
+  );
+  const { rates, pending } = useNonEmptyRates(
+    csv.rawRows,
+    editor.draft.standardization,
+  );
+  const resetKey = editor.draft.standardization
+    .map((transformation) => `${transformation.output}=${transformation.input}`)
+    .join(",");
+  return (
+    <>
+      <button type="button" className={styles.backlink} onClick={onBack}>
+        {"\u2190"} Back to Review &amp; create
+      </button>
+      <p className={styles.eyebrow}>Customize</p>
+      <h1 tabIndex={-1}>Cleaning</h1>
+      <p>
+        Each field below is cleaned before matching so small differences -
+        spacing, case, accents, date styles - do not hide a match. These steps
+        came from your file; change them only if you know your data needs it.
+      </p>
+      <CleaningErrorBoundary onReset={onResetCleaning} resetKey={resetKey}>
+        <StandardizationCards
+          standardization={editor.draft.standardization}
+          declaredFields={declaredFields}
+          metadata={editor.draft.metadata}
+          rawRows={csv.rawRows}
+          onStepsChange={(output, _input, steps) => onFieldSteps(output, steps)}
+          onInputColumnChange={onFieldInput}
+          onAddField={expertMode ? onFieldAdded : undefined}
+          onRemoveField={expertMode ? onFieldRemoved : undefined}
+          renderCoverage={(output) => (
+            <FieldCoverage
+              rate={rates?.get(output)}
+              pending={rates !== null && pending}
+            />
+          )}
+          isFieldSilentEmpty={(output) => {
+            const rate = rates?.get(output);
+            return rate !== undefined && isSilentEmpty(rate);
+          }}
+          onMissingField="skip"
+        />
+      </CleaningErrorBoundary>
+    </>
+  );
+}

--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -17,9 +17,11 @@ import { unlinkableFileAlert } from "@components/UnlinkableFileAlert";
 import { Rail, RailFacts, RailGroup, RailProblems, RailSteps } from "./Rail";
 import {
   editorFromCsv,
+  editorWithAlgorithm,
   editorWithAuthoredDraft,
   editorWithColumnDisclosure,
   editorWithColumnType,
+  editorWithDeduplicate,
   editorWithFieldAdded,
   editorWithFieldInput,
   editorWithFieldRemoved,
@@ -451,6 +453,12 @@ export function InviterBench() {
               }
               onStrategy={(strategy) =>
                 setEditor(editorWithLinkageStrategy(editor, strategy))
+              }
+              onAlgorithm={(algorithm) =>
+                setEditor(editorWithAlgorithm(editor, algorithm))
+              }
+              onDeduplicate={(deduplicate) =>
+                setEditor(editorWithDeduplicate(editor, deduplicate))
               }
               onImport={(terms) => {
                 setEditor(editorWithImportedTerms(editor, acquired, terms));

--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 
 import { Alert, Anchor, VisuallyHidden } from "@mantine/core";
+import { IconAlertCircle } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
 
 import { sanitizeErrorForDisplay, sanitizeForDisplay } from "@psilink/core";
@@ -116,11 +117,14 @@ export function InviterBench() {
 
   // A parse may still be in flight when the surface unmounts or a newer file
   // is dropped; the id lets the stale resolution fall on the floor instead of
-  // clobbering current state (the FileAcquire pattern).
+  // clobbering current state, and the abort tears the parse worker down so a
+  // discarded read does not run to completion (the FileAcquire pattern).
   const parseId = useRef(0);
+  const parseAbort = useRef<AbortController | undefined>(undefined);
   useEffect(
     () => () => {
       parseId.current += 1;
+      parseAbort.current?.abort();
     },
     [],
   );
@@ -138,10 +142,15 @@ export function InviterBench() {
 
   async function readFile(file: File) {
     const id = ++parseId.current;
+    parseAbort.current?.abort();
+    const controller = new AbortController();
+    parseAbort.current = controller;
     setReading(true);
     setIntakeAlert(undefined);
     try {
-      const result = await loadCSVFileOffMainThread(file);
+      const result = await loadCSVFileOffMainThread(file, {
+        signal: controller.signal,
+      });
       if (id !== parseId.current) return;
       const columns = result.meta.fields ?? [];
       const emptyPositions = emptyColumnPositions(columns);
@@ -197,6 +206,10 @@ export function InviterBench() {
   // bind to one read of the file.
   async function createInvitation() {
     if (editor === undefined || sourceFile === undefined) return;
+    // The Create button is disabled on any open problem; this repeats the gate
+    // because spineProblems covers the identifier conflict, which
+    // canGenerate alone does not.
+    if (spineProblems(editor).length > 0) return;
     const validation = reviewValidation(editor);
     if (!validation.canGenerate || validation.terms === undefined) return;
     setMinting(true);
@@ -407,8 +420,15 @@ export function InviterBench() {
                 onNavigate={goTo}
               />
               {createAlert !== undefined && (
-                <Alert color="red" title={createAlert.title} mt="md">
-                  {createAlert.message}
+                <Alert
+                  color="red"
+                  title={createAlert.title}
+                  icon={<IconAlertCircle />}
+                  mt="md"
+                >
+                  <span style={{ whiteSpace: "pre-line" }}>
+                    {createAlert.message}
+                  </span>
                 </Alert>
               )}
             </>

--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -1,9 +1,9 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 
-import { Alert, Anchor } from "@mantine/core";
+import { Alert, Anchor, VisuallyHidden } from "@mantine/core";
 import { Link } from "@tanstack/react-router";
 
-import { sanitizeErrorForDisplay } from "@psilink/core";
+import { sanitizeErrorForDisplay, sanitizeForDisplay } from "@psilink/core";
 
 import { InvitationFileError, generateInvitation } from "@psi/invitation";
 import { emptyColumnPositions, unnameableColumnsAlert } from "@psi/columnNames";
@@ -17,11 +17,22 @@ import { unlinkableFileAlert } from "@components/UnlinkableFileAlert";
 import { Rail, RailFacts, RailGroup, RailProblems, RailSteps } from "./Rail";
 import {
   editorFromCsv,
+  editorWithAuthoredDraft,
   editorWithColumnDisclosure,
   editorWithColumnType,
+  editorWithFieldAdded,
+  editorWithFieldInput,
+  editorWithFieldRemoved,
+  editorWithFieldSteps,
   editorWithIdentity,
+  editorWithImportedTerms,
+  editorWithKeyEnabled,
+  editorWithKeyMoved,
+  editorWithLegalAgreement,
   editorWithLifetime,
+  editorWithLinkageStrategy,
   editorWithOutputDirection,
+  editorWithRecommendedCleaning,
   inviterLedgerRows,
   inviterRailFacts,
   resetToRecommended,
@@ -29,32 +40,36 @@ import {
   sealEditor,
   spineProblems,
 } from "./inviterModel";
+import { AgreementTab } from "./AgreementTab";
 import { BenchShell } from "./BenchShell";
+import { CleaningTab } from "./CleaningTab";
+import { KeysTab } from "./KeysTab";
 import { Ledger } from "./Ledger";
 import { MatchingSharingSection } from "./MatchingSharingSection";
 import { ReviewCreateSection } from "./ReviewCreateSection";
 import { YourFileSection } from "./YourFileSection";
 
-import type { AcquiredCsv, InviterEditor } from "./inviterModel";
+import type { AcquiredCsv, InviterEditor, SpineTarget } from "./inviterModel";
 import type { DisclosureChoice } from "@psi/metadataEditing";
 import type { GeneratedInvitation } from "@psi/invitation";
 import type { IntakeAlert } from "./YourFileSection";
 import type { RailStep } from "./Rail";
 import type { SemanticType } from "@psilink/core";
 
-type SpineSection = "file" | "columns" | "review" | "share";
+type Section = SpineTarget | "share";
+type SpineStep = "file" | "columns" | "review";
 
-const SPINE_LABELS: Record<Exclude<SpineSection, "share">, string> = {
+const SPINE_LABELS: Record<SpineStep, string> = {
   file: "Your file",
   columns: "Matching & sharing",
   review: "Review & create",
 };
 
-const SPINE_ORDER: ReadonlyArray<Exclude<SpineSection, "share">> = [
-  "file",
-  "columns",
-  "review",
-];
+const SPINE_ORDER: ReadonlyArray<SpineStep> = ["file", "columns", "review"];
+
+function isSpineStep(section: Section): section is SpineStep {
+  return (SPINE_ORDER as ReadonlyArray<Section>).includes(section);
+}
 
 function demotionNotice(demoted: ReadonlyArray<string>): string {
   if (demoted.length === 0) return "";
@@ -70,7 +85,8 @@ function demotionNotice(demoted: ReadonlyArray<string>): string {
  */
 export function InviterBench() {
   const [name, setName] = useState("");
-  const [section, setSection] = useState<SpineSection>("file");
+  const [section, setSection] = useState<Section>("file");
+  const [lastSpineStep, setLastSpineStep] = useState<SpineStep>("file");
   const [acquired, setAcquired] = useState<AcquiredCsv>();
   const [sourceFile, setSourceFile] = useState<File>();
   const [editor, setEditor] = useState<InviterEditor>();
@@ -80,6 +96,13 @@ export function InviterBench() {
   const [invitation, setInvitation] = useState<GeneratedInvitation>();
   const [minting, setMinting] = useState(false);
   const [createAlert, setCreateAlert] = useState<IntakeAlert>();
+  const [expertMode, setExpertMode] = useState(false);
+  const [editorAnnouncement, setEditorAnnouncement] = useState("");
+
+  function goTo(next: Section) {
+    if (isSpineStep(next)) setLastSpineStep(next);
+    setSection(next);
+  }
 
   // A parse may still be in flight when the surface unmounts or a newer file
   // is dropped; the id lets the stale resolution fall on the floor instead of
@@ -180,7 +203,7 @@ export function InviterBench() {
       });
       setEditor(sealEditor(editor));
       setInvitation(minted);
-      setSection("share");
+      goTo("share");
     } catch (error) {
       if (error instanceof InvitationFileError) {
         // The mint re-parses the retained file, so it can fail in the same
@@ -224,8 +247,11 @@ export function InviterBench() {
   const fileReady = name.trim().length > 0 && linkable;
   const sealed = editor?.sealed === true;
 
+  // Inside a Customize tab no spine step is current; the step the operator
+  // came from stays navigable like any completed step.
+  const inTab = !isSpineStep(section) && section !== "share";
   const currentPosition = SPINE_ORDER.indexOf(
-    section === "share" ? "review" : section,
+    isSpineStep(section) ? section : lastSpineStep,
   );
   const steps: Array<RailStep> =
     section === "share"
@@ -237,23 +263,29 @@ export function InviterBench() {
         ]
       : SPINE_ORDER.map((step, position) => {
           const state =
-            step === section
+            !inTab && step === section
               ? "current"
-              : position < currentPosition
+              : position < currentPosition || (inTab && step === lastSpineStep)
                 ? "done"
                 : "pending";
           return {
             label: SPINE_LABELS[step],
             state,
-            onSelect: state === "done" ? () => setSection(step) : undefined,
+            onSelect: state === "done" ? () => goTo(step) : undefined,
           };
         });
+
+  const facts = inviterRailFacts(editor).map((fact) => ({
+    ...fact,
+    onSelect: editor !== undefined ? () => goTo(fact.target) : undefined,
+    current: section === fact.target,
+  }));
 
   const problems = sealed
     ? []
     : spineProblems(editor).map((problem) => ({
         label: problem.message,
-        onSelect: () => setSection(problem.target),
+        onSelect: () => goTo(problem.target),
       }));
 
   return (
@@ -271,7 +303,7 @@ export function InviterBench() {
               <RailSteps steps={steps} />
             </RailGroup>
             <RailGroup label="Customize" note="Filled in from your file.">
-              <RailFacts facts={inviterRailFacts(editor)} />
+              <RailFacts facts={facts} />
             </RailGroup>
             <RailProblems problems={problems} />
           </Rail>
@@ -311,7 +343,7 @@ export function InviterBench() {
             linkable={linkable}
             alert={intakeAlert}
             onContinue={() => {
-              if (fileReady) setSection("columns");
+              if (fileReady) goTo("columns");
             }}
           />
         )}
@@ -339,7 +371,7 @@ export function InviterBench() {
                 )
               }
               announcement={announcement}
-              onContinue={() => setSection("review")}
+              onContinue={() => goTo("review")}
             />
           )}
         {section === "review" &&
@@ -359,7 +391,7 @@ export function InviterBench() {
                 }
                 onReset={() => setEditor(resetToRecommended(editor, acquired))}
                 onCreate={() => void createInvitation()}
-                onNavigate={setSection}
+                onNavigate={goTo}
               />
               {createAlert !== undefined && (
                 <Alert color="red" title={createAlert.title} mt="md">
@@ -368,6 +400,78 @@ export function InviterBench() {
               )}
             </>
           )}
+        {section === "cleaning" &&
+          editor !== undefined &&
+          acquired !== undefined && (
+            <CleaningTab
+              editor={editor}
+              csv={acquired}
+              expertMode={expertMode}
+              onFieldSteps={(output, fieldSteps) =>
+                setEditor(editorWithFieldSteps(editor, output, fieldSteps))
+              }
+              onFieldInput={(output, input) =>
+                setEditor(editorWithFieldInput(editor, output, input))
+              }
+              onFieldAdded={(type) =>
+                setEditor(editorWithFieldAdded(editor, type))
+              }
+              onFieldRemoved={(output) =>
+                setEditor(editorWithFieldRemoved(editor, output))
+              }
+              onResetCleaning={() =>
+                setEditor(editorWithRecommendedCleaning(editor, acquired))
+              }
+              onBack={() => goTo("review")}
+            />
+          )}
+        {section === "keys" &&
+          editor !== undefined &&
+          acquired !== undefined && (
+            <KeysTab
+              editor={editor}
+              csv={acquired}
+              expertMode={expertMode}
+              onExpertMode={setExpertMode}
+              onKeyEnabled={(index, enabled) =>
+                setEditor(editorWithKeyEnabled(editor, index, enabled))
+              }
+              onKeyMoved={(index, offset) => {
+                const moved = editorWithKeyMoved(editor, index, offset);
+                setEditor(moved);
+                if (moved !== editor) {
+                  const key = moved.draft.keys[index + offset];
+                  setEditorAnnouncement(
+                    `Moved ${sanitizeForDisplay(key.key.name)} to position ${index + offset + 1} of ${moved.draft.keys.length}. Keys earlier in the list match first.`,
+                  );
+                }
+              }}
+              onAuthoredDraft={(draft) =>
+                setEditor(editorWithAuthoredDraft(editor, draft))
+              }
+              onStrategy={(strategy) =>
+                setEditor(editorWithLinkageStrategy(editor, strategy))
+              }
+              onImport={(terms) => {
+                setEditor(editorWithImportedTerms(editor, acquired, terms));
+                setEditorAnnouncement(
+                  "Imported. Review the loaded terms before creating.",
+                );
+              }}
+              announce={setEditorAnnouncement}
+              onBack={() => goTo("review")}
+            />
+          )}
+        {section === "agreement" && editor !== undefined && (
+          <AgreementTab
+            editor={editor}
+            validation={reviewValidation(editor)}
+            onAgreement={(agreement) =>
+              setEditor(editorWithLegalAgreement(editor, agreement))
+            }
+            onBack={() => goTo("review")}
+          />
+        )}
         {section === "share" && (
           <>
             <h1 tabIndex={-1}>Your invitation is ready</h1>
@@ -387,6 +491,11 @@ export function InviterBench() {
             </Alert>
           </>
         )}
+        <VisuallyHidden>
+          <p aria-live="polite" aria-atomic="true">
+            {editorAnnouncement}
+          </p>
+        </VisuallyHidden>
       </div>
     </BenchShell>
   );

--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -106,6 +106,14 @@ export function InviterBench() {
     setSection(next);
   }
 
+  // Non-announcing edits clear the live region (the old editor's
+  // cleared-by-the-next-interaction rule), so a stale notice never lingers
+  // and a repeated identical notice re-announces.
+  function applyEditor(next: InviterEditor) {
+    setEditor(next);
+    setEditorAnnouncement("");
+  }
+
   // A parse may still be in flight when the surface unmounts or a newer file
   // is dropped; the id lets the stale resolution fall on the floor instead of
   // clobbering current state (the FileAcquire pattern).
@@ -386,12 +394,15 @@ export function InviterBench() {
                 problems={spineProblems(editor)}
                 minting={minting}
                 onLifetime={(seconds) =>
-                  setEditor(editorWithLifetime(editor, seconds))
+                  applyEditor(editorWithLifetime(editor, seconds))
                 }
                 onDirection={(direction) =>
-                  setEditor(editorWithOutputDirection(editor, direction))
+                  applyEditor(editorWithOutputDirection(editor, direction))
                 }
-                onReset={() => setEditor(resetToRecommended(editor, acquired))}
+                onReset={() => {
+                  setEditor(resetToRecommended(editor, acquired));
+                  setEditorAnnouncement("Reset to the recommended settings.");
+                }}
                 onCreate={() => void createInvitation()}
                 onNavigate={goTo}
               />
@@ -410,20 +421,24 @@ export function InviterBench() {
               csv={acquired}
               expertMode={expertMode}
               onFieldSteps={(output, fieldSteps) =>
-                setEditor(editorWithFieldSteps(editor, output, fieldSteps))
+                applyEditor(editorWithFieldSteps(editor, output, fieldSteps))
               }
               onFieldInput={(output, input) =>
-                setEditor(editorWithFieldInput(editor, output, input))
+                applyEditor(editorWithFieldInput(editor, output, input))
               }
               onFieldAdded={(type) =>
-                setEditor(editorWithFieldAdded(editor, type))
+                applyEditor(editorWithFieldAdded(editor, type))
               }
               onFieldRemoved={(output) =>
-                setEditor(editorWithFieldRemoved(editor, output))
+                applyEditor(editorWithFieldRemoved(editor, output))
               }
-              onResetCleaning={() =>
-                setEditor(editorWithRecommendedCleaning(editor, acquired))
-              }
+              onResetCleaning={() => {
+                setEditor(editorWithRecommendedCleaning(editor, acquired));
+                setEditorAnnouncement(
+                  "Cleaning reset to the recommended steps.",
+                );
+              }}
+              cleaningError={reviewValidation(editor).errors.standardization}
               onBack={() => goTo("review")}
             />
           )}
@@ -436,7 +451,7 @@ export function InviterBench() {
               expertMode={expertMode}
               onExpertMode={setExpertMode}
               onKeyEnabled={(index, enabled) =>
-                setEditor(editorWithKeyEnabled(editor, index, enabled))
+                applyEditor(editorWithKeyEnabled(editor, index, enabled))
               }
               onKeyMoved={(index, offset) => {
                 const moved = editorWithKeyMoved(editor, index, offset);
@@ -449,16 +464,16 @@ export function InviterBench() {
                 }
               }}
               onAuthoredDraft={(draft) =>
-                setEditor(editorWithAuthoredDraft(editor, draft))
+                applyEditor(editorWithAuthoredDraft(editor, draft))
               }
               onStrategy={(strategy) =>
-                setEditor(editorWithLinkageStrategy(editor, strategy))
+                applyEditor(editorWithLinkageStrategy(editor, strategy))
               }
               onAlgorithm={(algorithm) =>
-                setEditor(editorWithAlgorithm(editor, algorithm))
+                applyEditor(editorWithAlgorithm(editor, algorithm))
               }
               onDeduplicate={(deduplicate) =>
-                setEditor(editorWithDeduplicate(editor, deduplicate))
+                applyEditor(editorWithDeduplicate(editor, deduplicate))
               }
               onImport={(terms) => {
                 setEditor(editorWithImportedTerms(editor, acquired, terms));
@@ -466,6 +481,7 @@ export function InviterBench() {
                   "Imported. Review the loaded terms before creating.",
                 );
               }}
+              keysError={reviewValidation(editor).errors.keys}
               announce={setEditorAnnouncement}
               onBack={() => goTo("review")}
             />
@@ -475,7 +491,7 @@ export function InviterBench() {
             editor={editor}
             validation={reviewValidation(editor)}
             onAgreement={(agreement) =>
-              setEditor(editorWithLegalAgreement(editor, agreement))
+              applyEditor(editorWithLegalAgreement(editor, agreement))
             }
             onBack={() => goTo("review")}
           />

--- a/apps/web/src/bench/KeysTab.tsx
+++ b/apps/web/src/bench/KeysTab.tsx
@@ -1,0 +1,222 @@
+import { useMemo } from "react";
+
+import {
+  ActionIcon,
+  Alert,
+  Checkbox,
+  NativeSelect,
+  Radio,
+  Switch,
+} from "@mantine/core";
+import { IconArrowDown, IconArrowUp } from "@tabler/icons-react";
+
+import { sanitizeForDisplay } from "@psilink/core";
+
+import { APPLIED_SETTINGS } from "@psi/appliedSettings";
+import { buildAdvancedTerms } from "@psi/advancedInvite";
+
+import { ExpertKeyEditor } from "@components/ExpertKeyEditor";
+import { TermsImportExport } from "@components/TermsImportExport";
+
+import { declaredFieldsFor, keySatisfiabilityFor } from "./inviterModel";
+import styles from "./bench.module.css";
+
+import type { AcquiredCsv, InviterEditor } from "./inviterModel";
+import type { LinkageStrategy, LinkageTerms } from "@psilink/core";
+import type { AdvancedInviteDraft } from "@psi/advancedInvite";
+
+/**
+ * The Matching keys tab: the guided ordered key list (enable + reorder, with
+ * satisfiability badges), the expert switch that opens element-by-element
+ * authoring and terms import/export, and the matching settings -- the live
+ * linkage strategy plus the gated method and deduplication controls, held
+ * visible but inert until the run honors them.
+ */
+export function KeysTab({
+  editor,
+  csv,
+  expertMode,
+  onExpertMode,
+  onKeyEnabled,
+  onKeyMoved,
+  onAuthoredDraft,
+  onStrategy,
+  onImport,
+  announce,
+  onBack,
+}: {
+  editor: InviterEditor;
+  csv: AcquiredCsv;
+  expertMode: boolean;
+  onExpertMode: (on: boolean) => void;
+  onKeyEnabled: (index: number, enabled: boolean) => void;
+  onKeyMoved: (index: number, offset: -1 | 1) => void;
+  onAuthoredDraft: (draft: AdvancedInviteDraft) => void;
+  onStrategy: (strategy: LinkageStrategy) => void;
+  onImport: (terms: LinkageTerms) => void;
+  announce: (message: string) => void;
+  onBack: () => void;
+}) {
+  const keyIsSatisfiable = useMemo(
+    () => keySatisfiabilityFor(editor),
+    [editor],
+  );
+  const declaredFields = useMemo(
+    () => declaredFieldsFor(editor.draft),
+    [editor.draft],
+  );
+  const currentTerms = useMemo(
+    () => buildAdvancedTerms(editor.draft),
+    [editor.draft],
+  );
+  const keyCount = editor.draft.keys.length;
+  return (
+    <>
+      <button type="button" className={styles.backlink} onClick={onBack}>
+        {"\u2190"} Back to Review &amp; create
+      </button>
+      <p className={styles.eyebrow}>Customize</p>
+      <h1 tabIndex={-1}>Matching keys</h1>
+      <p>
+        Records are matched on these keys, tried in order. Earlier keys match
+        first, so order the most precise keys first.
+      </p>
+      <ol className={styles.guidedKeys}>
+        {editor.draft.keys.map((entry, index) => {
+          const displayName = sanitizeForDisplay(entry.key.name);
+          const satisfiable = keyIsSatisfiable(index);
+          return (
+            <li key={entry.key.name}>
+              <Checkbox
+                checked={entry.enabled}
+                onChange={(event) =>
+                  onKeyEnabled(index, event.currentTarget.checked)
+                }
+                label={
+                  <>
+                    Key {index + 1} -{" "}
+                    <span className={styles.mono}>{displayName}</span>
+                    <span
+                      className={
+                        satisfiable
+                          ? `${styles.keyBadge} ${styles.keyBadgeSatisfiable}`
+                          : `${styles.keyBadge} ${styles.keyBadgeUnsatisfiable}`
+                      }
+                    >
+                      {satisfiable ? "satisfiable" : "not satisfiable"}
+                    </span>
+                  </>
+                }
+              />
+              <span className={styles.movers}>
+                <ActionIcon
+                  variant="default"
+                  aria-label={`Move ${displayName} earlier`}
+                  disabled={index === 0}
+                  onClick={() => onKeyMoved(index, -1)}
+                >
+                  <IconArrowUp size={15} />
+                </ActionIcon>
+                <ActionIcon
+                  variant="default"
+                  aria-label={`Move ${displayName} later`}
+                  disabled={index === keyCount - 1}
+                  onClick={() => onKeyMoved(index, 1)}
+                >
+                  <IconArrowDown size={15} />
+                </ActionIcon>
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+      <Switch
+        label="Expert authoring"
+        description="Build linkage keys element by element, edit transforms and swaps, and import or export the terms as JSON or YAML."
+        checked={expertMode}
+        onChange={(event) => onExpertMode(event.currentTarget.checked)}
+        my="md"
+      />
+      {expertMode ? (
+        <ExpertKeyEditor
+          draft={editor.draft}
+          declaredFields={declaredFields}
+          keyIsSatisfiable={keyIsSatisfiable}
+          fuzzyApplied={APPLIED_SETTINGS.fuzzyComparisons}
+          onChange={onAuthoredDraft}
+          announce={announce}
+        />
+      ) : (
+        <Alert variant="light" color="gray">
+          Fixed in this version. Turn on Expert authoring to edit keys element
+          by element and to import or export the terms.
+        </Alert>
+      )}
+      <h2>Matching settings</h2>
+      <Radio.Group
+        label="Linkage strategy"
+        value={editor.draft.linkageStrategy}
+        onChange={(value) => onStrategy(value)}
+      >
+        <Radio
+          value="cascade"
+          label="Cascade (recommended)"
+          description="Keys run in order; a record matched by an earlier key is settled and never re-exposed to later, broader keys."
+          mt="xs"
+        />
+        <Radio
+          value="single-pass"
+          label="Single-pass"
+          description="All keys run over all records at once."
+          mt="xs"
+        />
+      </Radio.Group>
+      {editor.draft.linkageStrategy === "single-pass" && (
+        <Alert
+          color="yellow"
+          title="Single-pass widens what one of you can observe"
+          mt="sm"
+        >
+          Every record meets every key, so a partner can learn more about
+          near-misses than under the cascade. Choose it only when both of you
+          accept that.
+        </Alert>
+      )}
+      <NativeSelect
+        label="Matching method"
+        description='"Reveal only the count (psi-c)" is not available yet; the standard method applies.'
+        disabled={!APPLIED_SETTINGS.psiC}
+        value={editor.draft.algorithm}
+        data={[
+          { value: "psi", label: "Reveal the matched identifiers (standard)" },
+          { value: "psi-c", label: "Reveal only the count (psi-c)" },
+        ]}
+        onChange={() => undefined}
+        mt="md"
+      />
+      <Checkbox
+        label="Allow several of your records to match one partner record"
+        description="Deduplication of your own inputs is not available yet; each record matches at most once."
+        disabled={!APPLIED_SETTINGS.deduplicate}
+        checked={editor.draft.deduplicate}
+        onChange={() => undefined}
+        mt="md"
+      />
+      {expertMode && (
+        <>
+          <h2>Import or export</h2>
+          <p className={`${styles.small} ${styles.sub}`}>
+            Carry these terms between exchanges, or keep them under version
+            control.
+          </p>
+          <TermsImportExport
+            currentTerms={currentTerms}
+            seed={editor.seed}
+            rawRows={csv.rawRows}
+            onImport={onImport}
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/bench/KeysTab.tsx
+++ b/apps/web/src/bench/KeysTab.tsx
@@ -10,7 +10,11 @@ import {
 } from "@mantine/core";
 import { IconArrowDown, IconArrowUp } from "@tabler/icons-react";
 
-import { sanitizeForDisplay } from "@psilink/core";
+import {
+  AlgorithmSchema,
+  LinkageStrategySchema,
+  sanitizeForDisplay,
+} from "@psilink/core";
 
 import { APPLIED_SETTINGS } from "@psi/appliedSettings";
 import { buildAdvancedTerms } from "@psi/advancedInvite";
@@ -22,7 +26,7 @@ import { declaredFieldsFor, keySatisfiabilityFor } from "./inviterModel";
 import styles from "./bench.module.css";
 
 import type { AcquiredCsv, InviterEditor } from "./inviterModel";
-import type { LinkageStrategy, LinkageTerms } from "@psilink/core";
+import type { Algorithm, LinkageStrategy, LinkageTerms } from "@psilink/core";
 import type { AdvancedInviteDraft } from "@psi/advancedInvite";
 
 /**
@@ -41,6 +45,8 @@ export function KeysTab({
   onKeyMoved,
   onAuthoredDraft,
   onStrategy,
+  onAlgorithm,
+  onDeduplicate,
   onImport,
   announce,
   onBack,
@@ -53,6 +59,8 @@ export function KeysTab({
   onKeyMoved: (index: number, offset: -1 | 1) => void;
   onAuthoredDraft: (draft: AdvancedInviteDraft) => void;
   onStrategy: (strategy: LinkageStrategy) => void;
+  onAlgorithm: (algorithm: Algorithm) => void;
+  onDeduplicate: (deduplicate: boolean) => void;
   onImport: (terms: LinkageTerms) => void;
   announce: (message: string) => void;
   onBack: () => void;
@@ -156,7 +164,9 @@ export function KeysTab({
       <Radio.Group
         label="Linkage strategy"
         value={editor.draft.linkageStrategy}
-        onChange={(value) => onStrategy(value)}
+        // Parsed rather than trusted so a Radio value literal drifting from
+        // the enum throws loudly instead of typechecking clean.
+        onChange={(value) => onStrategy(LinkageStrategySchema.parse(value))}
       >
         <Radio
           value="cascade"
@@ -184,22 +194,32 @@ export function KeysTab({
       )}
       <NativeSelect
         label="Matching method"
-        description='"Reveal only the count (psi-c)" is not available yet; the standard method applies.'
+        description={
+          APPLIED_SETTINGS.psiC
+            ? "Reveal the matched identifiers, or only the count."
+            : '"Reveal only the count (psi-c)" is not available yet; the standard method applies.'
+        }
         disabled={!APPLIED_SETTINGS.psiC}
         value={editor.draft.algorithm}
         data={[
           { value: "psi", label: "Reveal the matched identifiers (standard)" },
           { value: "psi-c", label: "Reveal only the count (psi-c)" },
         ]}
-        onChange={() => undefined}
+        onChange={(event) =>
+          onAlgorithm(AlgorithmSchema.parse(event.currentTarget.value))
+        }
         mt="md"
       />
       <Checkbox
         label="Allow several of your records to match one partner record"
-        description="Deduplication of your own inputs is not available yet; each record matches at most once."
+        description={
+          APPLIED_SETTINGS.deduplicate
+            ? undefined
+            : "Deduplication of your own inputs is not available yet; each record matches at most once."
+        }
         disabled={!APPLIED_SETTINGS.deduplicate}
         checked={editor.draft.deduplicate}
-        onChange={() => undefined}
+        onChange={(event) => onDeduplicate(event.currentTarget.checked)}
         mt="md"
       />
       {expertMode && (

--- a/apps/web/src/bench/KeysTab.tsx
+++ b/apps/web/src/bench/KeysTab.tsx
@@ -48,6 +48,7 @@ export function KeysTab({
   onAlgorithm,
   onDeduplicate,
   onImport,
+  keysError,
   announce,
   onBack,
 }: {
@@ -62,6 +63,9 @@ export function KeysTab({
   onAlgorithm: (algorithm: Algorithm) => void;
   onDeduplicate: (deduplicate: boolean) => void;
   onImport: (terms: LinkageTerms) => void;
+  /** The validation message for the key set, rendered inline beside the list
+   * it names (the rail's Problems block carries it too). */
+  keysError: string | undefined;
   announce: (message: string) => void;
   onBack: () => void;
 }) {
@@ -85,11 +89,11 @@ export function KeysTab({
       </button>
       <p className={styles.eyebrow}>Customize</p>
       <h1 tabIndex={-1}>Matching keys</h1>
-      <p>
+      <p id="bench-key-order-help">
         Records are matched on these keys, tried in order. Earlier keys match
         first, so order the most precise keys first.
       </p>
-      <ol className={styles.guidedKeys}>
+      <ol className={styles.guidedKeys} aria-describedby="bench-key-order-help">
         {editor.draft.keys.map((entry, index) => {
           const displayName = sanitizeForDisplay(entry.key.name);
           const satisfiable = keyIsSatisfiable(index);
@@ -138,6 +142,14 @@ export function KeysTab({
           );
         })}
       </ol>
+      {keysError !== undefined && (
+        <p
+          role="alert"
+          className={`${styles.small} ${styles.statusLine} ${styles.statusLineDanger}`}
+        >
+          {keysError}
+        </p>
+      )}
       <Switch
         label="Expert authoring"
         description="Build linkage keys element by element, edit transforms and swaps, and import or export the terms as JSON or YAML."
@@ -185,6 +197,9 @@ export function KeysTab({
         <Alert
           color="yellow"
           title="Single-pass widens what one of you can observe"
+          // Pinned so the consent-critical warning is announced on selection
+          // even if Mantine's default role changes.
+          role="alert"
           mt="sm"
         >
           Every record meets every key, so a partner can learn more about

--- a/apps/web/src/bench/MatchingSharingSection.tsx
+++ b/apps/web/src/bench/MatchingSharingSection.tsx
@@ -1,11 +1,16 @@
-import { Button, NativeSelect } from "@mantine/core";
+import { useEffect, useRef, useState } from "react";
+
+import { Button, NativeSelect, VisuallyHidden } from "@mantine/core";
 
 import {
   DISCLOSURE_LABELS,
   SEMANTIC_TYPE_LABELS,
   disclosureChoicesForType,
   disclosureOf,
+  hasMultipleIdentifiers,
 } from "@psi/metadataEditing";
+
+import { useDeferredAnnouncement } from "@components/useDeferredAnnouncement";
 
 import { disclosedColumnNames } from "@psilink/core";
 
@@ -39,6 +44,35 @@ export function MatchingSharingSection({
   onContinue: () => void;
 }) {
   const sent = disclosedColumnNames(metadata);
+
+  // The visible send set lives in the ledger and the extra-data block, which
+  // cannot speak for the selects; this debounced region voices the new set as
+  // it changes, computed from the same predicate the run transmits on. The
+  // timer clears on every change and on unmount, so an edit burst announces
+  // once.
+  const summary =
+    sent.length === 0
+      ? "No columns will be sent to your partner."
+      : `Columns sent to your partner: ${sent.join(", ")}.`;
+  const [summaryAnnouncement, setSummaryAnnouncement] = useState("");
+  const summaryRef = useRef(summary);
+  summaryRef.current = summary;
+  useEffect(() => {
+    const handle = setTimeout(
+      () => setSummaryAnnouncement(summaryRef.current),
+      600,
+    );
+    return () => clearTimeout(handle);
+  }, [summary]);
+
+  // The two-identifier conflict's visible surfaces are the standing hint and
+  // the rail's Problems entry, per the design; this deferred region is its
+  // audible half, voiced even when a seed mounts already in conflict.
+  const conflictAnnouncement = useDeferredAnnouncement(
+    hasMultipleIdentifiers(metadata)
+      ? "Problem: choose a single row identifier."
+      : "",
+  );
   return (
     <>
       <p className={styles.eyebrow}>Step 2 of 3</p>
@@ -63,7 +97,12 @@ export function MatchingSharingSection({
           <tbody>
             {metadata.map((column) => (
               <tr key={column.name}>
-                <td className={styles.mono}>{column.name}</td>
+                <th
+                  scope="row"
+                  className={`${styles.mono} ${styles.rowHeader}`}
+                >
+                  {column.name}
+                </th>
                 <td>
                   <NativeSelect
                     aria-label={`Type for ${column.name}`}
@@ -116,6 +155,12 @@ export function MatchingSharingSection({
       >
         {announcement}
       </p>
+      <VisuallyHidden role="status" aria-live="polite" aria-atomic="true">
+        {summaryAnnouncement}
+      </VisuallyHidden>
+      <VisuallyHidden role="status" aria-live="polite" aria-atomic="true">
+        {conflictAnnouncement}
+      </VisuallyHidden>
       <h2>Extra data for matched records</h2>
       <p className={styles.small}>
         <strong>You will send:</strong>{" "}

--- a/apps/web/src/bench/Rail.tsx
+++ b/apps/web/src/bench/Rail.tsx
@@ -23,12 +23,15 @@ export interface RailStep {
  * One row in a {@link RailFacts} group: an optional-surface label and the
  * quiet fact summarizing its state ("3 fields", "2 keys"). An absent fact
  * renders as an em-dash; `tone` colors the fact only when the surface has been
- * edited or needs attention, per the mockup's quiet-fact rule.
+ * edited or needs attention, per the mockup's quiet-fact rule. With `onSelect`
+ * the label is a link into the surface; `current` marks the open tab.
  */
 export interface RailFact {
   label: string;
   fact?: string;
   tone?: "edited" | "attention";
+  onSelect?: () => void;
+  current?: boolean;
 }
 
 /**
@@ -163,7 +166,22 @@ export function RailFacts({ facts }: { facts: ReadonlyArray<RailFact> }) {
     <ul className={styles.railFacts}>
       {facts.map((entry) => (
         <li key={entry.label}>
-          <span>{entry.label}</span>
+          {entry.onSelect !== undefined ? (
+            <button
+              type="button"
+              className={
+                entry.current === true
+                  ? `${styles.stepLink} ${styles.currentTab}`
+                  : styles.stepLink
+              }
+              aria-current={entry.current === true ? "true" : undefined}
+              onClick={entry.onSelect}
+            >
+              {entry.label}
+            </button>
+          ) : (
+            <span>{entry.label}</span>
+          )}
           <span
             className={
               entry.tone === undefined

--- a/apps/web/src/bench/ReviewCreateSection.tsx
+++ b/apps/web/src/bench/ReviewCreateSection.tsx
@@ -1,4 +1,6 @@
-import { Button, NativeSelect, Radio } from "@mantine/core";
+import { Button, NativeSelect, Radio, VisuallyHidden } from "@mantine/core";
+
+import { useDeferredAnnouncement } from "@components/useDeferredAnnouncement";
 
 import {
   LIFETIME_CHOICES,
@@ -56,6 +58,13 @@ export function ReviewCreateSection({
   onNavigate: (target: SpineTarget) => void;
 }) {
   const canCreate = problems.length === 0 && !minting;
+  // Voiced when the create gate flips either way; deferred so a blocked state
+  // present when the section mounts still announces.
+  const readiness = useDeferredAnnouncement(
+    problems.length === 0
+      ? "Ready to create the invitation."
+      : `${problems.length === 1 ? "A problem" : `${problems.length} problems`} in the rail must be resolved before you can create.`,
+  );
   return (
     <>
       <p className={styles.eyebrow}>Step 3 of 3</p>
@@ -176,6 +185,11 @@ export function ReviewCreateSection({
           </tbody>
         </table>
       </div>
+      <VisuallyHidden>
+        <p role="status" aria-live="polite" aria-atomic="true">
+          {readiness}
+        </p>
+      </VisuallyHidden>
       <div className={styles.workFoot}>
         <Button disabled={!canCreate} loading={minting} onClick={onCreate}>
           Create the invitation

--- a/apps/web/src/bench/YourFileSection.tsx
+++ b/apps/web/src/bench/YourFileSection.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
-import { Alert, Button, TextInput } from "@mantine/core";
+import { Alert, Button, Text, TextInput } from "@mantine/core";
 import { Dropzone } from "@mantine/dropzone";
+import { IconAlertCircle } from "@tabler/icons-react";
+import log from "loglevel";
 
 import { MAX_CSV_FILE_BYTES } from "@components/csvIntake";
 
@@ -9,6 +11,7 @@ import { fileCardMeta } from "./inviterModel";
 import styles from "./bench.module.css";
 
 import type { AcquiredCsv } from "./inviterModel";
+import type { FileRejection } from "@mantine/dropzone";
 
 /** A titled alert for a failed or unusable read, focused when it appears so
  * the failure is announced without clearing the operator's input. */
@@ -50,7 +53,30 @@ export function YourFileSection({
     if (alert !== undefined) alertRef.current?.focus();
   }, [alert]);
 
-  const ready = name.trim().length > 0 && acquired !== undefined && linkable;
+  // The dropzone enforces the size cap and type list itself but only flashes a
+  // reject icon; surface why, or a refused drop is a silent no-op. Codes only
+  // in the log -- a rejected file's NAME can itself be sensitive here.
+  const [rejectionMessage, setRejectionMessage] = useState<string>();
+  const maxMb = MAX_CSV_FILE_BYTES / 1024 ** 2;
+  function handleReject(rejections: Array<FileRejection>) {
+    const codes = new Set(
+      rejections.flatMap((rejection) =>
+        rejection.errors.map((error) => error.code),
+      ),
+    );
+    log.warn(`rejected ${rejections.length} file(s):`, [...codes]);
+    const reasons: Array<string> = [];
+    if (codes.has("file-too-large"))
+      reasons.push(`larger than the ${maxMb} MB maximum`);
+    if (codes.has("file-invalid-type") || reasons.length === 0)
+      reasons.push("not a supported file type");
+    setRejectionMessage(
+      `That file is ${reasons.join(" and ")}. Choose a CSV file under ${maxMb} MB.`,
+    );
+  }
+
+  const ready =
+    name.trim().length > 0 && acquired !== undefined && linkable && !reading;
   return (
     <>
       <p className={styles.eyebrow}>Step 1 of 3</p>
@@ -65,9 +91,11 @@ export function YourFileSection({
       <Dropzone
         className={styles.dropzone}
         onDrop={(files) => {
+          setRejectionMessage(undefined);
           const file = files.at(0);
           if (file !== undefined) onFile(file);
         }}
+        onReject={handleReject}
         accept={["text/plain", "text/csv", "application/vnd.ms-excel"]}
         maxSize={MAX_CSV_FILE_BYTES}
         multiple={false}
@@ -78,10 +106,13 @@ export function YourFileSection({
         <p>
           <strong>Drag your CSV here or click to select</strong>
         </p>
-        <p className={styles.dropzoneMax}>
-          (Max file size: {MAX_CSV_FILE_BYTES / 1024 ** 2} MB)
-        </p>
+        <p className={styles.dropzoneMax}>(Max file size: {maxMb} MB)</p>
       </Dropzone>
+      {rejectionMessage !== undefined && (
+        <Text role="alert" c="red" size="sm" mt="xs">
+          {rejectionMessage}
+        </Text>
+      )}
       {acquired !== undefined && (
         <div className={styles.fileCard}>
           <svg
@@ -112,11 +143,14 @@ export function YourFileSection({
         <Alert
           color="red"
           title={alert.title}
+          icon={<IconAlertCircle />}
           mt="md"
           ref={alertRef}
           tabIndex={-1}
         >
-          {alert.message}
+          {/* sanitizeErrorForDisplay separates a cause chain with newlines;
+              pre-line preserves them (its documented rendering contract). */}
+          <span style={{ whiteSpace: "pre-line" }}>{alert.message}</span>
         </Alert>
       )}
       {acquired !== undefined && linkable && (

--- a/apps/web/src/bench/bench.module.css
+++ b/apps/web/src/bench/bench.module.css
@@ -616,6 +616,13 @@
   margin-bottom: 4px;
 }
 
+.rowHeader {
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--bench-ink);
+  font-weight: 600;
+}
+
 .columnChips {
   display: flex;
   gap: 8px;

--- a/apps/web/src/bench/bench.module.css
+++ b/apps/web/src/bench/bench.module.css
@@ -493,6 +493,67 @@
   color: var(--bench-danger);
 }
 
+.currentTab {
+  color: var(--bench-accent);
+}
+
+.backlink {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 14px;
+  color: var(--bench-accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+  margin-bottom: 0.8rem;
+}
+
+.guidedKeys {
+  list-style: none;
+  margin: 0.8rem 0;
+  padding: 0;
+  max-width: 640px;
+}
+
+.guidedKeys li {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--bench-rule-soft);
+}
+
+.keyBadge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border-radius: 999px;
+  padding: 1px 8px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
+.keyBadgeSatisfiable {
+  color: var(--bench-ok);
+  border: 1px solid var(--bench-ok);
+}
+
+.keyBadgeUnsatisfiable {
+  color: var(--bench-danger);
+  border: 1px solid var(--bench-danger);
+}
+
+.movers {
+  display: inline-flex;
+  gap: 6px;
+  flex: none;
+}
+
 .radioCard {
   border: 2px solid var(--bench-rule);
   border-radius: 8px;

--- a/apps/web/src/bench/inviterModel.ts
+++ b/apps/web/src/bench/inviterModel.ts
@@ -8,6 +8,7 @@ import {
 import {
   defaultStandardizationForRows,
   draftFromTerms,
+  draftWithFieldAdded,
   producibleFieldNames,
   seedAdvancedInvite,
   setDraftMetadata,
@@ -256,43 +257,34 @@ export function editorWithFieldRemoved(
   };
 }
 
-/** Append a same-typed field bound to its first free column, named uniquely
- * off the type's first field and seeded with its steps, so the second field
- * starts from the same recommended pipeline. A type with no free column is a
- * no-op (the affordance is gated on one existing). */
+/** Append a same-typed field via the shared {@link draftWithFieldAdded}. */
 export function editorWithFieldAdded(
   editor: InviterEditor,
   type: LinkageField["type"],
 ): InviterEditor {
   if (editor.sealed === true) return editor;
-  const draft = editor.draft;
-  const bound = new Set(draft.standardization.map((t) => t.input));
-  const freeColumn = draft.metadata
-    .filter((column) => column.role === "linkage" && column.type === type)
-    .map((column) => column.name)
-    .find((column) => !bound.has(column));
-  if (freeColumn === undefined) return editor;
-  const typeByOutput = new Map(
-    declaredFieldsFor(draft).map((field) => [field.name, field.type]),
-  );
-  const sibling = draft.standardization.find(
-    (transformation) => typeByOutput.get(transformation.output) === type,
-  );
-  const base = sibling?.output ?? type;
-  const taken = new Set(draft.standardization.map((t) => t.output));
-  let n = 2;
-  let output = `${base}_${n}`;
-  while (taken.has(output)) output = `${base}_${++n}`;
-  return {
-    ...editor,
-    draft: {
-      ...draft,
-      standardization: [
-        ...draft.standardization,
-        { output, input: freeColumn, steps: sibling?.steps ?? [] },
-      ],
-    },
-  };
+  return { ...editor, draft: draftWithFieldAdded(editor.draft, type) };
+}
+
+/** Set the matching algorithm. Gated: while the run does not honor psi-c the
+ * control stays disabled and {@link validateAdvancedInvite}'s build clamps the
+ * minted terms to `psi` regardless of this draft state. */
+export function editorWithAlgorithm(
+  editor: InviterEditor,
+  algorithm: AdvancedInviteDraft["algorithm"],
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return { ...editor, draft: { ...editor.draft, algorithm } };
+}
+
+/** Set input deduplication. Gated exactly as {@link editorWithAlgorithm}: the
+ * build clamps minted terms to no-dedup until the run honors it. */
+export function editorWithDeduplicate(
+  editor: InviterEditor,
+  deduplicate: boolean,
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return { ...editor, draft: { ...editor.draft, deduplicate } };
 }
 
 /** Restore the recommended cleaning for the current metadata -- the cleaning
@@ -684,8 +676,8 @@ export interface AnswersRow {
 }
 
 /** The check-your-answers table: the full proposal restated before the point
- * of no return. Cleaning, key, and agreement rows carry no Change link until
- * their Customize tabs exist. */
+ * of no return, each row's Change link navigating to the spine step or
+ * Customize tab that owns the term. */
 export function answersRows(
   editor: InviterEditor,
   csv: AcquiredCsv,

--- a/apps/web/src/bench/inviterModel.ts
+++ b/apps/web/src/bench/inviterModel.ts
@@ -1,27 +1,40 @@
 import {
   MAX_INVITATION_LIFETIME_SECONDS,
+  authoredLinkageFields,
   disclosedColumnNames,
+  getDefaultLinkageTerms,
 } from "@psilink/core";
 
+import {
+  defaultStandardizationForRows,
+  draftFromTerms,
+  producibleFieldNames,
+  seedAdvancedInvite,
+  setDraftMetadata,
+  validateAdvancedInvite,
+} from "@psi/advancedInvite";
 import {
   hasMultipleIdentifiers,
   setColumnDisclosure,
   setColumnType,
 } from "@psi/metadataEditing";
-import {
-  seedAdvancedInvite,
-  setDraftMetadata,
-  validateAdvancedInvite,
-} from "@psi/advancedInvite";
 
 import type {
   AdvancedField,
   AdvancedInviteDraft,
   AdvancedInviteSeed,
   AdvancedValidation,
+  DraftLegalAgreement,
   OutputDirection,
 } from "@psi/advancedInvite";
-import type { CSVRow, LinkageKey, SemanticType } from "@psilink/core";
+import type {
+  CSVRow,
+  LinkageField,
+  LinkageKey,
+  LinkageStrategy,
+  LinkageTerms,
+  SemanticType,
+} from "@psilink/core";
 import type { DisclosureChoice } from "@psi/metadataEditing";
 
 /**
@@ -47,11 +60,15 @@ export interface AcquiredCsv {
 /** An editing session over the read file: the live draft and the fixed seed it
  * derived from ({@link seedAdvancedInvite}). Once `sealed` (the invitation was
  * created), every mutator in this module returns the session unchanged -- the
- * terms a partner is consenting to can never drift from what was minted. */
+ * terms a partner is consenting to can never drift from what was minted.
+ * `keysAuthored` marks the key set as author-controlled (an expert edit or an
+ * import): a later column edit then updates only the metadata, because the
+ * template-driven key reconciliation would silently drop authored keys. */
 export interface InviterEditor {
   draft: AdvancedInviteDraft;
   seed: AdvancedInviteSeed;
   sealed?: boolean;
+  keysAuthored?: boolean;
 }
 
 /** Seal the session at create time; see {@link InviterEditor.sealed}. */
@@ -97,6 +114,231 @@ export function editorWithOutputDirection(
   return { ...editor, draft: { ...editor.draft, outputDirection } };
 }
 
+/** Replace the whole draft -- the expert key editor's change channel. Marks
+ * the key set author-controlled, so later column edits stop reconciling it
+ * away ({@link InviterEditor.keysAuthored}). */
+export function editorWithAuthoredDraft(
+  editor: InviterEditor,
+  draft: AdvancedInviteDraft,
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return { ...editor, draft, keysAuthored: true };
+}
+
+/** Enable or disable the key at `index` in the guided list. */
+export function editorWithKeyEnabled(
+  editor: InviterEditor,
+  index: number,
+  enabled: boolean,
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return {
+    ...editor,
+    draft: {
+      ...editor.draft,
+      keys: editor.draft.keys.map((entry, at) =>
+        at === index ? { ...entry, enabled } : entry,
+      ),
+    },
+  };
+}
+
+/** Move the key at `index` one place earlier (`-1`) or later (`+1`); a move
+ * past either end is a no-op. Key order is match order, so this is the guided
+ * list's reorder control. */
+export function editorWithKeyMoved(
+  editor: InviterEditor,
+  index: number,
+  offset: -1 | 1,
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  const target = index + offset;
+  if (target < 0 || target >= editor.draft.keys.length) return editor;
+  const keys = [...editor.draft.keys];
+  [keys[index], keys[target]] = [keys[target], keys[index]];
+  return { ...editor, draft: { ...editor.draft, keys } };
+}
+
+/** Set how the agreed keys are exchanged (cascade or single-pass). */
+export function editorWithLinkageStrategy(
+  editor: InviterEditor,
+  linkageStrategy: LinkageStrategy,
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return { ...editor, draft: { ...editor.draft, linkageStrategy } };
+}
+
+/** Attach, edit, or (with `undefined`) detach the legal agreement. */
+export function editorWithLegalAgreement(
+  editor: InviterEditor,
+  legalAgreement: DraftLegalAgreement | undefined,
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return { ...editor, draft: { ...editor.draft, legalAgreement } };
+}
+
+/** Load an imported, validated terms document into the session, keeping the
+ * inviter's own columns and lifetime -- an unsupplyable imported key arrives
+ * disabled with its badge, never dropped ({@link draftFromTerms}). Imported
+ * keys are author-controlled. */
+export function editorWithImportedTerms(
+  editor: InviterEditor,
+  csv: AcquiredCsv,
+  terms: LinkageTerms,
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return {
+    ...editor,
+    draft: draftFromTerms(
+      terms,
+      editor.seed,
+      editor.draft.lifetimeSeconds,
+      csv.rawRows,
+    ),
+    keysAuthored: true,
+  };
+}
+
+/** Set one cleaned field's ordered steps. */
+export function editorWithFieldSteps(
+  editor: InviterEditor,
+  output: string,
+  steps: AdvancedInviteDraft["standardization"][number]["steps"],
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return {
+    ...editor,
+    draft: {
+      ...editor.draft,
+      standardization: editor.draft.standardization.map((transformation) =>
+        transformation.output === output
+          ? { ...transformation, steps }
+          : transformation,
+      ),
+    },
+  };
+}
+
+/** Rebind a cleaned field to a different input column. */
+export function editorWithFieldInput(
+  editor: InviterEditor,
+  output: string,
+  input: string,
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return {
+    ...editor,
+    draft: {
+      ...editor.draft,
+      standardization: editor.draft.standardization.map((transformation) =>
+        transformation.output === output
+          ? { ...transformation, input }
+          : transformation,
+      ),
+    },
+  };
+}
+
+/** Remove an authored same-typed field's transformation. */
+export function editorWithFieldRemoved(
+  editor: InviterEditor,
+  output: string,
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return {
+    ...editor,
+    draft: {
+      ...editor.draft,
+      standardization: editor.draft.standardization.filter(
+        (transformation) => transformation.output !== output,
+      ),
+    },
+  };
+}
+
+/** Append a same-typed field bound to its first free column, named uniquely
+ * off the type's first field and seeded with its steps, so the second field
+ * starts from the same recommended pipeline. A type with no free column is a
+ * no-op (the affordance is gated on one existing). */
+export function editorWithFieldAdded(
+  editor: InviterEditor,
+  type: LinkageField["type"],
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  const draft = editor.draft;
+  const bound = new Set(draft.standardization.map((t) => t.input));
+  const freeColumn = draft.metadata
+    .filter((column) => column.role === "linkage" && column.type === type)
+    .map((column) => column.name)
+    .find((column) => !bound.has(column));
+  if (freeColumn === undefined) return editor;
+  const typeByOutput = new Map(
+    declaredFieldsFor(draft).map((field) => [field.name, field.type]),
+  );
+  const sibling = draft.standardization.find(
+    (transformation) => typeByOutput.get(transformation.output) === type,
+  );
+  const base = sibling?.output ?? type;
+  const taken = new Set(draft.standardization.map((t) => t.output));
+  let n = 2;
+  let output = `${base}_${n}`;
+  while (taken.has(output)) output = `${base}_${++n}`;
+  return {
+    ...editor,
+    draft: {
+      ...draft,
+      standardization: [
+        ...draft.standardization,
+        { output, input: freeColumn, steps: sibling?.steps ?? [] },
+      ],
+    },
+  };
+}
+
+/** Restore the recommended cleaning for the current metadata -- the cleaning
+ * error boundary's recovery, scoped to the cleaning alone. */
+export function editorWithRecommendedCleaning(
+  editor: InviterEditor,
+  csv: AcquiredCsv,
+): InviterEditor {
+  if (editor.sealed === true) return editor;
+  return {
+    ...editor,
+    draft: {
+      ...editor.draft,
+      standardization: defaultStandardizationForRows(
+        editor.draft.metadata,
+        getDefaultLinkageTerms(editor.draft.identity, editor.draft.metadata),
+        csv.rawRows,
+      ),
+    },
+  };
+}
+
+/** The fields a key element may reference, in offer order -- the authored
+ * field set, so a second same-typed field is offerable. */
+export function declaredFieldsFor(
+  draft: AdvancedInviteDraft,
+): Array<LinkageField> {
+  return authoredLinkageFields(draft.metadata, draft.standardization);
+}
+
+/** Per-key satisfiability for the guided list's and expert editor's badges:
+ * whether the columns can produce every field the key references. */
+export function keySatisfiabilityFor(
+  editor: InviterEditor,
+): (index: number) => boolean {
+  const producible = producibleFieldNames(
+    editor.draft.metadata,
+    editor.draft.standardization,
+    editor.seed.columns,
+  );
+  return (index) =>
+    editor.draft.keys[index].key.elements.every((element) =>
+      producible.has(element.field),
+    );
+}
+
 /** Discard every edit and re-derive the recommended draft from the file,
  * keeping only the inviter's name -- step 3's "Reset to recommended". */
 export function resetToRecommended(
@@ -124,7 +366,10 @@ function withMetadata(
   return {
     editor: {
       ...editor,
-      draft: setDraftMetadata(editor.draft, metadata, csv.rawRows),
+      draft:
+        editor.keysAuthored === true
+          ? { ...editor.draft, metadata }
+          : setDraftMetadata(editor.draft, metadata, csv.rawRows),
     },
     demotedIdentifiers,
   };
@@ -316,10 +561,12 @@ export function inviterLedgerRows(
   ];
 }
 
-/** One rail quiet fact for the Customize group. */
+/** One rail quiet fact for the Customize group; `target` is the tab the
+ * fact's label opens. */
 export interface InviterRailFact {
   label: string;
   fact?: string;
+  target: Extract<SpineTarget, "cleaning" | "keys" | "agreement">;
 }
 
 function plural(count: number, noun: string): string {
@@ -348,34 +595,42 @@ export function inviterRailFacts(
     {
       label: "Cleaning",
       fact: editor === undefined ? undefined : cleaningFact(editor.draft),
+      target: "cleaning",
     },
     {
       label: "Matching keys",
       fact: editor === undefined ? undefined : keysFact(editor.draft),
+      target: "keys",
     },
     {
       label: "Legal agreement",
       fact: editor?.draft.legalAgreement?.reference,
+      target: "agreement",
     },
   ];
 }
 
-/** A bench section a Problems entry or a Change link can navigate to. */
-export type SpineTarget = "file" | "columns" | "review";
+/** A bench section a Problems entry or a Change link can navigate to: a spine
+ * step or a Customize tab. */
+export type SpineTarget =
+  | "file"
+  | "columns"
+  | "review"
+  | "cleaning"
+  | "keys"
+  | "agreement";
 
 /** The section that owns each validation field, so a Problems entry can link
- * to where the fix lives. Key, cleaning, and agreement fields point at step 2
- * until their Customize tabs exist -- the column table is where those terms
- * are shaped today. */
+ * to where the fix lives. */
 const FIELD_TARGETS: Record<AdvancedField, SpineTarget> = {
   identity: "file",
   payload: "columns",
-  keys: "columns",
-  standardization: "columns",
+  keys: "keys",
+  standardization: "cleaning",
   lifetime: "review",
-  legalReference: "review",
-  legalPurpose: "review",
-  legalExpiration: "review",
+  legalReference: "agreement",
+  legalPurpose: "agreement",
+  legalExpiration: "agreement",
 };
 
 /** One entry in the rail's Problems block: the message and the section that
@@ -457,15 +712,18 @@ export function answersRows(
     {
       label: "Cleaning",
       value: `${cleaningFact(editor.draft)}, filled in from your file`,
+      changeTarget: "cleaning",
     },
     {
       label: "Matching keys",
-      value: `${keysFact(editor.draft)}, recommended order`,
+      value: `${keysFact(editor.draft)}, tried in order`,
+      changeTarget: "keys",
     },
     {
       label: "Legal agreement",
       value: editor.draft.legalAgreement?.reference ?? "None",
       mono: editor.draft.legalAgreement?.reference !== undefined,
+      changeTarget: "agreement",
     },
     {
       label: "Invitation lifetime",

--- a/apps/web/src/components/LinkageTermsEditor.tsx
+++ b/apps/web/src/components/LinkageTermsEditor.tsx
@@ -45,6 +45,7 @@ import {
   buildAdvancedTerms,
   defaultStandardizationForRows,
   draftFromTerms,
+  draftWithFieldAdded,
   producibleFieldNames,
   setDraftMetadata,
   validateAdvancedInvite,
@@ -323,17 +324,6 @@ export function LinkageTermsEditor({
           silentEmptyLabels.length === 1 ? "produces" : "produce"
         } no value for any row and cannot match. Check the cleaning steps.`;
 
-  // The inviter's `role: linkage` columns of a semantic type, in metadata order --
-  // the columns a same-typed field MAY bind to. Drives the add-field free-column
-  // search below (StandardizationCards computes its own copy for the affordance).
-  const columnsForType = (
-    metadata: Metadata,
-    type: LinkageField["type"],
-  ): Array<string> =>
-    metadata
-      .filter((column) => column.role === "linkage" && column.type === type)
-      .map((column) => column.name);
-
   // A signature of each field's input binding for the cleaning error boundary's
   // auto-recovery (see CleaningErrorBoundary); a reset or remap changes it.
   const cleaningResetKey = useMemo(
@@ -368,41 +358,12 @@ export function LinkageTermsEditor({
       ...prev,
       standardization: prev.standardization.filter((t) => t.output !== output),
     }));
-  // Append a same-typed field bound to its first free column, named uniquely off the
-  // type's first field and seeded with its steps (so the second field starts from the
-  // same recommended pipeline). It reads the host's authoritative array via the
-  // functional updater, so the
-  // affordance the component gates on `addableTypes` and this free-column search stay
-  // consistent (the early return never fires while the component shows the button).
+  // Reads the host's authoritative array via the functional updater, so the
+  // affordance the component gates on `addableTypes` and the shared helper's
+  // free-column search stay consistent (its no-op return never fires while the
+  // component shows the button).
   const addFieldForType = (type: LinkageField["type"]) =>
-    setDraft((prev) => {
-      const bound = new Set(prev.standardization.map((t) => t.input));
-      const freeColumn = columnsForType(prev.metadata, type).find(
-        (c) => !bound.has(c),
-      );
-      if (freeColumn === undefined) return prev;
-      const typeByOutput = new Map(
-        authoredLinkageFields(prev.metadata, prev.standardization).map((f) => [
-          f.name,
-          f.type,
-        ]),
-      );
-      const sibling = prev.standardization.find(
-        (t) => typeByOutput.get(t.output) === type,
-      );
-      const base = sibling?.output ?? type;
-      const taken = new Set(prev.standardization.map((t) => t.output));
-      let n = 2;
-      let output = `${base}_${n}`;
-      while (taken.has(output)) output = `${base}_${++n}`;
-      return {
-        ...prev,
-        standardization: [
-          ...prev.standardization,
-          { output, input: freeColumn, steps: sibling?.steps ?? [] },
-        ],
-      };
-    });
+    setDraft((prev) => draftWithFieldAdded(prev, type));
 
   const updateDraft = (next: Partial<AdvancedInviteDraft>) => {
     setAnnouncement("");

--- a/apps/web/src/components/LinkageTermsEditor.tsx
+++ b/apps/web/src/components/LinkageTermsEditor.tsx
@@ -32,9 +32,7 @@ import {
   LinkageStrategySchema,
   MAX_NAME_LENGTH,
   MAX_TEXT_LENGTH,
-  assessLinkageSatisfiability,
   authoredLinkageFields,
-  getDefaultLinkageTerms,
   sanitizeForDisplay,
 } from "@psilink/core";
 
@@ -47,6 +45,7 @@ import {
   buildAdvancedTerms,
   defaultStandardizationForRows,
   draftFromTerms,
+  producibleFieldNames,
   setDraftMetadata,
   validateAdvancedInvite,
 } from "@psi/advancedInvite";
@@ -272,43 +271,15 @@ export function LinkageTermsEditor({
 
   // Per-key satisfiability badge, derived from the draft's CURRENT metadata AND
   // authored standardization so it tracks both column-type edits and per-field
-  // column bindings. A field is producible when the shared resolution binds it to a
-  // present column; deriving the field universe from authoredLinkageFields (not the
-  // one-field-per-type default) and resolving through draft.standardization -- the
-  // same inputs the Generate gate and the declared-field list use -- is what lets an
-  // authored same-typed second field (e.g. first_name_2) read as satisfiable. With
-  // the bare default field set and no standardization, such a field is absent from
-  // the universe and its key would wrongly badge unsatisfiable while it generates
-  // and produces at the exchange.
-  const producibleFieldNames = useMemo(() => {
-    // identity is deliberately NOT a dependency: getDefaultLinkageTerms uses it
-    // only to populate terms.identity, never to derive the field or key set, so
-    // it cannot change which fields are producible. Pass a constant so a keystroke
-    // in the name field does not recompute this (and the real input sensitivity --
-    // the column metadata and standardization -- stays legible in the dependency
-    // array). The probe restates the authored fields onto default terms; only its
-    // linkageFields are read (resolveFieldColumns ignores linkageKeys), so the
-    // default keys are inert.
-    const fields = authoredLinkageFields(draft.metadata, draft.standardization);
-    const probe: LinkageTerms = {
-      ...getDefaultLinkageTerms("", draft.metadata),
-      linkageFields: fields,
-    };
-    const { unsatisfied } = assessLinkageSatisfiability(
-      seed.columns,
-      probe,
-      draft.standardization,
-      draft.metadata,
-    );
-    const unsatisfiedNames = new Set(unsatisfied.map((f) => f.name));
-    return new Set(
-      fields.map((f) => f.name).filter((name) => !unsatisfiedNames.has(name)),
-    );
-  }, [draft.metadata, draft.standardization, seed.columns]);
+  // column bindings (see producibleFieldNames for why the universe is the
+  // authored field set, not the one-field-per-type default).
+  const producible = useMemo(
+    () =>
+      producibleFieldNames(draft.metadata, draft.standardization, seed.columns),
+    [draft.metadata, draft.standardization, seed.columns],
+  );
   const keyIsSatisfiable = (index: number): boolean =>
-    draft.keys[index].key.elements.every((el) =>
-      producibleFieldNames.has(el.field),
-    );
+    draft.keys[index].key.elements.every((el) => producible.has(el.field));
 
   // The fields a key element may reference: derived from the authored standardization
   // (not the one-field-per-type default), so when the operator binds two transformations

--- a/apps/web/src/psi/advancedInvite.ts
+++ b/apps/web/src/psi/advancedInvite.ts
@@ -674,6 +674,45 @@ function declarableFieldNames(
 }
 
 /**
+ * Append a same-typed linkage field bound to the type's first free
+ * `role: linkage` column, named uniquely off the type's first field and seeded
+ * with its steps -- so the second field starts from the same recommended
+ * pipeline. A type with no free column returns the draft unchanged (the
+ * add-field affordance is gated on one existing).
+ */
+export function draftWithFieldAdded(
+  draft: AdvancedInviteDraft,
+  type: LinkageField["type"],
+): AdvancedInviteDraft {
+  const bound = new Set(draft.standardization.map((t) => t.input));
+  const freeColumn = draft.metadata
+    .filter((column) => column.role === "linkage" && column.type === type)
+    .map((column) => column.name)
+    .find((column) => !bound.has(column));
+  if (freeColumn === undefined) return draft;
+  const typeByOutput = new Map(
+    authoredLinkageFields(draft.metadata, draft.standardization).map(
+      (field) => [field.name, field.type],
+    ),
+  );
+  const sibling = draft.standardization.find(
+    (transformation) => typeByOutput.get(transformation.output) === type,
+  );
+  const base = sibling?.output ?? type;
+  const taken = new Set(draft.standardization.map((t) => t.output));
+  let n = 2;
+  let output = `${base}_${n}`;
+  while (taken.has(output)) output = `${base}_${++n}`;
+  return {
+    ...draft,
+    standardization: [
+      ...draft.standardization,
+      { output, input: freeColumn, steps: sibling?.steps ?? [] },
+    ],
+  };
+}
+
+/**
  * The authored field names the operator's columns can actually PRODUCE -- the
  * satisfiability universe a key's badge is judged against. Derived from the
  * authored fields (not the one-field-per-type default) and resolved through

--- a/apps/web/src/psi/advancedInvite.ts
+++ b/apps/web/src/psi/advancedInvite.ts
@@ -673,6 +673,40 @@ function declarableFieldNames(
   );
 }
 
+/**
+ * The authored field names the operator's columns can actually PRODUCE -- the
+ * satisfiability universe a key's badge is judged against. Derived from the
+ * authored fields (not the one-field-per-type default) and resolved through
+ * the given standardization -- the same inputs the Generate gate uses -- so an
+ * authored same-typed second field (e.g. first_name_2) reads as satisfiable.
+ * The probe restates the authored fields onto default terms; only its
+ * linkageFields are read (resolveFieldColumns ignores linkageKeys), and the
+ * identity is a constant because it never affects the field or key set.
+ */
+export function producibleFieldNames(
+  metadata: Metadata,
+  standardization: Standardization,
+  columns: ReadonlyArray<string>,
+): Set<string> {
+  const fields = authoredLinkageFields(metadata, standardization);
+  const probe: LinkageTerms = {
+    ...getDefaultLinkageTerms("", metadata),
+    linkageFields: fields,
+  };
+  const { unsatisfied } = assessLinkageSatisfiability(
+    [...columns],
+    probe,
+    standardization,
+    metadata,
+  );
+  const unsatisfiedNames = new Set(unsatisfied.map((field) => field.name));
+  return new Set(
+    fields
+      .map((field) => field.name)
+      .filter((name) => !unsatisfiedNames.has(name)),
+  );
+}
+
 /** Whether the inviter's columns can supply every field `key` references (each
  * element's `field` is declarable -- see {@link declarableFieldNames}). A key that
  * is not supplyable dangles the built terms, so the import disables it

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -61,6 +61,37 @@ vi.mock("@psi/invitation", async (importOriginal) => {
   };
 });
 
+// Defer the CSV parse per-test to observe in-flight state (the Continue
+// gate, the abort signal). With `defer` unset it delegates to the real
+// loader.
+const csvLoadHarness = vi.hoisted(() => ({
+  defer: false,
+  lastSignal: undefined as AbortSignal | undefined,
+  resolve: undefined as ((value: unknown) => void) | undefined,
+}));
+vi.mock("@psi/csvParseController", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    loadCSVFileOffMainThread: (
+      file: unknown,
+      options?: { signal?: AbortSignal },
+    ) => {
+      csvLoadHarness.lastSignal = options?.signal;
+      if (!csvLoadHarness.defer)
+        return (
+          actual.loadCSVFileOffMainThread as (
+            f: unknown,
+            o?: unknown,
+          ) => Promise<unknown>
+        )(file, options);
+      return new Promise((resolve) => {
+        csvLoadHarness.resolve = resolve;
+      });
+    },
+  };
+});
+
 const EM_DASH = "\u2014";
 
 let container: HTMLElement | undefined;
@@ -79,6 +110,9 @@ afterEach(() => {
   root = undefined;
   container = undefined;
   mintHarness.fail = undefined;
+  csvLoadHarness.defer = false;
+  csvLoadHarness.lastSignal = undefined;
+  csvLoadHarness.resolve = undefined;
 });
 
 describe("bench lobby", () => {
@@ -243,6 +277,10 @@ describe("inviter bench", () => {
     await expect
       .element(page.getByText("Nothing - matching only"))
       .toBeInTheDocument();
+    // The debounced disclosure summary voices the new (empty) send set.
+    await expect
+      .element(page.getByText("No columns will be sent to your partner."))
+      .toBeInTheDocument();
     await expect
       .element(
         page.getByText("No values will be sent to your partner", {
@@ -294,6 +332,12 @@ describe("inviter bench", () => {
     await expect
       .element(page.getByRole("heading", { level: 1 }))
       .toHaveTextContent("Matching & sharing");
+
+    // The conflict's audible half: announced even though the seed mounted
+    // already in conflict.
+    await expect
+      .element(page.getByText("Problem: choose a single row identifier."))
+      .toBeInTheDocument();
 
     await page
       .getByLabelText("How identifier is used")
@@ -514,6 +558,46 @@ describe("inviter bench", () => {
         (heading) => heading.textContent === "Legal agreement",
       )?.parentElement?.textContent,
     ).toContain("None");
+  });
+
+  test("intake surfaces rejections and gates on an in-flight parse", async () => {
+    mount(createElement(InviterBench));
+
+    await expect.element(page.getByLabelText("Your name")).toBeInTheDocument();
+    await userEvent.fill(page.getByLabelText("Your name"), "Dana");
+    const fileInput = () =>
+      document.querySelector('input[type="file"]') as HTMLElement;
+
+    // A refused drop names its reason instead of flashing an icon.
+    await userEvent.upload(
+      page.elementLocator(fileInput()),
+      new File(["x"], "image.png", { type: "image/png" }),
+    );
+    await expect
+      .element(page.getByText("not a supported file type", { exact: false }))
+      .toBeInTheDocument();
+
+    // While a parse is in flight Continue stays gated and the read carries an
+    // abort signal; unmounting aborts it so the worker tears down.
+    csvLoadHarness.defer = true;
+    await userEvent.upload(
+      page.elementLocator(fileInput()),
+      new File(["first_name,last_name,dob\nAnn,Lee,01/02/1990\n"], "a.csv", {
+        type: "text/csv",
+      }),
+    );
+    await expect
+      .element(
+        page.getByRole("button", { name: "Continue to matching & sharing" }),
+      )
+      .toBeDisabled();
+    const signal = csvLoadHarness.lastSignal;
+    expect(signal).toBeDefined();
+    expect((signal as AbortSignal).aborted).toBe(false);
+
+    root?.unmount();
+    root = undefined;
+    expect((signal as AbortSignal).aborted).toBe(true);
   });
 
   test("a failed mint leaves the terms editable and create retryable", async () => {

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -424,11 +424,15 @@ describe("inviter bench", () => {
         (row) => row.querySelector("dt")?.childNodes[0].textContent === label,
       );
 
-    // The rail's Customize facts are links once the file is read.
+    // The rail's Customize facts are links once the file is read; the open
+    // tab carries aria-current="true" (spine steps use "step").
     await page.getByRole("button", { name: "Matching keys" }).click();
     await expect
       .element(page.getByRole("heading", { level: 1 }))
       .toHaveTextContent("Matching keys");
+    expect(document.querySelector('[aria-current="true"]')?.textContent).toBe(
+      "Matching keys",
+    );
 
     // Reordering the guided list reorders the ledger's matched-on keys.
     const orderBefore = ledgerRow("Matched on")?.querySelector("dd")
@@ -440,6 +444,13 @@ describe("inviter bench", () => {
     const orderAfter = ledgerRow("Matched on")?.querySelector("dd")
       ?.textContent as string;
     expect(orderAfter).not.toBe(orderBefore);
+
+    // Selecting single-pass flows through the schema-parse guard and
+    // surfaces the disclosure warning at the point of choice.
+    await page.getByLabelText("Single-pass").click();
+    await expect
+      .element(page.getByText("Single-pass widens what one of you can observe"))
+      .toBeInTheDocument();
 
     // The gated method and deduplication controls are visible but inert.
     await expect.element(page.getByLabelText("Matching method")).toBeDisabled();

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -396,6 +396,94 @@ describe("inviter bench", () => {
     expect(expiresRow?.querySelector("dd")?.textContent).toMatch(/20\d\d/);
   });
 
+  test("customize tabs: reorder keys, author an agreement, gated settings stay inert", async () => {
+    mount(createElement(InviterBench));
+
+    await expect.element(page.getByLabelText("Your name")).toBeInTheDocument();
+    await userEvent.fill(page.getByLabelText("Your name"), "Dana");
+    const fileInput = document.querySelector('input[type="file"]');
+    await userEvent.upload(
+      page.elementLocator(fileInput as HTMLElement),
+      new File(
+        [
+          "client_id,first_name,last_name,dob,program_code\n" +
+            "1,Ann,Lee,01/02/1990,A\n",
+        ],
+        "clients.csv",
+        { type: "text/csv" },
+      ),
+    );
+    await expect.element(page.getByText("clients.csv")).toBeInTheDocument();
+
+    const ledgerRow = (label: string) =>
+      Array.from(
+        document.querySelectorAll(
+          `aside[aria-label="This exchange"] .${styles.ledgerRow}`,
+        ),
+      ).find(
+        (row) => row.querySelector("dt")?.childNodes[0].textContent === label,
+      );
+
+    // The rail's Customize facts are links once the file is read.
+    await page.getByRole("button", { name: "Matching keys" }).click();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Matching keys");
+
+    // Reordering the guided list reorders the ledger's matched-on keys.
+    const orderBefore = ledgerRow("Matched on")?.querySelector("dd")
+      ?.textContent as string;
+    await page
+      .getByRole("button", { name: /^Move .+ later$/ })
+      .first()
+      .click();
+    const orderAfter = ledgerRow("Matched on")?.querySelector("dd")
+      ?.textContent as string;
+    expect(orderAfter).not.toBe(orderBefore);
+
+    // The gated method and deduplication controls are visible but inert.
+    await expect.element(page.getByLabelText("Matching method")).toBeDisabled();
+    await expect
+      .element(
+        page.getByLabelText(
+          "Allow several of your records to match one partner record",
+        ),
+      )
+      .toBeDisabled();
+
+    // The agreement authored in its tab reaches the ledger and the review
+    // table.
+    await page.getByRole("button", { name: "Legal agreement" }).click();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Legal agreement");
+    await page.getByLabelText("Attach a legal agreement").click();
+    await userEvent.fill(
+      page.getByLabelText("Agreement reference"),
+      "MOU-2025-0042",
+    );
+    await userEvent.fill(
+      page.getByLabelText("Purpose of the disclosure"),
+      "Program evaluation",
+    );
+    await userEvent.fill(page.getByLabelText("Expiration date"), "2099-12-31");
+    expect(ledgerRow("Agreement")?.querySelector("dd")?.textContent).toBe(
+      "MOU-2025-0042",
+    );
+
+    await page.getByRole("button", { name: /Back to Review & create/ }).click();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Review & create");
+    await expect
+      .element(page.getByText("Ready to create."))
+      .toBeInTheDocument();
+    const agreementRow = Array.from(document.querySelectorAll("th")).find(
+      (heading) => heading.textContent === "Legal agreement",
+    )?.parentElement;
+    expect(agreementRow?.textContent).toContain("MOU-2025-0042");
+  });
+
   test("a failed mint leaves the terms editable and create retryable", async () => {
     mount(createElement(InviterBench));
 

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -482,10 +482,20 @@ describe("inviter bench", () => {
       "MOU-2025-0042",
     );
 
+    // The ported input contracts survive the bench: the expiry is a real
+    // date input and the reference keeps its length bound.
+    const expiration = document.querySelector('input[type="date"]');
+    expect(expiration).not.toBeNull();
+    const reference = document.querySelector(
+      'input[placeholder="MOU-2025-0042"]',
+    );
+    expect(reference?.getAttribute("maxlength")).toBe("256");
+
     await page.getByRole("button", { name: /Back to Review & create/ }).click();
     await expect
       .element(page.getByRole("heading", { level: 1 }))
       .toHaveTextContent("Review & create");
+
     await expect
       .element(page.getByText("Ready to create."))
       .toBeInTheDocument();
@@ -493,6 +503,17 @@ describe("inviter bench", () => {
       (heading) => heading.textContent === "Legal agreement",
     )?.parentElement;
     expect(agreementRow?.textContent).toContain("MOU-2025-0042");
+
+    // Reset discards the authored terms and announces it politely.
+    await page.getByRole("button", { name: "Reset to recommended" }).click();
+    await expect
+      .element(page.getByText("Reset to the recommended settings."))
+      .toBeInTheDocument();
+    expect(
+      Array.from(document.querySelectorAll("th")).find(
+        (heading) => heading.textContent === "Legal agreement",
+      )?.parentElement?.textContent,
+    ).toContain("None");
   });
 
   test("a failed mint leaves the terms editable and create retryable", async () => {

--- a/apps/web/test/unit/benchInviterModel.test.ts
+++ b/apps/web/test/unit/benchInviterModel.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, test } from "vitest";
 import {
   answersRows,
   editorFromCsv,
+  editorWithAlgorithm,
   editorWithAuthoredDraft,
   editorWithColumnDisclosure,
   editorWithColumnType,
+  editorWithDeduplicate,
+  editorWithFieldAdded,
   editorWithFieldSteps,
   editorWithIdentity,
   editorWithImportedTerms,
@@ -290,14 +293,45 @@ describe("customize tabs", () => {
 
   test("gated settings cannot alter minted terms", () => {
     const seeded = editorFromCsv("Dana", csv);
-    const forced = editorWithAuthoredDraft(seeded, {
-      ...seeded.draft,
-      algorithm: "psi-c",
-      deduplicate: true,
-    });
+    const forced = editorWithDeduplicate(
+      editorWithAlgorithm(seeded, "psi-c"),
+      true,
+    );
+    expect(forced.draft.algorithm).toBe("psi-c");
+    expect(forced.draft.deduplicate).toBe(true);
     const terms = mintedTerms(forced);
     expect(terms.algorithm).toBe("psi");
     expect(terms.deduplicate).toBe(false);
+  });
+
+  test("adding a same-typed field binds the free column uniquely", () => {
+    const seeded = editorFromCsv("Dana", csv);
+    // Retype the payload column to a second first_name, then bind it: the new
+    // field takes the type's recommended pipeline under a unique name.
+    const { editor: retypedOnly } = editorWithColumnType(
+      seeded,
+      csv,
+      "program_code",
+      "first_name",
+    );
+    // A retype preserves the sent disclosure, so the column must also be set
+    // to match before it is a bindable linkage column.
+    const { editor: retyped } = editorWithColumnDisclosure(
+      retypedOnly,
+      csv,
+      "program_code",
+      "match",
+    );
+    const added = editorWithFieldAdded(retyped, "first_name");
+    const grown = added.draft.standardization.length;
+    expect(grown).toBe(retyped.draft.standardization.length + 1);
+    const appended = added.draft.standardization[grown - 1];
+    expect(appended.input).toBe("program_code");
+    expect(appended.output).toMatch(/_2$/);
+
+    // No free column of the type: the draft is untouched.
+    const noop = editorWithFieldAdded(seeded, "zip_code");
+    expect(noop.draft).toBe(seeded.draft);
   });
 
   test("importing terms with an unsupplyable field degrades gracefully", () => {

--- a/apps/web/test/unit/benchInviterModel.test.ts
+++ b/apps/web/test/unit/benchInviterModel.test.ts
@@ -3,16 +3,24 @@ import { describe, expect, test } from "vitest";
 import {
   answersRows,
   editorFromCsv,
+  editorWithAuthoredDraft,
   editorWithColumnDisclosure,
   editorWithColumnType,
+  editorWithFieldSteps,
   editorWithIdentity,
+  editorWithImportedTerms,
+  editorWithKeyEnabled,
+  editorWithKeyMoved,
+  editorWithLegalAgreement,
   editorWithLifetime,
+  editorWithLinkageStrategy,
   editorWithOutputDirection,
   enabledKeys,
   fileCardMeta,
   identifierProblem,
   inviterLedgerRows,
   inviterRailFacts,
+  keySatisfiabilityFor,
   lifetimeLabel,
   resetToRecommended,
   reviewValidation,
@@ -244,7 +252,7 @@ describe("review and create", () => {
       /^\d+ fields?, filled in from your file$/,
     );
     expect(byLabel.get("Matching keys")?.value).toMatch(
-      /^\d+ keys?, recommended order$/,
+      /^\d+ keys?, tried in order$/,
     );
     expect(byLabel.get("Invitation lifetime")?.value).toBe("1 day");
     expect(byLabel.get("Invitation lifetime")?.setAbove).toBe(true);
@@ -257,5 +265,135 @@ describe("review and create", () => {
     const rows = inviterLedgerRows(editor, "2026-07-08T19:32:00.000Z");
     const expires = rows.find((row) => row.label === "Expires");
     expect(expires?.value).toContain("July 8, 2026");
+  });
+});
+
+function mintedTerms(editor: ReturnType<typeof editorFromCsv>) {
+  const validation = reviewValidation(editor);
+  if (validation.terms === undefined)
+    throw new Error("draft unexpectedly cannot mint");
+  return validation.terms;
+}
+
+describe("customize tabs", () => {
+  test("reordering keys changes key order in minted terms", () => {
+    const editor = editorFromCsv("Dana", csv);
+    const before = mintedTerms(editor).linkageKeys.map((key) => key.name);
+    expect(before.length).toBeGreaterThan(1);
+
+    const moved = editorWithKeyMoved(editor, 0, 1);
+    const after = mintedTerms(moved).linkageKeys.map((key) => key.name);
+    expect(after[0]).toBe(before[1]);
+    expect(after[1]).toBe(before[0]);
+    expect(after.slice(2)).toEqual(before.slice(2));
+  });
+
+  test("gated settings cannot alter minted terms", () => {
+    const seeded = editorFromCsv("Dana", csv);
+    const forced = editorWithAuthoredDraft(seeded, {
+      ...seeded.draft,
+      algorithm: "psi-c",
+      deduplicate: true,
+    });
+    const terms = mintedTerms(forced);
+    expect(terms.algorithm).toBe("psi");
+    expect(terms.deduplicate).toBe(false);
+  });
+
+  test("importing terms with an unsupplyable field degrades gracefully", () => {
+    const donor = editorFromCsv("Dana", {
+      ...csv,
+      columns: ["ssn", "first_name", "last_name", "dob"],
+      rawRows: [
+        {
+          ssn: "123456789",
+          first_name: "Ann",
+          last_name: "Lee",
+          dob: "01/02/1990",
+        },
+      ],
+    });
+    const donorTerms = mintedTerms(donor);
+
+    // The receiving file has ssn4, not ssn: every donor key referencing the
+    // full-ssn field arrives disabled with its unsatisfiable badge, and the
+    // satisfiable subset still mints.
+    const editor = editorFromCsv("Dana", csv);
+    const imported = editorWithImportedTerms(editor, csv, donorTerms);
+    expect(imported.keysAuthored).toBe(true);
+    const disabled = imported.draft.keys.filter((entry) => !entry.enabled);
+    expect(disabled.length).toBeGreaterThan(0);
+    const satisfiable = keySatisfiabilityFor(imported);
+    expect(
+      imported.draft.keys.some((_entry, index) => !satisfiable(index)),
+    ).toBe(true);
+    expect(reviewValidation(imported).canGenerate).toBe(true);
+  });
+
+  test("terms export/import round-trips the minted terms", () => {
+    const editor = editorWithLegalAgreement(
+      editorWithKeyMoved(editorFromCsv("Dana", csv), 0, 1),
+      {
+        reference: "MOU-1",
+        purpose: "Eval",
+        expirationDate: "2099-12-31",
+      },
+    );
+    const exported = mintedTerms(editor);
+    const reimported = editorWithImportedTerms(editor, csv, exported);
+    expect(mintedTerms(reimported)).toEqual(exported);
+  });
+
+  test("column edits preserve authored keys", () => {
+    const seeded = editorFromCsv("Dana", csv);
+    const keyNames = (candidate: typeof seeded) =>
+      candidate.draft.keys.map((entry) => entry.key.name);
+
+    const { editor: reconciled } = editorWithColumnType(
+      seeded,
+      csv,
+      "ssn4",
+      "other",
+    );
+    expect(keyNames(reconciled).length).toBeLessThan(keyNames(seeded).length);
+
+    const authored = editorWithAuthoredDraft(seeded, seeded.draft);
+    const { editor: preserved } = editorWithColumnType(
+      authored,
+      csv,
+      "ssn4",
+      "other",
+    );
+    expect(keyNames(preserved)).toEqual(keyNames(seeded));
+  });
+
+  test("agreement fields flow into the minted terms and the ledger", () => {
+    const editor = editorWithLegalAgreement(editorFromCsv("Dana", csv), {
+      reference: "MOU-2025-0042",
+      purpose: "Program evaluation",
+      expirationDate: "2099-12-31",
+    });
+    const terms = mintedTerms(editor);
+    expect(terms.legalAgreement?.reference).toBe("MOU-2025-0042");
+    expect(inviterRailFacts(editor)[2].fact).toBe("MOU-2025-0042");
+    expect(ledgerValue(editor, "Agreement").value).toBe("MOU-2025-0042");
+  });
+
+  test("sealed sessions refuse the tab mutators", () => {
+    const donorTerms = mintedTerms(editorFromCsv("Dana", csv));
+    const sealed = sealEditor(editorFromCsv("Dana", csv));
+    expect(editorWithKeyMoved(sealed, 0, 1)).toBe(sealed);
+    expect(editorWithKeyEnabled(sealed, 0, false)).toBe(sealed);
+    expect(editorWithLinkageStrategy(sealed, "single-pass")).toBe(sealed);
+    expect(
+      editorWithLegalAgreement(sealed, {
+        reference: "x",
+        purpose: "y",
+        expirationDate: "2099-01-01",
+      }),
+    ).toBe(sealed);
+    expect(editorWithFieldSteps(sealed, "name", [])).toBe(sealed);
+    expect(editorWithAuthoredDraft(sealed, sealed.draft)).toBe(sealed);
+    expect(editorWithImportedTerms(sealed, csv, donorTerms)).toBe(sealed);
   });
 });


### PR DESCRIPTION
## Summary

The three unnumbered Customize tabs open off the inviter spine: Cleaning (per-field pipelines with previews and whole-file coverage), Matching keys (the guided ordered list with enable/reorder and satisfiability badges, the expert element-by-element editor, terms import/export, and the matching settings with gated psi-c/deduplication controls), and Legal agreement (the three values the partner must enter identically). The rail's quiet facts become links carrying the current-tab state, and the review table's cleaning, key, and agreement rows gain their Change links. The deep authoring surfaces are the existing tested editors mounted as controlled components over the bench's single draft; the bench owns the tab chrome and the guided layer.

Implements [211235800](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=211235800).

## Changes

- apps/web/src/bench/CleaningTab.tsx, KeysTab.tsx, AgreementTab.tsx: the three tab surfaces. Cleaning mounts the standardization workbench (with the cleaning error boundary and coverage readouts) over the bench draft; Matching keys renders the guided key list bench-native and mounts ExpertKeyEditor and TermsImportExport behind the expert switch, with the linkage-strategy choice live (single-pass warning at the point of choice) and the gated method/dedup controls wired but disabled; Agreement is a bench-native form with inline validation errors.
- apps/web/src/bench/inviterModel.ts: the tab mutators (key enable/reorder, strategy, algorithm, dedup, agreement, import, per-field cleaning edits, recommended-cleaning reset), all sealed-guarded; the `keysAuthored` rule ported from the old editor -- once keys are author-controlled (expert edit or import), a column edit updates only the metadata, because template-driven reconciliation would silently drop authored keys.
- apps/web/src/psi/advancedInvite.ts, components/LinkageTermsEditor.tsx: `producibleFieldNames` (the satisfiability universe) and `draftWithFieldAdded` (the add-same-typed-field algorithm) extracted so the old editor and the bench share one implementation of each.
- apps/web/src/bench/InviterBench.tsx, Rail.tsx, bench.module.css: tab navigation (rail facts as links with `aria-current`, back-links to Review & create, spine steps stay navigable from a tab), the expert-mode flag shared across tabs, a polite live region for editor announcements, and the guided-list/badge styling.
- Tests: unit (24) pin the named criteria -- reordering keys reorders the minted terms, gated settings cannot alter minted terms (driven through the real mutators), an import referencing an unsupplyable field degrades to a disabled badged key -- plus export/import round-tripping, authored-key preservation across column edits, same-typed field addition, agreement flow, and sealed-session refusal of every new mutator. The browser suite (9) drives the tabs end to end: rail-fact navigation, guided reorder moving the ledger's matched-on order, the single-pass warning through the schema-parse guard, inert gated controls, and an authored agreement reaching the ledger and review table.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run formatcheck`, `npm run test:unit -w apps/web` (625 passed, including the old editor's advancedInvite/expertAuthoring suites over the extracted helpers), `npm run test:browser -w apps/web` (345 passed, including the old LinkageTermsEditor suites), `npm run build -w apps/web`.
New tests cover: the three acceptance criteria named on the issue, plus round-tripping, keysAuthored preservation, field addition, agreement flow-through, and sealed refusal.

## Background

A light-review round (3 reviewers, 5 confirmed findings, 0 simpler-shape votes) drove fixes for all five, led by a genuine catch: the ported strategy radio group had dropped the old editor's deliberate `LinkageStrategySchema.parse` narrowing, so an enum-drifted value literal would have typechecked clean. The gated controls also gained real change wiring so a future capability-flag flip enables working controls; `buildAdvancedTerms` clamps minted terms regardless, which the tests assert through the real mutators.

Because three of the five findings were the same class (a port dropping behavior its original deliberately carried), a focused port-fidelity pass then compared every ported surface against its LinkageTermsEditor counterpart. It found eleven more dropped contracts, fixed in the follow-up commit -- most consequentially the editor-wide coverage announcement (FieldCoverage's per-card alarm is presentational by documented contract because the host announces once; the bench host never did), the create-gate readiness announcement, the date input's type, length bounds, role=alert discipline, focus into the opened agreement block, and the cleared-between-interactions live region rule.

## Out of scope / follow-on

- The deep editors keep their existing Mantine presentation inside the bench chrome; a visual re-skin to the mockup's card furniture, if wanted, belongs with the cutover item's parity pass.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed; the bench remains a parallel preview and the docs rewrite is scheduled with the cutover item
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: preview routes on the continuously deployed web app; no operator- or reviewer-actionable change
- [x] Security review -- n/a: no enumerated surface modified; the tabs re-surface existing tested authoring logic over the same mint boundary, gated settings remain clamped out of minted terms (test-asserted), and nothing new is sent, stored, or logged
