### PR TITLE
Rename buildInviterRunOutputs to the role-neutral buildRunOutputs

### DIFF
--- a/apps/web/src/bench/AcceptorExchangeSection.tsx
+++ b/apps/web/src/bench/AcceptorExchangeSection.tsx
@@ -19,8 +19,8 @@ import styles from "./bench.module.css";
 import type { AcceptableInvitation } from "@psi/acceptInvitation";
 import type { AlertContent } from "@components/csvIntake";
 import type { ExchangeRun } from "./exchangeRun";
-import type { InviterRunOutputs } from "./inviterRunOutputs";
 import type { RunFailure } from "./useInviterExchange";
+import type { RunOutputs } from "./runOutputs";
 
 /**
  * The acceptor's run/completion work column, re-using the shared run furniture
@@ -48,7 +48,7 @@ export function AcceptorExchangeSection({
 }: {
   invitation: AcceptableInvitation;
   run: ExchangeRun;
-  outputs: InviterRunOutputs | undefined;
+  outputs: RunOutputs | undefined;
   failure: RunFailure | undefined;
   /** The confirm-columns step's partial-coverage advisory, kept visible through
    * the run and cleared on a failure. */

--- a/apps/web/src/bench/InviterExchangeSection.tsx
+++ b/apps/web/src/bench/InviterExchangeSection.tsx
@@ -18,8 +18,8 @@ import styles from "./bench.module.css";
 
 import type { ExchangeRun } from "./exchangeRun";
 import type { GeneratedInvitation } from "@psi/invitation";
-import type { InviterRunOutputs } from "./inviterRunOutputs";
 import type { RunFailure } from "./useInviterExchange";
+import type { RunOutputs } from "./runOutputs";
 
 /**
  * The inviter's post-create work column, through the run's three phases: the
@@ -41,7 +41,7 @@ export function InviterExchangeSection({
 }: {
   invitation: GeneratedInvitation;
   run: ExchangeRun;
-  outputs: InviterRunOutputs | undefined;
+  outputs: RunOutputs | undefined;
   failure: RunFailure | undefined;
   onTryAgain: () => void;
   onStartOver: () => void;

--- a/apps/web/src/bench/runOutputs.ts
+++ b/apps/web/src/bench/runOutputs.ts
@@ -10,11 +10,11 @@ import type { ExchangeOutputs } from "@psi/exchangeLifecycle";
 /** The bench run's downloadable artifacts: the lifecycle's outputs widened
  * with the matched-row count the completion header states. Present exactly
  * when the result table is (a withheld result has no count to state). */
-export type InviterRunOutputs = ExchangeOutputs & {
+export type RunOutputs = ExchangeOutputs & {
   matchedRecordCount?: number;
 };
 
-/** The object-URL boundary {@link buildInviterRunOutputs} allocates through --
+/** The object-URL boundary {@link buildRunOutputs} allocates through --
  * `window.URL` in the app, a recording fake in tests. */
 export interface ObjectUrls {
   create: (blob: Blob) => string;
@@ -29,11 +29,11 @@ export interface ObjectUrls {
  * the results blob is matched-record PII, and a stranded object URL would keep
  * it alive until page unload.
  */
-export function buildInviterRunOutputs(
+export function buildRunOutputs(
   result: ExchangeResult,
   prepared: PreparedExchange,
   urls: ObjectUrls,
-): InviterRunOutputs {
+): RunOutputs {
   const created: Array<string> = [];
   const trackedUrl = (blob: Blob): string => {
     const url = urls.create(blob);
@@ -48,7 +48,7 @@ export function buildInviterRunOutputs(
     // PSI sender/helper): produce no results file -- the completion panel
     // shows it contributed but receives no result -- while still offering
     // the record downloads below.
-    const generated: InviterRunOutputs =
+    const generated: RunOutputs =
       result.associationTable === undefined
         ? { resultWithheld: true }
         : (() => {

--- a/apps/web/src/bench/useAcceptorExchange.ts
+++ b/apps/web/src/bench/useAcceptorExchange.ts
@@ -21,7 +21,7 @@ import {
   runWithStages,
   stagesFor,
 } from "./exchangeRun";
-import { buildInviterRunOutputs } from "./inviterRunOutputs";
+import { buildRunOutputs } from "./runOutputs";
 import { failureFor } from "./useInviterExchange";
 import { invitationUsable } from "./inviterModel";
 import { prepareAcceptorExchange } from "./acceptorExchange";
@@ -35,10 +35,8 @@ import type {
 import type { Acquire, GenerateOutput } from "@psi/exchangeLifecycle";
 import type { CSVRow } from "@psilink/core";
 import type { ExchangeRun } from "./exchangeRun";
-// buildInviterRunOutputs and its output type are role-neutral: the download
-// artifacts are the same both seats, so the acceptor reuses them verbatim.
-import type { InviterRunOutputs } from "./inviterRunOutputs";
 import type { RunFailure } from "./useInviterExchange";
+import type { RunOutputs } from "./runOutputs";
 
 /** The launch the acceptor commits to on "Start the exchange": the decoded
  * invitation, the committed name recorded in the exchange record, the acquired
@@ -78,12 +76,12 @@ export function useAcceptorExchange({
   launch: AcceptorLaunch | undefined;
 }): {
   run: ExchangeRun;
-  outputs: InviterRunOutputs | undefined;
+  outputs: RunOutputs | undefined;
   failure: RunFailure | undefined;
   tryAgain: () => void;
 } {
   const [run, setRun] = useState<ExchangeRun>(() => initialRun("acceptor"));
-  const [outputs, setOutputs] = useState<InviterRunOutputs>();
+  const [outputs, setOutputs] = useState<RunOutputs>();
   const [failure, setFailure] = useState<RunFailure>();
 
   // Drives the lifecycle's AbortSignal; the effect cleanup below aborts it so an
@@ -127,13 +125,10 @@ export function useAcceptorExchange({
 
     // Output-generation half. The URLs the build creates are revoked when the
     // outputs are replaced or the bench unmounts (effect above); a throw
-    // mid-build revokes its own partial URLs (see buildInviterRunOutputs).
-    const generateOutput: GenerateOutput<InviterRunOutputs> = (
-      result,
-      prepared,
-    ) => {
+    // mid-build revokes its own partial URLs (see buildRunOutputs).
+    const generateOutput: GenerateOutput<RunOutputs> = (result, prepared) => {
       log.info("linkage complete, generating results and record files");
-      return buildInviterRunOutputs(result, prepared, {
+      return buildRunOutputs(result, prepared, {
         create: (blob) => window.URL.createObjectURL(blob),
         revoke: (url) => window.URL.revokeObjectURL(url),
       });
@@ -177,7 +172,7 @@ export function useAcceptorExchange({
       return { peer, conn, psi, prepared };
     };
 
-    void runExchangeLifecycle<InviterRunOutputs>({
+    void runExchangeLifecycle<RunOutputs>({
       acquire,
       exchangeRole: "initiator",
       sharedSecret: token.sharedSecret,

--- a/apps/web/src/bench/useInviterExchange.ts
+++ b/apps/web/src/bench/useInviterExchange.ts
@@ -29,7 +29,7 @@ import {
   runWithStages,
   stagesFor,
 } from "./exchangeRun";
-import { buildInviterRunOutputs } from "./inviterRunOutputs";
+import { buildRunOutputs } from "./runOutputs";
 import { invitationUsable } from "./inviterModel";
 
 import type { PSILibrary } from "@openmined/psi.js/implementation/psi.d.ts";
@@ -41,7 +41,7 @@ import type {
 } from "@psi/exchangeLifecycle";
 import type { ExchangeRun } from "./exchangeRun";
 import type { GeneratedInvitation } from "@psi/invitation";
-import type { InviterRunOutputs } from "./inviterRunOutputs";
+import type { RunOutputs } from "./runOutputs";
 
 /** A failed run, ready to render: the lifecycle's category (which decides the
  * recovery the alert offers) and the operator-facing alert content, composed
@@ -153,12 +153,12 @@ export function useInviterExchange({
   inviterName: string;
 }): {
   run: ExchangeRun;
-  outputs: InviterRunOutputs | undefined;
+  outputs: RunOutputs | undefined;
   failure: RunFailure | undefined;
   tryAgain: () => void;
 } {
   const [run, setRun] = useState<ExchangeRun>(initialRun);
-  const [outputs, setOutputs] = useState<InviterRunOutputs>();
+  const [outputs, setOutputs] = useState<RunOutputs>();
   const [failure, setFailure] = useState<RunFailure>();
 
   // Drives the lifecycle's AbortSignal; the effect cleanup below aborts it so
@@ -200,13 +200,10 @@ export function useInviterExchange({
 
     // Output-generation half. The URLs the build creates are revoked when the
     // outputs are replaced or the bench unmounts (effect above); a throw
-    // mid-build revokes its own partial URLs (see buildInviterRunOutputs).
-    const generateOutput: GenerateOutput<InviterRunOutputs> = (
-      result,
-      prepared,
-    ) => {
+    // mid-build revokes its own partial URLs (see buildRunOutputs).
+    const generateOutput: GenerateOutput<RunOutputs> = (result, prepared) => {
       log.info("linkage complete, generating results and record files");
-      return buildInviterRunOutputs(result, prepared, {
+      return buildRunOutputs(result, prepared, {
         create: (blob) => window.URL.createObjectURL(blob),
         revoke: (url) => window.URL.revokeObjectURL(url),
       });
@@ -257,7 +254,7 @@ export function useInviterExchange({
       }
     };
 
-    void runExchangeLifecycle<InviterRunOutputs>({
+    void runExchangeLifecycle<RunOutputs>({
       acquire,
       exchangeRole: "responder",
       sharedSecret: minted.sharedSecret,

--- a/apps/web/test/unit/benchRunOutputs.test.ts
+++ b/apps/web/test/unit/benchRunOutputs.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "vitest";
 
-import { buildInviterRunOutputs } from "@bench/inviterRunOutputs";
+import { buildRunOutputs } from "@bench/runOutputs";
 
 import type { ExchangeResult, PreparedExchange } from "@psilink/core";
-import type { ObjectUrls } from "@bench/inviterRunOutputs";
+import type { ObjectUrls } from "@bench/runOutputs";
 
 // A recording ObjectUrls fake: each create hands out a distinct url (or throws
 // on the configured call), and both sides log what they were given, so the
@@ -58,14 +58,10 @@ function withheldResult(): ExchangeResult {
   } as unknown as ExchangeResult;
 }
 
-describe("buildInviterRunOutputs", () => {
+describe("buildRunOutputs", () => {
   test("a received result yields the results url, count, and timestamped record pair", () => {
     const { urls, created, revoked } = recordingUrls();
-    const outputs = buildInviterRunOutputs(
-      receivedResult(true),
-      prepared,
-      urls,
-    );
+    const outputs = buildRunOutputs(receivedResult(true), prepared, urls);
 
     expect(outputs.resultsUrl).toBe(created[0]);
     expect(outputs.matchedRecordCount).toBe(1);
@@ -82,7 +78,7 @@ describe("buildInviterRunOutputs", () => {
 
   test("a withheld result offers the record but no results url", () => {
     const { urls, created } = recordingUrls();
-    const outputs = buildInviterRunOutputs(withheldResult(), prepared, urls);
+    const outputs = buildRunOutputs(withheldResult(), prepared, urls);
 
     expect(outputs.resultWithheld).toBe(true);
     expect(outputs.resultsUrl).toBeUndefined();
@@ -94,20 +90,16 @@ describe("buildInviterRunOutputs", () => {
   test("a throw after the results url was created revokes it before propagating", () => {
     const { urls, created, revoked } = recordingUrls({ failOnCall: 2 });
 
-    expect(() =>
-      buildInviterRunOutputs(receivedResult(true), prepared, urls),
-    ).toThrow("createObjectURL refused");
+    expect(() => buildRunOutputs(receivedResult(true), prepared, urls)).toThrow(
+      "createObjectURL refused",
+    );
     expect(created).toHaveLength(1);
     expect(revoked).toEqual([created[0]]);
   });
 
   test("a result without an audit pair omits the record downloads", () => {
     const { urls, created, revoked } = recordingUrls();
-    const outputs = buildInviterRunOutputs(
-      receivedResult(false),
-      prepared,
-      urls,
-    );
+    const outputs = buildRunOutputs(receivedResult(false), prepared, urls);
 
     expect(outputs.record).toBeUndefined();
     expect(outputs.resultsUrl).toBe(created[0]);


### PR DESCRIPTION
## Summary

Both bench seats build their download artifacts through one module, but its names claimed the inviter seat: `buildInviterRunOutputs` becomes `buildRunOutputs`, `InviterRunOutputs` becomes `RunOutputs`, and the module (`runOutputs.ts`) and unit test file follow. The comment in the acceptor hook that existed solely to excuse the inviter-named import is deleted with the tension it flagged. Purely mechanical; no behavior change.

Implements [211607978](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=211607978).

## Changes

- apps/web/src/bench/inviterRunOutputs.ts -> runOutputs.ts: symbols and JSDoc links renamed; logic untouched.
- Consumers updated: useInviterExchange.ts, useAcceptorExchange.ts, InviterExchangeSection.tsx, AcceptorExchangeSection.tsx (imports, type parameters, prop types).
- apps/web/test/unit/benchInviterRunOutputs.test.ts -> benchRunOutputs.test.ts: imports and describe title; assertions unaltered.
- Zero references to the old names remain repo-wide (grepped without extension filter).

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format`, `npm run test -w apps/web` (747), `npm run test:browser -w apps/web` (299). The renamed unit file passes with assertions unaltered, pinning no behavior change.

## Checklist

- [x] Docs -- n/a: internal symbol rename
- [x] `CHANGELOG.md` -- n/a: not reader-observable
- [x] Security review -- n/a: no security surface; trivial mechanical tier (gates only, per the review-tier rule)
