### PR TITLE
Fix two flaky console job-API tests

### DIFF
--- a/apps/web/test/browser/benchConsoleSftp.test.ts
+++ b/apps/web/test/browser/benchConsoleSftp.test.ts
@@ -262,6 +262,16 @@ describe("console inviter bench, sftp channel", () => {
     expect(intent.port).toBeUndefined();
     expect(intent.path).toBeUndefined();
 
+    // The driver opens the SSE stream in a separate fetch after the POST
+    // resolves; wait for that request before emitting, or the event enqueues
+    // into a stream the driver has not yet subscribed to and is dropped.
+    await vi.waitFor(() =>
+      expect(
+        api.captured.some(
+          (request) => request.url === "/api/jobs/job-7/events",
+        ),
+      ).toBe(true),
+    );
     // A relay warning (the host-key divergence notice the security review
     // requires the operator to see) surfaces in the run UI without ending
     // the run.

--- a/apps/web/test/utils/stubCli.mjs
+++ b/apps/web/test/utils/stubCli.mjs
@@ -35,15 +35,11 @@ function writeFd3(line) {
   }
 }
 
-if (process.env.STUB_FD3_RAW !== undefined) writeFd3(process.env.STUB_FD3_RAW);
-const events = JSON.parse(process.env.STUB_FD3_EVENTS ?? "[]");
-for (const event of events) writeFd3(JSON.stringify(event) + "\n");
-
-if (process.env.STUB_STDERR !== undefined)
-  process.stderr.write(process.env.STUB_STDERR);
-if (process.env.STUB_STDOUT !== undefined)
-  process.stdout.write(process.env.STUB_STDOUT);
-
+// Write the result artifacts BEFORE the fd-3 events, so a terminal `result`
+// event implies the output/record/keys files are already on disk. This mirrors
+// the real CLI (whose result event means the result has been written) and lets a
+// test that waits for the terminal event read the files without racing the
+// child's write.
 if (process.env.STUB_OUTPUT_FILE !== undefined) {
   const outputPath = process.argv[process.argv.length - 1];
   fs.writeFileSync(outputPath, process.env.STUB_OUTPUT_FILE);
@@ -60,6 +56,15 @@ if (process.env.STUB_RECORD_JSON !== undefined) {
     fs.writeFileSync(keysPath, JSON.stringify({ salts: {} }));
   }
 }
+
+if (process.env.STUB_FD3_RAW !== undefined) writeFd3(process.env.STUB_FD3_RAW);
+const events = JSON.parse(process.env.STUB_FD3_EVENTS ?? "[]");
+for (const event of events) writeFd3(JSON.stringify(event) + "\n");
+
+if (process.env.STUB_STDERR !== undefined)
+  process.stderr.write(process.env.STUB_STDERR);
+if (process.env.STUB_STDOUT !== undefined)
+  process.stdout.write(process.env.STUB_STDOUT);
 
 const exitCode = Number.parseInt(process.env.STUB_EXIT_CODE ?? "0", 10);
 const delayMs = Number.parseInt(process.env.STUB_DELAY_MS ?? "0", 10);


### PR DESCRIPTION
## Summary

The `Build and Test for Elastic Beanstalk` job began failing on the post-merge push to staging starting at #452, blocking the deploy, while passing on every PR run. It was two flaky console job-API tests, not a product defect: the same job passed on the PR runs and failed on the push runs, and #452 and #453 failed at different tests -- the signature of races that only lose under the deploy runner's load. This fixes both at their root. No production code changes.

## Changes

- `apps/web/test/utils/stubCli.mjs`: the test stub emitted its fd-3 `result` event before writing the output/record/keys files, so a test that waits for the terminal event (`waitForTerminal`) could read a file the child had not written yet (`existsSync` false). The real CLI writes the result and then emits `result: {resultWritten: true}`; the stub now writes the artifacts before the events, so a terminal event implies the files are on disk. This is the `jobManager.unit.test.ts` "a result file is written" failure on #452's deploy, and it hardens every "file exists after terminal" assertion.
- `apps/web/test/browser/benchConsoleSftp.test.ts`: the test injected a relay `warning` after waiting only for the `POST /api/jobs`, but the driver opens the SSE stream in a separate fetch after the POST resolves. The mock's `emitEvent` enqueues into that stream's controller, so an emit before the driver subscribed was dropped and the warning alert never rendered (the `expect.element` timed out -- #453's deploy failure). The test now waits for the `/events` request before emitting.

## Test plan

Ran, all green and stable across repeats: `jobManager.unit.test.ts` x3, the `benchConsoleSftp` browser test x3, the full web unit project (`npx vitest run --project unit`, 1026 passed), and the full `npm run test:integration:browser -w apps/web` suite that the deploy runs (28 files, 313 passed). Root `npm run typecheck && npm run lint && npm run format` clean.

## Background

The stub's emit-before-write ordering has been latent since the Order-2 server-job-API stub; the console-engine merges grew the suite enough to push the pre-existing race over the flake threshold on the loaded deploy runner. The browser test's emit-before-subscribe was introduced with the SFTP console browser test in #452. Both are test-infrastructure fixes; the shipped code is correct. (A separate in-review PR adds `vi.restoreAllMocks()` to the jobManager test's `afterEach` as mock hygiene, which does not address either race -- these fixes are needed independently.)

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: test-only change, no documented behavior or interface changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: a test/CI fix, which the changelog scope excludes (no operator- or reviewer-visible change).
- [x] Security review -- n/a: test-only, no production, cryptographic, credential, or protocol code touched.
