### PR TITLE
Clear the terms import-error alert on paste-box edit

### DIFF
--- a/apps/web/src/components/TermsImportExport.tsx
+++ b/apps/web/src/components/TermsImportExport.tsx
@@ -178,6 +178,7 @@ export function TermsImportExport({
         onChange={(e) => {
           setText(e.currentTarget.value);
           setImported(false);
+          setError(undefined);
         }}
         autosize
         minRows={3}

--- a/apps/web/test/browser/termsImportExport.test.ts
+++ b/apps/web/test/browser/termsImportExport.test.ts
@@ -1,0 +1,94 @@
+/// <reference types="@vitest/browser-playwright/context" />
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { page, userEvent } from "vitest/browser";
+
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+
+import { MantineProvider } from "@mantine/core";
+
+import { buildAdvancedTerms, seedAdvancedInvite } from "@psi/advancedInvite";
+import { exportLinkageTerms } from "@psi/linkageTermsIO";
+
+import { TermsImportExport } from "@components/TermsImportExport";
+
+import type { Root } from "react-dom/client";
+
+const COLUMNS = ["ssn", "ssn4", "first_name", "last_name", "dob"];
+
+let container: HTMLElement | undefined;
+let root: Root | undefined;
+
+function mount() {
+  const { draft, seed } = seedAdvancedInvite("County Health Dept", COLUMNS);
+  const currentTerms = buildAdvancedTerms(draft);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  root.render(
+    createElement(
+      MantineProvider,
+      null,
+      createElement(TermsImportExport, {
+        currentTerms,
+        seed,
+        rawRows: [],
+        onImport: () => undefined,
+      }),
+    ),
+  );
+  return currentTerms;
+}
+
+const pasteBox = () =>
+  page.getByRole("textbox", {
+    name: "Paste a JSON or YAML linkage-terms document to import",
+  });
+const importButton = () => page.getByRole("button", { name: "Import" });
+
+afterEach(() => {
+  root?.unmount();
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+describe("TermsImportExport", () => {
+  test("editing the paste box after a failed import clears the rejection alert", async () => {
+    mount();
+    await userEvent.fill(pasteBox(), "not json or yaml: [");
+    await userEvent.click(importButton());
+    await expect
+      .element(page.getByText("Could not import these terms"))
+      .toBeInTheDocument();
+
+    await userEvent.type(pasteBox(), " ");
+    await expect
+      .element(page.getByText("Could not import these terms"))
+      .not.toBeInTheDocument();
+    expect(page.getByRole("status").element().textContent).toBe("");
+  });
+
+  test("a valid import after a failed one succeeds without the stale error lingering", async () => {
+    const currentTerms = mount();
+    await userEvent.fill(pasteBox(), "not json or yaml: [");
+    await userEvent.click(importButton());
+    await expect
+      .element(page.getByText("Could not import these terms"))
+      .toBeInTheDocument();
+
+    await userEvent.clear(pasteBox());
+    await userEvent.fill(pasteBox(), exportLinkageTerms(currentTerms, "json"));
+    await userEvent.click(importButton());
+    await expect
+      .element(
+        page
+          .getByText("Imported. Review the loaded terms before generating.")
+          .first(),
+      )
+      .toBeInTheDocument();
+    expect(page.getByText("Could not import these terms").query()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Editing the paste box after a failed terms import left the rejection Alert and its live-region announcement on screen, implying the current content still had the old problem. The Textarea `onChange` now clears the error alongside the imported-success flag.

Product board item 211451279.

## Changes

- `apps/web/src/components/TermsImportExport.tsx`: clear the import error on paste-box edit.
- `apps/web/test/browser/termsImportExport.test.ts`: added coverage.

## Test plan

Ran: typecheck, lint, format, and the covering unit tests pass.
New tests cover: editing the paste box after a failed import clears the rejection alert and its live-region announcement.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier -- n/a: UI-only affordance fix, no documented interface changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: internal UI polish (stale error alert clearing), not an operator- or reviewer-visible behavior/format/config change.
- [x] Security review -- n/a: UI alert-state fix; no cryptographic, credential, or disclosure surface touched. Recommended tier: gates only. Pre-review already performed: cold-reviewed clean. This is context for the human reviewer, not a substitute for the required review before merge.
