### PR TITLE
Repoint dead component references in comments

### DIFF
--- a/apps/web/src/bench/AcceptorBench.tsx
+++ b/apps/web/src/bench/AcceptorBench.tsx
@@ -125,8 +125,7 @@ function fileSizeLabel(sizeBytes: number): string {
  * re-derived: {@link InvitationTerms} renders the full, never-condensed terms at
  * the review step, and {@link acceptorConsentName} (the shared `commitAcceptance`
  * gate) governs the consent step's submit BOTH as its disabled state and as a
- * re-check inside the handler, exactly as the legacy AcceptInvitationPanel and
- * AcceptInvitation.handleAcquired do.
+ * re-check inside the handler, exactly as the legacy accept flow did.
  */
 export function AcceptorBench() {
   const [decode, setDecode] = useState<DecodeState>({ status: "pending" });
@@ -327,7 +326,7 @@ export function AcceptorBench() {
     token !== undefined ? acceptorLegalAgreementDisplay(token) : undefined;
 
   // The effective { metadata, standardization } the verdict and launch both consume,
-  // derived from the columns-step state exactly as PrepareData derives it (see
+  // derived from the columns-step state in one place (see
   // acceptorColumnsEditorState). Undefined until a file is acquired.
   const editorState =
     columnsState !== undefined &&
@@ -499,10 +498,10 @@ export function AcceptorBench() {
     name: acceptorName,
   });
 
-  // The columns-step edit callbacks over the shared layered state, ported from
-  // PrepareData: a metadata edit replaces the metadata layer; a remap re-roles the
-  // chosen column for matching (setColumnTypeForMatching, forcing role linkage, not a
-  // bare retype); a cleaning edit sets an override layer; reset returns to the seed.
+  // The columns-step edit callbacks over the shared layered state: a metadata edit
+  // replaces the metadata layer; a remap re-roles the chosen column for matching
+  // (setColumnTypeForMatching, forcing role linkage, not a bare retype); a cleaning
+  // edit sets an override layer; reset returns to the seed.
   const changeMetadata = (next: Metadata) =>
     setColumnsState((prev) =>
       prev === undefined ? prev : { ...prev, metadata: next },

--- a/apps/web/src/bench/AcceptorColumnsStep.tsx
+++ b/apps/web/src/bench/AcceptorColumnsStep.tsx
@@ -42,7 +42,7 @@ import type {
 
 /**
  * The acceptor's "Confirm your columns" work surface (step 3 of 3): a port of the
- * hardened legacy {@link PrepareData} editor's primary column, reseated in the bench
+ * hardened legacy column editor's primary column, reseated in the bench
  * furniture. Presentational over the shared column-step state the bench owns -- the
  * verdict, mapper, and gate view-models come in derived from
  * {@link acceptorColumnsModel}, and edits go up through the callbacks; the pure logic

--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -346,7 +346,7 @@ export function InviterBench() {
         // Internal and non-user-actionable: a fixed message avoids echoing
         // internals into a secret-bearing flow, the default log carries only
         // the error type, and the detail reaches the console only under
-        // diagnostic mode -- the InvitePanel rule, applied literally.
+        // diagnostic mode -- the legacy invite surface's rule, applied literally.
         console.error(
           "invitation creation failed:",
           error instanceof Error ? error.name : typeof error,

--- a/apps/web/src/bench/acceptorColumnsModel.ts
+++ b/apps/web/src/bench/acceptorColumnsModel.ts
@@ -32,9 +32,9 @@ import type { FieldValueCoverage } from "@psi/nonEmptyAggregate";
 
 /**
  * The pure, React-free model behind the acceptor bench's "Confirm your columns"
- * step -- a port of the hardened legacy {@link PrepareData} editor's derivations
- * (apps/web/src/components/PrepareData.tsx), moved out of the component so the
- * verdict, mapper, cleaning-attention, launch-payload, and gate logic are the one
+ * step -- a port of the hardened legacy column editor's derivations, moved out
+ * of the component so the verdict, mapper, cleaning-attention, launch-payload,
+ * and gate logic are the one
  * tested boundary and React stays thin. No I/O and no state; every consent/verdict
  * semantic re-surfaces the existing logic layer ({@link assessLinkageSatisfiability},
  * {@link normalizeForEditor}/{@link inferMetadata}, {@link defaultStandardizationForRows},
@@ -44,7 +44,7 @@ import type { FieldValueCoverage } from "@psi/nonEmptyAggregate";
  * The verdict and the launch payload derive from the SAME `{ metadata, standardization }`
  * pair ({@link acceptorColumnsEditorState} produces it once; {@link acceptorVerdict}
  * and {@link acceptorLaunchPayload} both read it), so the gate the operator sees and
- * the exchange that runs cannot disagree -- the invariant PrepareData holds.
+ * the exchange that runs cannot disagree -- the invariant the legacy editor held.
  *
  * The acceptor cannot edit fields or keys: they are adopted verbatim from the
  * invitation's `linkageTerms`. Satisfiability is assessed against those exact terms.
@@ -64,9 +64,10 @@ export interface AcceptorAcquiredCsv {
 }
 
 /**
- * The acceptor's column-step working state, layered exactly as PrepareData holds
- * it: the seed metadata, plus two override LAYERS (input-column rebinds and authored
- * step edits) over the standardization derived from the current metadata. Held as
+ * The acceptor's column-step working state, layered exactly as the legacy editor
+ * held it: the seed metadata, plus two override LAYERS (input-column rebinds and
+ * authored step edits) over the standardization derived from the current
+ * metadata. Held as
  * layers rather than a whole standardization so the binding is always re-derived and
  * the verdict stays honest; an empty override map means the effective standardization
  * equals the derived default byte for byte.
@@ -99,7 +100,7 @@ export function acceptorInitialColumnsState(
 
 /**
  * The effective `{ metadata, standardization }` the verdict and the launch consume,
- * derived from {@link AcceptorColumnsState} exactly as PrepareData derives it:
+ * derived from {@link AcceptorColumnsState} in a fixed order:
  *
  * 1. The base standardization is the recommended per-type cleaning for the current
  *    metadata, with the date-of-birth input format inferred from the operator's own
@@ -254,7 +255,7 @@ export function acceptorUnsatisfiedTypes(
 }
 
 /**
- * The launch gate's `disabled` predicate, identical to PrepareData's expression:
+ * The launch gate's `disabled` predicate, ported from the legacy editor:
  * disabled when no key can match (`satisfiableKeyCount === 0`), OR the metadata
  * carries more than one identifier column, OR any authored cleaning step is
  * invalid/mid-edit. Partial coverage does NOT gate -- it threads a warning instead.
@@ -332,8 +333,8 @@ export function acceptorHasIdentifierConflict(metadata: Metadata): boolean {
  * gate a mid-edit step already trips).
  *
  * `rates` is the host's full-CSV coverage (null before the first sweep settles); a
- * pending sweep contributes no silent-empty count, matching PrepareData, which reads
- * a resolved map.
+ * pending sweep contributes no silent-empty count -- attention is computed only
+ * from a resolved map.
  */
 export interface AcceptorCleaningAttention {
   /** Whether the tab needs attention (any failing reason present). */

--- a/apps/web/src/components/ColumnChips.tsx
+++ b/apps/web/src/components/ColumnChips.tsx
@@ -2,13 +2,11 @@ import { Badge, Group } from "@mantine/core";
 
 /**
  * A non-interactive list of column-name chips: the shared visual for the
- * "these columns" surfaces -- the home page's default exchange columns
- * ({@link DefaultExchangeColumns}) and the invitation preview's sent-columns
- * disclosure ({@link InvitationTerms}). Presentational only: the caller passes
- * names that are already safe to display (the home page sanitizes its
- * operator-entered headers; the invitation summary pre-sanitizes any
- * partner-controlled name) and supplies the accessible group label and the
- * surrounding copy.
+ * "these columns" surfaces in the terms panel ({@link InvitationTerms}: the
+ * sent-columns disclosure and the inviter's own send). Presentational only: the
+ * caller passes names that are already safe to display (the invitation summary
+ * pre-sanitizes any partner-controlled name) and supplies the accessible group
+ * label and the surrounding copy.
  *
  * Chips, not controls: no onClick and no remove affordance, marked up as a list
  * so assistive tech reads it as a list of names. Keyed by index -- a sanitized

--- a/apps/web/src/components/FieldCoverage.tsx
+++ b/apps/web/src/components/FieldCoverage.tsx
@@ -35,8 +35,9 @@ function formatRate(coverage: FieldValueCoverage): string {
  * preview -- so an all-empty field is not mislabelled as zero coverage.
  *
  * The alarm is `role="presentation"`: the assistive-tech announcement is made once,
- * for the whole editor, by {@link PrepareData}'s coverage live region (so N field
- * cards do not each fire their own region). An `unavailable` rate (steps left
+ * for the whole editor, by the host editor's coverage live region ({@link CleaningTab}
+ * and {@link AcceptorCleaningStep} each own one), so N field cards do not each fire
+ * their own region. An `unavailable` rate (steps left
  * mid-edit) renders nothing -- the offending step already carries its own inline error.
  */
 export function FieldCoverage({

--- a/apps/web/src/components/csvIntake.ts
+++ b/apps/web/src/components/csvIntake.ts
@@ -1,6 +1,5 @@
 /**
- * Maximum size, in bytes, of a file the intake dropzone ({@link FileSelect})
- * accepts -- 100 MB.
+ * Maximum size, in bytes, of a file the bench intake dropzones accept -- 100 MB.
  *
  * This is a browser-memory bound, not a parser bound. Core's `loadCSVFile` now
  * accumulates across PapaParse chunks (it no longer truncates a file that spans
@@ -17,8 +16,7 @@
  * No-silent-truncation is the invariant that actually matters here, and it is
  * pinned directly by a multi-chunk correctness test
  * (`test/browser/loadCSVFile.test.ts`), not by holding the cap below the chunk
- * size. The dropzone-wiring guard (`test/browser/fileSelect.test.ts`) separately
- * checks that {@link FileSelect} passes this constant through as `maxSize` rather
+ * size. Each intake dropzone passes this constant through as `maxSize` rather
  * than a stale literal.
  */
 export const MAX_CSV_FILE_BYTES = 100 * 1024 ** 2;

--- a/apps/web/src/psi/advancedInvite.ts
+++ b/apps/web/src/psi/advancedInvite.ts
@@ -990,7 +990,8 @@ export function validateAdvancedInvite(
   }
 
   // Every authored cleaning step must be well-formed before Generate -- the same
-  // launch gate the acceptor applies (PrepareData's standardizationValid). A step left
+  // launch gate the acceptor applies (acceptorLaunchDisabled's step-validity
+  // clause). A step left
   // mid-edit (a cleared substring.start) or a malformed/over-length raw pattern would
   // otherwise reach the exchange, where core runs it as a silent full-field exclusion
   // or throws at compile. Now that raw patterns are ungated for per-party cleaning,

--- a/apps/web/src/psi/authenticateExchange.ts
+++ b/apps/web/src/psi/authenticateExchange.ts
@@ -35,9 +35,9 @@ const NON_TRUST_KINDS: ReadonlySet<ConnectionErrorKind> = new Set([
  * exploitably).
  *
  * The web handshake role is the exchange role the web already assigns
- * (`"responder"` for the inviter, `"initiator"` for the acceptor): a
- * {@link PeerMessageConnection} has no separate negotiation step, so the same
- * role drives both the handshake and the subsequent PSI exchange.
+ * (`"responder"` for the inviter, `"initiator"` for the acceptor): the channel
+ * {@link openPeerMessageConnection} opens has no separate negotiation step, so
+ * the same role drives both the handshake and the subsequent PSI exchange.
  *
  * `requestEncryption` is `false`: a WebRTC data channel is end-to-end
  * confidential under DTLS against the peer-coordination server and any TURN

--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -214,8 +214,8 @@ export const mantineTheme: MantineThemeOverride = createTheme({
  *
  * Both are global tokens, so overriding them via {@link cssVariablesResolver}
  * raises every `c="dimmed"` site (and any code reading
- * `var(--mantine-color-dimmed)` directly, e.g. the dropzone icon in FileSelect)
- * and every input placeholder at once, rather than editing each call site.
+ * `var(--mantine-color-dimmed)` directly) and every input placeholder at once,
+ * rather than editing each call site.
  *
  * The palette has no in-scale step that both clears the floor and stays clearly
  * lower-emphasis than the body text (gray-6 fails; gray-7 (#495057) overshoots
@@ -242,8 +242,8 @@ const MUTED_TEXT = {
  * "success" Mantine `light` variant surfaces in the light scheme -- the Alert
  * title and icon, the yellow constraint-warning Badge label (the
  * StandardizationPreview violation badge), and the green satisfiability surfaces
- * (the "All keys can match" Alert in PrepareData; the satisfiable key Badges in
- * ExpertKeyEditor / LinkageTermsEditor). Mantine's default
+ * (the all-keys-covered verdict Alert in AcceptorColumnsStep; the satisfiable
+ * key Badges in ExpertKeyEditor). Mantine's default
  * `--mantine-color-{c}-light-color` is the color's shade 9 on its shade-1 tint,
  * which fails WCAG 2.1 AA 1.4.3 for normal-weight text:
  * - yellow-9 (#e67700) on yellow-1 (#fff3bf) = 2.69:1 -- and no yellow/orange

--- a/apps/web/test/browser/invitationTerms.test.ts
+++ b/apps/web/test/browser/invitationTerms.test.ts
@@ -427,13 +427,12 @@ describe("InvitationTerms: per-key matching disclosures", () => {
 });
 
 describe("InvitationTerms: the condensed reference view folds the lower tiers", () => {
-  // The post-consent / authored REFERENCE surfaces (both run screens, prepare-your-
-  // data, the inviter's live preview) render the summary condensed: the disclose/
-  // produce facts stay always-visible; the lower reference tiers (what you receive,
-  // how records are matched, the legal agreement, and "Other details") fold behind one
-  // "See the full terms" disclosure. The acceptor's PRE-CONSENT review screen never
-  // passes condensed -- guarded directly in acceptInvitationTerms.test.ts, and here by
-  // every other test rendering without it.
+  // Surfaces that show the terms as post-consent / authored REFERENCE render the
+  // summary condensed: the disclose/produce facts stay always-visible; the lower
+  // reference tiers (what you receive, how records are matched, the legal agreement,
+  // and "Other details") fold behind one "See the full terms" disclosure. The
+  // acceptor's PRE-CONSENT review screen never passes condensed -- guarded directly
+  // in benchAccept.test.ts, and here by every other test rendering without it.
   const FOLD = "See the full terms";
   function renderCondensed(overrides?: Partial<LinkageTerms>) {
     renderTerms(

--- a/apps/web/test/unit/metadataEditing.test.ts
+++ b/apps/web/test/unit/metadataEditing.test.ts
@@ -122,8 +122,8 @@ describe("quickInviteDisclosedColumns mirrors the quick path's wire", () => {
   });
 
   test("is empty when the quick path would send nothing", () => {
-    // Every column is a linkage type, so none is disclosed -- the condition under
-    // which InvitePanel shows no statement.
+    // Every column is a linkage type, so none is disclosed -- the empty list is
+    // the caller's cue to show no disclosed-columns statement.
     expect(quickInviteDisclosedColumns(["first_name", "ssn"])).toEqual([]);
   });
 

--- a/packages/core/test/invitation.test.ts
+++ b/packages/core/test/invitation.test.ts
@@ -412,7 +412,7 @@ test("rejects invalid base64url characters in the body", async () => {
 // messages can quote partner-controlled input bytes. That thrown .message is
 // relayed verbatim by describeDecodeError for a non-Zod Error. Its load-bearing
 // consumer is the web accept page's operator-facing alert (apps/web
-// AcceptInvitation), which renders describeDecodeError's output in a React text
+// AcceptorBench), which renders describeDecodeError's output in a React text
 // node with no further sanitize pass: React neutralizes HTML markup but NOT the
 // deceptive-Unicode / terminal-control / bidi-override / zero-width bytes below.
 // (The CLI accept path renders the same decode error to a terminal but escapes


### PR DESCRIPTION
## Summary

Removes dangling `{@link}` tags and prose references to components the bench redesign deleted. These pointed at symbols that no longer exist (`PrepareData`, `InvitePanel`, `FileSelect`, `DefaultExchangeColumns`, `PeerMessageConnection`, `AcceptInvitationPanel`), so a reader following them found nothing. Each is repointed to the current component or reworded to drop the dead link while preserving the technical point. Comment-only; no code or identifier changed.

Follow-on to #444 and #445 (the same stale-vocabulary cleanup); found by sweeping every `{@link}` target in the repo, not just the seed list.

## Changes

- apps/web/src/theme.ts, bench/AcceptorBench.tsx, bench/AcceptorColumnsStep.tsx, bench/acceptorColumnsModel.ts, bench/InviterBench.tsx, components/FieldCoverage.tsx, psi/advancedInvite.ts: references to the deleted `PrepareData` / `InvitePanel` / `AcceptInvitationPanel` are repointed to their successors (`AcceptorColumnsStep`, `AcceptorCleaningStep`, `CleaningTab`, `InviterBench`, `AcceptorBench`) or reworded to "the legacy editor"/"the legacy accept flow" where there is no single successor. Each repoint was verified against the current symbol (e.g. the coverage live regions at CleaningTab.tsx:109 and AcceptorCleaningStep.tsx:162).
- apps/web/src/components/ColumnChips.tsx, components/csvIntake.ts, psi/authenticateExchange.ts: dangling `{@link DefaultExchangeColumns}` / `{@link FileSelect}` / `{@link PeerMessageConnection}` and a citation of a nonexistent test file, repointed to the real render sites / the `openPeerMessageConnection` export / the current intake dropzones.
- apps/web/test/unit/metadataEditing.test.ts, apps/web/test/browser/invitationTerms.test.ts, packages/core/test/invitation.test.ts: describe/comment references to deleted surfaces repointed to the current ones.

Every new `{@link}` target was confirmed to resolve to a real symbol; a repo sweep finds zero remaining references to the dead names outside `dist/`.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format`, `npm run test` (root, all workspaces green). Comment-only, so no behavior to add tests for; each repoint was verified against the current component's definition.

## Out of scope / follow-on (flagged for an owner decision, not touched here)

- `InvitationTerms`'s `condensed` prop and `CondensableDetails` have no PRODUCTION caller (AcceptorBench renders only the never-condensed review terms), but `test/browser/invitationTerms.test.ts` actively exercises `condensed: true`. Removing it would mean deleting those test suites -- a deliberate decision (is the condensed reference view planned for the inviter run/preview screens, or should the prop, component, and its tests be removed together?).
- `loadCSVColumns` (packages/core/src/file.ts) has zero callers anywhere but its `main.ts` re-export. It is a `@psilink/core` export not marked `private`, so removing it is a public-API decision.
- `quickInviteDisclosedColumns` (apps/web/src/psi/metadataEditing.ts) is referenced only by its own unit tests -- the same class as above.
- Board-item ids appear in comments at packages/core/test/invitation.test.ts and apps/web/src/psi/authenticateExchange.ts, against the "board ids stay out of code" convention -- a separate small cleanup.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: this PR changes only in-source JSDoc/comments that cross-reference code symbols; no `docs/` page references these components.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: comment-only change, not visible to an operator/deployer or security reviewer.
- [x] Security review -- n/a: no runtime, protocol, credential, auth, or disclosure change; comment prose only, no identifier renamed.
