### PR TITLE
Verify the vendored PSI addon hash in the release publish job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # This job builds the image from its own checkout rather than an artifact
+      # from the test job, so it must re-verify the vendored tarball here too;
+      # see .github/actions/setup for the same check ahead of the test job's build.
+      - name: Verify vendored native tarball integrity
+        run: sha256sum -c lib/openmined-psi.js-*.tgz.sha256
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 


### PR DESCRIPTION
## Summary

The release publish job does its own checkout and builds the Docker image straight from it, but only the test job ran the vendored PSI addon's sha256 integrity check (via the setup action) before install, so a corrupted or substituted addon tarball would reach the shipped image unverified. The publish job now runs the same `sha256sum -c` check as its first step, before the build, so a tampered native addon fails the build closed before the image is built and signed.

This PR arose from a supply-chain review of the release pipeline, not a board item.

## Changes

- `.github/workflows/release.yaml`: run the sha256 integrity check on the vendored PSI addon tarball as the first step of the publish job, mirroring the existing check in the test job.

## Test plan

Ran: typecheck, lint, format, and the covering tests pass (workflow-level change; verified by inspection against the existing test-job check it mirrors).
New tests cover: n/a -- CI workflow change, no unit-testable code path.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier -- n/a: CI workflow change, no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: release-pipeline CI hardening, not an operator- or reviewer-visible behavior/format/config change.
- [x] Security review -- SECURITY/SUPPLY-CHAIN (release CI). Recommended tier: light/standard. Pre-review already performed: mirrors the existing sha256 integrity check into the publish job so a tampered native addon fails the build closed before the image is built and signed. This is context for the human reviewer, not a substitute for the required review before merge.
