### PR TITLE
Reset FileAcquire submit state on a blocked accept handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ This changelog records, per release, the changes that affect how PSI-Link is run
 - The web app's peer-discovery endpoint (`/api/peerjs/:key/peers`) now actually responds 401 when discovery is disabled (the default), instead of a 200 with an empty client list -- a caller relying on the status code to distinguish the two previously could not.
 - The web file dropzone now restricts a drop or file-picker selection to a single file, warning when more than one is chosen, instead of accepting the batch into the UI while silently linking only the first.
 - The `parse_date` standardization step now drops a record whose date is calendar-impossible (for example 02/29 in a non-leap year, or 04/31), instead of silently rolling it over to the next valid day and hashing the wrong value into the linkage key.
+- The web accept screen recovers when consent is revoked (or the name cleared) while a chosen file is still parsing: the acceptor can re-consent and resubmit the same file in place, instead of the "Accept and continue" button staying stuck disabled until a page reload.
 
 ### Security
 

--- a/apps/web/src/components/AcceptInvitation.tsx
+++ b/apps/web/src/components/AcceptInvitation.tsx
@@ -160,7 +160,7 @@ export function AcceptInvitation() {
     else if (decode.status === "error") errorRef.current?.focus();
   }, [decode.status, phase.status]);
 
-  const handleAcquired = (bundle: AcquiredBundle) => {
+  const handleAcquired = (bundle: AcquiredBundle): boolean => {
     // The authoritative consent gate: no name is committed -- and so the prepare
     // editor never mounts -- unless the user has consented and named themselves.
     // The acquire phase already gates its submit on the same check
@@ -170,11 +170,15 @@ export function AcceptInvitation() {
       consented: consentedRef.current,
       name: acceptorNameRef.current,
     });
-    if (name === undefined) return;
+    // Consent (or the name) no longer holds at handoff time: refuse the commit and
+    // tell the acquire phase, which resets its submit state so the operator can
+    // re-consent and resubmit the same file in place.
+    if (name === undefined) return false;
     // The seed has now done its job; a back edge to reviewing must not resurrect it
     // over the file just acquired (see handoffConsumedRef).
     handoffConsumedRef.current = true;
     setPhase({ status: "preparing", name, bundle });
+    return true;
   };
 
   return (

--- a/apps/web/src/components/AcceptInvitationPanel.tsx
+++ b/apps/web/src/components/AcceptInvitationPanel.tsx
@@ -74,8 +74,9 @@ export function AcceptInvitationPanel({
   onAcquireError: (alert: AlertContent | undefined) => void;
   /** Receive the parsed CSV; wired to the file-acquire phase's `onAcquired`. The
    * route commits consent and transitions to the "Prepare your data" editor from
-   * here. */
-  onAcquired: (bundle: AcquiredBundle) => void;
+   * here, returning whether the commit was accepted so the acquire phase can
+   * reset and let the operator retry a blocked handoff in place. */
+  onAcquired: (bundle: AcquiredBundle) => boolean;
 }) {
   return (
     <>

--- a/apps/web/src/components/FileAcquire.tsx
+++ b/apps/web/src/components/FileAcquire.tsx
@@ -43,12 +43,17 @@ export interface FileAcquireProps {
    * attempt. The review screen owns the alert state; the acquire phase only writes
    * its read-failure case. */
   onError: (alert: AlertContent | undefined) => void;
-  /** Hand the parsed CSV to the review screen, which moves on to the "Prepare your
-   * data" editor. Called at most once per mount: a fresh acquire comes from a
-   * fresh mount. The linkage-satisfiability verdict is NOT computed here -- it
-   * lives in the editor, over the operator's edited metadata/standardization, so
-   * the gate and the editor agree. */
-  onAcquired: (bundle: AcquiredBundle) => void;
+  /** Hand the parsed CSV to the review screen, which re-checks its own commit
+   * precondition (e.g. consent, still live at handoff time) before advancing to
+   * the "Prepare your data" editor. Returns whether the owner accepted the
+   * handoff: `true` advances, and this phase stays submitted (a fresh acquire
+   * comes from a fresh mount); `false` means the owner's precondition was no
+   * longer met, so this phase resets `submitted` and the abort controller,
+   * letting the operator fix the precondition and resubmit the SAME file in
+   * place. The linkage-satisfiability verdict is NOT computed here -- it lives in
+   * the editor, over the operator's edited metadata/standardization, so the gate
+   * and the editor agree. */
+  onAcquired: (bundle: AcquiredBundle) => boolean;
 }
 
 /**
@@ -136,7 +141,17 @@ export default function FileAcquire(props: FileAcquireProps) {
         return;
       }
 
-      onAcquired({ rawRows, columns });
+      // The owner re-checks its own commit precondition (e.g. live consent) at
+      // handoff time and may refuse it even though the parse succeeded. Mirror the
+      // read-failure and empty-header resets above so a blocked handoff leaves the
+      // operator able to fix the precondition and resubmit this same file, rather
+      // than dead-ended with submit stuck disabled.
+      const accepted = onAcquired({ rawRows, columns });
+      if (!accepted) {
+        controller.abort();
+        abortRef.current = undefined;
+        setSubmitted(false);
+      }
     })();
   };
 

--- a/apps/web/test/browser/acceptConsentGate.test.ts
+++ b/apps/web/test/browser/acceptConsentGate.test.ts
@@ -369,6 +369,47 @@ describe("accept review screen (consent + file before any connection)", () => {
     expect(exchangeMounted()).toBe(false);
   });
 
+  test("re-consenting after a blocked commit lets the operator resubmit the same file in place", async () => {
+    window.location.hash = await encodeAcceptToken();
+    csvLoadHarness.defer = true;
+    mountAcceptRoute();
+
+    await expect
+      .element(page.getByText("Invitation from County Health Department"))
+      .toBeInTheDocument();
+
+    await reviewAndChoose(csvFile("first_name,last_name\nAlice,Smith\n"));
+    await userEvent.click(page.getByTestId("accept"));
+
+    // Revoke consent while the parse is in flight, then let it resolve: the
+    // re-check reads the revoked consent, so the commit is blocked and the acquire
+    // phase must reset -- otherwise "accept" stays stuck disabled below.
+    await expect.poll(() => csvLoadHarness.resolve !== undefined).toBe(true);
+    await userEvent.click(page.getByRole("checkbox"));
+    await expect.element(page.getByRole("checkbox")).not.toBeChecked();
+    resolveParse();
+
+    // The blocked handoff must not dead-end the control: consent is still off here,
+    // so "accept" stays disabled by the live consent gate (submitDisabled), not by
+    // a stuck `submitted` -- re-consenting (the name is untouched throughout) makes
+    // it interactive again with no remount and no page reload.
+    const accept = page.getByTestId("accept");
+    await userEvent.click(page.getByRole("checkbox"));
+    await expect.element(page.getByRole("checkbox")).toBeChecked();
+    await expect.element(accept).toBeEnabled();
+
+    // Resubmitting the SAME file (still selected; reviewAndChoose is not called
+    // again) now commits and reaches the prepare editor. Let this second parse
+    // resolve inline (the first is already spent) so the resubmit does not hang on
+    // another deferred promise the test would otherwise have to resolve.
+    csvLoadHarness.defer = false;
+    await userEvent.click(accept);
+    await expect
+      .element(page.getByRole("heading", { name: "Prepare your data" }))
+      .toBeInTheDocument();
+    expect(exchangeMounted()).toBe(false);
+  });
+
   test("consent kept through the parse commits and reaches the prepare editor", async () => {
     window.location.hash = await encodeAcceptToken();
     csvLoadHarness.defer = true;

--- a/apps/web/test/browser/acceptInvitationTerms.test.ts
+++ b/apps/web/test/browser/acceptInvitationTerms.test.ts
@@ -149,7 +149,7 @@ function renderPanel(
       acceptorName: "",
       onAcceptorNameChange: () => {},
       onAcquireError: () => {},
-      onAcquired: () => {},
+      onAcquired: () => true,
       ...overrides,
     }),
   );
@@ -191,7 +191,7 @@ describe("accept screen: terms render from a decoded token", () => {
             acceptorName: "",
             onAcceptorNameChange: () => {},
             onAcquireError: () => {},
-            onAcquired: () => {},
+            onAcquired: () => true,
           }),
         ),
       ),

--- a/apps/web/test/browser/fileAcquire.test.ts
+++ b/apps/web/test/browser/fileAcquire.test.ts
@@ -82,7 +82,7 @@ function csvFile(content: string): File {
 function makeSpies() {
   return {
     onError: vi.fn((_alert: AlertContent | undefined): void => {}),
-    onAcquired: vi.fn((_bundle: AcquiredBundle): void => {}),
+    onAcquired: vi.fn((_bundle: AcquiredBundle): boolean => true),
   };
 }
 type Spies = ReturnType<typeof makeSpies>;

--- a/apps/web/test/unit/acceptConsent.test.ts
+++ b/apps/web/test/unit/acceptConsent.test.ts
@@ -117,7 +117,7 @@ function renderPanel(
       acceptorName: "",
       onAcceptorNameChange: () => {},
       onAcquireError: () => {},
-      onAcquired: () => {},
+      onAcquired: () => true,
       ...overrides,
     }),
   );


### PR DESCRIPTION
## Summary

On the web accept flow, revoking consent (or clearing the acceptor name) after clicking to proceed but before the file parse resolves correctly blocks the commit, but previously left the submit control permanently disabled -- the operator was dead-ended until a page reload. This makes that state recoverable: on a blocked handoff the acquire phase resets so the operator can re-consent and resubmit the same file in place. The consent gate itself is unchanged; only post-block recoverability is added.

Implements [211571635](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=211571635).

## Changes

- apps/web/src/components/FileAcquire.tsx: onAcquired now returns a boolean; on a false (blocked) handoff, abort the controller, clear abortRef, and reset submitted, mirroring the existing read-failure and empty-header reset paths. The one-acquire-per-attempt re-entry guard is preserved.
- apps/web/src/components/AcceptInvitation.tsx: handleAcquired returns false when commitAcceptance blocks (consent revoked or name cleared) and true after advancing to the prepare step.
- apps/web/src/components/AcceptInvitationPanel.tsx: onAcquired prop type updated (passthrough, no logic change).
- apps/web/test/browser/acceptConsentGate.test.ts: new case covering revoke-mid-parse then re-consent and resubmit without a remount; sibling test stubs updated to the boolean return.

## Test plan

Ran: the apps/web browser project and the full root fan-out (core, cli, web) -- all green.
New tests cover: a blocked-then-recovered accept -- consent revoked mid-parse blocks the commit, re-consenting re-enables submit, and resubmitting the same file reaches the prepare step, all without a remount. The case fails against the pre-fix code.

## Background

commitAcceptance is a pure re-check, so a blocked call followed by a resubmit cannot double-commit. The reset only re-enables the submit button behind the still-live commitAcceptance gate, so it cannot bypass the consent re-check, and the button stays disabled until the operator actually re-consents. The bench accept path is a placeholder with no acquire or commit logic and needs nothing.

## Checklist

- [x] Docs: n/a -- internal accept-flow UI recoverability; no docs/ or docs/spec/ page describes this behavior.
- [x] CHANGELOG.md [Unreleased] updated -- added under Fixed.
- [x] Security review -- consent-flow recoverability review: the commitAcceptance consent check and what is disclosed are unchanged; only post-block UI state resets. Independently reviewed to confirm a blocked commit is never treated as accepted and the reset stays gated behind the live re-check.
