### PR TITLE
Exclude exact-pinned deps from the non-critical dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,14 @@ updates:
           - "ssh2-sftp-client"
           - "peerjs"
           - "peerjs-js-binarypack"
+          # Exact-pinned, matching-critical: both parties' runtime behavior for
+          # these must stay byte-identical or PSI key derivation silently
+          # diverges. Excluded so each bump is an individual, reviewable PR
+          # instead of riding along in this batch -- see "Why these are
+          # exact-pinned" in docs/spec/DEPENDENCY_PINS.md.
+          - "re2js"
+          - "yaml"
+          - "canonicalize"
     ignore:
       # The OpenMined PSI module is vendored; updates require manual review
       # of the tarball and NOTICE file before the lock file is updated.


### PR DESCRIPTION
## Summary

Exclude the matching-critical exact-pinned npm packages from Dependabot's "non-critical" group so they surface as individual, reviewable PRs instead of riding along with tooling bumps. A recent group PR bundled `re2js` -- whose regex engine must behave byte-identically on both parties or PSI keys silently mismatch -- with eslint, prettier, and vite; that class of dependency should not be bulk-grouped.

## Changes

- .github/dependabot.yml: add `re2js`, `yaml`, `canonicalize` to the non-critical group's `exclude-patterns`, with a rationale comment. The other exact-pins are already separated (`@noble/curves`, `ssh2`, `ssh2-sftp-client`, `node-forge` in the `cryptographic` group; `peerjs`/`peerjs-js-binarypack` in `webrtc-stack`), so only these three needed excluding. No `ignore` rules or other groups touched.

## Test plan

Ran: YAML parse validation (js-yaml) -- ok.
New tests cover: n/a -- Dependabot config.

## Background

Like the existing floating-major `ignore` rules, this governs Dependabot only once it lands on the default branch (`main`), since Dependabot reads its config from there.

## Checklist

- [x] Docs: n/a -- rationale captured inline and already in docs/spec/DEPENDENCY_PINS.md (unchanged).
- [x] CHANGELOG.md [Unreleased] updated -- n/a: CI/tooling config, no operator-visible change.
- [x] Security review -- supply-chain hygiene: makes matching/crypto-critical dependency bumps individually reviewable rather than auto-groupable. No code, runtime dependency version, or protocol change; Dependabot output stays gated by required review regardless.
