### PR TITLE
Fix lobby button contrast and demote the verify card

### DIFF
--- a/apps/web/src/bench/BenchLobby.tsx
+++ b/apps/web/src/bench/BenchLobby.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { Button, Textarea, VisuallyHidden } from "@mantine/core";
+import { Anchor, Button, Textarea, VisuallyHidden } from "@mantine/core";
 import { Link, useNavigate } from "@tanstack/react-router";
 
 import { tokenFromInput } from "@psi/invitation";
@@ -10,10 +10,10 @@ import { FILE_ASSURANCE_LINE } from "./fileAssurance";
 import styles from "./bench.module.css";
 
 /**
- * The app's landing screen: the three actions side by side -- set up an
- * exchange, accept an invitation you were sent, or verify a receipt -- above
- * the standing how-it-works explanation. Mirrors the mockup's landing screen,
- * with the verify card as its third action.
+ * The app's landing screen: two primary actions side by side -- set up an
+ * exchange, or accept an invitation you were sent -- above the standing
+ * how-it-works explanation. Verifying a receipt is a secondary action, given
+ * as an inline text link below the two cards rather than equal billing.
  */
 export function BenchLobby() {
   const navigate = useNavigate();
@@ -98,23 +98,17 @@ export function BenchLobby() {
               </Button>
             </p>
           </div>
-          <div className={styles.actionCard}>
-            <h3>Verify a receipt</h3>
-            <p className={`${styles.small} ${styles.sub}`}>
-              Check that an exchange record you kept is internally consistent.
-              Load the record and its keys; re-supply your files to open the
-              commitments. Everything is checked in your browser.
-            </p>
-            <p>
-              <Button component={Link} to="/verify" variant="outline">
-                Verify a receipt
-              </Button>
-            </p>
-          </div>
         </div>
         <p className={`${styles.sub} ${styles.small}`}>
           Running exchanges on a schedule? The same setup saves an SFTP exchange
           file for the command-line tool.
+        </p>
+        <p className={`${styles.sub} ${styles.small}`}>
+          Already have an exchange record?{" "}
+          <Anchor component={Link} to="/verify">
+            Verify a receipt
+          </Anchor>{" "}
+          checks it&apos;s internally consistent, entirely in your browser.
         </p>
         <div className={styles.howItWorks}>
           <p>

--- a/apps/web/src/bench/bench.module.css
+++ b/apps/web/src/bench/bench.module.css
@@ -46,7 +46,20 @@
   max-width: 68ch;
 }
 
-.page a {
+/* Excludes a Mantine Button rendered as an anchor (component={Link}): a filled
+   Button's label color is --button-color (routed to the per-scheme contrast
+   color by the theme, see theme.ts FILLED_PRIMARY_CONTRAST), and this rule's
+   higher specificity (a class + type selector vs. Mantine's single class on
+   .mantine-Button-root) would otherwise overwrite that with --bench-accent --
+   which resolves close enough to the filled background color that the label
+   became unreadable until :hover repainted the background. An outline/light
+   Button legitimately wants accent-colored text, so the exclusion is scoped
+   to the Button root, not to Mantine controls generally. mantine-Button-root
+   is one of Mantine's global static class names (unhashed by design, so apps
+   can target it), so it must be wrapped in :global() here -- CSS Modules
+   would otherwise locally scope/hash the name inside :not() and the
+   exclusion would silently never match. */
+.page a:not(:global(.mantine-Button-root)) {
   color: var(--bench-accent);
 }
 

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -313,7 +313,6 @@ describe("bench lobby", () => {
     expect(cardHeadings).toEqual([
       "Set up an exchange",
       "Accept an invitation you were sent",
-      "Verify a receipt",
     ]);
 
     // The in-browser processing assurance is a preserved invariant of the
@@ -333,6 +332,12 @@ describe("bench lobby", () => {
 
     await expect
       .element(page.getByLabelText("Invitation link or code"))
+      .toBeInTheDocument();
+
+    // Verifying a receipt is a secondary action below the two cards, not a
+    // third card of equal billing.
+    await expect
+      .element(page.getByRole("link", { name: "Verify a receipt" }))
       .toBeInTheDocument();
   });
 

--- a/apps/web/test/browser/benchVerify.test.ts
+++ b/apps/web/test/browser/benchVerify.test.ts
@@ -133,18 +133,12 @@ afterEach(() => {
   container = undefined;
 });
 
-describe("bench lobby: verify a receipt card", () => {
-  test("the third action card links to the verify bench", async () => {
+describe("bench lobby: verify a receipt link", () => {
+  test("the inline verify link below the two action cards navigates to the verify bench", async () => {
     mount(createElement(BenchLobby));
-    await expect
-      .element(
-        page.getByRole("heading", { level: 3, name: "Verify a receipt" }),
-      )
-      .toBeInTheDocument();
-    const verifyLink = Array.from(document.querySelectorAll("a")).find(
-      (anchor) => anchor.textContent === "Verify a receipt",
-    );
-    expect(verifyLink?.getAttribute("href")).toBe("/verify");
+    const verifyLink = page.getByRole("link", { name: "Verify a receipt" });
+    await expect.element(verifyLink).toBeInTheDocument();
+    await expect.element(verifyLink).toHaveAttribute("href", "/verify");
   });
 });
 

--- a/apps/web/test/browser/themeContrast.test.ts
+++ b/apps/web/test/browser/themeContrast.test.ts
@@ -20,6 +20,13 @@ import { IconCheck, IconCopy } from "@tabler/icons-react";
 
 import { cssVariablesResolver, mantineTheme } from "@theme";
 
+// tokens.css defines the --bench-* custom properties bench.module.css reads
+// (--bench-accent among them); BenchPage.tsx imports it as a side effect in
+// the real app, so the anchor-inside-.page case below needs it too, or
+// --bench-accent resolves to nothing and masks the rule this test targets.
+import "@bench/tokens.css";
+import benchStyles from "@bench/bench.module.css";
+
 import type { ComponentType, ReactNode } from "react";
 import type { Root } from "react-dom/client";
 
@@ -28,6 +35,14 @@ import type { Root } from "react-dom/client";
 // JSX), and createElement cannot resolve their overloaded type directly -- cast each
 // to the plain component shape this test renders.
 const FilledButton = Button as unknown as ComponentType<{
+  children?: ReactNode;
+}>;
+// Rendered with component="a" -- a bare host tag reproduces the exact selector
+// clash a component={Link} render hits (Link ultimately renders a real <a>
+// too), without pulling the router into this harness.
+const LinkRenderedButton = Button as unknown as ComponentType<{
+  component?: string;
+  href?: string;
   children?: ReactNode;
 }>;
 const PrimaryCheckbox = Checkbox as unknown as ComponentType<{
@@ -303,6 +318,36 @@ describe("rendered filled-primary contrast (WCAG 2.1 AA)", () => {
     // clear the floor and read brighter than the hover fill it replaced.
     expect(restingContrast).toBeGreaterThanOrEqual(4.5);
     expect(restingContrast).toBeGreaterThan(hoverContrast);
+  });
+
+  // A filled-primary Button rendered as an anchor (component={Link} in the
+  // app; component="a" here, see LinkRenderedButton above) inside the bench's
+  // .page wrapper. bench.module.css's `.page a` rule once outranked Mantine's
+  // --button-color on specificity (class+type beats Mantine's single class on
+  // .mantine-Button-root) and repainted the label --bench-accent -- a teal
+  // close enough to the cyan-9 filled background that the label was
+  // unreadable until :hover changed the background. This proves the label and
+  // background are actually distinguishable colors, not just that each
+  // individually clears an arithmetic floor -- the two could still be pinned
+  // to the same value and pass a floor-only check.
+  test("a Button rendered as an anchor inside .page keeps its filled label legible", async () => {
+    mount(
+      "light",
+      createElement(
+        "div",
+        { className: benchStyles.page },
+        createElement(
+          LinkRenderedButton,
+          { component: "a", href: "/exchange" },
+          "Set up an exchange",
+        ),
+      ),
+    );
+    const btn = await waitForEl(".mantine-Button-root");
+    const backgroundColor = await restingBackground(btn);
+    const { color } = getComputedStyle(btn);
+    expect(color).not.toBe(backgroundColor);
+    expect(contrast(color, backgroundColor)).toBeGreaterThanOrEqual(4.5);
   });
 });
 


### PR DESCRIPTION
## Summary

Two owner-requested lobby adjustments. First, a contrast bug: the "Set up an exchange" button's label rendered in the same color as the button's fill, visible only on hover. Root cause: the bench page's global anchor color rule (`.page a`) outranks Mantine's button-label rule by one point of specificity, so any FILLED Button rendered as a router `Link` -- an anchor in the DOM -- took the accent text color on the accent-family fill; hover only moves the background, which is why hovering "fixed" it. The rule now excludes Mantine's button root at the stylesheet level, healing every current and future Button-as-Link (a second affected button on the run surface is fixed by the same change). Second, "Verify a receipt" loses its equal billing: the lobby keeps two primary action cards, and verification becomes an inline text link in a sentence below them, in the same register as the existing schedule hint.

## Changes

- apps/web/src/bench/bench.module.css: `.page a` becomes `.page a:not(:global(.mantine-Button-root))` -- the `:global()` wrapper is load-bearing, since CSS Modules would otherwise hash the class name inside `:not()` and the exclusion would silently never match. Outline/light buttons keep their accent text, which is legitimate on their transparent fills.
- apps/web/src/bench/BenchLobby.tsx: the verify action card is removed; below the two cards and the schedule hint, a sentence ("Already have an exchange record? Verify a receipt checks it's internally consistent, entirely in your browser.") carries an inline Anchor to `/verify` with the accessible name "Verify a receipt".
- Tests: the themeContrast browser suite gains the case it structurally missed -- an anchor-rendered filled Button inside the bench page wrapper, asserted legible at rest (the existing cases mount plain buttons, which is exactly why this bug escaped); the fix was verified to fail against the unfixed rule (1.11:1) and pass against the fix (5.59:1). The benchVerify lobby test is rewritten for the inline placement, and the bench lobby structure test now expects two cards plus the link.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format`, `npm run test -w apps/web` (747), `npm run test:browser -w apps/web` (300, cold cache).

## Checklist

- [x] Docs -- n/a: no behavior contract change; the lobby's shape is UI presentation
- [x] `CHANGELOG.md` -- n/a: pre-release web UI presentation change, not operator-actionable
- [x] Security review -- n/a: no security surface; a CSS specificity fix and a layout change
