### PR TITLE
Re-check live consent, not a stale closure, on accept

### DIFF
--- a/apps/web/src/components/AcceptInvitation.tsx
+++ b/apps/web/src/components/AcceptInvitation.tsx
@@ -64,6 +64,15 @@ export function AcceptInvitation() {
   // affirmatively checks this and provides a name (see commitAcceptance).
   const [consented, setConsented] = useState(false);
   const [acceptorName, setAcceptorName] = useState("");
+  // handleAcquired fires after an async CSV parse, during which the consent
+  // checkbox and name field stay interactive; a plain closure would re-check the
+  // values captured when the parse started. Refs synced to the latest state on
+  // every render make the re-check read the live consent and name at commit time,
+  // so revoking consent (or clearing the name) mid-parse blocks the commit.
+  const consentedRef = useRef(consented);
+  consentedRef.current = consented;
+  const acceptorNameRef = useRef(acceptorName);
+  acceptorNameRef.current = acceptorName;
   // The post-consent phase: reviewing -> preparing -> exchange, with a back edge
   // preparing -> reviewing so the operator can pick a different file. Its presence
   // (anything past "reviewing") is the in-route transition off the review screen.
@@ -157,7 +166,10 @@ export function AcceptInvitation() {
     // The acquire phase already gates its submit on the same check
     // (submitDisabled), but re-check here so the security-relevant invariant does
     // not rest on the disabled state alone.
-    const name = commitAcceptance({ consented, name: acceptorName });
+    const name = commitAcceptance({
+      consented: consentedRef.current,
+      name: acceptorNameRef.current,
+    });
     if (name === undefined) return;
     // The seed has now done its job; a back edge to reviewing must not resurrect it
     // over the file just acquired (see handoffConsumedRef).

--- a/apps/web/test/browser/acceptConsentGate.test.ts
+++ b/apps/web/test/browser/acceptConsentGate.test.ts
@@ -92,6 +92,34 @@ vi.mock("@components/FileSelect", () => ({
     ),
 }));
 
+// Hold the CSV parse open per-test so the consent state can change WHILE the parse
+// is in flight -- the window in which the re-check must read live consent, not the
+// value captured when the parse started. With `defer` unset it delegates to the
+// real inline loader (every other test's synchronous small-file parse); with it set
+// the returned promise settles only when the test calls `resolve`.
+const csvLoadHarness = vi.hoisted(() => ({
+  defer: false,
+  resolve: undefined as ((value: unknown) => void) | undefined,
+}));
+vi.mock("@psi/csvParseController", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    loadCSVFileOffMainThread: (file: unknown, options?: unknown) => {
+      if (!csvLoadHarness.defer)
+        return (
+          actual.loadCSVFileOffMainThread as (
+            f: unknown,
+            o?: unknown,
+          ) => Promise<unknown>
+        )(file, options);
+      return new Promise((resolve) => {
+        csvLoadHarness.resolve = resolve;
+      });
+    },
+  };
+});
+
 // Two single-element linkage keys, one per name field, so a CSV can satisfy both,
 // one, or neither -- the three pre-flight outcomes the acceptor distinguishes. The
 // identity drives the "Invitation from ..." heading the terms render.
@@ -192,6 +220,8 @@ afterEach(() => {
   container = undefined;
   harness.files = [];
   exchange.lastProps = undefined;
+  csvLoadHarness.defer = false;
+  csvLoadHarness.resolve = undefined;
   window.location.hash = "";
   // Drop any accept hand-off a test stashed, so it cannot leak into the next mount.
   clearAcceptHandoff();
@@ -289,6 +319,76 @@ describe("accept review screen (consent + file before any connection)", () => {
       .element(page.getByText("Invitation from County Health Department"))
       .toBeInTheDocument();
     await expect.element(page.getByTestId("file-count")).toHaveTextContent("0");
+  });
+
+  // Settle the deferred parse with a satisfiable two-name result, letting the
+  // acquire handler's consent re-check run against whatever consent state the test
+  // has since set.
+  function resolveParse() {
+    if (csvLoadHarness.resolve === undefined)
+      throw new Error("the deferred parse has not started");
+    csvLoadHarness.resolve({
+      data: [{ first_name: "Alice", last_name: "Smith" }],
+      errors: [],
+      meta: { fields: ["first_name", "last_name"] },
+    });
+  }
+
+  test("revoking consent while the parse is in flight blocks the commit", async () => {
+    window.location.hash = await encodeAcceptToken();
+    csvLoadHarness.defer = true;
+    mountAcceptRoute();
+
+    await expect
+      .element(page.getByText("Invitation from County Health Department"))
+      .toBeInTheDocument();
+
+    await reviewAndChoose(csvFile("first_name,last_name\nAlice,Smith\n"));
+    await userEvent.click(page.getByTestId("accept"));
+
+    // The parse is now in flight (its promise is held open). Revoke consent before
+    // it resolves: the checkbox is still live.
+    await expect.poll(() => csvLoadHarness.resolve !== undefined).toBe(true);
+    await userEvent.click(page.getByRole("checkbox"));
+    await expect.element(page.getByRole("checkbox")).not.toBeChecked();
+
+    // The parse now resolves against revoked consent. The re-check reads the live
+    // (revoked) consent, so nothing commits.
+    resolveParse();
+
+    // Committing would swap the review panel for the prepare editor and unmount the
+    // consent checkbox. Assert the POSITIVE, stable signal that the review screen
+    // stands -- the checkbox is still present -- rather than racing the absence of a
+    // heading that a wrong commit would mount only after a further render. Poll long
+    // enough that a mis-fired commit would have transitioned by now.
+    for (let i = 0; i < 20; i++) {
+      expect(page.getByRole("checkbox").elements()).toHaveLength(1);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(document.body.textContent).not.toContain("Prepare your data");
+    expect(exchangeMounted()).toBe(false);
+  });
+
+  test("consent kept through the parse commits and reaches the prepare editor", async () => {
+    window.location.hash = await encodeAcceptToken();
+    csvLoadHarness.defer = true;
+    mountAcceptRoute();
+
+    await expect
+      .element(page.getByText("Invitation from County Health Department"))
+      .toBeInTheDocument();
+
+    await reviewAndChoose(csvFile("first_name,last_name\nAlice,Smith\n"));
+    await userEvent.click(page.getByTestId("accept"));
+
+    // Consent is given and kept through the deferred parse; resolving it commits and
+    // advances to the prepare editor.
+    await expect.poll(() => csvLoadHarness.resolve !== undefined).toBe(true);
+    resolveParse();
+    await expect
+      .element(page.getByRole("heading", { name: "Prepare your data" }))
+      .toBeInTheDocument();
+    expect(exchangeMounted()).toBe(false);
   });
 
   test("does not enable accept (or mount anything) without consent", async () => {


### PR DESCRIPTION
## Summary

The accept screen's consent re-check ran when the post-click CSV parse resolved, but read the consent and name captured in the render that started the parse. Because the consent checkbox and name field stay interactive during that async parse, revoking consent mid-parse still committed the acceptance against the captured `consented: true`, so the re-check did not enforce the invariant it exists for. `consented` and `acceptorName` are now synced into refs updated on every render, and the acquire handler reads those refs instead of the closed-over state, so the re-check observes live state at commit time.

Product board item 211450962.

## Changes

- `apps/web/src/components/AcceptInvitation.tsx`: sync `consented` and `acceptorName` into refs on every render; read the refs in the acquire handler's re-check instead of the closed-over state.
- `apps/web/test/browser/acceptConsentGate.test.ts`: added a browser test that drives a deferred parse, revokes consent while it is in flight, and asserts the acceptance does not commit, alongside the consent-kept happy path.

## Test plan

Ran: typecheck, lint, format, and the covering unit tests pass.
New tests cover: revoking consent (or clearing the acceptor name) while an async CSV parse is in flight blocks the commit; the happy path where consent is kept still commits.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier -- n/a: internal state-timing fix to an existing consent re-check, no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: branch does not add an entry; flagging for reviewer judgment given this closes a consent-gate race.
- [x] Security review -- SECURITY-ADJACENT (consent gate). Recommended tier: light, security-aware. Pre-review already performed: cold-reviewed clean and independently adversarially verified sound (no path commits against stale/revoked consent). This is context for the human reviewer, not a substitute for the required review before merge.
