### PR TITLE
Reject calendar-impossible dates in parse_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@ This changelog records, per release, the changes that affect how PSI-Link is run
 - The web inviter's "Advanced options" import now re-generates the rest of an imported linkage-terms document faithfully: linkage-field order and any declared-but-unreferenced field (with its constraints) are preserved rather than reordered or dropped, and a benign empty `constraints: {}` is kept rather than refused, so the regenerated invitation commits the same cross-party agreement. A custom constraint on a field a key uses is still refused. See `docs/COMMUNICATION.md`.
 - The web app parses a dropped CSV in a Web Worker, so a large (near-10MB) file no longer freezes the interface -- input and painting stay responsive -- while it is read.
 - The invitation consent displays now show the inviter's requested-from-you payload columns consistently on the web and the CLI, with a declared-empty `payload.receive` rendered "(none) -- any payload column would abort the exchange" rather than hidden: previously the web showed only a non-empty request and the CLI showed this direction not at all, so a declared-empty receive read identically to an unstated (lazy) one with the opposite runtime meaning. The empty-vs-absent behavior itself is unchanged. See `docs/EXCHANGE_REFERENCE.md`.
+- The `parse_date` standardization step now drops a record whose date is calendar-impossible (for example 02/29 in a non-leap year, or 04/31), instead of silently rolling it over to the next valid day and hashing the wrong value into the linkage key.
 
 ### Security
 

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -185,6 +185,24 @@ interface ParsedDateFormat {
   order: DateFormatToken[];
 }
 
+// The ISO-string Date constructor rolls an out-of-range day/month over (e.g.
+// Feb 29 in a non-leap year becomes Mar 1) instead of returning an Invalid
+// Date, so isNaN alone would accept it; round-trip the parsed UTC components
+// back against the input to catch rollover.
+function isCalendarDateValid(
+  year: string,
+  month: string,
+  day: string,
+): boolean {
+  const date = new Date(`${year}-${month}-${day}T00:00:00Z`);
+  return (
+    !isNaN(date.getTime()) &&
+    date.getUTCFullYear() === Number(year) &&
+    date.getUTCMonth() + 1 === Number(month) &&
+    date.getUTCDate() === Number(day)
+  );
+}
+
 // Build the anchored regex source and capture order for a parse_date input
 // format. The format is partner-controlled and its MM/DD tokens EXPAND into
 // adjacent `(\d{1,2})` groups, which catastrophically backtrack on the JavaScript
@@ -257,19 +275,7 @@ function parseDateFactory(params: Params): StandardizingFn {
 
     if (!parts.YYYY || !parts.MM || !parts.DD) return null;
 
-    // The ISO-string Date constructor rolls an out-of-range day/month over
-    // (e.g. Feb 29 in a non-leap year becomes Mar 1) instead of returning an
-    // Invalid Date, so isNaN alone would accept it; round-trip the parsed UTC
-    // components back against the input to catch rollover, matching
-    // isValidStandardizedDate.
-    const asDate = new Date(`${parts.YYYY}-${parts.MM}-${parts.DD}T00:00:00Z`);
-    if (
-      isNaN(asDate.getTime()) ||
-      asDate.getUTCFullYear() !== Number(parts.YYYY) ||
-      asDate.getUTCMonth() + 1 !== Number(parts.MM) ||
-      asDate.getUTCDate() !== Number(parts.DD)
-    )
-      return null;
+    if (!isCalendarDateValid(parts.YYYY, parts.MM, parts.DD)) return null;
 
     return outputFormat
       .replace("YYYY", parts.YYYY)
@@ -1991,13 +1997,7 @@ function isValidStandardizedDate(value: string): boolean {
   const match = /^(\d{4})(\d{2})(\d{2})$/.exec(value);
   if (match === null) return true;
   const [, year, month, day] = match;
-  const date = new Date(`${year}-${month}-${day}T00:00:00Z`);
-  return (
-    !Number.isNaN(date.getTime()) &&
-    date.getUTCFullYear() === Number(year) &&
-    date.getUTCMonth() + 1 === Number(month) &&
-    date.getUTCDate() === Number(day)
-  );
+  return isCalendarDateValid(year, month, day);
 }
 
 /** Whether a 9-digit value satisfies the SSA structural rules: area not 000 or

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -257,9 +257,19 @@ function parseDateFactory(params: Params): StandardizingFn {
 
     if (!parts.YYYY || !parts.MM || !parts.DD) return null;
 
-    // Reject calendar-invalid dates (e.g. month 13).
-    const asDate = new Date(`${parts.YYYY}-${parts.MM}-${parts.DD}`);
-    if (isNaN(asDate.getTime())) return null;
+    // The ISO-string Date constructor rolls an out-of-range day/month over
+    // (e.g. Feb 29 in a non-leap year becomes Mar 1) instead of returning an
+    // Invalid Date, so isNaN alone would accept it; round-trip the parsed UTC
+    // components back against the input to catch rollover, matching
+    // isValidStandardizedDate.
+    const asDate = new Date(`${parts.YYYY}-${parts.MM}-${parts.DD}T00:00:00Z`);
+    if (
+      isNaN(asDate.getTime()) ||
+      asDate.getUTCFullYear() !== Number(parts.YYYY) ||
+      asDate.getUTCMonth() + 1 !== Number(parts.MM) ||
+      asDate.getUTCDate() !== Number(parts.DD)
+    )
+      return null;
 
     return outputFormat
       .replace("YYYY", parts.YYYY)

--- a/packages/core/test/standardization.test.ts
+++ b/packages/core/test/standardization.test.ts
@@ -331,6 +331,50 @@ describe("runPipeline — parse_date", () => {
       ]),
     ).toBeNull();
   });
+
+  test("Feb 29 in a non-leap year returns null (rolls over to Mar 1)", () => {
+    expect(
+      runPipeline("02/29/2021", [
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD/YYYY", outputFormat: "YYYYMMDD" },
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  test("Feb 29 in a leap year round-trips", () => {
+    expect(
+      runPipeline("02/29/2020", [
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD/YYYY", outputFormat: "YYYYMMDD" },
+        },
+      ]),
+    ).toBe("20200229");
+  });
+
+  test("a day exceeding the month's length returns null (rolls over)", () => {
+    expect(
+      runPipeline("04/31/2021", [
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD/YYYY", outputFormat: "YYYYMMDD" },
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  test("a valid ordinary date round-trips", () => {
+    expect(
+      runPipeline("06/15/2021", [
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD/YYYY", outputFormat: "YYYYMMDD" },
+        },
+      ]),
+    ).toBe("20210615");
+  });
 });
 
 // --- runPipeline: phonetic ---------------------------------------------------


### PR DESCRIPTION
## Summary

The `parse_date` standardizing step validated a parsed date with `new Date(...)` plus `isNaN`, but the ISO-string `Date` constructor silently rolls an out-of-range day over to the next valid one (Feb 29 in a non-leap year becomes Mar 1) instead of producing an Invalid Date, so the guard passed and the rolled-over value was hashed into the linkage key. The parsed UTC components are now round-tripped back against the input, matching the check `isValidStandardizedDate` already used for constraint validation, so a rollover is dropped as null instead of silently corrupting the record. The round-trip check itself was deduplicated into a shared `isCalendarDateValid` helper used by both call sites.

Product board item 211450184.

## Changes

- `packages/core/src/standardization.ts`: added `isCalendarDateValid` and used it in both `parseDateFactory`'s rollover guard and `isValidStandardizedDate`, replacing each site's own copy of the check.
- `packages/core/test/standardization.test.ts`: added regression coverage for calendar-impossible dates.
- `CHANGELOG.md`: entry added.

## Test plan

Ran: typecheck, lint, format, and the covering unit tests pass.
New tests cover: `parse_date` drops a calendar-impossible date (e.g. Feb 29 in a non-leap year, Apr 31) as null instead of accepting the rolled-over value.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier -- n/a: internal standardization-step correctness fix, no documented interface changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- added: `parse_date` now drops a record whose date is calendar-impossible instead of silently rolling it over and hashing the wrong value into the linkage key.
- [x] Security review -- n/a: standardization-step correctness fix; no cryptographic, credential, or disclosure surface touched. Recommended tier: light. Pre-review already performed: cold-reviewed. This is context for the human reviewer, not a substitute for the required review before merge.
