### PR TITLE
Adopt prettier 3.9.4 and reformat

### DIFF
--- a/apps/cli/src/commands/exchange.ts
+++ b/apps/cli/src/commands/exchange.ts
@@ -183,11 +183,9 @@ export function parseArgs(argv: Arguments): ExchangeArgs {
     keyFile: expandTilde(common.keyFile),
     recordFile: expandTilde(common.recordFile),
     serverPassword: resolveAtSignRefs(common.serverPassword) as
-      | string
-      | undefined,
+      string | undefined,
     serverPrivateKey: resolveAtSignRefs(common.serverPrivateKey) as
-      | string
-      | undefined,
+      string | undefined,
     // Resolved here for the same reason as the sibling credentials above: the
     // override is layered on after resolveExchangeSpecRefs, so a @path passphrase
     // would otherwise reach the live connection unresolved.

--- a/apps/cli/src/commands/fingerprint.ts
+++ b/apps/cli/src/commands/fingerprint.ts
@@ -337,15 +337,12 @@ export async function handler(argv: Arguments): Promise<void> {
     // `force` is a boolean (last-one-wins on repeat), so it keeps a plain cast.
     const identityArg = singleValue(argv, "identity") as string | undefined;
     const identityFileArg = singleValue(argv, "identity-file") as
-      | string
-      | undefined;
+      string | undefined;
     const configFileArg = singleValue(argv, "config-file") as
-      | string
-      | undefined;
+      string | undefined;
     const force = argv["force"] as boolean;
     const exportCertificate = singleValue(argv, "export-certificate") as
-      | string
-      | undefined;
+      string | undefined;
     const hints = readConfigHints(configFileArg, configFileArg !== undefined);
     const identityPath = expandTilde(
       identityFileArg ?? hints.identityFile ?? defaultSigningIdentityPath(),

--- a/apps/cli/src/commands/verifyReceipt.ts
+++ b/apps/cli/src/commands/verifyReceipt.ts
@@ -313,8 +313,7 @@ export async function handler(argv: Arguments): Promise<void> {
     const keysArg = singleValue(argv, "keys") as string | undefined;
     const configFile = singleValue(argv, "config-file") as string | undefined;
     const partnerTermsFile = singleValue(argv, "partner-terms") as
-      | string
-      | undefined;
+      string | undefined;
 
     if ((inputFile === undefined) !== (resultFile === undefined))
       throw new UsageError(

--- a/apps/cli/src/optionDefinitions.ts
+++ b/apps/cli/src/optionDefinitions.ts
@@ -290,8 +290,7 @@ export function parseCommonBootstrapArgs(
     // resolved secret.
     serverPassword: singleValue(argv, "server-password") as string | undefined,
     serverPrivateKey: singleValue(argv, "server-private-key") as
-      | string
-      | undefined,
+      string | undefined,
     serverPrivateKeyPassphrase: singleValue(
       argv,
       "server-private-key-passphrase",
@@ -299,8 +298,7 @@ export function parseCommonBootstrapArgs(
     // Boolean toggle, so it keeps a plain cast (a repeat is valid, like the other
     // boolean flags); yargs yields true only when the enabling form is passed.
     serverKeyboardInteractive: argv["server-keyboard-interactive"] as
-      | boolean
-      | undefined,
+      boolean | undefined,
     connectionTimeout: durationFlagSeconds(
       argv,
       "connection-timeout",

--- a/apps/cli/test/sftpServer/nativeSshdServer.ts
+++ b/apps/cli/test/sftpServer/nativeSshdServer.ts
@@ -60,11 +60,7 @@ const VALIDATE_ONLY_PORT = 22222;
  *   - `allowlist`: an explicit user@host allow matrix.
  */
 export type NativeProfile =
-  | "baseline"
-  | "chroot"
-  | "restricted-crypto"
-  | "rate-limited"
-  | "allowlist";
+  "baseline" | "chroot" | "restricted-crypto" | "rate-limited" | "allowlist";
 
 export const NATIVE_PROFILES: readonly NativeProfile[] = [
   "baseline",

--- a/apps/cli/test/unit/config.test.ts
+++ b/apps/cli/test/unit/config.test.ts
@@ -1851,8 +1851,7 @@ test("connection.options.sweep_exchange_files is not a persistable config field 
   };
   const parsed = parseExchangeSpec(raw);
   const options = parsed.connection.options as
-    | Record<string, unknown>
-    | undefined;
+    Record<string, unknown> | undefined;
   expect(options?.["sweepExchangeFiles"]).toBeUndefined();
   expect(options?.["forceRetainSweep"]).toBeUndefined();
 });

--- a/apps/cli/test/unit/onlineBootstrap.test.ts
+++ b/apps/cli/test/unit/onlineBootstrap.test.ts
@@ -1682,8 +1682,7 @@ test("observedReceivedColumnsForSave drops an over-cap observation (stays loadab
 function mockSuccessfulExchange(observed: string[] | undefined): void {
   vi.mocked(runProtocol).mockImplementation((async (...callArgs: unknown[]) => {
     const onAuthenticated = callArgs.find((a) => typeof a === "function") as
-      | (() => void | Promise<void>)
-      | undefined;
+      (() => void | Promise<void>) | undefined;
     await onAuthenticated?.();
     return { observedReceivedPayloadColumns: observed };
   }) as never);
@@ -1774,8 +1773,7 @@ test("runOnlineBootstrap keeps a failed observed-payload write non-fatal", async
   const configPath = path.join(dir, "psilink.yaml");
   vi.mocked(runProtocol).mockImplementation((async (...callArgs: unknown[]) => {
     const onAuthenticated = callArgs.find((a) => typeof a === "function") as
-      | (() => void | Promise<void>)
-      | undefined;
+      (() => void | Promise<void>) | undefined;
     await onAuthenticated?.(); // hook writes configPath as a file
     fs.rmSync(configPath); // swap it for a directory so the second
     fs.mkdirSync(configPath); // saveConfig's rename throws (EISDIR)
@@ -1984,8 +1982,7 @@ test("runOnlineBootstrap persists an @path credential as the reference while con
   vi.mocked(runProtocol).mockImplementation((async (...callArgs: unknown[]) => {
     connectionPassedToRunProtocol = callArgs[0] as SFTPConnectionConfig;
     const onAuthenticated = callArgs.find((a) => typeof a === "function") as
-      | (() => void | Promise<void>)
-      | undefined;
+      (() => void | Promise<void>) | undefined;
     await onAuthenticated?.();
     return {};
   }) as never);
@@ -2039,8 +2036,7 @@ test("runOnlineBootstrap persists an @path private-key passphrase as the referen
   vi.mocked(runProtocol).mockImplementation((async (...callArgs: unknown[]) => {
     connectionPassedToRunProtocol = callArgs[0] as SFTPConnectionConfig;
     const onAuthenticated = callArgs.find((a) => typeof a === "function") as
-      | (() => void | Promise<void>)
-      | undefined;
+      (() => void | Promise<void>) | undefined;
     await onAuthenticated?.();
     return {};
   }) as never);

--- a/apps/web/src/bench/inviterModel.ts
+++ b/apps/web/src/bench/inviterModel.ts
@@ -640,12 +640,7 @@ export function inviterRailFacts(
 /** A bench section a Problems entry or a Change link can navigate to: a spine
  * step or a Customize tab. */
 export type SpineTarget =
-  | "file"
-  | "columns"
-  | "review"
-  | "cleaning"
-  | "keys"
-  | "agreement";
+  "file" | "columns" | "review" | "cleaning" | "keys" | "agreement";
 
 /** The section that owns each validation field, so a Problems entry can link
  * to where the fix lives. */

--- a/apps/web/src/psi/exchangeLifecycle.ts
+++ b/apps/web/src/psi/exchangeLifecycle.ts
@@ -54,10 +54,7 @@ export interface StageDefinition {
  * owner-local discriminants (an output-generation failure is not a connection
  * error). */
 export type ExchangeErrorCategory =
-  | "exchange"
-  | "output"
-  | "security"
-  | "config";
+  "exchange" | "output" | "security" | "config";
 
 /** Maps a lifecycle failure to the alert {@link ExchangeErrorCategory} the UI
  * shows, given the `phase` it came from. A `security`-kind {@link ConnectionError}

--- a/apps/web/src/psi/linkageTermsIO.ts
+++ b/apps/web/src/psi/linkageTermsIO.ts
@@ -75,8 +75,7 @@ export interface LinkageTermsImportFailure {
 }
 
 export type LinkageTermsImportResult =
-  | LinkageTermsImportSuccess
-  | LinkageTermsImportFailure;
+  LinkageTermsImportSuccess | LinkageTermsImportFailure;
 
 /**
  * Serialize linkage terms to a snake_case `format` document. JSON is pretty-

--- a/apps/web/src/psi/rendezvous.ts
+++ b/apps/web/src/psi/rendezvous.ts
@@ -227,8 +227,7 @@ export async function listenAsInviter(
 /** The result of one dial attempt: an opened channel, or a recoverable
  * "the inviter is not registered yet" that the caller backs off and re-dials. */
 type DialAttempt =
-  | { outcome: "open"; conn: DataConnection }
-  | { outcome: "unavailable" };
+  { outcome: "open"; conn: DataConnection } | { outcome: "unavailable" };
 
 /** Is `err` PeerJS's non-fatal `peer-unavailable`? The dialed id is not
  * registered yet, but the dialing peer survives, so the caller may re-dial. */

--- a/apps/web/src/psi/standardizationAuthoring.ts
+++ b/apps/web/src/psi/standardizationAuthoring.ts
@@ -246,11 +246,7 @@ export function functionDisplay(functionName: string): {
  *   dialect-and-length schema).
  */
 export type ParamFieldKind =
-  | "number"
-  | "string"
-  | "enum"
-  | "stringArray"
-  | "boolean";
+  "number" | "string" | "enum" | "stringArray" | "boolean";
 
 /**
  * One parameter of a standardization function, reduced to what the editor needs to

--- a/apps/web/test/unit/csvParseController.test.ts
+++ b/apps/web/test/unit/csvParseController.test.ts
@@ -46,9 +46,11 @@ function streamedReply(
   batches: Array<CSVParseRows>,
 ): Array<CSVParseResponse> {
   return [
-    ...batches.map(
-      (rows): CSVParseResponse => ({ ok: true, done: false, rows }),
-    ),
+    ...batches.map((rows): CSVParseResponse => ({
+      ok: true,
+      done: false,
+      rows,
+    })),
     { ok: true, done: true, errors: result.errors, meta: result.meta },
   ];
 }
@@ -70,10 +72,7 @@ class FakeCSVParseWorker implements CSVParseWorker {
   // "messageerror" fires the undeserializable-reply path.
   constructor(
     private readonly reply:
-      | Array<CSVParseResponse>
-      | "error"
-      | "never"
-      | "messageerror",
+      Array<CSVParseResponse> | "error" | "never" | "messageerror",
   ) {}
 
   postMessage(message: CSVParseRequest): void {

--- a/apps/web/test/unit/expertAuthoring.test.ts
+++ b/apps/web/test/unit/expertAuthoring.test.ts
@@ -77,11 +77,10 @@ describe("gated settings cannot reach the built terms", () => {
               ...entry,
               key: {
                 ...entry.key,
-                elements: entry.key.elements.map(
-                  (el, j): LinkageKeyElement =>
-                    j === 0
-                      ? { ...el, generateFuzzyComparisons: "edit_distances" }
-                      : el,
+                elements: entry.key.elements.map((el, j): LinkageKeyElement =>
+                  j === 0
+                    ? { ...el, generateFuzzyComparisons: "edit_distances" }
+                    : el,
                 ),
               },
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",
-        "prettier": "^3.8.4",
+        "prettier": "^3.9.4",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9",
         "yaml": "^2.9.0"
@@ -9032,9 +9032,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.5.0",
-    "prettier": "^3.8.4",
+    "prettier": "^3.9.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9",
     "yaml": "^2.9.0"

--- a/packages/core/src/config/connection.ts
+++ b/packages/core/src/config/connection.ts
@@ -855,9 +855,7 @@ export interface FileDropConnectionConfig {
 
 /** Connection configuration for an exchange. Discriminated by `channel`. */
 export type ConnectionConfig =
-  | WebRTCConnectionConfig
-  | SFTPConnectionConfig
-  | FileDropConnectionConfig;
+  WebRTCConnectionConfig | SFTPConnectionConfig | FileDropConnectionConfig;
 
 // These intermediate schemas are intentionally left without z.ZodType<T>
 // annotations: z.discriminatedUnion requires a concrete ZodObject, and the

--- a/packages/core/src/config/invitation.ts
+++ b/packages/core/src/config/invitation.ts
@@ -94,9 +94,7 @@ export interface FileDropEndpoint {
  * invitation; see docs/SECURITY_DESIGN.md.
  */
 export type ConnectionEndpoint =
-  | WebRTCEndpoint
-  | SFTPEndpoint
-  | FileDropEndpoint;
+  WebRTCEndpoint | SFTPEndpoint | FileDropEndpoint;
 
 // Custom error for the strict-object guard below: any field outside a channel's
 // locator allowlist is rejected rather than silently stripped. The message

--- a/packages/core/src/config/linkageTerms.ts
+++ b/packages/core/src/config/linkageTerms.ts
@@ -504,9 +504,7 @@ const LinkageFieldSchema: z.ZodType<LinkageField> = z.discriminatedUnion(
 // --- Linkage key elements ----------------------------------------------------
 
 type GenerateFuzzyComparisons =
-  | "transpositions"
-  | "edit_distances"
-  | "adjacent_years";
+  "transpositions" | "edit_distances" | "adjacent_years";
 
 const GenerateFuzzyComparisonsSchema: z.ZodType<GenerateFuzzyComparisons> =
   z.enum(["transpositions", "edit_distances", "adjacent_years"]);

--- a/packages/core/src/connection/messageConnection.ts
+++ b/packages/core/src/connection/messageConnection.ts
@@ -22,11 +22,7 @@ import type { Connection } from "../types";
  *   docs/COMMUNICATION.md ("Error handling") for the rationale.
  */
 export type ConnectionErrorKind =
-  | "transport"
-  | "security"
-  | "usage"
-  | "protocol"
-  | "closed";
+  "transport" | "security" | "usage" | "protocol" | "closed";
 
 /** A terminal connection failure, tagged with a {@link ConnectionErrorKind}. */
 export class ConnectionError extends Error {

--- a/packages/core/src/exchangeRecord.ts
+++ b/packages/core/src/exchangeRecord.ts
@@ -77,9 +77,7 @@ export const SALT_BYTES = 32;
  * as another, and the key under which the commitment and its salt are stored
  * in the record and verification-keys files. */
 export type CommitmentName =
-  | "associationTable"
-  | "localPayloadSent"
-  | "partnerPayloadReceived";
+  "associationTable" | "localPayloadSent" | "partnerPayloadReceived";
 
 // Domain-separation labels, one per commitment kind. Folded into the committed
 // message (not the salt) so the three kinds are cryptographically distinct even

--- a/packages/core/src/participant.ts
+++ b/packages/core/src/participant.ts
@@ -168,9 +168,7 @@ export class PSIParticipant {
   config: Config;
   private setStage: (id: ProtocolId) => void;
   private stages:
-    | typeof joinerProtocolStages
-    | typeof starterProtocolStages
-    | undefined;
+    typeof joinerProtocolStages | typeof starterProtocolStages | undefined;
   private log: ReturnType<typeof getLoggerForVerbosity>;
   private elementBounds: PsiElementBounds;
   private engine: PsiEngine;

--- a/packages/core/src/recordVerification.ts
+++ b/packages/core/src/recordVerification.ts
@@ -46,10 +46,7 @@ import type { AssociationTable } from "./types.js";
  *   or drifted keys file), or a mandatory commitment is absent from the record.
  */
 export type CommitmentStatus =
-  | "verified"
-  | "mismatch"
-  | "not-supplied"
-  | "unopenable";
+  "verified" | "mismatch" | "not-supplied" | "unopenable";
 
 /**
  * The outcome of the agreed-terms-hash check. `not-checked` when either party's

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -1544,11 +1544,7 @@ test("send streams the header and payload as two chunks, without a concat copy",
   conn.peerId = "stub-peer";
 
   let putSrc:
-    | string
-    | Buffer
-    | Uint8Array[]
-    | NodeJS.ReadableStream
-    | undefined;
+    string | Buffer | Uint8Array[] | NodeJS.ReadableStream | undefined;
   const origPut = client.put.bind(client);
   client.put = async (src, dest, opts) => {
     putSrc = src;

--- a/packages/core/test/psiIntersectionVectors.test.ts
+++ b/packages/core/test/psiIntersectionVectors.test.ts
@@ -37,10 +37,7 @@ import { UNBOUNDED_PSI_ELEMENTS } from "./utils/psiElementBounds";
 
 type Table = [number[], number[]];
 type Cardinality =
-  | "one-to-one"
-  | "one-to-many"
-  | "many-to-one"
-  | "many-to-many";
+  "one-to-one" | "one-to-many" | "many-to-one" | "many-to-many";
 
 interface IdentifyVector {
   name: string;

--- a/packages/core/test/utils/prebuildTarball.ts
+++ b/packages/core/test/utils/prebuildTarball.ts
@@ -52,7 +52,7 @@ export function readTgz(tarballPath: string): TarEntry[] {
     maxOutputLength: MAX_DECOMPRESSED_BYTES,
   });
   const entries: TarEntry[] = [];
-  for (let off = 0; off + 512 <= buf.length; ) {
+  for (let off = 0; off + 512 <= buf.length;) {
     const header = buf.subarray(off, off + 512);
     // The archive ends with (at least) one zero-filled block.
     if (header.every((byte) => byte === 0)) break;


### PR DESCRIPTION
## Summary

Adopt prettier 3.9.4 and reformat the repo to match. prettier 3.9.4 collapses multi-line union-type cast expressions that now fit on one line, so about two dozen pre-existing files no longer matched the formatter and `formatcheck` fails once prettier is bumped. This bumps the pinned prettier and applies the reformat in one commit, so the check passes again. It is also the wall the Dependabot npm group PR hit: with this on staging, that group's prettier line becomes a no-op on rebase.

## Changes

- package.json / package-lock.json: prettier `^3.8.4` -> `^3.9.4` (root devDependency).
- 24 source files across packages/core, apps/cli, apps/web: mechanical reformatting only (union-type casts collapsed where they now fit on one line), produced by `prettier --write`.

## Test plan

Ran: `formatcheck` (zero files listed), typecheck, lint, `build -w packages/core`, and the full test fan-out -- core 2140, cli 1112, web 718 (3970 total), all passing. No hand-written logic changes; the diff is entirely auto-generated by prettier.

## Checklist

- [x] Docs: n/a -- formatter version bump and mechanical reformat; no documented behavior changed.
- [x] CHANGELOG.md [Unreleased] updated -- n/a: tooling change no operator, deployer, or security reviewer acts on.
- [x] Security review -- n/a: formatter version bump and auto-generated reformatting; no cryptographic, protocol, credential, runtime-dependency, or disclosure surface touched.
