### PR TITLE
Update stale surface names in code comments

### DIFF
--- a/apps/web/src/bench/inviterModel.ts
+++ b/apps/web/src/bench/inviterModel.ts
@@ -78,10 +78,10 @@ export function isCliTransport(
  * from the read file, applying the two column edits step 2 offers, and the
  * view-model builders the rail facts and the disclosure ledger render from.
  * No React, no I/O -- the tested boundary for "default terms derive from the
- * file" and "the ledger tracks term edits". The draft itself is the Advanced
- * editor's ({@link AdvancedInviteDraft}); the bench re-surfaces that model, so
- * every derivation and edit goes through the same seed/reconcile helpers the
- * old editor is tested on.
+ * file" and "the ledger tracks term edits". The draft itself is the AdvancedInvite
+ * model's ({@link AdvancedInviteDraft}); the bench re-surfaces that model, so
+ * every derivation and edit goes through the same seed/reconcile helpers that
+ * model is tested on.
  */
 
 /** The read file the spine works over: identity for the file card plus the
@@ -722,7 +722,7 @@ export interface SpineProblem {
   target: SpineTarget;
 }
 
-/** Validate the draft for the create gate -- the Advanced editor's own
+/** Validate the draft for the create gate -- the AdvancedInvite model's own
  * validation over the bench's session. */
 export function reviewValidation(
   editor: InviterEditor,

--- a/apps/web/src/components/InvitationTerms.tsx
+++ b/apps/web/src/components/InvitationTerms.tsx
@@ -259,10 +259,8 @@ function MatchKeyDetails({ summary }: { summary: InvitationKeySummary }) {
  * Wraps the terms panel's lower reference tiers (what you receive, how records are
  * matched, the legal agreement, and "Other details") in one default-collapsed
  * disclosure when {@link condensed}; otherwise renders them inline unchanged.
- * condensed is set on the surfaces that show the terms as post-consent or authored
- * REFERENCE -- both roles' during-run exchange screens, the acceptor's "prepare your
- * data" screen, and the inviter's own live authoring preview -- so the panel stays
- * short (and, for the inviter's run screen, keeps the share block above it in view).
+ * condensed is set on surfaces that show the terms as post-consent or authored
+ * REFERENCE, so the panel stays short.
  * It is NEVER set on the acceptor's pre-consent "review" screen, the one place
  * informed consent is captured, which keeps every tier always-visible. So even though
  * this can fold a tier, it never hides one from the party at the consent decision
@@ -462,9 +460,8 @@ export function InvitationTerms({
   /** Fold the lower reference tiers (what you receive, how records are matched, the
    * legal agreement, and "Other details") into one default-collapsed disclosure,
    * keeping only "What you disclose" and "What the exchange produces" always visible.
-   * Set on the surfaces that show the terms as post-consent or authored REFERENCE
-   * (both roles' during-run exchange screens, the acceptor's "prepare your data"
-   * screen, and the inviter's live authoring preview). NEVER set on the acceptor's
+   * Set on surfaces that show the terms as post-consent or authored
+   * REFERENCE. NEVER set on the acceptor's
    * pre-consent "review" screen, whose every tier must stay always-visible for
    * informed consent. See {@link CondensableDetails}. */
   condensed?: boolean;

--- a/apps/web/src/components/MetadataGrid.tsx
+++ b/apps/web/src/components/MetadataGrid.tsx
@@ -42,11 +42,11 @@ const SINGLE_IDENTIFIER_MESSAGE =
  * The shared metadata grid: a real table mapping each input column to a semantic
  * type and a single consequence-labeled disclosure choice. Presentational -- it
  * holds no metadata state of its own; it renders `metadata` and emits the next
- * array through {@link onChange}, so each host (the acceptor "Prepare your data"
- * screen and the inviter Advanced-options editor) owns the model and decides what
+ * array through {@link onChange}, so the host (the acceptor's Confirm-your-columns
+ * step) owns the model and decides what
  * the edit means.
  *
- * The grid does not paint the disclosed-columns list itself: each host already
+ * The grid does not paint the disclosed-columns list itself: the host already
  * shows it visibly as the "What you will send to your partner" chips beside the
  * agreed terms, so a second text copy here would be a same-screen duplicate. What
  * the grid keeps is the aria-live ANNOUNCEMENT of that list -- computed

--- a/apps/web/src/components/StandardizationCards.tsx
+++ b/apps/web/src/components/StandardizationCards.tsx
@@ -20,7 +20,7 @@ import type { ReactNode } from "react";
 
 /**
  * The shared, presentational per-field cleaning card loop, used by BOTH the inviter's
- * advanced-options editor and the acceptor's "Prepare your data" screen. It holds NO
+ * and the acceptor's Cleaning tabs. It holds NO
  * model state: it renders the effective {@link Standardization} the host passes and
  * emits each edit through GRANULAR, intent-shaped callbacks -- never a whole-array
  * `onChange`. That granularity is what lets the two hosts keep opposite data-flow

--- a/apps/web/src/components/UnlinkableFileAlert.tsx
+++ b/apps/web/src/components/UnlinkableFileAlert.tsx
@@ -6,12 +6,12 @@ import type { AlertContent } from "@components/csvIntake";
 
 /**
  * The operator-facing alert for a file whose columns satisfy zero default linkage
- * keys, shared by both invite surfaces so the wording cannot drift: the quick
- * invite (rendered from an {@link InvitationFileError} zero-satisfiable-keys
- * failure in {@link InvitePanel}) and the Advanced editor's file entry
- * ({@link AdvancedInvite}). When every default key references at least one field
+ * keys, shared by the inviter bench's create and save-exchange-file gates so the
+ * wording cannot drift: each renders it from an {@link InvitationFileError}
+ * zero-satisfiable-keys failure raised by the mint-time re-parse. When every
+ * default key references at least one field
  * type the file lacks, no match is possible and the exchange would yield a result
- * byte-indistinguishable from a legitimately empty intersection, so both surfaces
+ * byte-indistinguishable from a legitimately empty intersection, so both gates
  * refuse the file EARLY with this shared message rather than running it.
  *
  * `unsatisfied` is the missing linkage fields from {@link assessLinkageSatisfiability}

--- a/apps/web/src/psi/acceptInvitation.ts
+++ b/apps/web/src/psi/acceptInvitation.ts
@@ -13,8 +13,8 @@ import type {
   WebRTCEndpoint,
 } from "@psilink/core";
 
-/** The per-party data preparation the acceptor authored in the "Prepare your
- * data" editor: the edited column metadata (semantic type + disclosure role) and
+/** The per-party data preparation the acceptor authored in its confirm-columns
+ * step: the edited column metadata (semantic type + disclosure role) and
  * the standardization pipeline. Both are local to this party, derived from its own
  * CSV, and never cross-checked with the partner -- see
  * {@link acceptorExchangeDataSpec}. */

--- a/apps/web/src/psi/advancedInvite.ts
+++ b/apps/web/src/psi/advancedInvite.ts
@@ -40,10 +40,10 @@ export type FuzzyComparison = NonNullable<
 >;
 
 /**
- * The pure data model behind the Advanced-options editor: seeding a draft from the
+ * The pure data model behind the inviter's authoring bench: seeding a draft from the
  * inviter's columns, building the {@link LinkageTerms} a draft represents, and
- * validating it. No React, no I/O -- the single tested boundary the editor
- * component drives, so the seed/build/validate contract is checked here rather
+ * validating it. No React, no I/O -- the single tested boundary the bench
+ * drives, so the seed/build/validate contract is checked here rather
  * than through the UI.
  *
  * Scope: the guided editor reviews and reorders the metadata-derived default
@@ -450,7 +450,7 @@ export function standardizationForTerms(
 }
 
 /** The inviter's edited per-party data settings, threaded into its own exchange
- * spec: the metadata and standardization it authored in the Advanced editor. Both
+ * spec: the metadata and standardization it authored in the inviter bench. Both
  * are absent on the quick (name-only) path, where they are inferred downstream.
  * The inviter analogue of `AcceptorDataEdits`. */
 export interface InviterDataEdits {

--- a/apps/web/src/psi/columnNames.ts
+++ b/apps/web/src/psi/columnNames.ts
@@ -20,9 +20,10 @@ export function emptyColumnPositions(
 
 /**
  * The operator-facing alert for a file whose header carries unnamed column(s),
- * shared by every web intake surface so the wording cannot drift: the quick invite
- * (rendered from an {@link InvitationFileError} `unnameable` failure), the
- * Advanced editor's file entry, and the acceptor's file acquire. `positions` are
+ * shared by every web intake surface so the wording cannot drift: the inviter
+ * bench's file entry (and its create/save gates, rendered from an
+ * {@link InvitationFileError} `unnameable` failure raised by the mint-time
+ * re-parse) and the acceptor's file acquire. `positions` are
  * the 1-based column positions from {@link emptyColumnPositions} and are not
  * operator-controlled content, so they are surfaced directly. The return shape is
  * the structural {@link AlertContent} (`{ title, message }`) every caller assigns

--- a/apps/web/src/psi/invitation.ts
+++ b/apps/web/src/psi/invitation.ts
@@ -129,8 +129,8 @@ export interface GeneratedInvitation {
    * inviter's exchange feeds to `prepareForExchange`. Local-only. */
   columns: Array<string>;
   /**
-   * The inviter's edited per-party column metadata, from the Advanced-options
-   * editor. Threaded into the inviter's own `prepareForExchange` (never encoded in
+   * The inviter's edited per-party column metadata, from the bench's Matching &
+   * sharing section. Threaded into the inviter's own `prepareForExchange` (never encoded in
    * the token), so its disclosure choices govern what the inviter sends and its
    * column->type bindings match the run that the authored keys were derived from.
    * Absent on the quick path, where metadata is inferred from the columns
@@ -138,8 +138,8 @@ export interface GeneratedInvitation {
    */
   metadata?: Metadata;
   /**
-   * The inviter's authored per-party standardization, from the Advanced-options
-   * editor's data-prep workbench. Paired with {@link metadata} and threaded into
+   * The inviter's authored per-party standardization, from the bench's Cleaning
+   * tab. Paired with {@link metadata} and threaded into
    * the inviter's own `prepareForExchange` (never embedded in the token), so the
    * cleaning -- and the per-field input-column binding that lets two fields of one
    * semantic type bind to distinct columns -- matches the run the authored fields
@@ -319,14 +319,15 @@ export async function generateInvitation(params: {
   /**
    * Invitation lifetime in seconds; defaults to {@link INVITATION_LIFETIME_SECONDS}
    * (one hour) and must be in the range `(0, {@link MAX_INVITATION_LIFETIME_SECONDS}]`
-   * (up to one year). The quick path omits it and takes the default; the Advanced-
-   * options editor passes the inviter's chosen lifetime. The bounds are enforced
+   * (up to one year). The quick path omits it and takes the default; the inviter
+   * bench passes the inviter's chosen lifetime. The bounds are enforced
    * here so that seam cannot mint an unbounded token.
    */
   lifetimeSeconds?: number;
   /**
-   * Authored linkage terms to embed, from the Advanced-options editor. When
-   * supplied they are embedded VERBATIM: the editor seeded them from this file's
+   * Authored linkage terms to embed, from the AdvancedInvite model
+   * (`buildAdvancedTerms`). When
+   * supplied they are embedded VERBATIM: the model seeded them from this file's
    * columns, validated them through {@link safeParseLinkageTerms}, and confirmed
    * at least one key is satisfiable, so the default-terms derivation is skipped
    * and `inviterName` is not consulted for the terms (the authored terms carry
@@ -337,7 +338,8 @@ export async function generateInvitation(params: {
    */
   linkageTerms?: LinkageTerms;
   /**
-   * The inviter's edited column metadata from the Advanced-options editor, paired
+   * The inviter's edited column metadata from the bench's Matching & sharing
+   * section, paired
    * with `linkageTerms`. Returned on {@link GeneratedInvitation} and threaded into
    * the inviter's own exchange (never embedded in the token); the fail-closed
    * satisfiability re-check binds against it too, so the verdict matches the run.
@@ -345,8 +347,8 @@ export async function generateInvitation(params: {
    */
   metadata?: Metadata;
   /**
-   * The inviter's authored per-party standardization from the Advanced-options
-   * data-prep workbench, paired with `metadata`/`linkageTerms`. Returned on
+   * The inviter's authored per-party standardization from the bench's Cleaning
+   * tab, paired with `metadata`/`linkageTerms`. Returned on
    * {@link GeneratedInvitation} for the inviter's own exchange and threaded into
    * the fail-closed satisfiability re-check (which binds against it, mirroring how
    * `metadata` already does), so the verdict matches the run that produces the
@@ -419,7 +421,7 @@ export async function generateInvitation(params: {
       positions: emptyPositions,
     });
 
-  // The terms to embed. The Advanced-options editor's authored terms are embedded
+  // The terms to embed. The AdvancedInvite model's authored terms are embedded
   // verbatim; the quick path derives them from the file's columns (inferred
   // metadata filters the default keys to those the columns can satisfy -- the same
   // filter the inviter's own exchange would otherwise re-derive -- and authors a
@@ -451,7 +453,7 @@ export async function generateInvitation(params: {
     // Reject a payload.send that does not match the disclosed set before the token
     // is minted, so the partner's consent screen never misstates what is sent (a
     // column metadata gates off, or one it transmits but the dictionary omits). The
-    // Advanced editor derives payload.send from the disclosed columns, so its send
+    // AdvancedInvite model derives payload.send from the disclosed columns, so its send
     // equals what metadata transmits and this is a defense-in-depth backstop
     // (against a regression or a non-editor caller) rather than a gate the editor
     // reaches; it runs here because the exchange-time check in prepareForExchange

--- a/apps/web/src/psi/invitationLocation.ts
+++ b/apps/web/src/psi/invitationLocation.ts
@@ -5,8 +5,8 @@ import type { InvitationLocation } from "@psi/invitation";
  * reads `window`, so it must be called from a client-side path; it throws rather
  * than return a wrong value if ever reached during SSR, since there is no sensible
  * server-side location. Callers invoke it from a submit/generate handler, an event
- * that cannot fire during render. Shared by the quick compose screen (InvitePanel)
- * and the Advanced editor (AdvancedInvite) so both build the locator identically.
+ * that cannot fire during render. Shared by the inviter bench's create and
+ * save-exchange-file paths so both build the locator identically.
  */
 export function invitationLocation(): InvitationLocation {
   if (typeof window === "undefined")

--- a/apps/web/src/psi/metadataEditing.ts
+++ b/apps/web/src/psi/metadataEditing.ts
@@ -10,8 +10,8 @@ import type {
 /**
  * The pure model behind the web metadata grid: the collapsed disclosure control,
  * the semantic-type and disclosure label tables, and the metadata-editing helpers
- * both hosts (the acceptor "Prepare your data" screen and the inviter
- * Advanced-options editor) drive their grids from. No React, no I/O -- the single
+ * both hosts (the acceptor's Confirm-your-columns step and the inviter's
+ * Matching & sharing section) drive their grids from. No React, no I/O -- the single
  * tested boundary, so the disclosure <-> {role, isPayload} mapping is checked here
  * rather than through the UI.
  *
@@ -310,7 +310,7 @@ export function quickInviteDisclosedColumns(
  * acceptor mirrors this send into its own receive and validates that exactly).
  *
  * Shared by both invite paths so they cannot drift in how they declare what they
- * send: the Advanced editor (`buildAdvancedTerms`) over its edited metadata and the
+ * send: the AdvancedInvite model (`buildAdvancedTerms`) over its edited metadata and the
  * quick path (`generateInvitation`) over the inferred metadata its own exchange
  * falls back to. This declares what already transmits; it does not change which
  * columns flow.

--- a/packages/core/src/config/linkageTerms.ts
+++ b/packages/core/src/config/linkageTerms.ts
@@ -1224,7 +1224,7 @@ export function safeParseLinkageTerms(raw: unknown) {
  *   empty case kept distinct from the absent case above, which yields an absent send.
  *
  * `deduplicate` is left as adopted from the inviter's terms. It is per-party in
- * principle, but the web Advanced-options editor and the CLI default acceptance
+ * principle, but the web app's AdvancedInvite authoring and the CLI default acceptance
  * never author it one-sided (`deduplicate` stays false), so for the configurations
  * those front ends produce a verbatim adoption is correct and the mirror is always
  * coherent. Metadata and standardization stay per-party and local (they are never

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -382,9 +382,9 @@ export async function loadCSVFile(
 }
 
 /**
- * Read only the column header names from a CSV, without parsing its rows. The
- * Advanced-options editor (apps/web) is column-aware -- it seeds metadata-aware
- * defaults and populates field pickers from the header alone -- and needs those
+ * Read only the column header names from a CSV, without parsing its rows. A
+ * column-aware authoring surface seeds metadata-aware
+ * defaults and populates field pickers from the header alone, and needs those
  * names before the inviter commits to generating, where parsing the whole file
  * (which `loadCSVFile` does, and which `generateInvitation` still does at mint
  * time) would be wasted work held in memory through the edit session.


### PR DESCRIPTION
## Summary

Corrects stale web-UI surface names in code comments and JSDoc across apps/web and packages/core. The bench redesign renamed the web app's surfaces; the docs were repaired earlier (#444), and this is the code-comment counterpart. Comment prose only -- no identifier, export, or file was renamed, and no logic changed.

Follow-on to #444 (the docs half of the same stale-vocabulary cleanup).

## Changes

Each reference was adjudicated per-hit: a dead user-facing surface name was replaced with the current surface, while a reference that names a live code entity was pointed at that entity by its real name.

- apps/web/src/psi/invitation.ts, advancedInvite.ts, metadataEditing.ts, columnNames.ts, invitationLocation.ts, acceptInvitation.ts: "the Advanced options editor" / "the acceptor's 'Prepare your data' screen" -> the current surfaces (the Cleaning tab, the Matching & sharing section, the Confirm-your-columns step) or the `AdvancedInvite` model / `buildAdvancedTerms` where the comment named the code path.
- apps/web/src/components/MetadataGrid.tsx, StandardizationCards.tsx, UnlinkableFileAlert.tsx, InvitationTerms.tsx, bench/inviterModel.ts: same, with consumer re-descriptions matched to each component's actual importers (MetadataGrid -> AcceptorColumnsStep only; UnlinkableFileAlert -> InviterBench only; StandardizationCards -> both parties' Cleaning tabs). InvitationTerms's `condensed` doc drops an enumeration of dead surfaces while keeping its load-bearing invariant (never set on the pre-consent review screen) verbatim.
- packages/core/src/file.ts, config/linkageTerms.ts: the two core comments that named the web "Advanced options editor" now name the web app's authoring at the same register.

Left as-is (not stale): the live "advanced" regex-tier badge label in StepListEditor/standardizationAuthoring, and API-level "quick path" naming.

## Test plan

Ran: `npm run build -w packages/core`, `npm run typecheck`, `npm run lint`, `npm run format`, `npm run test` (root, all workspaces: 828 web + core + cli green). Comment-only, so no behavior to add tests for; the consumer claims were verified by reading each component's importers (MetadataGrid, UnlinkableFileAlert, StandardizationCards, columnNames all confirmed).

## Out of scope / follow-on

Observed during the pass, not touched (each a candidate for a separate cleanup):
- Dead code-symbol `{@link}`/prose references to deleted components (`PrepareData`, `InvitePanel`, `AcceptInvitationPanel`) remain in several files -- these name dead code entities, not user surfaces.
- `InvitationTerms`'s `condensed` prop and `CondensableDetails` now have no caller; `loadCSVColumns` (packages/core/src/file.ts) has no in-repo caller. Both are live-but-unexercised code.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: this PR changes only in-source code comments; the doc-tier surface names were already corrected in #444 and no `docs/` page is affected.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: comment-only change, not visible to an operator/deployer or security reviewer.
- [x] Security review -- n/a: no runtime, protocol, credential, auth, or disclosure change; comment prose only, with no identifier renamed.
