### PR TITLE
Display the legal agreement at acceptor consent

### DIFF
--- a/apps/web/src/bench/AcceptorBench.tsx
+++ b/apps/web/src/bench/AcceptorBench.tsx
@@ -736,7 +736,8 @@ export function AcceptorBench() {
                   </span>
                 </Text>
                 <Text size="sm">
-                  Purpose of the disclosure: {legalAgreementDisplay.purpose}
+                  Stated purpose of the disclosure:{" "}
+                  {legalAgreementDisplay.purpose}
                 </Text>
                 <Text size="sm">
                   Expiration date:{" "}
@@ -744,6 +745,13 @@ export function AcceptorBench() {
                     {legalAgreementDisplay.expirationDate}
                   </span>
                 </Text>
+                {legalAgreementDisplay.alteredForDisplay && (
+                  <p className={`${styles.small} ${styles.sub}`}>
+                    Some characters here are shown as escape codes because they
+                    fall outside plain ASCII, so these values may not read
+                    exactly as they do in your document.
+                  </p>
+                )}
               </fieldset>
             )}
             <div className={styles.workFoot}>

--- a/apps/web/src/bench/AcceptorBench.tsx
+++ b/apps/web/src/bench/AcceptorBench.tsx
@@ -26,6 +26,7 @@ import {
   acceptorDoneLedgerTag,
   acceptorLedgerRows,
   acceptorLedgerTag,
+  acceptorLegalAgreementDisplay,
   acceptorRailFacts,
   acceptorSpine,
   invitingPartyName,
@@ -318,6 +319,11 @@ export function AcceptorBench() {
   const ready = decode.status === "ready";
   const token = ready ? decode.invitation.token : undefined;
   const linkageTerms = token?.linkageTerms;
+  // The sanitized legal-agreement values the consent step displays beside the
+  // attestation; undefined when the invitation attaches none (no fieldset then).
+  // Display only -- consent stays gated on the checkbox and name alone.
+  const legalAgreementDisplay =
+    token !== undefined ? acceptorLegalAgreementDisplay(token) : undefined;
 
   // The effective { metadata, standardization } the verdict and launch both consume,
   // derived from the columns-step state exactly as PrepareData derives it (see
@@ -715,6 +721,30 @@ export function AcceptorBench() {
                   {parseAlert.message}
                 </span>
               </Alert>
+            )}
+            {legalAgreementDisplay !== undefined && (
+              <fieldset className={styles.fieldset}>
+                <legend>Legal agreement</legend>
+                <p className={`${styles.small} ${styles.sub}`}>
+                  Check these values against your signed agreement before you
+                  accept.
+                </p>
+                <Text size="sm">
+                  Agreement reference:{" "}
+                  <span className={styles.mono}>
+                    {legalAgreementDisplay.reference}
+                  </span>
+                </Text>
+                <Text size="sm">
+                  Purpose of the disclosure: {legalAgreementDisplay.purpose}
+                </Text>
+                <Text size="sm">
+                  Expiration date:{" "}
+                  <span className={styles.mono}>
+                    {legalAgreementDisplay.expirationDate}
+                  </span>
+                </Text>
+              </fieldset>
             )}
             <div className={styles.workFoot}>
               <Button

--- a/apps/web/src/bench/acceptorModel.ts
+++ b/apps/web/src/bench/acceptorModel.ts
@@ -7,6 +7,8 @@ import { dateTimeLabel } from "./inviterModel";
 
 import type { InvitationToken, LinkageTerms, Metadata } from "@psilink/core";
 
+import type { InvitationLegalAgreementSummary } from "@psi/invitationSummary";
+
 import type { RailFact, RailStepState } from "./Rail";
 
 /**
@@ -324,4 +326,18 @@ export function acceptorConsentReady(input: {
   name: string;
 }): boolean {
   return acceptorConsentName(input) !== undefined;
+}
+
+/**
+ * The legal-agreement values the consent step displays beside the attestation,
+ * or undefined when the invitation attaches none. Display only -- no gate and no
+ * comparison; the acceptor is invited to check the values against the signed
+ * document, not to transcribe them. Derived through {@link summarizeInvitation},
+ * the one sanitizing boundary, so the three partner-controlled strings are
+ * display-safe -- never the raw token values.
+ */
+export function acceptorLegalAgreementDisplay(
+  token: InvitationToken,
+): InvitationLegalAgreementSummary | undefined {
+  return summarizeInvitation(token).legalAgreement;
 }

--- a/apps/web/src/bench/acceptorModel.ts
+++ b/apps/web/src/bench/acceptorModel.ts
@@ -7,8 +7,6 @@ import { dateTimeLabel } from "./inviterModel";
 
 import type { InvitationToken, LinkageTerms, Metadata } from "@psilink/core";
 
-import type { InvitationLegalAgreementSummary } from "@psi/invitationSummary";
-
 import type { RailFact, RailStepState } from "./Rail";
 
 /**
@@ -328,16 +326,48 @@ export function acceptorConsentReady(input: {
   return acceptorConsentName(input) !== undefined;
 }
 
+/** The consent-step legal-agreement display: the three sanitized values plus
+ * whether sanitization changed how any of them reads. */
+export interface AcceptorLegalAgreementDisplay {
+  /** Agreement identifier, sanitized for display. */
+  reference: string;
+  /** Stated purpose of the disclosure, sanitized for display. */
+  purpose: string;
+  /** Expiration date (ISO 8601, YYYY-MM-DD), sanitized for display. */
+  expirationDate: string;
+  /**
+   * True when the display does not read exactly as the authored value:
+   * sanitizeForDisplay escaped a code point outside plain ASCII or truncated a
+   * long value in at least one of the three fields. The consent step then adds
+   * a caveat so "check these against your signed agreement" does not overclaim
+   * a visual match the escaping makes impossible.
+   */
+  alteredForDisplay: boolean;
+}
+
 /**
  * The legal-agreement values the consent step displays beside the attestation,
  * or undefined when the invitation attaches none. Display only -- no gate and no
  * comparison; the acceptor is invited to check the values against the signed
- * document, not to transcribe them. Derived through {@link summarizeInvitation},
- * the one sanitizing boundary, so the three partner-controlled strings are
- * display-safe -- never the raw token values.
+ * document, not to transcribe them. The three strings derive through
+ * {@link summarizeInvitation}, the one sanitizing boundary, so they are
+ * display-safe -- never the raw token values. `alteredForDisplay` compares each
+ * against its raw counterpart, the one place the raw values are consulted, and
+ * only for inequality -- no raw string is returned.
  */
 export function acceptorLegalAgreementDisplay(
   token: InvitationToken,
-): InvitationLegalAgreementSummary | undefined {
-  return summarizeInvitation(token).legalAgreement;
+): AcceptorLegalAgreementDisplay | undefined {
+  const sanitized = summarizeInvitation(token).legalAgreement;
+  const raw = token.linkageTerms.legalAgreement;
+  if (sanitized === undefined || raw === undefined) return undefined;
+  return {
+    reference: sanitized.reference,
+    purpose: sanitized.purpose,
+    expirationDate: sanitized.expirationDate,
+    alteredForDisplay:
+      sanitized.reference !== raw.reference ||
+      sanitized.purpose !== raw.purpose ||
+      sanitized.expirationDate !== raw.expirationDate,
+  };
 }

--- a/apps/web/test/browser/benchAccept.test.ts
+++ b/apps/web/test/browser/benchAccept.test.ts
@@ -624,16 +624,44 @@ describe("acceptor bench: consent-step legal-agreement display", () => {
       "Check these values against your signed agreement",
     );
     expect(fieldset?.textContent).toContain("MOU-2025-0042");
-    expect(fieldset?.textContent).toContain("Program evaluation");
+    // The purpose keeps its provenance marker: partner-attested free text,
+    // never presented as psilink-endorsed (the InvitationTerms convention).
+    expect(fieldset?.textContent).toContain(
+      "Stated purpose of the disclosure: Program evaluation",
+    );
     expect(fieldset?.textContent).toContain("2026-12-31");
     // Display only: nothing to type, so the fieldset holds no inputs.
     expect(fieldset?.querySelector("input")).toBeNull();
+    // Plain-ASCII values read exactly as authored, so no escaping caveat.
+    expect(fieldset?.textContent).not.toContain("shown as escape codes");
 
     // And it adds no precondition: consent plus a name still completes the gate.
     await consentAndName();
     await expect
       .element(page.getByRole("button", { name: "Accept and continue" }))
       .toBeEnabled();
+  });
+
+  test("a non-ASCII agreement value renders escaped, with the caveat line", async () => {
+    // An accented purpose is legitimate authored text, but sanitizeForDisplay
+    // escapes every non-ASCII code point -- the display cannot visually match
+    // the signed document, so the caveat line must accompany the escaped form.
+    await reachConsentWith({
+      ...agreementTerms,
+      legalAgreement: {
+        reference: "MOU-2025-0042",
+        purpose: "Evaluaci\u00f3n del programa",
+        expirationDate: "2026-12-31",
+      },
+    });
+    const fieldset = document.querySelector("fieldset");
+    expect(fieldset).not.toBeNull();
+    // The escaped form displays; the raw accented character never renders.
+    expect(fieldset?.textContent).toContain("Evaluaci\\xf3n del programa");
+    expect(fieldset?.textContent).not.toContain("\u00f3");
+    expect(fieldset?.textContent).toContain(
+      "shown as escape codes because they fall outside plain ASCII",
+    );
   });
 
   test("an agreement-less invitation shows no legal-agreement fieldset", async () => {

--- a/apps/web/test/browser/benchAccept.test.ts
+++ b/apps/web/test/browser/benchAccept.test.ts
@@ -587,6 +587,61 @@ describe("acceptor bench: consent gate and parse-behind-consent", () => {
   });
 });
 
+describe("acceptor bench: consent-step legal-agreement display", () => {
+  // acceptorTerms carries no agreement, so the display tests mint their own
+  // agreement-bearing terms; the shared fixture keeps the no-fieldset case.
+  const agreementTerms: LinkageTerms = {
+    ...acceptorTerms,
+    legalAgreement: {
+      reference: "MOU-2025-0042",
+      purpose: "Program evaluation",
+      expirationDate: "2026-12-31",
+    },
+  };
+
+  async function reachConsentWith(terms: LinkageTerms) {
+    window.location.hash = await encodeAcceptToken(terms);
+    mount(createElement(AcceptorBench));
+    await expect
+      .element(page.getByText("Invitation from County Health Department"))
+      .toBeInTheDocument();
+    await userEvent.click(
+      page.getByRole("button", { name: "Continue: consent & your file" }),
+    );
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Consent & your file");
+  }
+
+  test("an agreement-bearing invitation shows the three values, read-only", async () => {
+    await reachConsentWith(agreementTerms);
+    const fieldset = document.querySelector("fieldset");
+    expect(fieldset).not.toBeNull();
+    expect(fieldset?.querySelector("legend")?.textContent).toBe(
+      "Legal agreement",
+    );
+    expect(fieldset?.textContent).toContain(
+      "Check these values against your signed agreement",
+    );
+    expect(fieldset?.textContent).toContain("MOU-2025-0042");
+    expect(fieldset?.textContent).toContain("Program evaluation");
+    expect(fieldset?.textContent).toContain("2026-12-31");
+    // Display only: nothing to type, so the fieldset holds no inputs.
+    expect(fieldset?.querySelector("input")).toBeNull();
+
+    // And it adds no precondition: consent plus a name still completes the gate.
+    await consentAndName();
+    await expect
+      .element(page.getByRole("button", { name: "Accept and continue" }))
+      .toBeEnabled();
+  });
+
+  test("an agreement-less invitation shows no legal-agreement fieldset", async () => {
+    await reachConsentWith(acceptorTerms);
+    expect(document.querySelector("fieldset")).toBeNull();
+  });
+});
+
 describe("acceptor bench: confirm your columns (verdict, mapper, launch)", () => {
   // Consent, name, choose a file, and press Accept to land on the columns step.
   async function reachColumns(content: string) {

--- a/apps/web/test/unit/benchAcceptorModel.test.ts
+++ b/apps/web/test/unit/benchAcceptorModel.test.ts
@@ -354,19 +354,21 @@ describe("acceptor consent gate", () => {
 });
 
 describe("acceptor legal-agreement display", () => {
-  test("derives the invitation's three values for the consent step", () => {
+  test("derives the invitation's three values, unaltered for a plain-ASCII agreement", () => {
     expect(acceptorLegalAgreementDisplay(makeToken())).toEqual({
       reference: "MOU-2025-0042",
       purpose: "Program evaluation",
       expirationDate: "2026-12-31",
+      alteredForDisplay: false,
     });
   });
 
-  test("neutralizes hostile agreement values for display", () => {
+  test("neutralizes hostile agreement values and flags the alteration", () => {
     // The agreement strings are partner-controlled free text; a reference or
     // purpose carrying ANSI-escape and bidi-override bytes must reach the
     // consent step neutralized -- the summarizeInvitation boundary, never the
-    // raw token values.
+    // raw token values. The escaping changes how the values read, so the
+    // display carries alteredForDisplay for the consent step's caveat line.
     const display = acceptorLegalAgreementDisplay(
       makeToken({
         legalAgreement: {
@@ -384,6 +386,24 @@ describe("acceptor legal-agreement display", () => {
     expect(display?.purpose).not.toContain(RLO);
     expect(display?.purpose).toContain("evaluation");
     expect(display?.expirationDate).toBe("2026-12-31");
+    expect(display?.alteredForDisplay).toBe(true);
+  });
+
+  test("a long value truncated by sanitization also flags the alteration", () => {
+    // sanitizeForDisplay caps output length as well as escaping; a legitimate
+    // very long purpose cannot read exactly as authored, so the caveat flag
+    // must cover truncation, not only escaping.
+    const display = acceptorLegalAgreementDisplay(
+      makeToken({
+        legalAgreement: {
+          reference: "MOU-2025-0042",
+          purpose: "x".repeat(1000),
+          expirationDate: "2026-12-31",
+        },
+      }),
+    );
+    expect(display?.purpose.length).toBeLessThan(1000);
+    expect(display?.alteredForDisplay).toBe(true);
   });
 
   test("an invitation without an agreement yields no display", () => {

--- a/apps/web/test/unit/benchAcceptorModel.test.ts
+++ b/apps/web/test/unit/benchAcceptorModel.test.ts
@@ -8,6 +8,7 @@ import {
   acceptorDoneLedgerTag,
   acceptorLedgerRows,
   acceptorLedgerTag,
+  acceptorLegalAgreementDisplay,
   acceptorRailFacts,
   acceptorSpine,
   invitingPartyName,
@@ -349,5 +350,45 @@ describe("acceptor consent gate", () => {
     expect(
       acceptorConsentReady({ consented: true, name: "  Sam Alvarez  " }),
     ).toBe(true);
+  });
+});
+
+describe("acceptor legal-agreement display", () => {
+  test("derives the invitation's three values for the consent step", () => {
+    expect(acceptorLegalAgreementDisplay(makeToken())).toEqual({
+      reference: "MOU-2025-0042",
+      purpose: "Program evaluation",
+      expirationDate: "2026-12-31",
+    });
+  });
+
+  test("neutralizes hostile agreement values for display", () => {
+    // The agreement strings are partner-controlled free text; a reference or
+    // purpose carrying ANSI-escape and bidi-override bytes must reach the
+    // consent step neutralized -- the summarizeInvitation boundary, never the
+    // raw token values.
+    const display = acceptorLegalAgreementDisplay(
+      makeToken({
+        legalAgreement: {
+          reference: `MOU${ESC}[31m${RLO}-0042`,
+          purpose: `Program${ESC}[0m${RLO} evaluation`,
+          expirationDate: "2026-12-31",
+        },
+      }),
+    );
+    expect(display).toBeDefined();
+    expect(display?.reference).not.toContain(ESC);
+    expect(display?.reference).not.toContain(RLO);
+    expect(display?.reference).toContain("MOU");
+    expect(display?.purpose).not.toContain(ESC);
+    expect(display?.purpose).not.toContain(RLO);
+    expect(display?.purpose).toContain("evaluation");
+    expect(display?.expirationDate).toBe("2026-12-31");
+  });
+
+  test("an invitation without an agreement yields no display", () => {
+    expect(
+      acceptorLegalAgreementDisplay(makeToken({ legalAgreement: undefined })),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

When an invitation carries a legal agreement, the acceptor's consent step now presents its reference, stated purpose of the disclosure, and expiration date read-only beside the consent attestation, with a prompt to check them against the signed agreement. The agreement's substance sits in front of the acceptor at the moment of consent, not only one screen back in the full terms review. Display only: consent stays gated on the existing checkbox-plus-typed-name attestation, an invitation without an agreement shows no fieldset, and nothing leaves the browser.

Implements [211607920](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=211607920).

## Changes

- apps/web/src/bench/acceptorModel.ts: `acceptorLegalAgreementDisplay` -- the consent step's display derivation through `summarizeInvitation`, the one sanitizing boundary, so the three partner-controlled strings reach the DOM display-safe, never as raw token values. The returned shape carries `alteredForDisplay`, true when any sanitized value differs from its authored counterpart (escaping or truncation); the raw values are consulted only for that inequality and never returned.
- apps/web/src/bench/AcceptorBench.tsx: the read-only fieldset on the consent step, rendered only when the invitation attaches an agreement -- legend, a check-your-signed-agreement lead line, the three values ("Stated purpose" carries the same provenance marker the terms review deliberately uses, so partner-authored free text does not read as endorsed), and a one-line caveat that appears only when sanitization altered how a value reads, so the check prompt cannot overclaim a visual match escaping makes impossible.
- Tests: 4 unit tests (derivation, hostile ESC/RLO values neutralized and flagged, truncation flagged, agreement-less yields no display) and 3 browser tests (values render read-only with no inputs and no new precondition -- consent plus name alone still enables Accept; agreement-less invitation shows no fieldset; a non-ASCII value renders escaped with the caveat line, never the raw character).

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format`, `npm run test` (root: web 753 including the new unit tests), `npm run test:browser -w apps/web` (415).
The issue's criteria are pinned directly: the three values render read-only and sanitized when an agreement is present; no fieldset when absent; no re-entry inputs and no new consent precondition (asserted by a browser test that completes consent with checkbox and name alone); hostile agreement values reach the display neutralized.

## Background

This slice was reshaped mid-flight by an owner decision: the board item originally specified a re-entry ceremony (the acceptor re-types the three values and a mismatch blocks consent), which was implemented, reviewed, and then rejected by the owner as an unacceptable usability burden -- users should not have to retype agreement information. The item was rewritten to the display-and-attest shape this PR carries; the branch history contains only the final shape.

Review ran in two orchestrated rounds plus two security panels (ledger in scratch, not committed):

- Round 1 and a three-seat panel targeted the retired re-entry shape; their findings died with it, except the sanitization discipline they sharpened (raw values for comparison, sanitized for display), which shaped the final implementation.
- Round 2, against this diff: one confirmed cluster and two simpler-shape votes, all making the same point -- the consent fieldset repeats values the review step already shows. Deliberate, not accidental: at-consent visibility is the owner-chosen behavior (see Decisions of record). No code change.
- A two-seat panel on the final shape. Hostile-inputs: acceptable, zero findings -- every token-to-DOM path routes through the sanitizing boundary, the unit test runs against the real unmocked sanitizer and fails on a bypass, and nothing new leaves the browser. Truthfulness: two findings, both fixed and test-pinned here -- the check prompt overclaimed display fidelity for non-ASCII or truncated values (now caveated exactly when sanitization altered a value) and the purpose label lacked the "Stated" provenance marker (now carried).

## Decisions of record

- Re-entry rejected, display-and-attest chosen (owner, 2026-07-10): no retyping, no matching, no new consent precondition. The board item records the decision; this PR implements it.
- The at-consent fieldset deliberately repeats the agreement block the review step shows: the point is the agreement's substance beside the attestation at the consent moment. The mockup's accept-consent screen shows re-entry inputs instead; the divergence is recorded on the cutover item for its parity pass.
- The caveat line renders conditionally rather than always: an ASCII agreement (the common case) displays verbatim and gets no noise; the caveat appears exactly when the display genuinely differs from the authored value.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no format, protocol, or behavior contract change; a pre-cutover bench surface gains a display element
- [x] `CHANGELOG.md` `[Unreleased]` -- n/a: not operator-actionable; the bench is not yet the primary surface
- [x] Security review -- a two-seat panel (hostile inputs, claim truthfulness) on the final shape: one seat acceptable with zero findings, two truthfulness findings fixed and test-pinned on this branch (see Background)
