### PR TITLE
Add a reviewed install-script allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,14 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.9",
     "yaml": "^2.9.0"
+  },
+  "allowScripts": {
+    "esbuild@0.28.1": true,
+    "protobufjs@7.6.4": true,
+    "ssh2@1.17.0": true,
+    "cpu-features@0.0.10": true,
+    "@parcel/watcher": false,
+    "unrs-resolver": false,
+    "protoc-gen-js": false
   }
 }


### PR DESCRIPTION
## Summary

npm 11.17 flags every dependency with an install or postinstall script as un-reviewed until it is listed in a root `allowScripts` allowlist. This records a deliberate allow/deny decision for all seven, silencing the warning and, more usefully, leaving a reviewed supply-chain audit trail: a future new install script surfaces as "pending" for conscious review, and the field is the forward policy for npm's coming hard gate. The scripts still run today (the field is advisory in 11.17), so this changes no build or runtime behavior.

## Changes

- package.json: add `allowScripts`. Allowed (pinned to version, so a bump re-flags for review): `esbuild` (build tool, self-verifies its binary download with a sha256 check), `ssh2` and `cpu-features` (the SFTP stack -- a trusted exact-pinned transport and its source-compiled, fail-open native accelerator), and `protobufjs` (its postinstall is a proven no-op here). Denied (name-only): `@parcel/watcher` and `unrs-resolver` (web dev/lint-only, unreachable from the shipped CLI image, both no-ops here), and `protoc-gen-js` (an unauthenticated, unverified binary download whose plugin is never invoked at runtime).

## Test plan

Ran: `npm approve-scripts --allow-scripts-pending` reports "No packages with unreviewed install scripts"; `npm run format` clean; the change touches only `package.json` (no lockfile churn) and no dependency versions.

## Background

`protoc-gen-js` is slated for removal by patching the vendored `@openmined/psi.js` fork (low priority); the `deny` here records the intent in the meantime. Because npm 11.17's enforcement is advisory, this `deny` documents policy and clears the warning but does not itself block the download at install time.

## Checklist

- [x] Docs: n/a -- no documented behavior changed; the rationale lives in this allowlist and its commit.
- [x] CHANGELOG.md [Unreleased] updated -- n/a: a dev/CI supply-chain policy addition, advisory in npm 11.17, that changes no operator- or deployer-visible behavior.
- [x] Security review -- supply-chain hygiene: establishes a reviewed install-script allowlist. It grants no new trust that was not already implicit (the scripts already run); it records the decisions and denies an unused unauthenticated-download script. No cryptographic, protocol, credential, or runtime-dependency change.
