### PR TITLE
Discard the prior read when a bench re-read fails

### DIFF
--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -140,6 +140,17 @@ export function InviterBench() {
     mounted.current = true;
   }, [section]);
 
+  // A failed read discards any prior read as well: the file card, the
+  // recommended-terms callout, and the Continue gate all vouch for
+  // `acquired`/`editor`, so leaving them set would present the previous file
+  // as the one the operator just dropped.
+  function discardRead(alert: IntakeAlert) {
+    setAcquired(undefined);
+    setSourceFile(undefined);
+    setEditor(undefined);
+    setIntakeAlert(alert);
+  }
+
   async function readFile(file: File) {
     const id = ++parseId.current;
     parseAbort.current?.abort();
@@ -155,7 +166,7 @@ export function InviterBench() {
       const columns = result.meta.fields ?? [];
       const emptyPositions = emptyColumnPositions(columns);
       if (emptyPositions.length > 0) {
-        setIntakeAlert(unnameableColumnsAlert(emptyPositions));
+        discardRead(unnameableColumnsAlert(emptyPositions));
         return;
       }
       const csv: AcquiredCsv = {
@@ -176,7 +187,7 @@ export function InviterBench() {
         });
     } catch (error) {
       if (id !== parseId.current) return;
-      setIntakeAlert({
+      discardRead({
         title: "The file could not be read",
         message: sanitizeErrorForDisplay(error),
       });

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -61,11 +61,13 @@ vi.mock("@psi/invitation", async (importOriginal) => {
   };
 });
 
-// Defer the CSV parse per-test to observe in-flight state (the Continue
-// gate, the abort signal). With `defer` unset it delegates to the real
-// loader.
+// Defer or fail the CSV parse per-test to observe in-flight state (the
+// Continue gate, the abort signal) and the read-failure path, which a real
+// parse of an inline File cannot reach deterministically. With both knobs
+// unset it delegates to the real loader.
 const csvLoadHarness = vi.hoisted(() => ({
   defer: false,
+  fail: undefined as Error | undefined,
   lastSignal: undefined as AbortSignal | undefined,
   resolve: undefined as ((value: unknown) => void) | undefined,
 }));
@@ -78,6 +80,8 @@ vi.mock("@psi/csvParseController", async (importOriginal) => {
       options?: { signal?: AbortSignal },
     ) => {
       csvLoadHarness.lastSignal = options?.signal;
+      if (csvLoadHarness.fail !== undefined)
+        return Promise.reject(csvLoadHarness.fail);
       if (!csvLoadHarness.defer)
         return (
           actual.loadCSVFileOffMainThread as (
@@ -111,6 +115,7 @@ afterEach(() => {
   container = undefined;
   mintHarness.fail = undefined;
   csvLoadHarness.defer = false;
+  csvLoadHarness.fail = undefined;
   csvLoadHarness.lastSignal = undefined;
   csvLoadHarness.resolve = undefined;
 });
@@ -656,6 +661,72 @@ describe("inviter bench", () => {
     await expect
       .element(page.getByRole("heading", { level: 1 }))
       .toHaveTextContent("Your invitation is ready");
+  });
+
+  test("a failed re-read discards the prior file; a good re-read swaps it", async () => {
+    mount(createElement(InviterBench));
+
+    await expect.element(page.getByLabelText("Your name")).toBeInTheDocument();
+    await userEvent.fill(page.getByLabelText("Your name"), "Dana");
+    const fileInput = () =>
+      document.querySelector('input[type="file"]') as HTMLElement;
+    const continueButton = page.getByRole("button", {
+      name: "Continue to matching & sharing",
+    });
+    const goodFile = (name: string) =>
+      new File(["first_name,last_name,dob\nAnn,Lee,01/02/1990\n"], name, {
+        type: "text/csv",
+      });
+
+    await userEvent.upload(page.elementLocator(fileInput()), goodFile("a.csv"));
+    await expect.element(page.getByText("a.csv")).toBeInTheDocument();
+    await expect.element(continueButton).toBeEnabled();
+
+    // A good re-read swaps to the new file.
+    await userEvent.upload(page.elementLocator(fileInput()), goodFile("b.csv"));
+    await expect.element(page.getByText("b.csv")).toBeInTheDocument();
+    expect(document.querySelector(`.${styles.fileName}`)?.textContent).toBe(
+      "b.csv",
+    );
+    await expect.element(continueButton).toBeEnabled();
+
+    // An unnameable-columns re-read discards the prior read: no file card, no
+    // recommended-terms callout, Continue disabled, facts back to quiet.
+    await userEvent.upload(
+      page.elementLocator(fileInput()),
+      new File(["a,,b\n1,2,3\n"], "unnamed.csv", { type: "text/csv" }),
+    );
+    await expect
+      .element(page.getByText("This file has an unnamed column"))
+      .toBeInTheDocument();
+    expect(document.querySelector(`.${styles.fileCard}`)).toBeNull();
+    expect(document.querySelector(`.${styles.callout}`)).toBeNull();
+    await expect.element(continueButton).toBeDisabled();
+    const facts = Array.from(
+      document.querySelectorAll(
+        `nav[aria-label="Exchange setup"] .${styles.val}`,
+      ),
+    );
+    expect(facts.map((fact) => fact.textContent)).toEqual([
+      EM_DASH,
+      EM_DASH,
+      EM_DASH,
+    ]);
+
+    // Readiness comes back with the next good read.
+    await userEvent.upload(page.elementLocator(fileInput()), goodFile("c.csv"));
+    await expect.element(page.getByText("c.csv")).toBeInTheDocument();
+    await expect.element(continueButton).toBeEnabled();
+
+    // A parse failure discards the prior read the same way.
+    csvLoadHarness.fail = new Error("torn mid-read");
+    await userEvent.upload(page.elementLocator(fileInput()), goodFile("d.csv"));
+    await expect
+      .element(page.getByText("The file could not be read"))
+      .toBeInTheDocument();
+    expect(document.querySelector(`.${styles.fileCard}`)).toBeNull();
+    expect(document.querySelector(`.${styles.callout}`)).toBeNull();
+    await expect.element(continueButton).toBeDisabled();
   });
 
   test("collapses to the single-column layout without rail and ledger", async () => {


### PR DESCRIPTION
## Summary

On the inviter bench, a failed CSV re-read (unnameable columns or a parse failure) left the previously read file fully active: the stale file card and recommended-terms callout stayed visible and Continue stayed enabled, so continuing proceeded on the first file's columns and keys while the operator believed the file they just dropped was in effect. A failed read now discards the prior read alongside the intake alert, so the card, callout, rail facts, ledger, and the Continue gate all fall back to the no-file state.

Implements [211450976](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=211450976).

## Changes

- apps/web/src/bench/InviterBench.tsx: add a discardRead helper that clears the acquired file, retained source file, and editor, and call it from both of readFile's failure branches (the unnameable-columns early return and the parse-failure catch). The zero-keys success case is unchanged: it deliberately keeps the card while linkable gates Continue.
- apps/web/test/browser/bench.test.ts: add a staged test covering a good re-read swapping the file, both failure branches discarding the prior read (no card, no callout, Continue disabled, rail facts back to quiet), and readiness returning on the next good read. The suite's CSV-load harness gains a fail knob because a real parse of an inline File cannot fail deterministically; the unnameable-columns branch runs against the real loader.

## Test plan

Ran: npx vitest run --project browser test/browser/bench.test.ts in apps/web (11 passed, including the new test), npm run test:unit -w apps/web (625 passed), npm run typecheck, npm run lint, npm run format.
New tests cover: failed re-read after a good read leaves Continue disabled with no stale card or callout, for both the unnameable-columns and parse-failure branches; a good re-read swaps to the new file; readiness returns on the next good read.

## Checklist

- [x] Docs: enumerated docs/ and docs/spec/ -- n/a: no documented behavior changed; the bench intake surface is not yet described in either tier
- [x] CHANGELOG.md [Unreleased] updated -- n/a: fix to the under-construction bench surface, not yet an operator-facing behavior
- [x] Security review -- n/a: UI readiness gating only; no change to what is sent, logged, displayed, or written to disk, or to any credential, cryptographic, or bounds control