### PR TITLE
Sweep a finding class when a round shows a pattern

### DIFF
--- a/.claude/commands/assess-review.md
+++ b/.claude/commands/assess-review.md
@@ -60,6 +60,11 @@ hunks/files it names, not the whole diff), then decide.
   or a new code path (error handling, a guard, a fallback), pin its guarantees
   with a test in the same pass. No later round re-reviews a fix: another round
   exists only for the step-back triggers.
+- **A pattern in the findings gets a class sweep.** When several findings share
+  one mechanism (a port dropping behavior its original carried, a rename
+  missing sites, a repeated idiom misused), run one focused pass over that
+  class across the whole branch in the same triage -- a review round samples;
+  the sweep completes.
 - **Prose findings get a high bar.** Fix a finding that asks for a comment,
   JSDoc, or doc paragraph only when the missing constraint is unrecoverable
   from the code, names, types, and tests AND its absence enables a concrete


### PR DESCRIPTION
## Summary

Add one triage rule to the assess-review skill: when several of a round's findings share one mechanism, the same triage runs a focused pass over that class across the whole branch -- a review round samples a systematic defect class; the sweep completes it.

## Changes

- .claude/commands/assess-review.md: new bullet in Step 3's triage list, after the fix-gets-a-test rule.

## Test plan

Ran: `npm run lint`, `npm run formatcheck`, `npm run linkcheck`.
New tests cover: n/a - contributor-process text only.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: agent skill text, not product documentation
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: process text only, nothing operator- or reviewer-visible
- [x] Security review -- n/a: no code touched
