### PR TITLE
Gate allowedCharacters length before compiling it

### DIFF
--- a/packages/core/src/config/linkageTerms.ts
+++ b/packages/core/src/config/linkageTerms.ts
@@ -333,15 +333,23 @@ const NameConstraintsSchema: z.ZodType<NameConstraints> = z.object({
   // never silently un-checked),
   // so the advisory cannot silently fail open on a class the native engine accepts
   // but re2js rejects (a backreference, a POSIX/Unicode class, or the degenerate
-  // empty class). Note the brackets that get added. The `.max()` precedes the
-  // refine so an oversized value is rejected on length before a large
-  // partner-controlled string is compiled; a real class is short.
+  // empty class).
+  //
+  // The length short-circuit in the refine is a real pre-compile gate, not an
+  // ordering assumption: a failed `.max()` does NOT stop the refine from running
+  // (Zod does not short-circuit chained checks), so without the guard an oversized
+  // partner-controlled value would be interpolated into `[${val}]` and compiled
+  // under re2js -- super-linear in length, a multi-second synchronous stall. An
+  // over-length value passes the refine so `.max()` rejects it on length alone;
+  // only an in-length class reaches patternConformsToDialect.
   allowedCharacters: z
     .string()
     .max(MAX_NAME_LENGTH)
-    .refine((val) => patternConformsToDialect(`[${val}]`), {
-      message: "allowedCharacters must be a valid regex character class",
-    })
+    .refine(
+      (val) =>
+        val.length > MAX_NAME_LENGTH || patternConformsToDialect(`[${val}]`),
+      { message: "allowedCharacters must be a valid regex character class" },
+    )
     .optional(),
   affixesAllowed: z.boolean().optional(),
   exclude: ExcludeSchema.optional(),

--- a/packages/core/test/linkageTerms.test.ts
+++ b/packages/core/test/linkageTerms.test.ts
@@ -2010,6 +2010,32 @@ test("rejects an over-long allowedCharacters constraint", () => {
   ).toThrow(ZodError);
 });
 
+test("over-long allowedCharacters is rejected without compiling the class", () => {
+  // "z-a" is an invalid (reversed) range: had the refine compiled this value it
+  // would have produced the class-validity message. The value is also over the
+  // length cap, so the refine's length short-circuit rejects on length alone and
+  // never reaches the compiler. The absence of the class-validity message proves
+  // the value was not compiled.
+  const result = safeParseLinkageTerms({
+    ...base,
+    linkageFields: [
+      {
+        name: "firstName",
+        type: "first_name",
+        constraints: {
+          allowedCharacters: "z-a" + "a".repeat(MAX_NAME_LENGTH),
+        },
+      },
+    ],
+    linkageKeys: [{ name: "FN", elements: [{ field: "firstName" }] }],
+  });
+  expect(result.success).toBe(false);
+  if (result.success) return;
+  expect(
+    result.error.issues.some((issue) => /character class/.test(issue.message)),
+  ).toBe(false);
+});
+
 test("rejects an over-long transform params key", () => {
   expect(() =>
     parseLinkageTerms({


### PR DESCRIPTION
## Summary

The `allowedCharacters` name constraint is a partner-controlled string that gets compiled as a regex character class during schema parse. Zod does not short-circuit chained checks, so a failed `.max()` still ran the later `.refine()`, letting a multi-megabyte value reach the RE2JS compiler -- compile time is super-linear in source length, a synchronous stall reachable from a mutually-distrusting counterparty. This closes that gap by rejecting an over-length value on length alone before it is ever interpolated into the character class and compiled.

Product board item 211449739.

## Changes

- `packages/core/src/config/linkageTerms.ts`: short-circuit the `refine` on length so an over-length value is rejected by `.max()` before compilation; replaced the stale comment (which claimed `.max()` already precedes the refine) with the real pre-compile-gate constraint.
- `packages/core/test/linkageTerms.test.ts`: added a test proving an over-length invalid class is refused without ever emitting the class-validity message (i.e. without being compiled).

## Test plan

Ran: typecheck, lint, format, and the covering unit tests pass.
New tests cover: an over-length `allowedCharacters` value that is also an invalid character class is rejected on length alone, never reaching the compiler (verified by the absence of the class-validity error message).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier -- n/a: internal parse-time check-ordering fix, no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: branch does not add an entry; flagging for reviewer judgment given the security nature of the fix.
- [x] Security review -- SECURITY (partner-controlled DoS bound). Recommended tier: full pipeline. Pre-review already performed: light-review and assess-review clean, and a three-lens security panel with adversarial verification found no standing defects. This is context for the human reviewer, not a substitute for the required review before merge.
