### PR TITLE
Add inviter post-create flow: share, run, completion

### DIFF
--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -1,8 +1,7 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 
-import { Alert, Anchor, VisuallyHidden } from "@mantine/core";
+import { Alert, VisuallyHidden } from "@mantine/core";
 import { IconAlertCircle } from "@tabler/icons-react";
-import { Link } from "@tanstack/react-router";
 
 import { sanitizeErrorForDisplay, sanitizeForDisplay } from "@psilink/core";
 
@@ -42,15 +41,19 @@ import {
   reviewValidation,
   sealEditor,
   spineProblems,
+  unsealEditor,
 } from "./inviterModel";
 import { AgreementTab } from "./AgreementTab";
 import { BenchShell } from "./BenchShell";
 import { CleaningTab } from "./CleaningTab";
+import { InviterExchangeSection } from "./InviterExchangeSection";
 import { KeysTab } from "./KeysTab";
 import { Ledger } from "./Ledger";
 import { MatchingSharingSection } from "./MatchingSharingSection";
 import { ReviewCreateSection } from "./ReviewCreateSection";
 import { YourFileSection } from "./YourFileSection";
+import { timelineSteps } from "./exchangeRun";
+import { useInviterExchange } from "./useInviterExchange";
 
 import type { AcquiredCsv, InviterEditor, SpineTarget } from "./inviterModel";
 import type { DisclosureChoice } from "@psi/metadataEditing";
@@ -101,6 +104,26 @@ export function InviterBench() {
   const [createAlert, setCreateAlert] = useState<IntakeAlert>();
   const [expertMode, setExpertMode] = useState(false);
   const [editorAnnouncement, setEditorAnnouncement] = useState("");
+
+  // The run starts the moment the invitation exists (the hook listens for the
+  // partner right away) and is torn down when the invitation is discarded or
+  // the bench unmounts.
+  const { run, outputs, failure, tryAgain } = useInviterExchange({
+    invitation,
+    inviterName: editor?.draft.identity ?? "",
+  });
+
+  // The failure alerts' "start over with a fresh invitation": the seal lifts
+  // with every input intact, the failed invitation is discarded (its run has
+  // already torn down; the hook drops the run state), and the operator lands
+  // back on Review & create, where the next create mints a fresh secret.
+  function startOver() {
+    setEditor((current) =>
+      current === undefined ? current : unsealEditor(current),
+    );
+    setInvitation(undefined);
+    goTo("review");
+  }
 
   function goTo(next: Section) {
     if (isSpineStep(next)) setLastSpineStep(next);
@@ -289,12 +312,7 @@ export function InviterBench() {
   );
   const steps: Array<RailStep> =
     section === "share"
-      ? [
-          { label: "Share", state: "current" },
-          { label: "Partner accepts", state: "pending" },
-          { label: "Exchange runs", state: "pending" },
-          { label: "Results", state: "pending" },
-        ]
+      ? timelineSteps(run)
       : SPINE_ORDER.map((step, position) => {
           const state =
             !inTab && step === section
@@ -345,7 +363,17 @@ export function InviterBench() {
       }
       ledger={
         <Ledger
-          rows={inviterLedgerRows(editor, invitation?.expires).map((row) => ({
+          tag={sealed ? "Terms sealed at create" : undefined}
+          rows={inviterLedgerRows(
+            editor,
+            invitation?.expires,
+            outputs === undefined
+              ? undefined
+              : {
+                  matchedRecordCount: outputs.matchedRecordCount,
+                  resultWithheld: outputs.resultWithheld,
+                },
+          ).map((row) => ({
             label: row.label,
             reference: row.reference,
             muted: row.muted,
@@ -362,7 +390,11 @@ export function InviterBench() {
               row.value
             ),
           }))}
-          footer="Your file stays in this browser. Nothing is uploaded; your partner receives only what this ledger names."
+          footer={
+            outputs === undefined
+              ? "Your file stays in this browser. Nothing is uploaded; your partner receives only what this ledger names."
+              : "Your file never left this browser. The results above are all your partner received about your data."
+          }
         />
       }
     >
@@ -527,24 +559,15 @@ export function InviterBench() {
             onBack={() => goTo("review")}
           />
         )}
-        {section === "share" && (
-          <>
-            <h1 tabIndex={-1}>Your invitation is ready</h1>
-            <p>
-              The terms are sealed: the invitation your partner consents to is
-              exactly the proposal you just reviewed.
-            </p>
-            <Alert color="yellow" title="Under construction" mt="md">
-              The share screen - the invitation link and code with their copy
-              actions - arrives with the next bench screens. Nothing has been
-              shared: the invitation exists only in this browser and expires on
-              its own. To run an exchange today, use the{" "}
-              <Anchor component={Link} to="/">
-                current app
-              </Anchor>
-              .
-            </Alert>
-          </>
+        {section === "share" && invitation !== undefined && (
+          <InviterExchangeSection
+            invitation={invitation}
+            run={run}
+            outputs={outputs}
+            failure={failure}
+            onTryAgain={tryAgain}
+            onStartOver={startOver}
+          />
         )}
         <VisuallyHidden>
           <p aria-live="polite" aria-atomic="true">

--- a/apps/web/src/bench/InviterExchangeSection.tsx
+++ b/apps/web/src/bench/InviterExchangeSection.tsx
@@ -4,16 +4,16 @@ import { Alert, Button, CopyButton } from "@mantine/core";
 import { IconAlertCircle } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
 
+import { dateTimeLabel, invitationUsable } from "./inviterModel";
 import { awaitingPartner } from "./exchangeRun";
-import { dateTimeLabel } from "./inviterModel";
 
 import { StatusPanel } from "./StatusPanel";
 import styles from "./bench.module.css";
 
-import type { InviterRunOutputs, RunFailure } from "./useInviterExchange";
-
 import type { ExchangeRun } from "./exchangeRun";
 import type { GeneratedInvitation } from "@psi/invitation";
+import type { InviterRunOutputs } from "./inviterRunOutputs";
+import type { RunFailure } from "./useInviterExchange";
 
 /** A labelled, copy-to-clipboard view of one shareable artifact. Client-only
  * by construction (the post-create section mounts from the create handler, so
@@ -128,6 +128,13 @@ export function InviterExchangeSection({
   const phase =
     outputs !== undefined ? "done" : awaitingPartner(run) ? "share" : "running";
 
+  // A retry is genuine only while the invitation can still be accepted:
+  // re-listening on a lapsed credential cannot succeed, so an expired
+  // exchange failure routes to start-over and stops advertising the link.
+  const retryable =
+    failure?.category === "exchange" &&
+    invitationUsable(invitation.expires, new Date());
+
   // The phase-level focus throughline. The bench host moves focus to the h1
   // when the section mounts; within the section, focus moves again when the
   // partner connects or a retry clears the alert -- the share block or the
@@ -183,24 +190,27 @@ export function InviterExchangeSection({
           mb="md"
         >
           <span style={{ whiteSpace: "pre-line" }}>{failure.message}</span>
-          {failure.category === "exchange" && (
+          {retryable && (
             <Button color="red" variant="light" mt="sm" onClick={onTryAgain}>
               Try again
             </Button>
           )}
-          {(failure.category === "security" ||
-            failure.category === "config") && (
+          {/* Every non-retryable failure except "output" (whose exchange
+              already succeeded, so nothing here may invite a re-run) offers
+              exactly one recovery: a fresh invitation. */}
+          {!retryable && failure.category !== "output" && (
             <Button color="red" variant="light" mt="sm" onClick={onStartOver}>
               Start over with a fresh invitation
             </Button>
           )}
         </Alert>
       )}
-      {/* The share block drops out once the partner connects (nothing left to
-          share) and on a security failure (a link that failed authentication
-          must not keep being advertised for copying); a retryable failure
-          keeps it, since the same link stays valid for another attempt. */}
-      {phase === "share" && failure?.category !== "security" && (
+      {/* The copy artifacts drop out once the partner connects (nothing left
+          to share) and on any failure except a retryable one -- a dead
+          invitation (failed authentication, terminal config fault, lapsed
+          expiry) must not keep being advertised for copying, while a
+          retryable failure's link stays valid for another attempt. */}
+      {phase === "share" && (failure === undefined || retryable) && (
         <>
           <h2>Share this invitation</h2>
           <p>
@@ -227,14 +237,19 @@ export function InviterExchangeSection({
               .
             </strong>
           </p>
-          <div className={styles.callout}>
-            <p className={styles.calloutLead}>Keep this tab open.</p>
-            <p className={styles.small}>
-              Your browser is listening for your partner. Closing the tab
-              cancels the invitation; reloading starts over.
-            </p>
-          </div>
         </>
+      )}
+      {/* The "listening" claim is false the moment any failure lands (the
+          lifecycle tore down), so the callout outlives no failure -- not even
+          a retryable one. */}
+      {phase === "share" && failure === undefined && (
+        <div className={styles.callout}>
+          <p className={styles.calloutLead}>Keep this tab open.</p>
+          <p className={styles.small}>
+            Your browser is listening for your partner. Closing the tab cancels
+            the invitation; reloading starts over.
+          </p>
+        </div>
       )}
       {phase === "done" && (
         <div className={styles.donePanel}>

--- a/apps/web/src/bench/InviterExchangeSection.tsx
+++ b/apps/web/src/bench/InviterExchangeSection.tsx
@@ -130,11 +130,13 @@ export function InviterExchangeSection({
 
   // The phase-level focus throughline. The bench host moves focus to the h1
   // when the section mounts; within the section, focus moves again when the
-  // partner connects -- the share block (which may hold focus on a copy
+  // partner connects or a retry clears the alert -- the share block or the
+  // alert (either of which may hold focus, on a copy button or the Try again
   // button) unmounts, so without this the browser drops focus to <body> --
-  // and at completion, so the results are read. The connect move fires only
+  // and at completion, so the results are read. The recovery moves fire only
   // when focus was actually orphaned onto <body>, so focus the user placed on
-  // a live element is not stolen; completion always moves it.
+  // a live element is not stolen; completion always moves it. While a failure
+  // is showing, the alert-focus effect below owns the moment.
   const headingRef = useRef<HTMLHeadingElement>(null);
   const mounted = useRef(false);
   useEffect(() => {
@@ -146,9 +148,10 @@ export function InviterExchangeSection({
       headingRef.current?.focus();
       return;
     }
+    if (failure !== undefined) return;
     const active = document.activeElement;
     if (!active || active === document.body) headingRef.current?.focus();
-  }, [phase]);
+  }, [phase, failure]);
 
   // A failure alert receives focus when it appears, so the message is read
   // before anything else. Failure and completion are mutually exclusive (a

--- a/apps/web/src/bench/InviterExchangeSection.tsx
+++ b/apps/web/src/bench/InviterExchangeSection.tsx
@@ -1,0 +1,317 @@
+import { useEffect, useRef } from "react";
+
+import { Alert, Button, CopyButton } from "@mantine/core";
+import { IconAlertCircle } from "@tabler/icons-react";
+import { Link } from "@tanstack/react-router";
+
+import { awaitingPartner } from "./exchangeRun";
+import { dateTimeLabel } from "./inviterModel";
+
+import { StatusPanel } from "./StatusPanel";
+import styles from "./bench.module.css";
+
+import type { InviterRunOutputs, RunFailure } from "./useInviterExchange";
+
+import type { ExchangeRun } from "./exchangeRun";
+import type { GeneratedInvitation } from "@psi/invitation";
+
+/** A labelled, copy-to-clipboard view of one shareable artifact. Client-only
+ * by construction (the post-create section mounts from the create handler, so
+ * it never server-renders); the `typeof navigator` check is defence-in-depth
+ * and hides the button on non-secure origins, where `navigator.clipboard` is
+ * undefined -- the text itself stays selectable for a manual copy. */
+function CopyRow({
+  label,
+  hint,
+  value,
+}: {
+  label: string;
+  hint: string;
+  value: string;
+}) {
+  return (
+    <div className={styles.copyRow}>
+      <span className={styles.copyLabel}>{label}</span>
+      <span className={styles.copyHint}>{hint}</span>
+      <div className={styles.copyBox}>
+        <div className={`${styles.codeBlock} ${styles.mono}`}>{value}</div>
+        {
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          typeof navigator !== "undefined" && navigator.clipboard ? (
+            <CopyButton value={value} timeout={1000}>
+              {({ copied, copy }) => (
+                <Button
+                  className={styles.copyBtn}
+                  variant="default"
+                  onClick={copy}
+                  // Name reflects the copied state so a screen reader announces
+                  // the success (the label swap alone is not reliably conveyed
+                  // to assistive tech).
+                  aria-label={
+                    copied ? `${label} copied` : `Copy ${label.toLowerCase()}`
+                  }
+                >
+                  {copied ? "Copied" : "Copy"}
+                </Button>
+              )}
+            </CopyButton>
+          ) : null
+        }
+      </div>
+    </div>
+  );
+}
+
+function DownloadRow({
+  label,
+  caveat,
+  href,
+  fileName,
+}: {
+  label: string;
+  caveat?: "keep private";
+  href: string;
+  fileName: string;
+}) {
+  return (
+    <div className={styles.dlRow}>
+      <span className={styles.dlLabel}>
+        {label}
+        {caveat !== undefined && (
+          <>
+            {" "}
+            <span className={styles.keepPrivate}>({caveat})</span>
+          </>
+        )}
+        :
+      </span>
+      {/* The accessible name carries the caveat as well as the filename: the
+          caveat is part of what the operator agrees to by downloading, so a
+          screen reader browsing links must hear it, not only the filename. */}
+      <a
+        className={`${styles.linkLike} ${styles.mono}`}
+        href={href}
+        download={fileName}
+        aria-label={`${label}${caveat === undefined ? "" : ` (${caveat})`}: ${fileName}`}
+      >
+        {fileName}
+      </a>
+    </div>
+  );
+}
+
+/**
+ * The inviter's post-create work column, through the run's three phases: the
+ * share screen (copy artifacts, one-time-secret guidance, expiry) while the
+ * browser listens for the partner, the running screen once a protocol stage
+ * begins, and the completion panel with the downloads and their caveats. The
+ * status panel spans all three from one stable mount so its live region
+ * persists. A failed run renders the failure vocabulary's alert for its
+ * category, each with its one concrete way forward; no failure clears what
+ * the operator authored.
+ */
+export function InviterExchangeSection({
+  invitation,
+  run,
+  outputs,
+  failure,
+  onTryAgain,
+  onStartOver,
+}: {
+  invitation: GeneratedInvitation;
+  run: ExchangeRun;
+  outputs: InviterRunOutputs | undefined;
+  failure: RunFailure | undefined;
+  onTryAgain: () => void;
+  onStartOver: () => void;
+}) {
+  const phase =
+    outputs !== undefined ? "done" : awaitingPartner(run) ? "share" : "running";
+
+  // The phase-level focus throughline. The bench host moves focus to the h1
+  // when the section mounts; within the section, focus moves again when the
+  // partner connects -- the share block (which may hold focus on a copy
+  // button) unmounts, so without this the browser drops focus to <body> --
+  // and at completion, so the results are read. The connect move fires only
+  // when focus was actually orphaned onto <body>, so focus the user placed on
+  // a live element is not stolen; completion always moves it.
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const mounted = useRef(false);
+  useEffect(() => {
+    if (!mounted.current) {
+      mounted.current = true;
+      return;
+    }
+    if (phase === "done") {
+      headingRef.current?.focus();
+      return;
+    }
+    const active = document.activeElement;
+    if (!active || active === document.body) headingRef.current?.focus();
+  }, [phase]);
+
+  // A failure alert receives focus when it appears, so the message is read
+  // before anything else. Failure and completion are mutually exclusive (a
+  // failed run never reaches `done`), so the two effects cannot fight.
+  const alertRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (failure !== undefined) alertRef.current?.focus();
+  }, [failure]);
+
+  const title =
+    phase === "done"
+      ? "Exchange complete"
+      : phase === "running"
+        ? "Exchange in progress"
+        : "Your invitation is ready";
+
+  return (
+    <>
+      <h1 tabIndex={-1} ref={headingRef}>
+        {title}
+      </h1>
+      {failure !== undefined && (
+        <Alert
+          color="red"
+          icon={<IconAlertCircle aria-hidden />}
+          title={failure.title}
+          ref={alertRef}
+          tabIndex={-1}
+          mb="md"
+        >
+          <span style={{ whiteSpace: "pre-line" }}>{failure.message}</span>
+          {failure.category === "exchange" && (
+            <Button color="red" variant="light" mt="sm" onClick={onTryAgain}>
+              Try again
+            </Button>
+          )}
+          {(failure.category === "security" ||
+            failure.category === "config") && (
+            <Button color="red" variant="light" mt="sm" onClick={onStartOver}>
+              Start over with a fresh invitation
+            </Button>
+          )}
+        </Alert>
+      )}
+      {/* The share block drops out once the partner connects (nothing left to
+          share) and on a security failure (a link that failed authentication
+          must not keep being advertised for copying); a retryable failure
+          keeps it, since the same link stays valid for another attempt. */}
+      {phase === "share" && failure?.category !== "security" && (
+        <>
+          <h2>Share this invitation</h2>
+          <p>
+            Send one of these to your partner over a trusted channel (for
+            example, secure email). It carries a one-time secret, so treat it as
+            confidential. Keep this tab open while your partner accepts.
+          </p>
+          <CopyRow
+            label="Invitation link"
+            hint="Opens the accept page with the invitation prefilled"
+            value={invitation.deepLink}
+          />
+          <CopyRow
+            label="Invitation code"
+            hint="Paste into the accept form if the link cannot be used"
+            value={invitation.encoded}
+          />
+          <p className={styles.small}>
+            <strong>
+              This invitation expires{" "}
+              <span className={styles.mono}>
+                {dateTimeLabel(new Date(invitation.expires))}
+              </span>
+              .
+            </strong>
+          </p>
+          <div className={styles.callout}>
+            <p className={styles.calloutLead}>Keep this tab open.</p>
+            <p className={styles.small}>
+              Your browser is listening for your partner. Closing the tab
+              cancels the invitation; reloading starts over.
+            </p>
+          </div>
+        </>
+      )}
+      {phase === "done" && (
+        <div className={styles.donePanel}>
+          <p className={styles.bigCount}>
+            Exchange complete
+            {outputs?.matchedRecordCount !== undefined && (
+              <>
+                {" - "}
+                <span className={styles.mono}>
+                  {new Intl.NumberFormat("en-US").format(
+                    outputs.matchedRecordCount,
+                  )}
+                </span>{" "}
+                matched records
+              </>
+            )}
+          </p>
+          {run.finishedAt !== undefined && (
+            <p className={`${styles.small} ${styles.sub} ${styles.mono}`}>
+              Finished {dateTimeLabel(run.finishedAt)}
+            </p>
+          )}
+        </div>
+      )}
+      <StatusPanel
+        run={run}
+        done={phase === "done"}
+        halted={failure !== undefined}
+      />
+      {phase === "done" && outputs !== undefined && (
+        <>
+          <h2>Downloads</h2>
+          {outputs.resultWithheld === true ? (
+            <div className={styles.stateInset}>
+              <p className={styles.stateLabel}>Results withheld by the terms</p>
+              <p className={styles.small} style={{ margin: 0 }}>
+                Your records contributed to the match. By the agreed terms, you
+                receive no result table, so there is nothing to download here.
+              </p>
+            </div>
+          ) : (
+            <DownloadRow
+              label="Download result"
+              href={outputs.resultsUrl}
+              fileName="results.csv"
+            />
+          )}
+          {outputs.record !== undefined && (
+            <>
+              <DownloadRow
+                label="Download record (safe to share)"
+                href={outputs.record.recordUrl}
+                fileName={outputs.record.recordFileName}
+              />
+              <DownloadRow
+                label="Download verification keys"
+                caveat="keep private"
+                href={outputs.record.keysUrl}
+                fileName={outputs.record.keysFileName}
+              />
+              <div className={styles.callout}>
+                <p className={styles.calloutLead}>Keep a record.</p>
+                <p className={styles.small}>
+                  File the record JSON with your project documentation - it is
+                  safe to share and lets either party verify this run later. The
+                  verification keys prove the record came from this exchange;
+                  store them where only you can read them.
+                </p>
+              </div>
+            </>
+          )}
+        </>
+      )}
+      {(phase === "done" || failure?.category === "output") && (
+        <div className={styles.workFoot}>
+          <Button component={Link} to="/bench">
+            Set up another exchange
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/bench/Ledger.tsx
+++ b/apps/web/src/bench/Ledger.tsx
@@ -23,16 +23,21 @@ export interface LedgerRow {
  */
 export function Ledger({
   title = "This exchange",
+  tag,
   rows,
   footer,
 }: {
   title?: string;
+  /** A standing state marker under the title -- "Terms sealed at create" once
+   * the invitation is minted and the ledger stops being editable. */
+  tag?: string;
   rows: ReadonlyArray<LedgerRow>;
   footer?: ReactNode;
 }) {
   return (
     <aside className={styles.ledger} aria-label={title}>
       <h2>{title}</h2>
+      {tag !== undefined && <span className={styles.sealedTag}>{tag}</span>}
       <dl>
         {rows.map((row) => (
           <div key={row.label} className={styles.ledgerRow}>

--- a/apps/web/src/bench/StatusPanel.tsx
+++ b/apps/web/src/bench/StatusPanel.tsx
@@ -1,0 +1,95 @@
+import {
+  currentStageLabel,
+  progressPercent,
+  timeOfDayLabel,
+} from "./exchangeRun";
+import styles from "./bench.module.css";
+
+import type { ExchangeRun } from "./exchangeRun";
+
+/**
+ * The run's status panel: the live stage label, the protocol progress bar, and
+ * the visited-stage history with completion times. Rendered through every
+ * post-create phase from one stable mount, so the polite live region around
+ * the stage label persists and each stage change (including the final "Done")
+ * is announced -- a region replaced with its phase would announce nothing.
+ * At completion (`done`) the panel drops its frame and history and keeps just
+ * the label and the filled bar, per the design; while `halted` (the run
+ * failed) the spinner stops presenting the open stage as in flight and the
+ * adjacent alert carries the state.
+ */
+export function StatusPanel({
+  run,
+  done,
+  halted,
+}: {
+  run: ExchangeRun;
+  done: boolean;
+  halted: boolean;
+}) {
+  const percent = progressPercent(run);
+  const lastVisit = run.visits[run.visits.length - 1];
+  return (
+    <section
+      className={
+        done
+          ? `${styles.statusPanel} ${styles.statusPanelDone}`
+          : styles.statusPanel
+      }
+      aria-label="Status"
+    >
+      {!done && <h2>Status</h2>}
+      <p className={styles.stageLabel}>
+        {!done && !halted && (
+          <span className={styles.spinner} aria-hidden="true" />
+        )}
+        <span className={styles.mono} aria-live="polite" aria-atomic="true">
+          {currentStageLabel(run)}
+        </span>
+      </p>
+      <div
+        className={
+          done
+            ? `${styles.progress} ${styles.progressDone}`
+            : halted
+              ? `${styles.progress} ${styles.progressHalted}`
+              : styles.progress
+        }
+        role="progressbar"
+        aria-label="Exchange progress"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={percent}
+      >
+        <div className={styles.progressBar} style={{ width: `${percent}%` }} />
+      </div>
+      {!done && (
+        <ol className={styles.stageHistory}>
+          {run.visits.map((visit) => (
+            <li
+              key={visit.id}
+              className={
+                visit === lastVisit && visit.completedAt === undefined
+                  ? styles.historyNow
+                  : undefined
+              }
+            >
+              <span className={styles.tick} aria-hidden="true" />
+              <span>
+                {visit.label}
+                {visit.completedAt !== undefined && (
+                  <>
+                    {" - done "}
+                    <span className={styles.mono}>
+                      {timeOfDayLabel(visit.completedAt)}
+                    </span>
+                  </>
+                )}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/bench/StatusPanel.tsx
+++ b/apps/web/src/bench/StatusPanel.tsx
@@ -29,6 +29,15 @@ export function StatusPanel({
 }) {
   const percent = progressPercent(run);
   const lastVisit = run.visits[run.visits.length - 1];
+  // Cannot happen by construction -- runExchange emits stage ids from the same
+  // prepared exchange the tree was built from -- so a mismatch is a desync bug
+  // worth a development-time signal (the model still renders defensively: the
+  // raw id as the label, the bar held at the last known stage).
+  if (
+    import.meta.env.DEV &&
+    !run.stages.some((stage) => stage.id === run.stageId)
+  )
+    console.warn(`StatusPanel: unknown stageId "${run.stageId}"`);
   return (
     <section
       className={

--- a/apps/web/src/bench/bench.module.css
+++ b/apps/web/src/bench/bench.module.css
@@ -640,6 +640,232 @@
   font-weight: 600;
 }
 
+/* ---------- post-create: share, run, completion ---------- */
+
+.sealedTag {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 650;
+  color: var(--bench-accent);
+  border: 1px solid var(--bench-accent);
+  border-radius: 999px;
+  padding: 1px 8px;
+  margin-bottom: 6px;
+}
+
+.copyRow {
+  margin: 1.1rem 0;
+  max-width: 640px;
+}
+
+.copyBox {
+  display: flex;
+  gap: 10px;
+  align-items: stretch;
+}
+
+.copyLabel {
+  font-weight: 650;
+  display: block;
+}
+
+.copyHint {
+  display: block;
+  color: var(--bench-secondary);
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.codeBlock {
+  flex: 1;
+  background: var(--bench-code-bg);
+  border: 1px solid var(--bench-rule);
+  border-radius: 6px;
+  padding: 10px 12px;
+  overflow-wrap: anywhere;
+  min-width: 0;
+}
+
+.copyBtn {
+  flex: none;
+  align-self: center;
+}
+
+.statusPanel {
+  border: 1px solid var(--bench-rule);
+  border-radius: 8px;
+  padding: 16px 20px;
+  max-width: 640px;
+  margin: 1.2rem 0;
+}
+
+.statusPanelDone {
+  border: none;
+  padding: 0;
+}
+
+.statusPanel h2 {
+  margin: 0 0 8px 0;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--bench-secondary);
+}
+
+.stageLabel {
+  text-align: center;
+  font-weight: 650;
+  font-size: 1.05rem;
+  margin: 6px 0 12px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.spinner {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 3px solid var(--bench-rule);
+  border-top-color: var(--bench-accent);
+  animation: spin 0.9s linear infinite;
+  flex: none;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.progress {
+  height: 14px;
+  border: 1px solid var(--bench-rule);
+  border-radius: 7px;
+  overflow: hidden;
+  background: var(--bench-code-bg);
+}
+
+.progressBar {
+  height: 100%;
+  background: repeating-linear-gradient(
+    45deg,
+    var(--bench-accent) 0 10px,
+    var(--bench-stripe) 10px 20px
+  );
+  background-size: 28.28px 28.28px;
+  animation: slide 1.1s linear infinite;
+}
+
+.progressHalted .progressBar,
+.progressDone .progressBar {
+  animation: none;
+  background: var(--bench-accent);
+}
+
+@keyframes slide {
+  to {
+    background-position: 28.28px 0;
+  }
+}
+
+.stageHistory {
+  list-style: none;
+  margin: 0.8rem 0 0 0;
+  padding: 0;
+  font-size: 14.5px;
+}
+
+.stageHistory li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 0;
+  color: var(--bench-secondary);
+}
+
+.stageHistory li.historyNow {
+  color: var(--bench-ink);
+  font-weight: 650;
+}
+
+.tick {
+  flex: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--bench-ok) var(--bench-check) center / 10px no-repeat;
+}
+
+.historyNow .tick {
+  background: var(--bench-accent);
+}
+
+.donePanel {
+  border: 1px solid var(--bench-rule);
+  border-left: 6px solid var(--bench-accent);
+  border-radius: 8px;
+  padding: 20px 24px;
+  max-width: 640px;
+  margin: 1.2rem 0;
+}
+
+.bigCount {
+  font-size: 1.5rem;
+  font-weight: 650;
+  margin: 0;
+}
+
+.dlRow {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--bench-rule-soft);
+  max-width: 640px;
+  flex-wrap: wrap;
+}
+
+.dlLabel {
+  flex: 1 1 220px;
+  font-weight: 600;
+}
+
+.keepPrivate {
+  color: var(--bench-danger);
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 12.5px;
+  letter-spacing: 0.05em;
+}
+
+.linkLike {
+  background: none;
+  border: none;
+  padding: 0;
+  font-weight: 600;
+  color: var(--bench-accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+    border-top-color: var(--bench-rule);
+    border-left-color: var(--bench-accent);
+  }
+
+  .progressBar {
+    animation: none;
+    background: var(--bench-accent);
+  }
+}
+
 /* ---------- lobby ---------- */
 
 .lobby {

--- a/apps/web/src/bench/exchangeRun.ts
+++ b/apps/web/src/bench/exchangeRun.ts
@@ -1,0 +1,216 @@
+import {
+  CONFIRMING_PROTOCOL_STAGE_ID,
+  ProcessState,
+  describeExchangeStages,
+} from "@psilink/core";
+
+import type { PreparedExchange } from "@psilink/core";
+import type { StageDefinition } from "@psi/exchangeLifecycle";
+
+/**
+ * The pure model behind the bench's post-create flow: the run's stage tree and
+ * visit history as the lifecycle reports them, and the view-model builders the
+ * protocol timeline, the status panel, and the completion header render from.
+ * No React, no I/O -- the tested boundary for "the timeline advances on stage
+ * events". Stage ids and labels come from the same lifecycle seam the current
+ * exchange screen renders ({@link describeExchangeStages} plus the owner's
+ * pre/done stages), so the Console engine's driver contract later fronts this
+ * model unchanged.
+ */
+
+export const BEFORE_START_STAGE_ID = "before start";
+export const WAITING_STAGE_ID = "waiting for peer";
+export const DONE_STAGE_ID = "done";
+
+const preStages: Array<StageDefinition> = [
+  {
+    id: BEFORE_START_STAGE_ID,
+    label: "Before start",
+    state: ProcessState.BeforeStart,
+  },
+  {
+    id: WAITING_STAGE_ID,
+    label: "Waiting for your partner",
+    state: ProcessState.Waiting,
+  },
+];
+
+const doneStage: StageDefinition = {
+  id: DONE_STAGE_ID,
+  label: "Done",
+  state: ProcessState.Done,
+};
+
+/** The stage tree before the prepared exchange exists: the pre-stages, the
+ * protocol-confirmation stage every exchange opens with, and the terminal done
+ * stage. Replaced wholesale once `prepare` yields the real tree. */
+export function initialStages(): Array<StageDefinition> {
+  return [
+    ...preStages,
+    {
+      id: CONFIRMING_PROTOCOL_STAGE_ID,
+      label: "Confirming protocol",
+      state: ProcessState.Working,
+    },
+    doneStage,
+  ];
+}
+
+/** The full per-exchange stage tree, built once after prepare: the pre-stages,
+ * the protocol stages the prepared exchange declares, and the done stage. */
+export function stagesFor(prepared: PreparedExchange): Array<StageDefinition> {
+  return [
+    ...preStages,
+    ...describeExchangeStages(prepared).map((stage) => ({
+      ...stage,
+      state: ProcessState.Working as const,
+    })),
+    doneStage,
+  ];
+}
+
+/** One stage the run has entered: the visit closes (gains `completedAt`) when
+ * the run moves on -- the status panel's history rows. */
+export interface StageVisit {
+  id: string;
+  label: string;
+  completedAt?: Date;
+}
+
+/** The run's live state, advanced by the lifecycle's `onStages`/`onStage`/
+ * result/error events through the `runWith*` builders below. */
+export interface ExchangeRun {
+  stages: Array<StageDefinition>;
+  stageId: string;
+  visits: Array<StageVisit>;
+  finishedAt?: Date;
+  failed: boolean;
+}
+
+export function initialRun(): ExchangeRun {
+  return {
+    stages: initialStages(),
+    stageId: BEFORE_START_STAGE_ID,
+    visits: [{ id: BEFORE_START_STAGE_ID, label: "Before start" }],
+    failed: false,
+  };
+}
+
+/** Adopt the full stage tree the lifecycle emits after prepare. */
+export function runWithStages(
+  run: ExchangeRun,
+  stages: Array<StageDefinition>,
+): ExchangeRun {
+  return { ...run, stages };
+}
+
+function closedVisits(visits: Array<StageVisit>, at: Date): Array<StageVisit> {
+  return visits.map((visit, index) =>
+    index === visits.length - 1 && visit.completedAt === undefined
+      ? { ...visit, completedAt: at }
+      : visit,
+  );
+}
+
+/** Advance to a stage: the open visit closes at `at` and the new stage's visit
+ * opens. A repeat of the current stage is a no-op, so a re-emitted stage id
+ * cannot duplicate a history row. */
+export function runWithStage(
+  run: ExchangeRun,
+  stageId: string,
+  at: Date,
+): ExchangeRun {
+  if (stageId === run.stageId) return run;
+  const label =
+    run.stages.find((stage) => stage.id === stageId)?.label ?? stageId;
+  return {
+    ...run,
+    stageId,
+    visits: [...closedVisits(run.visits, at), { id: stageId, label }],
+  };
+}
+
+/** Complete the run: the open visit closes, the stage becomes the terminal
+ * done stage, and the finish instant is recorded for the completion header. */
+export function runWithCompletion(run: ExchangeRun, at: Date): ExchangeRun {
+  return {
+    ...run,
+    stageId: DONE_STAGE_ID,
+    visits: closedVisits(run.visits, at),
+    finishedAt: at,
+  };
+}
+
+/** Mark the run failed: the timeline and history freeze where they stand and
+ * the status panel stops presenting the open stage as in flight. */
+export function runWithFailure(run: ExchangeRun): ExchangeRun {
+  return { ...run, failed: true };
+}
+
+/** One step of the five-step protocol timeline the rail shows after create. */
+export interface TimelineStep {
+  label: string;
+  state: "done" | "current" | "pending";
+}
+
+const TIMELINE_LABELS = [
+  "Share",
+  "Partner accepts",
+  "Confirm protocol",
+  "Link keys",
+  "Done",
+] as const;
+
+/**
+ * The rail's protocol timeline, derived from the run's stage: Share while the
+ * exchange waits for the partner, Confirm protocol during the protocol
+ * handshake, Link keys through the per-key rounds, everything done at
+ * completion. "Partner accepts" is a moment rather than a duration, so it is
+ * never current -- it flips to done the instant a protocol stage begins.
+ */
+export function timelineSteps(run: ExchangeRun): Array<TimelineStep> {
+  const current =
+    run.stageId === DONE_STAGE_ID
+      ? TIMELINE_LABELS.length
+      : preStages.some((stage) => stage.id === run.stageId)
+        ? 0
+        : run.stageId === CONFIRMING_PROTOCOL_STAGE_ID
+          ? 2
+          : 3;
+  return TIMELINE_LABELS.map((label, index) => ({
+    label,
+    state: index < current ? "done" : index === current ? "current" : "pending",
+  }));
+}
+
+/** The status panel's progress, as the current stage's position through the
+ * stage tree (0 before start, 100 at done). */
+export function progressPercent(run: ExchangeRun): number {
+  if (run.stageId === DONE_STAGE_ID) return 100;
+  const index = run.stages.findIndex((stage) => stage.id === run.stageId);
+  if (index <= 0 || run.stages.length < 2) return 0;
+  return Math.round((index / (run.stages.length - 1)) * 100);
+}
+
+/** The status panel's current stage label -- the open visit's, which tracked
+ * the stage tree when the visit was recorded. */
+export function currentStageLabel(run: ExchangeRun): string {
+  return run.visits[run.visits.length - 1].label;
+}
+
+/** A history row's completion time, e.g. `2:43 PM`. */
+export function timeOfDayLabel(at: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(at);
+}
+
+/** Whether the run still waits for the partner -- the share phase, during
+ * which the copy artifacts are the operator's task. Over the moment a
+ * protocol stage begins. */
+export function awaitingPartner(run: ExchangeRun): boolean {
+  return (
+    run.stageId === BEFORE_START_STAGE_ID || run.stageId === WAITING_STAGE_ID
+  );
+}

--- a/apps/web/src/bench/exchangeRun.ts
+++ b/apps/web/src/bench/exchangeRun.ts
@@ -130,13 +130,19 @@ export function runWithStage(
   };
 }
 
-/** Complete the run: the open visit closes, the stage becomes the terminal
- * done stage, and the finish instant is recorded for the completion header. */
+/** Complete the run: the open visit closes, the terminal done stage is
+ * entered as its own (already-closed) visit -- the lifecycle never emits a
+ * "done" stage event, so the completion synthesizes it here and the status
+ * label's live region announces the final "Done" -- and the finish instant is
+ * recorded for the completion header. */
 export function runWithCompletion(run: ExchangeRun, at: Date): ExchangeRun {
   return {
     ...run,
     stageId: DONE_STAGE_ID,
-    visits: closedVisits(run.visits, at),
+    visits: [
+      ...closedVisits(run.visits, at),
+      { id: DONE_STAGE_ID, label: "Done", completedAt: at },
+    ],
     finishedAt: at,
   };
 }
@@ -184,12 +190,19 @@ export function timelineSteps(run: ExchangeRun): Array<TimelineStep> {
 }
 
 /** The status panel's progress, as the current stage's position through the
- * stage tree (0 before start, 100 at done). */
+ * stage tree (0 before start, 100 at done). A stage id outside the tree
+ * asserts nothing new: the bar holds at the last stage the tree knows rather
+ * than regressing to zero. */
 export function progressPercent(run: ExchangeRun): number {
   if (run.stageId === DONE_STAGE_ID) return 100;
-  const index = run.stages.findIndex((stage) => stage.id === run.stageId);
-  if (index <= 0 || run.stages.length < 2) return 0;
-  return Math.round((index / (run.stages.length - 1)) * 100);
+  if (run.stages.length < 2) return 0;
+  for (let visit = run.visits.length - 1; visit >= 0; visit--) {
+    const index = run.stages.findIndex(
+      (stage) => stage.id === run.visits[visit].id,
+    );
+    if (index > 0) return Math.round((index / (run.stages.length - 1)) * 100);
+  }
+  return 0;
 }
 
 /** The status panel's current stage label -- the open visit's, which tracked

--- a/apps/web/src/bench/inviterModel.ts
+++ b/apps/web/src/bench/inviterModel.ts
@@ -481,6 +481,13 @@ export function expiryLabel(lifetimeSeconds: number, now: Date): string {
   return dateTimeLabel(new Date(now.getTime() + lifetimeSeconds * 1000));
 }
 
+/** Whether a minted invitation's ISO `expires` moment is still ahead of `now`
+ * -- past it, no partner can pass the credential, so a retry is pointless and
+ * the link must stop being offered. */
+export function invitationUsable(expiresIso: string, now: Date): boolean {
+  return new Date(expiresIso).getTime() > now.getTime();
+}
+
 /** Ledger phrasing for who receives the matched results. */
 export const RESULTS_DIRECTION_LABELS: Record<OutputDirection, string> = {
   both: "You and your partner",

--- a/apps/web/src/bench/inviterModel.ts
+++ b/apps/web/src/bench/inviterModel.ts
@@ -77,6 +77,16 @@ export function sealEditor(editor: InviterEditor): InviterEditor {
   return { ...editor, sealed: true };
 }
 
+/** Reopen the session -- the "start over with a fresh invitation" recovery
+ * after a failed run. Every input survives (a failure never clears what the
+ * operator authored); only the seal lifts, and the invitation it certified is
+ * discarded by the caller, so the next create mints a fresh secret. */
+export function unsealEditor(editor: InviterEditor): InviterEditor {
+  if (editor.sealed !== true) return editor;
+  const { sealed: _sealed, ...unsealed } = editor;
+  return unsealed;
+}
+
 /** Seed the editing session from the read file -- the "default terms derive
  * from the file the moment it is read" moment of the design. */
 export function editorFromCsv(
@@ -488,16 +498,27 @@ export interface InviterLedgerRow {
   muted?: string;
 }
 
+/** What a completed exchange settled, folded into the ledger: the invitation
+ * is consumed (its expiry no longer means anything), and the receive row can
+ * state what actually arrived -- the matched-row count, or that the agreed
+ * terms withheld the result table from this party. */
+export interface LedgerOutcome {
+  matchedRecordCount?: number;
+  resultWithheld?: boolean;
+}
+
 /**
  * The disclosure ledger for the spine, filling in as the exchange takes shape:
  * before a file is read every value is the em-dash placeholder; once a session
  * exists the send list, matched-on keys, expiry, and result direction are read
  * live from the draft. Once the invitation is minted its absolute `expires`
- * moment replaces the relative lifetime phrase.
+ * moment replaces the relative lifetime phrase, and once the exchange
+ * completes `outcome` replaces the forward-looking rows with what happened.
  */
 export function inviterLedgerRows(
   editor: InviterEditor | undefined,
   expiresIso?: string,
+  outcome?: LedgerOutcome,
 ): Array<InviterLedgerRow> {
   if (editor === undefined) {
     return [
@@ -523,7 +544,12 @@ export function inviterLedgerRows(
     {
       label: "You will receive",
       reference: "Step 2",
-      value: "Matched rows + your partner's shared columns",
+      value:
+        outcome === undefined
+          ? "Matched rows + your partner's shared columns"
+          : outcome.resultWithheld === true
+            ? "No result table - withheld by the agreed terms"
+            : `${new Intl.NumberFormat("en-US").format(outcome.matchedRecordCount ?? 0)} matched rows + shared columns`,
     },
     keys.length > 0
       ? {
@@ -536,9 +562,11 @@ export function inviterLedgerRows(
       label: "Expires",
       reference: "Step 3",
       value:
-        expiresIso !== undefined
-          ? dateTimeLabel(new Date(expiresIso))
-          : lifetimeLabel(editor.draft.lifetimeSeconds),
+        outcome !== undefined
+          ? "Invitation used"
+          : expiresIso !== undefined
+            ? dateTimeLabel(new Date(expiresIso))
+            : lifetimeLabel(editor.draft.lifetimeSeconds),
     },
     {
       label: "Results go to",

--- a/apps/web/src/bench/inviterRunOutputs.ts
+++ b/apps/web/src/bench/inviterRunOutputs.ts
@@ -1,0 +1,90 @@
+import {
+  buildOutputTable,
+  serializeExchangeRecord,
+  serializeVerificationKeys,
+} from "@psilink/core";
+
+import type { ExchangeResult, PreparedExchange } from "@psilink/core";
+import type { ExchangeOutputs } from "@psi/exchangeLifecycle";
+
+/** The bench run's downloadable artifacts: the lifecycle's outputs widened
+ * with the matched-row count the completion header states. Present exactly
+ * when the result table is (a withheld result has no count to state). */
+export type InviterRunOutputs = ExchangeOutputs & {
+  matchedRecordCount?: number;
+};
+
+/** The object-URL boundary {@link buildInviterRunOutputs} allocates through --
+ * `window.URL` in the app, a recording fake in tests. */
+export interface ObjectUrls {
+  create: (blob: Blob) => string;
+  revoke: (url: string) => void;
+}
+
+/**
+ * Build the run's downloadable artifacts from the exchange result: the results
+ * CSV (unless the terms withheld it) with its matched-row count, plus the
+ * record pair when the audit exists. If anything throws after a URL was
+ * created, every already-created URL is revoked before the error propagates:
+ * the results blob is matched-record PII, and a stranded object URL would keep
+ * it alive until page unload.
+ */
+export function buildInviterRunOutputs(
+  result: ExchangeResult,
+  prepared: PreparedExchange,
+  urls: ObjectUrls,
+): InviterRunOutputs {
+  const created: Array<string> = [];
+  const trackedUrl = (blob: Blob): string => {
+    const url = urls.create(blob);
+    created.push(url);
+    return url;
+  };
+  const jsonUrl = (text: string): string =>
+    trackedUrl(new Blob([text], { type: "application/json" }));
+  try {
+    // The exchange withholds the result table from a party whose agreed
+    // terms give it no output (a one-sided exchange where this party is the
+    // PSI sender/helper): produce no results file -- the completion panel
+    // shows it contributed but receives no result -- while still offering
+    // the record downloads below.
+    const generated: InviterRunOutputs =
+      result.associationTable === undefined
+        ? { resultWithheld: true }
+        : (() => {
+            const { headers, rows } = buildOutputTable(
+              result.associationTable,
+              prepared.rawRows,
+              prepared.metadata,
+              result.partnerPayload,
+            );
+            const csv =
+              headers.join(",") +
+              "\n" +
+              rows.map((r) => r.join(",") + "\n").join("");
+            return {
+              resultsUrl: trackedUrl(new Blob([csv], { type: "text/csv" })),
+              matchedRecordCount: rows.length,
+            };
+          })();
+    // The record downloads are produced only when the audit pair exists;
+    // absent if building the record failed after a successful exchange, in
+    // which case they are intentionally omitted without a blocking alert.
+    // Filenames are timestamped per exchange (the record's own createdAt,
+    // made filesystem-safe) so repeated downloads accumulate rather than
+    // collide.
+    if (result.audit !== undefined) {
+      const stamp = result.audit.record.createdAt.replace(/[:.]/g, "-");
+      generated.record = {
+        recordUrl: jsonUrl(serializeExchangeRecord(result.audit.record)),
+        recordFileName: `psilink-record-${stamp}.json`,
+        keysUrl: jsonUrl(serializeVerificationKeys(result.audit.keys)),
+        keysFileName: `psilink-record-${stamp}.keys.json`,
+      };
+    }
+    return generated;
+  } catch (error) {
+    for (const url of created) urls.revoke(url);
+    throw error;
+  }
+}

--- a/apps/web/src/bench/tokens.css
+++ b/apps/web/src/bench/tokens.css
@@ -27,6 +27,7 @@
   --bench-code-bg: #efede4;
   --bench-stripe: #4fa2af;
   --bench-shadow: 0 1px 3px rgba(26, 28, 26, 0.1);
+  --bench-check: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="none" stroke="%23FFFFFF" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" d="M3 8.5 6.5 12 13 4.5"/></svg>');
 }
 
 :root[data-mantine-color-scheme="dark"] {
@@ -53,4 +54,5 @@
   --bench-code-bg: #171a14;
   --bench-stripe: #2e8c9c;
   --bench-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+  --bench-check: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="none" stroke="%230B2A30" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" d="M3 8.5 6.5 12 13 4.5"/></svg>');
 }

--- a/apps/web/src/bench/useInviterExchange.ts
+++ b/apps/web/src/bench/useInviterExchange.ts
@@ -83,7 +83,9 @@ function failureFor(
     // because an OperatorConfigError's message names only local content (the
     // lifecycle scopes "config" to that type). Not a transport drop: retrying
     // as-is fails identically, so the message -- actionable -- is surfaced and
-    // the alert steers back to the settings rather than to a retry.
+    // the alert offers start-over (back to Review & create with every input
+    // intact, where the rail's Problems block routes to the fix) rather than
+    // a retry.
     return {
       category,
       title: "Could not prepare the exchange",

--- a/apps/web/src/bench/useInviterExchange.ts
+++ b/apps/web/src/bench/useInviterExchange.ts
@@ -6,15 +6,13 @@ import { useEffect, useRef, useState } from "react";
 import PSI from "@openmined/psi.js/psi_wasm_web";
 
 import {
-  buildOutputTable,
   errorMessage,
   loadPsiBackend,
   prepareForExchange,
   sanitizeForDisplay,
-  serializeExchangeRecord,
-  serializeVerificationKeys,
 } from "@psilink/core";
 
+import { hasRecoveryHint } from "@psi/authenticateExchange";
 import { inviterExchangeDataSpec } from "@psi/advancedInvite";
 import { listenAsInviter } from "@psi/rendezvous";
 import { runExchangeLifecycle } from "@psi/exchangeLifecycle";
@@ -31,24 +29,19 @@ import {
   runWithStages,
   stagesFor,
 } from "./exchangeRun";
+import { buildInviterRunOutputs } from "./inviterRunOutputs";
+import { invitationUsable } from "./inviterModel";
 
 import type { PSILibrary } from "@openmined/psi.js/implementation/psi.d.ts";
 
 import type {
   Acquire,
   ExchangeErrorCategory,
-  ExchangeOutputs,
   GenerateOutput,
 } from "@psi/exchangeLifecycle";
 import type { ExchangeRun } from "./exchangeRun";
 import type { GeneratedInvitation } from "@psi/invitation";
-
-/** The bench run's downloadable artifacts: the lifecycle's outputs widened
- * with the matched-row count the completion header states. Present exactly
- * when the result table is (a withheld result has no count to state). */
-export type InviterRunOutputs = ExchangeOutputs & {
-  matchedRecordCount?: number;
-};
+import type { InviterRunOutputs } from "./inviterRunOutputs";
 
 /** A failed run, ready to render: the lifecycle's category (which decides the
  * recovery the alert offers) and the operator-facing alert content, composed
@@ -60,7 +53,8 @@ export interface RunFailure {
   message: string;
 }
 
-function failureFor(
+/** @internal */
+export function failureFor(
   category: ExchangeErrorCategory,
   error: unknown,
 ): RunFailure {
@@ -93,6 +87,19 @@ function failureFor(
     };
   }
   if (category === "security") {
+    // A tagged credential/expiry error's message is composed only from local
+    // values and carries its own recovery guidance (core's recovery-hint
+    // contract, preserved across authenticateExchange's re-wrap), so it is
+    // safe and more accurate to surface than partner-blame copy: an expired
+    // invitation is not a failed partner check. Still the security category,
+    // so the alert offers only a fresh invitation -- correct for expiry too.
+    if (hasRecoveryHint(error)) {
+      return {
+        category,
+        title: "This invitation can no longer be used",
+        message: sanitizeForDisplay(errorMessage(error)),
+      };
+    }
     // The authenticated key exchange failed closed: this connection could not
     // be confirmed as the invited partner. Not retryable -- a silent retry
     // would re-run into the same wrong secret, or into a peer that is
@@ -112,13 +119,15 @@ function failureFor(
   // Generic, retryable transport/exchange failure. The raw error reads as an
   // internal/developer message and can embed partner-/server-controlled
   // bytes, so the alert uses a fixed, friendly message; the detailed error
-  // stays in the dev-gated console.error for diagnosis.
+  // stays in the dev-gated console.error for diagnosis. A mid-run drop lands
+  // here too, after agreed payload columns may already have flowed to the
+  // authenticated partner, so the copy must not claim the data stayed local.
   return {
     category,
     title: "Exchange failed",
     message:
       "The exchange could not be completed - usually a temporary " +
-      "connection problem. Your data stayed on your device.",
+      "connection problem rather than an issue with your data.",
   };
 }
 
@@ -189,60 +198,18 @@ export function useInviterExchange({
     setOutputs(undefined);
     setFailure(undefined);
 
-    // Pure output-generation half: the current exchange screen's, plus the
-    // matched-row count the completion header states. The object URLs are
-    // revoked when they are replaced or the bench unmounts (effect above).
+    // Output-generation half. The URLs the build creates are revoked when the
+    // outputs are replaced or the bench unmounts (effect above); a throw
+    // mid-build revokes its own partial URLs (see buildInviterRunOutputs).
     const generateOutput: GenerateOutput<InviterRunOutputs> = (
       result,
       prepared,
     ) => {
       log.info("linkage complete, generating results and record files");
-      const jsonUrl = (text: string): string =>
-        window.URL.createObjectURL(
-          new Blob([text], { type: "application/json" }),
-        );
-      // The exchange withholds the result table from a party whose agreed
-      // terms give it no output (a one-sided exchange where this party is the
-      // PSI sender/helper): produce no results file -- the completion panel
-      // shows it contributed but receives no result -- while still offering
-      // the record downloads below.
-      const generated: InviterRunOutputs =
-        result.associationTable === undefined
-          ? { resultWithheld: true }
-          : (() => {
-              const { headers, rows } = buildOutputTable(
-                result.associationTable,
-                prepared.rawRows,
-                prepared.metadata,
-                result.partnerPayload,
-              );
-              const csv =
-                headers.join(",") +
-                "\n" +
-                rows.map((r) => r.join(",") + "\n").join("");
-              return {
-                resultsUrl: window.URL.createObjectURL(
-                  new Blob([csv], { type: "text/csv" }),
-                ),
-                matchedRecordCount: rows.length,
-              };
-            })();
-      // The record downloads are produced only when the audit pair exists;
-      // absent if building the record failed after a successful exchange, in
-      // which case they are intentionally omitted without a blocking alert.
-      // Filenames are timestamped per exchange (the record's own createdAt,
-      // made filesystem-safe) so repeated downloads accumulate rather than
-      // collide.
-      if (result.audit !== undefined) {
-        const stamp = result.audit.record.createdAt.replace(/[:.]/g, "-");
-        generated.record = {
-          recordUrl: jsonUrl(serializeExchangeRecord(result.audit.record)),
-          recordFileName: `psilink-record-${stamp}.json`,
-          keysUrl: jsonUrl(serializeVerificationKeys(result.audit.keys)),
-          keysFileName: `psilink-record-${stamp}.keys.json`,
-        };
-      }
-      return generated;
+      return buildInviterRunOutputs(result, prepared, {
+        create: (blob) => window.URL.createObjectURL(blob),
+        revoke: (url) => window.URL.revokeObjectURL(url),
+      });
     };
 
     // The inviter is the PSI responder: it must attach its inbound listener
@@ -345,9 +312,16 @@ export function useInviterExchange({
   // lifecycle tore down), so a fresh listen on the same invitation cannot race
   // it, and the same secret stays valid for the partner's original link --
   // the security category instead forces a fresh invitation, and an output
-  // failure must not re-run an exchange that already succeeded.
+  // failure must not re-run an exchange that already succeeded. Gated on the
+  // invitation's expiry as well: re-listening on a lapsed credential cannot
+  // succeed (no peer can pass it) and would keep the dead link advertised.
   function tryAgain() {
-    if (invitation === undefined || failure?.category !== "exchange") return;
+    if (
+      invitation === undefined ||
+      failure?.category !== "exchange" ||
+      !invitationUsable(invitation.expires, new Date())
+    )
+      return;
     abortRef.current?.abort();
     abortRef.current = undefined;
     start(invitation);

--- a/apps/web/src/bench/useInviterExchange.ts
+++ b/apps/web/src/bench/useInviterExchange.ts
@@ -1,0 +1,355 @@
+import log from "loglevel";
+
+import { useEffect, useRef, useState } from "react";
+
+// @ts-ignore this is really there
+import PSI from "@openmined/psi.js/psi_wasm_web";
+
+import {
+  buildOutputTable,
+  errorMessage,
+  loadPsiBackend,
+  prepareForExchange,
+  sanitizeForDisplay,
+  serializeExchangeRecord,
+  serializeVerificationKeys,
+} from "@psilink/core";
+
+import { inviterExchangeDataSpec } from "@psi/advancedInvite";
+import { listenAsInviter } from "@psi/rendezvous";
+import { runExchangeLifecycle } from "@psi/exchangeLifecycle";
+import { waitForIncomingConnection } from "@psi/waitForConnection";
+
+import { whenDiagnostic } from "@utils/diagnostics";
+
+import {
+  WAITING_STAGE_ID,
+  initialRun,
+  runWithCompletion,
+  runWithFailure,
+  runWithStage,
+  runWithStages,
+  stagesFor,
+} from "./exchangeRun";
+
+import type { PSILibrary } from "@openmined/psi.js/implementation/psi.d.ts";
+
+import type {
+  Acquire,
+  ExchangeErrorCategory,
+  ExchangeOutputs,
+  GenerateOutput,
+} from "@psi/exchangeLifecycle";
+import type { ExchangeRun } from "./exchangeRun";
+import type { GeneratedInvitation } from "@psi/invitation";
+
+/** The bench run's downloadable artifacts: the lifecycle's outputs widened
+ * with the matched-row count the completion header states. Present exactly
+ * when the result table is (a withheld result has no count to state). */
+export type InviterRunOutputs = ExchangeOutputs & {
+  matchedRecordCount?: number;
+};
+
+/** A failed run, ready to render: the lifecycle's category (which decides the
+ * recovery the alert offers) and the operator-facing alert content, composed
+ * here so the sanitize-at-the-display-boundary discipline stays beside the
+ * error it applies to. */
+export interface RunFailure {
+  category: ExchangeErrorCategory;
+  title: string;
+  message: string;
+}
+
+function failureFor(
+  category: ExchangeErrorCategory,
+  error: unknown,
+): RunFailure {
+  if (category === "output") {
+    // The exchange succeeded; only results-file generation failed. The user
+    // must not be told to re-run a privacy-sensitive exchange, so unlike the
+    // other categories this alert offers no way to run again. Sanitized at
+    // the display boundary: the output error is local, but the alert is
+    // operator-facing, so escape it like any other.
+    return {
+      category,
+      title: "Results unavailable",
+      message:
+        "The linkage completed, but generating the results file failed: " +
+        sanitizeForDisplay(errorMessage(error)),
+    };
+  }
+  if (category === "config") {
+    // A prepare-time fault in the operator's OWN config, safe to surface
+    // because an OperatorConfigError's message names only local content (the
+    // lifecycle scopes "config" to that type). Not a transport drop: retrying
+    // as-is fails identically, so the message -- actionable -- is surfaced and
+    // the alert steers back to the settings rather than to a retry.
+    return {
+      category,
+      title: "Could not prepare the exchange",
+      message: sanitizeForDisplay(errorMessage(error)),
+    };
+  }
+  if (category === "security") {
+    // The authenticated key exchange failed closed: this connection could not
+    // be confirmed as the invited partner. Not retryable -- a silent retry
+    // would re-run into the same wrong secret, or into a peer that is
+    // tampering -- so the copy forbids it and the alert steers to a fresh
+    // invitation. The underlying error is dev-gated to the console (below)
+    // and deliberately kept out of the alert: the kex failure message is
+    // intentionally non-oracular.
+    return {
+      category,
+      title: "Could not verify your partner",
+      message:
+        "The check that proves the other side holds this invitation's " +
+        "secret did not pass. Do not retry; start over with a fresh " +
+        "invitation.",
+    };
+  }
+  // Generic, retryable transport/exchange failure. The raw error reads as an
+  // internal/developer message and can embed partner-/server-controlled
+  // bytes, so the alert uses a fixed, friendly message; the detailed error
+  // stays in the dev-gated console.error for diagnosis.
+  return {
+    category,
+    title: "Exchange failed",
+    message:
+      "The exchange could not be completed - usually a temporary " +
+      "connection problem. Your data stayed on your device.",
+  };
+}
+
+/**
+ * The run half of the inviter bench, started the moment the invitation is
+ * minted: listen on the invitation's derived id, run the exchange when the
+ * partner connects, and surface the downloads. The connection lifecycle
+ * (acquire/open/run/teardown, abort in any phase) is {@link runExchangeLifecycle},
+ * exactly as the current exchange screen drives it; this hook owns the single
+ * AbortController per invitation and folds the lifecycle's events into the
+ * bench's pure {@link ExchangeRun} model for the timeline and status panel.
+ *
+ * A regenerated invitation (a new object after start-over) restarts the whole
+ * run: the effect keyed on `invitation` aborts the old lifecycle and starts a
+ * fresh one, the bench-side equivalent of the current app keying its exchange
+ * subtree by the shared secret.
+ */
+export function useInviterExchange({
+  invitation,
+  inviterName,
+}: {
+  invitation: GeneratedInvitation | undefined;
+  inviterName: string;
+}): {
+  run: ExchangeRun;
+  outputs: InviterRunOutputs | undefined;
+  failure: RunFailure | undefined;
+  tryAgain: () => void;
+} {
+  const [run, setRun] = useState<ExchangeRun>(initialRun);
+  const [outputs, setOutputs] = useState<InviterRunOutputs>();
+  const [failure, setFailure] = useState<RunFailure>();
+
+  // Drives the lifecycle's AbortSignal; the effect cleanup below aborts it so
+  // an unmount (or a superseded invitation) tears down any in-flight wait or
+  // exchange and every owner-driven seam stops firing. The cleanup also
+  // clears the ref: under React StrictMode's mount/unmount/mount the start
+  // effect re-runs, and a stale aborted controller left in the ref would trip
+  // the re-entry guard and the real run would never start.
+  const abortRef = useRef<AbortController | undefined>(undefined);
+
+  // Revoke this run's object URLs when they are replaced or the owner
+  // unmounts: createObjectURL keeps each Blob alive until revoked, and the
+  // verification-keys blob is private material, so it should not outlive the
+  // run that backs it.
+  useEffect(() => {
+    if (outputs === undefined) return;
+    return () => {
+      if (outputs.resultsUrl !== undefined)
+        window.URL.revokeObjectURL(outputs.resultsUrl);
+      if (outputs.record !== undefined) {
+        window.URL.revokeObjectURL(outputs.record.recordUrl);
+        window.URL.revokeObjectURL(outputs.record.keysUrl);
+      }
+    };
+  }, [outputs]);
+
+  function start(minted: GeneratedInvitation) {
+    // Guard against re-entry: once a run is in flight its AbortController is
+    // stored here, and starting a second would orphan the first's signal and
+    // race two lifecycles on shared state. A deliberate restart (try again,
+    // a new invitation) clears the ref first.
+    if (abortRef.current) return;
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setRun(initialRun());
+    setOutputs(undefined);
+    setFailure(undefined);
+
+    // Pure output-generation half: the current exchange screen's, plus the
+    // matched-row count the completion header states. The object URLs are
+    // revoked when they are replaced or the bench unmounts (effect above).
+    const generateOutput: GenerateOutput<InviterRunOutputs> = (
+      result,
+      prepared,
+    ) => {
+      log.info("linkage complete, generating results and record files");
+      const jsonUrl = (text: string): string =>
+        window.URL.createObjectURL(
+          new Blob([text], { type: "application/json" }),
+        );
+      // The exchange withholds the result table from a party whose agreed
+      // terms give it no output (a one-sided exchange where this party is the
+      // PSI sender/helper): produce no results file -- the completion panel
+      // shows it contributed but receives no result -- while still offering
+      // the record downloads below.
+      const generated: InviterRunOutputs =
+        result.associationTable === undefined
+          ? { resultWithheld: true }
+          : (() => {
+              const { headers, rows } = buildOutputTable(
+                result.associationTable,
+                prepared.rawRows,
+                prepared.metadata,
+                result.partnerPayload,
+              );
+              const csv =
+                headers.join(",") +
+                "\n" +
+                rows.map((r) => r.join(",") + "\n").join("");
+              return {
+                resultsUrl: window.URL.createObjectURL(
+                  new Blob([csv], { type: "text/csv" }),
+                ),
+                matchedRecordCount: rows.length,
+              };
+            })();
+      // The record downloads are produced only when the audit pair exists;
+      // absent if building the record failed after a successful exchange, in
+      // which case they are intentionally omitted without a blocking alert.
+      // Filenames are timestamped per exchange (the record's own createdAt,
+      // made filesystem-safe) so repeated downloads accumulate rather than
+      // collide.
+      if (result.audit !== undefined) {
+        const stamp = result.audit.record.createdAt.replace(/[:.]/g, "-");
+        generated.record = {
+          recordUrl: jsonUrl(serializeExchangeRecord(result.audit.record)),
+          recordFileName: `psilink-record-${stamp}.json`,
+          keysUrl: jsonUrl(serializeVerificationKeys(result.audit.keys)),
+          keysFileName: `psilink-record-${stamp}.keys.json`,
+        };
+      }
+      return generated;
+    };
+
+    // The inviter is the PSI responder: it must attach its inbound listener
+    // before the WASM library resolves, so `psi` stays a pending promise here
+    // and the lifecycle awaits it late (after the message connection opens).
+    const acquire: Acquire = async ({ signal, onStage, onStages }) => {
+      const psi = loadPsiBackend(
+        { loadWasm: () => PSI() as Promise<PSILibrary> },
+        { isNode: false },
+      ).then((selection) => selection.library);
+      // The owner awaits `psi` late; if connection setup fails or the signal
+      // aborts first, that await is never reached. A fire-and-forget handler
+      // keeps a rejecting PSI() on a torn-down exchange from surfacing as an
+      // unhandled rejection -- the real `await psi` still throws.
+      void psi.catch(() => undefined);
+
+      // The exchange runs on the very terms embedded in the token (the
+      // acceptor adopts them from the invitation), with this party's authored
+      // metadata and standardization threaded in locally -- the same spec
+      // assembly the current exchange screen performs, through the same
+      // builder that reconciles authored standardization to the terms.
+      const prepared = prepareForExchange(
+        inviterExchangeDataSpec(minted.linkageTerms, {
+          metadata: minted.metadata,
+          standardization: minted.standardization,
+        }),
+        inviterName,
+        minted.rawRows,
+        minted.columns,
+      );
+      onStages(stagesFor(prepared));
+
+      onStage(WAITING_STAGE_ID);
+      // Listen on the derived inviter id, then await the acceptor's inbound
+      // connection. Destroy the peer on a wait failure so acquisition stays
+      // atomic (the lifecycle's teardown only ever covers a returned
+      // {peer, conn}).
+      const peer = await listenAsInviter(minted.sharedSecret, { signal });
+      try {
+        const conn = await waitForIncomingConnection(peer, { signal });
+        return { peer, conn, psi, prepared };
+      } catch (error) {
+        peer.destroy();
+        throw error;
+      }
+    };
+
+    void runExchangeLifecycle<InviterRunOutputs>({
+      acquire,
+      exchangeRole: "responder",
+      sharedSecret: minted.sharedSecret,
+      expires: minted.expires,
+      signal: controller.signal,
+      generateOutput,
+      onStages: (stages) => setRun((current) => runWithStages(current, stages)),
+      onStage: (stageId) =>
+        setRun((current) => runWithStage(current, stageId, new Date())),
+      onResult: (generated) => {
+        setOutputs(generated);
+        setRun((current) => runWithCompletion(current, new Date()));
+      },
+      onError: ({ category, error }) => {
+        // Dev-gated: the raw Error object's message/cause can embed partner-/
+        // server-controlled bytes, so a production console carries none of it,
+        // while a developer (or a deployed client with the diagnostics toggle
+        // on) keeps the full object. The user-facing alert is separately
+        // sanitized in failureFor.
+        whenDiagnostic(() => console.error(error));
+        setFailure(failureFor(category, error));
+        setRun((current) => runWithFailure(current));
+      },
+    });
+  }
+
+  // Start the run the moment an invitation exists -- the bench's partner may
+  // open the link right away, so the inviter listens without a Start press,
+  // exactly as the current app's post-generate screen does. Keyed on the
+  // invitation: a superseded or discarded invitation aborts its run, and a
+  // fresh mint after start-over begins a fresh one.
+  const startRef = useRef(start);
+  startRef.current = start;
+  useEffect(() => {
+    if (invitation === undefined) {
+      // Start-over discarded the invitation: drop the finished run's state so
+      // the output URLs are revoked now (the revocation effect's cleanup)
+      // rather than lingering until the bench unmounts.
+      setRun(initialRun());
+      setOutputs(undefined);
+      setFailure(undefined);
+      return;
+    }
+    startRef.current(invitation);
+    return () => {
+      abortRef.current?.abort();
+      abortRef.current = undefined;
+    };
+  }, [invitation]);
+
+  // Offered by the retryable-failure alert alone: the run is over (the
+  // lifecycle tore down), so a fresh listen on the same invitation cannot race
+  // it, and the same secret stays valid for the partner's original link --
+  // the security category instead forces a fresh invitation, and an output
+  // failure must not re-run an exchange that already succeeded.
+  function tryAgain() {
+    if (invitation === undefined || failure?.category !== "exchange") return;
+    abortRef.current?.abort();
+    abortRef.current = undefined;
+    start(invitation);
+  }
+
+  return { run, outputs, failure, tryAgain };
+}

--- a/apps/web/src/psi/authenticateExchange.ts
+++ b/apps/web/src/psi/authenticateExchange.ts
@@ -169,9 +169,11 @@ function hasNonTrustConnectionError(error: unknown): boolean {
 }
 
 /** Whether `error` carries authenticateConnection's `psilinkRecoveryHintEmitted`
- * tag (set on its credential-validation and expiry errors, whose messages
- * already include recovery instructions). */
-function hasRecoveryHint(error: unknown): boolean {
+ * tag, set on its credential-validation and expiry errors. Per core's contract a
+ * tagged message is composed only from local values and already includes its
+ * recovery instructions, so a display layer may surface it (sanitized) instead
+ * of fixed copy, and must not add a second, generic advisory. */
+export function hasRecoveryHint(error: unknown): boolean {
   return (
     typeof error === "object" &&
     error !== null &&

--- a/apps/web/src/psi/exchangeLifecycle.ts
+++ b/apps/web/src/psi/exchangeLifecycle.ts
@@ -178,14 +178,16 @@ export type ExchangeOutputs = ReceivedExchangeOutputs | WithheldExchangeOutputs;
 /** Pure output-generation step: build the local results file plus the
  * exchange-record artifacts (record + verification keys) from the exchange result
  * and return their URLs. May throw (classified as `"output"`); runs inside the
- * owner after the exchange and before teardown. */
-export type GenerateOutput = (
-  result: ExchangeResult,
-  prepared: PreparedExchange,
-) => ExchangeOutputs;
+ * owner after the exchange and before teardown. `TOutputs` lets an owner return
+ * a widened {@link ExchangeOutputs} (extra owner-local fields such as a matched
+ * count) and receive the same type back in `onResult` without a cast. */
+export type GenerateOutput<TOutputs extends ExchangeOutputs = ExchangeOutputs> =
+  (result: ExchangeResult, prepared: PreparedExchange) => TOutputs;
 
 /** Options for {@link runExchangeLifecycle}. */
-export interface RunExchangeLifecycleOptions {
+export interface RunExchangeLifecycleOptions<
+  TOutputs extends ExchangeOutputs = ExchangeOutputs,
+> {
   acquire: Acquire;
   /** This party's PSI handshake role: the web client is the `"initiator"`, the
    * web server the `"responder"`. The same role drives the pre-exchange
@@ -203,10 +205,10 @@ export interface RunExchangeLifecycleOptions {
    * for an unbounded credential, leaving the guards no-op. */
   expires?: string;
   signal: AbortSignal;
-  generateOutput: GenerateOutput;
+  generateOutput: GenerateOutput<TOutputs>;
   onStages: (stages: Array<StageDefinition>) => void;
   onStage: (stageId: string) => void;
-  onResult: (outputs: ExchangeOutputs) => void;
+  onResult: (outputs: TOutputs) => void;
   onError: (failure: {
     category: ExchangeErrorCategory;
     error: unknown;
@@ -239,9 +241,9 @@ export interface RunExchangeLifecycleOptions {
  *   owner-driven seam no-ops once aborted, so no setState fires after unmount on
  *   any path (success, progress, or error).
  */
-export async function runExchangeLifecycle(
-  options: RunExchangeLifecycleOptions,
-): Promise<void> {
+export async function runExchangeLifecycle<
+  TOutputs extends ExchangeOutputs = ExchangeOutputs,
+>(options: RunExchangeLifecycleOptions<TOutputs>): Promise<void> {
   const {
     acquire,
     exchangeRole,
@@ -393,7 +395,7 @@ export async function runExchangeLifecycle(
     // The privacy-sensitive exchange has succeeded here. A failure building the
     // local results file is an "output" failure, never an "exchange" one, so the
     // user is not told to re-run a PSI exchange that in fact already completed.
-    let outputs: ExchangeOutputs;
+    let outputs: TOutputs;
     try {
       outputs = generateOutput(result, prepared);
     } catch (error) {

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -158,6 +158,9 @@ function mount(content: ReactNode) {
 }
 
 afterEach(() => {
+  // Backstop for the fake-Date test below: a failure between useFakeTimers and
+  // its finally must not leak a frozen clock into the rest of the suite.
+  vi.useRealTimers();
   root?.unmount();
   container?.remove();
   root = undefined;
@@ -1043,7 +1046,9 @@ describe("inviter bench", () => {
     });
 
     // The alert takes focus, states the temporary nature, and keeps the copy
-    // artifacts on screen: the same link stays valid for another attempt.
+    // artifacts on screen: the same link stays valid for another attempt. The
+    // listening callout leaves, though -- the lifecycle tore down, so nothing
+    // is listening while the alert shows.
     await expect.element(page.getByText("Exchange failed")).toBeInTheDocument();
     await vi.waitFor(() => {
       expect(
@@ -1053,11 +1058,16 @@ describe("inviter bench", () => {
     await expect
       .element(page.getByText("Share this invitation"))
       .toBeInTheDocument();
+    expect(page.getByText("Keep this tab open.").query()).toBeNull();
 
     await page.getByRole("button", { name: "Try again" }).click();
     await vi.waitFor(() => expect(lifecycleHarness.calls).toHaveLength(2));
     expect(lifecycleCall(1).sharedSecret).toBe(lifecycleCall(0).sharedSecret);
     expect(page.getByText("Exchange failed").query()).toBeNull();
+    // The retry listens again, so the callout's claim is true once more.
+    await expect
+      .element(page.getByText("Keep this tab open."))
+      .toBeInTheDocument();
     // The clicked Try again unmounted with its alert, orphaning focus onto
     // <body>; the recovery lands it back on the heading.
     await vi.waitFor(() => {
@@ -1110,7 +1120,8 @@ describe("inviter bench", () => {
 
     // The prepare-time fault names only local config, so the actionable
     // message is surfaced, and the recovery is the start-over path (a retry
-    // would fail identically).
+    // would fail identically). Nothing will ever serve the link, so the copy
+    // artifacts and the listening callout leave with the failure.
     await expect
       .element(page.getByText("Could not prepare the exchange"))
       .toBeInTheDocument();
@@ -1119,6 +1130,8 @@ describe("inviter bench", () => {
         page.getByText("standardization output name contradicts the terms"),
       )
       .toBeInTheDocument();
+    expect(page.getByText("Share this invitation").query()).toBeNull();
+    expect(page.getByText("Keep this tab open.").query()).toBeNull();
     expect(page.getByRole("button", { name: "Try again" }).query()).toBeNull();
     await page
       .getByRole("button", { name: "Start over with a fresh invitation" })
@@ -1126,6 +1139,80 @@ describe("inviter bench", () => {
     await expect
       .element(page.getByRole("heading", { level: 1 }))
       .toHaveTextContent("Review & create");
+  });
+
+  test("post-create: an expired invitation names itself, not the partner", async () => {
+    await createSealedInvitation();
+    lifecycleCall(0).onStage("waiting for peer");
+    // The tagged expiry error core's guards raise (the tag marks its message
+    // as locally-composed recovery guidance, safe to surface).
+    lifecycleCall(0).onError({
+      category: "security",
+      error: Object.assign(
+        new Error(
+          "shared secret expired at 2026-07-08T19:32:00.000Z; obtain a new invitation",
+        ),
+        { psilinkRecoveryHintEmitted: true },
+      ),
+    });
+
+    await expect
+      .element(page.getByText("This invitation can no longer be used"))
+      .toBeInTheDocument();
+    await expect
+      .element(
+        page.getByText("expired at 2026-07-08T19:32:00.000Z", {
+          exact: false,
+        }),
+      )
+      .toBeInTheDocument();
+    expect(page.getByRole("button", { name: "Try again" }).query()).toBeNull();
+    await expect
+      .element(
+        page.getByRole("button", {
+          name: "Start over with a fresh invitation",
+        }),
+      )
+      .toBeInTheDocument();
+  });
+
+  test("post-create: an exchange failure past expiry swaps retry for start-over", async () => {
+    await createSealedInvitation();
+    lifecycleCall(0).onStage("waiting for peer");
+
+    // Jump past the invitation's 1-hour lifetime (Date only: timers stay real
+    // so React scheduling and vi.waitFor's polling keep working), then land a
+    // failure that would otherwise be retryable.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(Date.now() + 2 * 3600 * 1000);
+      lifecycleCall(0).onError({
+        category: "exchange",
+        error: new Error("transport"),
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          Array.from(document.querySelectorAll("button")).some(
+            (button) =>
+              button.textContent === "Start over with a fresh invitation",
+          ),
+        ).toBe(true);
+      });
+      expect(
+        Array.from(document.querySelectorAll("button")).some(
+          (button) => button.textContent === "Try again",
+        ),
+      ).toBe(false);
+      // The lapsed link is no longer advertised either.
+      expect(
+        Array.from(document.querySelectorAll("h2")).some(
+          (heading) => heading.textContent === "Share this invitation",
+        ),
+      ).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("post-create: a security failure forces a fresh invitation, inputs intact", async () => {

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -957,6 +957,10 @@ describe("inviter bench", () => {
       .element(page.getByText(/1,847.*matched records/))
       .toBeInTheDocument();
     await expect.element(page.getByText(/^Finished /)).toBeInTheDocument();
+    // The status label's live region reaches the final "Done".
+    expect(document.querySelector(`.${styles.stageLabel}`)?.textContent).toBe(
+      "Done",
+    );
 
     // Three artifacts, three verbs: the result, the shareable record, the
     // private keys -- each caveat on the download row itself.
@@ -1054,6 +1058,13 @@ describe("inviter bench", () => {
     await vi.waitFor(() => expect(lifecycleHarness.calls).toHaveLength(2));
     expect(lifecycleCall(1).sharedSecret).toBe(lifecycleCall(0).sharedSecret);
     expect(page.getByText("Exchange failed").query()).toBeNull();
+    // The clicked Try again unmounted with its alert, orphaning focus onto
+    // <body>; the recovery lands it back on the heading.
+    await vi.waitFor(() => {
+      expect(document.activeElement?.textContent).toBe(
+        "Your invitation is ready",
+      );
+    });
   });
 
   test("post-create: an output failure offers no re-run, only a fresh setup", async () => {

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -13,8 +13,10 @@ import { AcceptUnderConstruction } from "@bench/placeholders";
 import { BenchLobby } from "@bench/BenchLobby";
 import { InvitationFileError } from "@psi/invitation";
 import { InviterBench } from "@bench/InviterBench";
+import { stagesFor } from "@bench/exchangeRun";
 import styles from "@bench/bench.module.css";
 
+import type { PreparedExchange } from "@psilink/core";
 import type { ReactNode } from "react";
 import type { Root } from "react-dom/client";
 
@@ -96,6 +98,53 @@ vi.mock("@psi/csvParseController", async (importOriginal) => {
   };
 });
 
+// Stub the rendezvous module: importing it runs a top-level config load that
+// reads `process` (absent in the browser runner). Its listen function only
+// runs inside the run lifecycle's acquire closure, which the lifecycle stub
+// below never invokes (the exchangeView.test.ts pattern).
+vi.mock("@psi/rendezvous", () => ({
+  dialAsAcceptor: vi.fn(),
+  listenAsInviter: vi.fn(),
+}));
+
+// Stub the run lifecycle so creating an invitation never dials: record each
+// invocation's options so a test can drive the captured onStages/onStage/
+// onResult/onError seams -- the same seams the real lifecycle fires -- and
+// assert the bench's post-create screens against them.
+interface CapturedLifecycle {
+  exchangeRole: "initiator" | "responder";
+  sharedSecret: string;
+  expires?: string;
+  signal: AbortSignal;
+  onStages: (stages: Array<unknown>) => void;
+  onStage: (stageId: string) => void;
+  onResult: (outputs: {
+    resultsUrl?: string;
+    resultWithheld?: boolean;
+    matchedRecordCount?: number;
+    record?: {
+      recordUrl: string;
+      recordFileName: string;
+      keysUrl: string;
+      keysFileName: string;
+    };
+  }) => void;
+  onError: (failure: { category: string; error: unknown }) => void;
+}
+const lifecycleHarness = vi.hoisted(() => ({
+  calls: [] as Array<unknown>,
+}));
+vi.mock("@psi/exchangeLifecycle", () => ({
+  runExchangeLifecycle: (options: unknown) => {
+    lifecycleHarness.calls.push(options);
+    return Promise.resolve();
+  },
+}));
+
+function lifecycleCall(index: number): CapturedLifecycle {
+  return lifecycleHarness.calls[index] as CapturedLifecycle;
+}
+
 const EM_DASH = "\u2014";
 
 let container: HTMLElement | undefined;
@@ -118,7 +167,60 @@ afterEach(() => {
   csvLoadHarness.fail = undefined;
   csvLoadHarness.lastSignal = undefined;
   csvLoadHarness.resolve = undefined;
+  lifecycleHarness.calls.length = 0;
 });
+
+// Walk the spine to a sealed invitation: name, file, straight through to
+// Review & create, then the real mint (the lifecycle beneath it is stubbed,
+// so nothing dials).
+async function createSealedInvitation() {
+  mount(createElement(InviterBench));
+  await expect.element(page.getByLabelText("Your name")).toBeInTheDocument();
+  await userEvent.fill(page.getByLabelText("Your name"), "Dana Okafor");
+  const fileInput = document.querySelector('input[type="file"]');
+  await userEvent.upload(
+    page.elementLocator(fileInput as HTMLElement),
+    new File(
+      [
+        "client_id,first_name,last_name,dob,program_code\n" +
+          "1,Ann,Lee,01/02/1990,A\n2,Bo,Ray,03/04/1985,B\n",
+      ],
+      "clients.csv",
+      { type: "text/csv" },
+    ),
+  );
+  await expect.element(page.getByText("clients.csv")).toBeInTheDocument();
+  await page
+    .getByRole("button", { name: "Continue to matching & sharing" })
+    .click();
+  await page
+    .getByRole("button", { name: "Continue to review & create" })
+    .click();
+  await page.getByRole("button", { name: "Create the invitation" }).click();
+  await expect
+    .element(page.getByRole("heading", { level: 1 }))
+    .toHaveTextContent("Your invitation is ready");
+  // The run starts from an effect after the invitation lands; wait for it so
+  // callers can drive the captured lifecycle seams right away.
+  await vi.waitFor(() => expect(lifecycleHarness.calls).toHaveLength(1));
+}
+
+// stagesFor reads only the linkage terms off the prepared exchange (the unit
+// suite's stand-in), so the tests can hand the captured onStages the real
+// derived tree.
+function preparedWith(
+  linkageStrategy: "cascade" | "single-pass",
+  keyCount: number,
+): PreparedExchange {
+  return {
+    linkageTerms: {
+      linkageStrategy,
+      linkageKeys: Array.from({ length: keyCount }, (_, i) => ({
+        name: `key ${i + 1}`,
+      })),
+    },
+  } as unknown as PreparedExchange;
+}
 
 describe("bench lobby", () => {
   test("renders the landing structure with one main and one h1", async () => {
@@ -727,6 +829,268 @@ describe("inviter bench", () => {
     expect(document.querySelector(`.${styles.fileCard}`)).toBeNull();
     expect(document.querySelector(`.${styles.callout}`)).toBeNull();
     await expect.element(continueButton).toBeDisabled();
+  });
+
+  test("post-create: the share screen offers the artifacts while listening", async () => {
+    await createSealedInvitation();
+
+    // Both copy artifacts render, the link wrapping the code's token, each
+    // with its copy action; the one-time-secret guidance and the expiry sit
+    // on the thing being shared.
+    const codeBlocks = Array.from(
+      document.querySelectorAll(`.${styles.codeBlock}`),
+    ).map((block) => block.textContent);
+    expect(codeBlocks).toHaveLength(2);
+    expect(codeBlocks[0]).toContain("/accept#");
+    expect(codeBlocks[1].length).toBeGreaterThan(0);
+    expect(codeBlocks[0]).toContain(codeBlocks[1]);
+    await expect
+      .element(page.getByRole("button", { name: "Copy invitation link" }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByRole("button", { name: "Copy invitation code" }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("It carries a one-time secret", { exact: false }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("This invitation expires", { exact: false }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("Keep this tab open."))
+      .toBeInTheDocument();
+
+    // The run started as the responder on the minted secret the moment the
+    // invitation existed, and the sealed ledger marks the frozen terms.
+    expect(lifecycleHarness.calls).toHaveLength(1);
+    const call = lifecycleCall(0);
+    expect(call.exchangeRole).toBe("responder");
+    expect(call.sharedSecret.length).toBeGreaterThan(0);
+    expect(call.expires).toBeDefined();
+    expect(call.signal.aborted).toBe(false);
+    await expect
+      .element(page.getByText("Terms sealed at create"))
+      .toBeInTheDocument();
+
+    // The status panel tracks the lifecycle's stage events; Share stays the
+    // timeline's current step while the browser waits for the partner. (The
+    // label and its history row repeat the text by design, so the assertion
+    // reads the label node.)
+    call.onStage("waiting for peer");
+    await vi.waitFor(() => {
+      expect(document.querySelector(`.${styles.stageLabel}`)?.textContent).toBe(
+        "Waiting for your partner",
+      );
+    });
+    const rail = document.querySelector('nav[aria-label="Exchange progress"]');
+    expect(
+      (rail as Element).querySelector('[aria-current="step"]')?.textContent,
+    ).toBe("Share");
+  });
+
+  test("post-create: the timeline advances with the exchange stages", async () => {
+    await createSealedInvitation();
+    const call = lifecycleCall(0);
+    call.onStages(stagesFor(preparedWith("cascade", 2)));
+    call.onStage("waiting for peer");
+
+    // The partner connecting moves the run into the protocol stages: the
+    // share block leaves (nothing left to share), the heading changes, and
+    // the orphaned focus is recovered onto it.
+    call.onStage("confirming protocol");
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Exchange in progress");
+    expect(page.getByText("Share this invitation").query()).toBeNull();
+    await vi.waitFor(() => {
+      expect(document.activeElement?.textContent).toBe("Exchange in progress");
+    });
+
+    const rail = () =>
+      document.querySelector('nav[aria-label="Exchange progress"]') as Element;
+    expect(rail().querySelector('[aria-current="step"]')?.textContent).toBe(
+      "Confirm protocol",
+    );
+
+    // Per-key stages sit under Link keys; the history keeps the completed
+    // stages with their times, and the progress bar tracks the position.
+    call.onStage("stage 2 / 2");
+    await vi.waitFor(() => {
+      expect(document.querySelector(`.${styles.stageLabel}`)?.textContent).toBe(
+        "Linking key 2 / 2",
+      );
+    });
+    expect(rail().querySelector('[aria-current="step"]')?.textContent).toBe(
+      "Link keys",
+    );
+    await expect
+      .element(page.getByText(/Waiting for your partner - done/))
+      .toBeInTheDocument();
+    expect(
+      document
+        .querySelector('[role="progressbar"]')
+        ?.getAttribute("aria-valuenow"),
+    ).toBe("80");
+  });
+
+  test("post-create: completion offers the three downloads with caveats", async () => {
+    await createSealedInvitation();
+    const call = lifecycleCall(0);
+    call.onStages(stagesFor(preparedWith("cascade", 2)));
+    call.onStage("waiting for peer");
+    call.onStage("confirming protocol");
+    call.onResult({
+      resultsUrl: URL.createObjectURL(new Blob(["a,b\n"])),
+      matchedRecordCount: 1847,
+      record: {
+        recordUrl: URL.createObjectURL(new Blob(["{}"])),
+        recordFileName: "psilink-record-2026-07-08T14-32.json",
+        keysUrl: URL.createObjectURL(new Blob(["{}"])),
+        keysFileName: "psilink-record-2026-07-08T14-32.keys.json",
+      },
+    });
+
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Exchange complete");
+    await expect
+      .element(page.getByText(/1,847.*matched records/))
+      .toBeInTheDocument();
+    await expect.element(page.getByText(/^Finished /)).toBeInTheDocument();
+
+    // Three artifacts, three verbs: the result, the shareable record, the
+    // private keys -- each caveat on the download row itself.
+    const links = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>("a[download]"),
+    );
+    expect(links.map((link) => link.textContent)).toEqual([
+      "results.csv",
+      "psilink-record-2026-07-08T14-32.json",
+      "psilink-record-2026-07-08T14-32.keys.json",
+    ]);
+    expect(links[2].getAttribute("aria-label")).toBe(
+      "Download verification keys (keep private): " +
+        "psilink-record-2026-07-08T14-32.keys.json",
+    );
+    await expect.element(page.getByText("Keep a record.")).toBeInTheDocument();
+
+    // The timeline finishes whole, and the ledger settles what happened: the
+    // invitation is consumed and the receive row reports the actual count.
+    const rail = document.querySelector('nav[aria-label="Exchange progress"]');
+    expect((rail as Element).querySelector('[aria-current="step"]')).toBeNull();
+    const ledger = document.querySelector(
+      'aside[aria-label="This exchange"]',
+    ) as Element;
+    expect(ledger.textContent).toContain("Invitation used");
+    expect(ledger.textContent).toContain("1,847 matched rows + shared columns");
+    expect(ledger.textContent).toContain("Your file never left this browser.");
+
+    const another = Array.from(document.querySelectorAll("a")).find(
+      (anchor) => anchor.textContent === "Set up another exchange",
+    );
+    expect(another?.getAttribute("href")).toBe("/bench");
+  });
+
+  test("post-create: a one-sided exchange states the withheld-result caveat", async () => {
+    await createSealedInvitation();
+    const call = lifecycleCall(0);
+    call.onStage("waiting for peer");
+    call.onResult({
+      resultWithheld: true,
+      record: {
+        recordUrl: URL.createObjectURL(new Blob(["{}"])),
+        recordFileName: "psilink-record-x.json",
+        keysUrl: URL.createObjectURL(new Blob(["{}"])),
+        keysFileName: "psilink-record-x.keys.json",
+      },
+    });
+
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Exchange complete");
+    // No results download and no count -- the caveat states the terms did
+    // this, while the record downloads are still offered.
+    await expect
+      .element(
+        page.getByText(
+          "Your records contributed to the match. By the agreed terms, you " +
+            "receive no result table, so there is nothing to download here.",
+        ),
+      )
+      .toBeInTheDocument();
+    const links = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>("a[download]"),
+    ).map((link) => link.textContent);
+    expect(links).toEqual([
+      "psilink-record-x.json",
+      "psilink-record-x.keys.json",
+    ]);
+    expect(
+      document.querySelector('aside[aria-label="This exchange"]')?.textContent,
+    ).toContain("No result table - withheld by the agreed terms");
+  });
+
+  test("post-create: a retryable failure offers one more try on the same invitation", async () => {
+    await createSealedInvitation();
+    lifecycleCall(0).onStage("waiting for peer");
+    lifecycleCall(0).onError({
+      category: "exchange",
+      error: new Error("transport"),
+    });
+
+    // The alert takes focus, states the temporary nature, and keeps the copy
+    // artifacts on screen: the same link stays valid for another attempt.
+    await expect.element(page.getByText("Exchange failed")).toBeInTheDocument();
+    await vi.waitFor(() => {
+      expect(
+        (document.activeElement as HTMLElement | null)?.textContent,
+      ).toContain("Exchange failed");
+    });
+    await expect
+      .element(page.getByText("Share this invitation"))
+      .toBeInTheDocument();
+
+    await page.getByRole("button", { name: "Try again" }).click();
+    await vi.waitFor(() => expect(lifecycleHarness.calls).toHaveLength(2));
+    expect(lifecycleCall(1).sharedSecret).toBe(lifecycleCall(0).sharedSecret);
+    expect(page.getByText("Exchange failed").query()).toBeNull();
+  });
+
+  test("post-create: a security failure forces a fresh invitation, inputs intact", async () => {
+    await createSealedInvitation();
+    lifecycleCall(0).onStage("waiting for peer");
+    lifecycleCall(0).onError({
+      category: "security",
+      error: new Error("kex failed"),
+    });
+
+    // The copy artifacts leave the screen -- a link that failed
+    // authentication must not keep being advertised -- and the alert forbids
+    // a retry.
+    await expect
+      .element(page.getByText("Could not verify your partner"))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("Do not retry", { exact: false }))
+      .toBeInTheDocument();
+    expect(page.getByText("Share this invitation").query()).toBeNull();
+    expect(page.getByRole("button", { name: "Try again" }).query()).toBeNull();
+
+    // Start over lifts the seal with every input intact: back on Review &
+    // create, the spine rail returns and the authored terms still mint.
+    await page
+      .getByRole("button", { name: "Start over with a fresh invitation" })
+      .click();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Review & create");
+    expect(
+      document.querySelector('nav[aria-label="Exchange setup"]'),
+    ).not.toBeNull();
+    await expect
+      .element(page.getByText("Ready to create."))
+      .toBeInTheDocument();
+    expect(page.getByText("Terms sealed at create").query()).toBeNull();
   });
 
   test("collapses to the single-column layout without rail and ledger", async () => {

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -1056,6 +1056,67 @@ describe("inviter bench", () => {
     expect(page.getByText("Exchange failed").query()).toBeNull();
   });
 
+  test("post-create: an output failure offers no re-run, only a fresh setup", async () => {
+    await createSealedInvitation();
+    lifecycleCall(0).onStage("waiting for peer");
+    lifecycleCall(0).onStage("confirming protocol");
+    lifecycleCall(0).onError({
+      category: "output",
+      error: new Error("blob quota exceeded"),
+    });
+
+    // The exchange already succeeded, so the alert must not invite running it
+    // again: no Try again, no start-over-and-remint -- only the sanitized
+    // detail and the way out to a new exchange.
+    await expect
+      .element(page.getByText("Results unavailable"))
+      .toBeInTheDocument();
+    await expect
+      .element(
+        page.getByText(
+          /generating the results file failed: blob quota exceeded/,
+        ),
+      )
+      .toBeInTheDocument();
+    expect(page.getByRole("button", { name: "Try again" }).query()).toBeNull();
+    expect(
+      page
+        .getByRole("button", { name: "Start over with a fresh invitation" })
+        .query(),
+    ).toBeNull();
+    const another = Array.from(document.querySelectorAll("a")).find(
+      (anchor) => anchor.textContent === "Set up another exchange",
+    );
+    expect(another?.getAttribute("href")).toBe("/bench");
+  });
+
+  test("post-create: a config failure surfaces its message and starts over", async () => {
+    await createSealedInvitation();
+    lifecycleCall(0).onError({
+      category: "config",
+      error: new Error("standardization output name contradicts the terms"),
+    });
+
+    // The prepare-time fault names only local config, so the actionable
+    // message is surfaced, and the recovery is the start-over path (a retry
+    // would fail identically).
+    await expect
+      .element(page.getByText("Could not prepare the exchange"))
+      .toBeInTheDocument();
+    await expect
+      .element(
+        page.getByText("standardization output name contradicts the terms"),
+      )
+      .toBeInTheDocument();
+    expect(page.getByRole("button", { name: "Try again" }).query()).toBeNull();
+    await page
+      .getByRole("button", { name: "Start over with a fresh invitation" })
+      .click();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Review & create");
+  });
+
   test("post-create: a security failure forces a fresh invitation, inputs intact", async () => {
     await createSealedInvitation();
     lifecycleCall(0).onStage("waiting for peer");

--- a/apps/web/test/unit/benchExchangeRun.test.ts
+++ b/apps/web/test/unit/benchExchangeRun.test.ts
@@ -136,6 +136,9 @@ describe("the timeline advances on stage events", () => {
     ]);
     expect(done.finishedAt).toEqual(at(47));
     expect(progressPercent(done)).toBe(100);
+    // The lifecycle never emits a "done" stage event, so completion must
+    // synthesize the final label the live region announces.
+    expect(currentStageLabel(done)).toBe("Done");
   });
 
   test("under single-pass, Link keys completes without ever being current", () => {
@@ -197,6 +200,18 @@ describe("the visit history", () => {
     const run = runWithStage(initialRun(), "surprise stage", at(32));
     expect(currentStageLabel(run)).toBe("surprise stage");
     expect(states(run)[3]).toBe("Link keys:current");
+  });
+
+  test("a stage id outside the tree holds the bar at the last known stage", () => {
+    const seeded = runWithStages(
+      initialRun(),
+      stagesFor(preparedWith("cascade", 2)),
+    );
+    const waiting = runWithStage(seeded, WAITING_STAGE_ID, at(32));
+    expect(progressPercent(waiting)).toBe(20);
+    expect(
+      progressPercent(runWithStage(waiting, "surprise stage", at(33))),
+    ).toBe(20);
   });
 
   test("failure freezes the run where it stands", () => {

--- a/apps/web/test/unit/benchExchangeRun.test.ts
+++ b/apps/web/test/unit/benchExchangeRun.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "vitest";
+
+import { CONFIRMING_PROTOCOL_STAGE_ID } from "@psilink/core";
+
+import {
+  BEFORE_START_STAGE_ID,
+  DONE_STAGE_ID,
+  WAITING_STAGE_ID,
+  awaitingPartner,
+  currentStageLabel,
+  initialRun,
+  progressPercent,
+  runWithCompletion,
+  runWithFailure,
+  runWithStage,
+  runWithStages,
+  stagesFor,
+  timeOfDayLabel,
+  timelineSteps,
+} from "@bench/exchangeRun";
+
+import type { ExchangeRun } from "@bench/exchangeRun";
+import type { PreparedExchange } from "@psilink/core";
+
+// stagesFor and describeExchangeStages beneath it read only the linkage terms
+// off the prepared exchange, so a terms-only stand-in exercises the real
+// stage-tree derivation without preparing a full exchange.
+function preparedWith(
+  linkageStrategy: "cascade" | "single-pass",
+  keyCount: number,
+): PreparedExchange {
+  return {
+    linkageTerms: {
+      linkageStrategy,
+      linkageKeys: Array.from({ length: keyCount }, (_, i) => ({
+        name: `key ${i + 1}`,
+      })),
+    },
+  } as unknown as PreparedExchange;
+}
+
+function states(run: ExchangeRun): Array<string> {
+  return timelineSteps(run).map((step) => `${step.label}:${step.state}`);
+}
+
+describe("stage trees", () => {
+  test("the full tree carries pre-stages, protocol stages, and done", () => {
+    const stages = stagesFor(preparedWith("cascade", 2));
+    expect(stages.map((stage) => stage.id)).toEqual([
+      BEFORE_START_STAGE_ID,
+      WAITING_STAGE_ID,
+      CONFIRMING_PROTOCOL_STAGE_ID,
+      "stage 1 / 2",
+      "stage 2 / 2",
+      DONE_STAGE_ID,
+    ]);
+    expect(stages[1].label).toBe("Waiting for your partner");
+    expect(stages[3].label).toBe("Linking key 1 / 2");
+  });
+
+  test("a single-pass tree has no per-key stages", () => {
+    const ids = stagesFor(preparedWith("single-pass", 3)).map(
+      (stage) => stage.id,
+    );
+    expect(ids).toEqual([
+      BEFORE_START_STAGE_ID,
+      WAITING_STAGE_ID,
+      CONFIRMING_PROTOCOL_STAGE_ID,
+      DONE_STAGE_ID,
+    ]);
+  });
+});
+
+describe("the timeline advances on stage events", () => {
+  const at = (minute: number) => new Date(2026, 6, 8, 14, minute);
+
+  function runToWaiting(): ExchangeRun {
+    const seeded = runWithStages(
+      initialRun(),
+      stagesFor(preparedWith("cascade", 2)),
+    );
+    return runWithStage(seeded, WAITING_STAGE_ID, at(32));
+  }
+
+  test("before and while waiting, Share is the current step", () => {
+    expect(states(initialRun())).toEqual([
+      "Share:current",
+      "Partner accepts:pending",
+      "Confirm protocol:pending",
+      "Link keys:pending",
+      "Done:pending",
+    ]);
+    const waiting = runToWaiting();
+    expect(states(waiting)[0]).toBe("Share:current");
+    expect(awaitingPartner(waiting)).toBe(true);
+    expect(currentStageLabel(waiting)).toBe("Waiting for your partner");
+  });
+
+  test("a protocol stage flips Share and Partner accepts to done at once", () => {
+    const confirming = runWithStage(
+      runToWaiting(),
+      CONFIRMING_PROTOCOL_STAGE_ID,
+      at(39),
+    );
+    expect(states(confirming)).toEqual([
+      "Share:done",
+      "Partner accepts:done",
+      "Confirm protocol:current",
+      "Link keys:pending",
+      "Done:pending",
+    ]);
+    expect(awaitingPartner(confirming)).toBe(false);
+  });
+
+  test("the per-key stages sit under Link keys", () => {
+    const linking = runWithStage(
+      runWithStage(runToWaiting(), CONFIRMING_PROTOCOL_STAGE_ID, at(39)),
+      "stage 2 / 2",
+      at(43),
+    );
+    expect(states(linking)[3]).toBe("Link keys:current");
+    expect(currentStageLabel(linking)).toBe("Linking key 2 / 2");
+  });
+
+  test("completion finishes every step and pins the finish instant", () => {
+    const done = runWithCompletion(
+      runWithStage(runToWaiting(), CONFIRMING_PROTOCOL_STAGE_ID, at(39)),
+      at(47),
+    );
+    expect(states(done)).toEqual([
+      "Share:done",
+      "Partner accepts:done",
+      "Confirm protocol:done",
+      "Link keys:done",
+      "Done:done",
+    ]);
+    expect(done.finishedAt).toEqual(at(47));
+    expect(progressPercent(done)).toBe(100);
+  });
+
+  test("under single-pass, Link keys completes without ever being current", () => {
+    const seeded = runWithStages(
+      initialRun(),
+      stagesFor(preparedWith("single-pass", 3)),
+    );
+    const confirming = runWithStage(
+      runWithStage(seeded, WAITING_STAGE_ID, at(32)),
+      CONFIRMING_PROTOCOL_STAGE_ID,
+      at(39),
+    );
+    expect(states(confirming)[3]).toBe("Link keys:pending");
+    expect(states(runWithCompletion(confirming, at(41)))[3]).toBe(
+      "Link keys:done",
+    );
+  });
+
+  test("progress tracks the stage's position through the tree", () => {
+    const waiting = runToWaiting();
+    expect(progressPercent(initialRun())).toBe(0);
+    expect(progressPercent(waiting)).toBe(20);
+    expect(progressPercent(runWithStage(waiting, "stage 2 / 2", at(43)))).toBe(
+      80,
+    );
+  });
+});
+
+describe("the visit history", () => {
+  const at = (minute: number) => new Date(2026, 6, 8, 14, minute);
+
+  test("advancing closes the open visit with its completion time", () => {
+    const seeded = runWithStages(
+      initialRun(),
+      stagesFor(preparedWith("cascade", 2)),
+    );
+    const run = runWithStage(
+      runWithStage(seeded, WAITING_STAGE_ID, at(32)),
+      CONFIRMING_PROTOCOL_STAGE_ID,
+      at(39),
+    );
+    expect(run.visits).toEqual([
+      { id: BEFORE_START_STAGE_ID, label: "Before start", completedAt: at(32) },
+      {
+        id: WAITING_STAGE_ID,
+        label: "Waiting for your partner",
+        completedAt: at(39),
+      },
+      { id: CONFIRMING_PROTOCOL_STAGE_ID, label: "Confirming protocol" },
+    ]);
+  });
+
+  test("a re-emitted stage id does not duplicate a history row", () => {
+    const waiting = runWithStage(initialRun(), WAITING_STAGE_ID, at(32));
+    expect(runWithStage(waiting, WAITING_STAGE_ID, at(33))).toBe(waiting);
+  });
+
+  test("a stage id outside the tree reads mid-protocol with itself as label", () => {
+    const run = runWithStage(initialRun(), "surprise stage", at(32));
+    expect(currentStageLabel(run)).toBe("surprise stage");
+    expect(states(run)[3]).toBe("Link keys:current");
+  });
+
+  test("failure freezes the run where it stands", () => {
+    const waiting = runWithStage(initialRun(), WAITING_STAGE_ID, at(32));
+    const failed = runWithFailure(waiting);
+    expect(failed.failed).toBe(true);
+    expect(failed.stageId).toBe(WAITING_STAGE_ID);
+    expect(states(failed)).toEqual(states(waiting));
+  });
+
+  test("completion times render as a time of day", () => {
+    expect(timeOfDayLabel(at(43))).toBe("2:43 PM");
+  });
+});

--- a/apps/web/test/unit/benchInviterFailures.test.ts
+++ b/apps/web/test/unit/benchInviterFailures.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+
+import { failureFor } from "@bench/useInviterExchange";
+
+describe("failureFor", () => {
+  test("each category carries its alert title", () => {
+    expect(failureFor("output", new Error("x")).title).toBe(
+      "Results unavailable",
+    );
+    expect(failureFor("config", new Error("x")).title).toBe(
+      "Could not prepare the exchange",
+    );
+    expect(failureFor("security", new Error("x")).title).toBe(
+      "Could not verify your partner",
+    );
+    expect(failureFor("exchange", new Error("x")).title).toBe(
+      "Exchange failed",
+    );
+  });
+
+  test("a tagged security error surfaces its own recovery guidance", () => {
+    const failure = failureFor(
+      "security",
+      Object.assign(
+        new Error(
+          "shared secret expired at 2026-07-08T19:32:00.000Z; obtain a new invitation",
+        ),
+        { psilinkRecoveryHintEmitted: true },
+      ),
+    );
+    expect(failure.category).toBe("security");
+    expect(failure.title).toBe("This invitation can no longer be used");
+    expect(failure.message).toContain("expired at 2026-07-08T19:32:00.000Z");
+  });
+
+  test("an untagged security error keeps the fixed non-oracular copy", () => {
+    const failure = failureFor(
+      "security",
+      new Error("kex transcript diverged"),
+    );
+    expect(failure.title).toBe("Could not verify your partner");
+    expect(failure.message).not.toContain("kex transcript diverged");
+    expect(failure.message).toContain("start over with a fresh invitation");
+  });
+
+  test("the exchange message makes no on-device data claim", () => {
+    expect(failureFor("exchange", new Error("ICE failed")).message).toBe(
+      "The exchange could not be completed - usually a temporary " +
+        "connection problem rather than an issue with your data.",
+    );
+  });
+});

--- a/apps/web/test/unit/benchInviterModel.test.ts
+++ b/apps/web/test/unit/benchInviterModel.test.ts
@@ -29,6 +29,7 @@ import {
   reviewValidation,
   sealEditor,
   spineProblems,
+  unsealEditor,
 } from "@bench/inviterModel";
 
 import type { AcquiredCsv } from "@bench/inviterModel";
@@ -268,6 +269,54 @@ describe("review and create", () => {
     const rows = inviterLedgerRows(editor, "2026-07-08T19:32:00.000Z");
     const expires = rows.find((row) => row.label === "Expires");
     expect(expires?.value).toContain("July 8, 2026");
+  });
+});
+
+describe("after the exchange completes", () => {
+  function outcomeRow(
+    outcome: Parameters<typeof inviterLedgerRows>[2],
+    label: string,
+  ) {
+    const rows = inviterLedgerRows(
+      editorFromCsv("Dana", csv),
+      "2026-07-08T19:32:00.000Z",
+      outcome,
+    );
+    return rows.find((row) => row.label === label);
+  }
+
+  test("the ledger reports the invitation used and the matched count", () => {
+    expect(outcomeRow({ matchedRecordCount: 1847 }, "Expires")?.value).toBe(
+      "Invitation used",
+    );
+    expect(
+      outcomeRow({ matchedRecordCount: 1847 }, "You will receive")?.value,
+    ).toBe("1,847 matched rows + shared columns");
+  });
+
+  test("a withheld result states the caveat rather than a count", () => {
+    expect(
+      outcomeRow({ resultWithheld: true }, "You will receive")?.value,
+    ).toBe("No result table - withheld by the agreed terms");
+  });
+
+  test("unsealing reopens the session with every input intact", () => {
+    const authored = editorWithLegalAgreement(editorFromCsv("Dana", csv), {
+      reference: "MOU-1",
+      purpose: "Eval",
+      expirationDate: "2099-12-31",
+    });
+    const sealed = sealEditor(authored);
+    expect(editorWithLifetime(sealed, 86400)).toBe(sealed);
+
+    const reopened = unsealEditor(sealed);
+    expect(reopened.sealed).toBeUndefined();
+    expect(reopened.draft).toBe(authored.draft);
+    expect(editorWithLifetime(reopened, 86400).draft.lifetimeSeconds).toBe(
+      86400,
+    );
+
+    expect(unsealEditor(authored)).toBe(authored);
   });
 });
 

--- a/apps/web/test/unit/benchInviterModel.test.ts
+++ b/apps/web/test/unit/benchInviterModel.test.ts
@@ -21,6 +21,7 @@ import {
   enabledKeys,
   fileCardMeta,
   identifierProblem,
+  invitationUsable,
   inviterLedgerRows,
   inviterRailFacts,
   keySatisfiabilityFor,
@@ -183,6 +184,12 @@ describe("display helpers", () => {
       "12,408 rows - 8.4 MB",
     );
     expect(fileCardMeta(3, 2048)).toBe("3 rows - 2 KB");
+  });
+
+  test("invitationUsable is true only before the expiry moment", () => {
+    const now = new Date("2026-07-08T19:00:00.000Z");
+    expect(invitationUsable("2026-07-08T19:32:00.000Z", now)).toBe(true);
+    expect(invitationUsable("2026-07-08T18:32:00.000Z", now)).toBe(false);
   });
 });
 

--- a/apps/web/test/unit/benchInviterRunOutputs.test.ts
+++ b/apps/web/test/unit/benchInviterRunOutputs.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "vitest";
+
+import { buildInviterRunOutputs } from "@bench/inviterRunOutputs";
+
+import type { ExchangeResult, PreparedExchange } from "@psilink/core";
+import type { ObjectUrls } from "@bench/inviterRunOutputs";
+
+// A recording ObjectUrls fake: each create hands out a distinct url (or throws
+// on the configured call), and both sides log what they were given, so the
+// tests can assert the create/revoke pairing without a DOM.
+function recordingUrls(options?: { failOnCall?: number }) {
+  const created: Array<string> = [];
+  const revoked: Array<string> = [];
+  const urls: ObjectUrls = {
+    create: (blob) => {
+      if (created.length + 1 === options?.failOnCall)
+        throw new Error("createObjectURL refused");
+      const url = `blob:test-${created.length + 1}-${blob.type}`;
+      created.push(url);
+      return url;
+    },
+    revoke: (url) => {
+      revoked.push(url);
+    },
+  };
+  return { urls, created, revoked };
+}
+
+// The smallest inputs buildOutputTable accepts: one matched pair (our row 0 to
+// the partner's row 5) with one payload column, and an identifier column so
+// the CSV's first header is real.
+const prepared = {
+  rawRows: [{ client_id: "17", program_code: "A" }],
+  metadata: [
+    { name: "client_id", role: "identifier" },
+    { name: "program_code", role: "payload" },
+  ],
+} as unknown as PreparedExchange;
+
+const audit = {
+  record: { createdAt: "2026-07-08T14:32:00.000Z" },
+  keys: { salts: {} },
+} as unknown as NonNullable<ExchangeResult["audit"]>;
+
+function receivedResult(withAudit: boolean): ExchangeResult {
+  return {
+    associationTable: [[0], [5]],
+    partnerPayload: { columns: ["program"], rowIndices: [5], rows: [["B"]] },
+    audit: withAudit ? audit : undefined,
+  } as unknown as ExchangeResult;
+}
+
+function withheldResult(): ExchangeResult {
+  return {
+    associationTable: undefined,
+    partnerPayload: { columns: [], rowIndices: [], rows: [] },
+    audit,
+  } as unknown as ExchangeResult;
+}
+
+describe("buildInviterRunOutputs", () => {
+  test("a received result yields the results url, count, and timestamped record pair", () => {
+    const { urls, created, revoked } = recordingUrls();
+    const outputs = buildInviterRunOutputs(
+      receivedResult(true),
+      prepared,
+      urls,
+    );
+
+    expect(outputs.resultsUrl).toBe(created[0]);
+    expect(outputs.matchedRecordCount).toBe(1);
+    expect(outputs.resultWithheld).toBeUndefined();
+    expect(outputs.record).toEqual({
+      recordUrl: created[1],
+      recordFileName: "psilink-record-2026-07-08T14-32-00-000Z.json",
+      keysUrl: created[2],
+      keysFileName: "psilink-record-2026-07-08T14-32-00-000Z.keys.json",
+    });
+    expect(created).toHaveLength(3);
+    expect(revoked).toEqual([]);
+  });
+
+  test("a withheld result offers the record but no results url", () => {
+    const { urls, created } = recordingUrls();
+    const outputs = buildInviterRunOutputs(withheldResult(), prepared, urls);
+
+    expect(outputs.resultWithheld).toBe(true);
+    expect(outputs.resultsUrl).toBeUndefined();
+    expect(outputs.matchedRecordCount).toBeUndefined();
+    expect(outputs.record?.recordUrl).toBe(created[0]);
+    expect(created).toHaveLength(2);
+  });
+
+  test("a throw after the results url was created revokes it before propagating", () => {
+    const { urls, created, revoked } = recordingUrls({ failOnCall: 2 });
+
+    expect(() =>
+      buildInviterRunOutputs(receivedResult(true), prepared, urls),
+    ).toThrow("createObjectURL refused");
+    expect(created).toHaveLength(1);
+    expect(revoked).toEqual([created[0]]);
+  });
+
+  test("a result without an audit pair omits the record downloads", () => {
+    const { urls, created, revoked } = recordingUrls();
+    const outputs = buildInviterRunOutputs(
+      receivedResult(false),
+      prepared,
+      urls,
+    );
+
+    expect(outputs.record).toBeUndefined();
+    expect(outputs.resultsUrl).toBe(created[0]);
+    expect(created).toHaveLength(1);
+    expect(revoked).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The inviter's post-create flow: after Create the rail becomes the five-step protocol timeline (Share -> Partner accepts -> Confirm protocol -> Link keys -> Done), the share screen carries the invitation link and code with copy actions, the one-time-secret guidance, and the expiry while the browser listens for the partner, the running screen tracks stage labels, progress, and a visited-stage history with completion times, and the completion panel offers the three downloads with their caveats -- including the withheld-result variant for a one-sided exchange. The designed failure vocabulary renders per category, each with its one concrete way forward. The run drives the existing `runExchangeLifecycle` seam exactly as the current exchange screen does, so the Console engine's driver contract later fronts the same interface.

Implements [211235811](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=211235811).

## Changes

- apps/web/src/bench/exchangeRun.ts: the pure run model -- the stage tree (the lifecycle's pre/protocol/done stages, with the bench's "Waiting for your partner" label), the visit history with completion times, and the view-model builders for the timeline, progress, and stage label. Completion synthesizes the terminal Done visit the lifecycle never emits.
- apps/web/src/bench/useInviterExchange.ts: the run hook, porting the current exchange screen's inviter wiring (acquire via listen/wait with atomic teardown, output generation with the two-file record split and timestamped names, the four error categories with their sanitization and console discipline, object-URL revocation, re-entry and StrictMode guards, abort on unmount or superseded invitation). Adds the matched-record count to the outputs and a category-gated `tryAgain`.
- apps/web/src/bench/InviterExchangeSection.tsx, StatusPanel.tsx: the work column through the three phases and the status panel rendered from one stable mount so its polite live region persists across them. Downloads carry their caveats in both the visible row and the anchor's accessible name; failure alerts take focus and never clear input.
- apps/web/src/bench/InviterBench.tsx, inviterModel.ts, Ledger.tsx: the timeline replaces the placeholder rail steps; the sealed ledger gains its tag and, at completion, settles into what happened ("Invitation used", the matched count or the withheld caveat, the past-tense trust footer). `unsealEditor` backs the start-over recovery: the seal lifts with every input intact and the next create mints a fresh secret.
- apps/web/src/psi/exchangeLifecycle.ts: `runExchangeLifecycle`/`GenerateOutput` gain a type parameter so an owner's generateOutput can return widened outputs (the matched count) without a cast; no behavior change.
- Tests: unit (14 new) pin the run model -- the timeline advances on stage events, per-key stages sit under Link keys, single-pass completes Link keys without it ever being current, completion synthesizes Done, visit history, defensive unknown-stage behavior; unit (4 new) pin the ledger outcome rows and unseal. Browser (8 new) drive the whole flow through a captured lifecycle stub: the share artifacts and sealed ledger, the timeline advancing with focus recovery, completion with the three downloads and the settled ledger, the withheld variant, and all four failure categories with their recoveries.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run formatcheck`, `npm run test:unit -w apps/web` (642 passed), `npm run test:browser -w apps/web` (354 passed), `npm run build -w apps/web`.
New tests cover: the two acceptance criteria named on the issue (timeline advances on stage events; the withheld-result caveat), plus the share artifacts, downloads and caveats, the failure vocabulary per category, and the run model's edge cases.

## Background

One deliberate behavior change from the current app: **the retryable-failure alert's "Try again" re-runs the exchange on the same invitation** (the inviter re-listens on the same secret), where the current app offers no inviter-side retry. A role-specialized security panel (protocol/cryptography, adversarial, and disclosure reviewers, each deriving a position independently) unanimously judged the reuse sound: the credential is designed for multiple handshake attempts within its expiry, every attempt runs a fresh fail-closed authenticated key exchange with the expiry re-enforced, and every trust-relevant failure routes to the non-retryable security category, which offers only a fresh invitation. An output failure (exchange already succeeded) offers no re-run -- the mockup's "run the exchange again" copy for that case was not adopted because it contradicts the run screen's must-not-re-run discipline.

The panel's findings were presentational and are fixed on this branch: a tagged credential/expiry error now surfaces its own recovery guidance instead of partner-blame copy (an expired invitation is not a failed partner check), the retryable alert no longer claims data stayed on the device (falsifiable by a mid-run failure), the share artifacts stop being advertised whenever the invitation is dead (terminal config fault, failed authentication, or lapsed expiry -- which also swaps Try again for start-over), and output generation revokes any object URLs it created if it throws partway.

Before that, a light-review round (3 reviewers, 2 confirmed minors, 0 simpler-shape votes) drove browser coverage for the output and config failure categories, and a proactive port-fidelity sweep against the three ported surfaces (ExchangeView's inviter role, ShareBlock, Status) restored the announced final Done stage, the unknown-stage development warning, and focus recovery on the retry path. Each fix is test-pinned.

## Out of scope / follow-on

- The running screen's partial-coverage advisory (the rail's amber Problems block in the mockup) has no inviter-side producer today; it arrives with the acceptor slice, whose pre-flight raises that warning.
- The mockup's select-on-click clipboard fallback for insecure origins is not implemented; like the current app, the copy button hides and the text stays manually selectable.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed; the bench remains a parallel preview and the docs rewrite is scheduled with the cutover item
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: preview routes on the continuously deployed web app; no operator- or reviewer-actionable change
- [x] Security review -- a role-specialized panel (protocol, adversarial, disclosure) reviewed the same-invitation retry and the branch's disclosure surface: unanimous acceptable, presentational findings fixed on the branch (see Background); the run re-surfaces the existing tested lifecycle unchanged, the kex/expiry guards are threaded per attempt, error alerts keep the sanitization discipline, and nothing new is sent, stored, or logged
