### PR TITLE
Guard board reads against cross-project id alias

### DIFF
--- a/.claude/scripts/fetch-issues.mjs
+++ b/.claude/scripts/fetch-issues.mjs
@@ -109,7 +109,13 @@ async function main() {
   for (const item of items) {
     process.stdout.write(`=== ${item.id} ===\n`);
     if (item.type === "missing") {
-      process.stdout.write(`(not found on project ${projectNumber})\n\n`);
+      const hint =
+        item.resolvedProject !== undefined
+          ? ` (this id resolves to an item on project ${item.resolvedProject}; try that board)`
+          : "";
+      process.stdout.write(
+        `(not found on project ${projectNumber}${hint})\n\n`,
+      );
       continue;
     }
     process.stdout.write(`TITLE: ${item.title}\n`);

--- a/.claude/scripts/lib/projectItems.mjs
+++ b/.claude/scripts/lib/projectItems.mjs
@@ -276,7 +276,7 @@ export function fieldValueInput(field, value) {
  */
 export async function fetchItems(projectNumber, numericIds) {
   const fields =
-    "... on ProjectV2Item { databaseId " +
+    "... on ProjectV2Item { databaseId project { number } " +
     FIELD_VALUES_FRAGMENT +
     " content { __typename " +
     "... on DraftIssue { title body } " +
@@ -294,28 +294,50 @@ export async function fetchItems(projectNumber, numericIds) {
   // whole fetch -- the missing aliases simply come back as null nodes below.
   const data = (await graphql(query)).data;
 
-  return numericIds.map((id, i) => {
-    const node = data[`i${i}`];
-    if (!node || !node.content) {
-      return {
-        id,
-        type: "missing",
-        title: null,
-        body: null,
-        url: null,
-        fields: {},
-      };
-    }
-    const c = node.content;
-    return {
-      id,
-      type: c.__typename,
-      title: c.title ?? null,
-      body: c.body ?? null,
-      url: c.url ?? null,
-      fields: extractFields(node.fieldValues),
-    };
+  return numericIds.map((id, i) =>
+    mapFetchedNode(data[`i${i}`], id, projectNumber),
+  );
+}
+
+/**
+ * Map one node from a fetchItems response to its result. A node that is absent or
+ * has no content is `missing`. So is a node whose own project does not match the
+ * requested one: pvtiNodeId builds a node id from the requested project's byte
+ * prefix plus the numeric id, but that prefix is not a reliable per-project
+ * discriminator -- GitHub can resolve the constructed id to an item on a
+ * DIFFERENT project (a numeric id whose item lives on another board reads back
+ * that other board's item). Verifying the resolved node's own project closes that
+ * cross-board read, which would otherwise return another board's item as if it
+ * were this one. The mismatch result carries `resolvedProject` so a caller can
+ * point at the board the id actually belongs to. Exported for unit testing.
+ */
+export function mapFetchedNode(node, id, projectNumber) {
+  const missing = (extra = {}) => ({
+    id,
+    type: "missing",
+    title: null,
+    body: null,
+    url: null,
+    fields: {},
+    ...extra,
   });
+  if (!node || !node.content) return missing();
+  const resolvedProject = node.project?.number;
+  if (
+    typeof resolvedProject === "number" &&
+    resolvedProject !== projectNumber
+  ) {
+    return missing({ resolvedProject });
+  }
+  const c = node.content;
+  return {
+    id,
+    type: c.__typename,
+    title: c.title ?? null,
+    body: c.body ?? null,
+    url: c.url ?? null,
+    fields: extractFields(node.fieldValues),
+  };
 }
 
 // GitHub's projectV2 items connection caps `first` at 100, so this is also the

--- a/.claude/scripts/lib/projectItems.test.mjs
+++ b/.claude/scripts/lib/projectItems.test.mjs
@@ -3,6 +3,7 @@ import {
   fetchAllItems,
   fieldValueInput,
   githubToken,
+  mapFetchedNode,
   numericIdFromNodeId,
   PAGE_SIZE,
   pvtiNodeId,
@@ -112,6 +113,45 @@ describe("fetchAllItems pagination", () => {
     });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe(199240250);
+  });
+});
+
+describe("mapFetchedNode cross-project guard", () => {
+  const contentNode = (projectNumber) => ({
+    databaseId: 1,
+    project: { number: projectNumber },
+    fieldValues: {
+      nodes: [
+        {
+          __typename: "ProjectV2ItemFieldNumberValue",
+          number: 4,
+          field: { name: "Order" },
+        },
+      ],
+    },
+    content: { __typename: "DraftIssue", title: "T", body: "B" },
+  });
+
+  it("resolves a node whose project matches the requested one", () => {
+    const r = mapFetchedNode(contentNode(9), 123, 9);
+    expect(r.type).toBe("DraftIssue");
+    expect(r.fields).toEqual({ Order: 4 });
+    expect(r.resolvedProject).toBeUndefined();
+  });
+
+  it("treats a node resolved on a different project as missing, noting the resolved project", () => {
+    // The core foot-gun: a numeric id whose item lives on board 10, read under
+    // board 9, must not come back as a board-9 item.
+    const r = mapFetchedNode(contentNode(10), 123, 9);
+    expect(r.type).toBe("missing");
+    expect(r.resolvedProject).toBe(10);
+    expect(r.body).toBeNull();
+  });
+
+  it("treats an absent or contentless node as missing without a resolved project", () => {
+    expect(mapFetchedNode(null, 123, 9).type).toBe("missing");
+    expect(mapFetchedNode({ content: null }, 123, 9).type).toBe("missing");
+    expect(mapFetchedNode(null, 123, 9).resolvedProject).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes a silent cross-board read in the project-board scripts. A numeric item id plus a project's byte prefix does not uniquely identify a board item, so `fetch-issues.mjs 9 <id>` for an id whose item lives on board 10 returned that board-10 item's fields as if it were on board 9. `fetchItems` now verifies the resolved node's own project and reports a mismatch as not-found, pointing at the board the id actually belongs to.

## Changes

- .claude/scripts/lib/projectItems.mjs: `fetchItems` selects `project { number }` on each resolved node; the per-node mapping is extracted into an exported `mapFetchedNode(node, id, projectNumber)` that returns `missing` when the resolved node's project does not match the requested one, carrying `resolvedProject` for diagnostics.
- .claude/scripts/fetch-issues.mjs: the not-found line appends a hint ("this id resolves to an item on project N; try that board") when `resolvedProject` is set.
- .claude/scripts/lib/projectItems.test.mjs: three `mapFetchedNode` cases -- a matching project resolves normally, a differing project is missing with `resolvedProject`, an absent/contentless node is missing without one.

## Test plan

Ran: `npx vitest run --config .claude/scripts/vitest.config.mjs` (24 pass, 3 new), `npm run lint`, `npm run format`. Verified end to end against the live board: `fetch-issues.mjs 9 <a-board-10-id>` now prints "(not found on project 9 (this id resolves to an item on project 10; try that board))" instead of the board-10 item's data.

## Background

Surfaced while investigating why a Console engine epic item appeared absent from board 9's listing. The item lived on board 10, but `fetch-issues.mjs 9 <its-id>` returned it with full fields, which read as an orphaned/corrupted board-9 item until the write path (correctly project-scoped) failed with "item does not exist in the project." The listing scripts (`fetchAllItems`) were never affected -- they page one project's own connection and cannot cross boards; only the numeric-id read path could. The existing `numericIdFromNodeId` project guard covers a node-id STRING passed in with an expected project; this covers the other direction, where the id is constructed from a numeric id and the requested project and the resolved node must be checked.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: the board scripts are agent/developer tooling under `.claude/scripts/`, documented by their own header comments and `CLAUDE.md`'s GitHub-project-items section, which describe behavior this change does not alter (it makes a wrong read fail cleanly).
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: internal developer/agent tooling, not part of the shipped product an operator or deployer runs.
- [x] Security review -- n/a: no product runtime, protocol, credential, auth, or disclosure surface; a correctness guard in a local board-listing script.
