### PR TITLE
Drop credentials from the SFTP host-key probe

### DIFF
--- a/packages/core/src/connection/fileSyncConnection.ts
+++ b/packages/core/src/connection/fileSyncConnection.ts
@@ -1145,7 +1145,9 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
       this.path = inboundDir;
       this.outbound = split ? outboundDir : undefined;
 
-      const connectOptions = this.buildSftpConnectOptions(config);
+      const connectOptions = this.buildSftpConnectOptions(config, {
+        includeCredentials: true,
+      });
 
       // Host-key verification, installed AFTER providerOptions (which the
       // allowlist already strips of hostVerifier/hostHash) so a providerOptions
@@ -1421,10 +1423,20 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
    * are assigned AFTER and always win, so a providerOptions entry can never
    * override them even if the allowlist were loosened. Shared by {@link open}
    * and {@link probeHostKeyFingerprint} so the probe negotiates with the exact
-   * same options (and therefore the same host-key type) the real connect uses.
+   * same options (and therefore the same host-key type) the real connect uses;
+   * only credentials differ, gated by `includeCredentials`.
+   *
+   * `includeCredentials` is false for the host-key probe, which refuses before
+   * authenticating and so needs no credential. Omitting them is not merely tidy:
+   * the probe runs before `@path` credential refs are resolved, so an included
+   * `privateKey`/`password` could still be an unresolved "@/path" string, and
+   * ssh2 parses `privateKey` eagerly at connect time -- it would abort the probe
+   * with "Unsupported key format" before ever reading the host key. Credentials
+   * never affect host-key negotiation, so the probe still sees the same key.
    */
   private buildSftpConnectOptions(
     config: SFTPConnectionConfig,
+    { includeCredentials }: { includeCredentials: boolean },
   ): Record<string, unknown> {
     const connectOptions: Record<string, unknown> = {};
     this.applyProviderOptions(connectOptions, config.providerOptions);
@@ -1436,26 +1448,28 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
       connectOptions["port"] = config.server.port;
     if (config.server.username !== undefined)
       connectOptions["username"] = config.server.username;
-    if (config.server.password !== undefined)
-      connectOptions["password"] = config.server.password;
-    if (config.server.privateKey !== undefined)
-      connectOptions["privateKey"] = config.server.privateKey;
-    if (config.server.privateKeyPassphrase !== undefined)
-      connectOptions["passphrase"] = config.server.privateKeyPassphrase;
-    // Offer the keyboard-interactive auth method alongside `password` for a
-    // server that disables the direct `password` method but accepts the same
-    // password over keyboard-interactive (ssh2 tries password first, then
-    // keyboard-interactive, exactly as a GUI SFTP client does). The transport
-    // adapter reads this flag to install a handler that answers the server's
-    // prompts with `password`; gated on a password being present so the handler
-    // always has a value to answer with (the schema also refines this). Nothing
-    // is installed unless the operator opted in, so default behavior is
-    // unchanged. See SSH2SFTPClientAdapter.connect and docs/EXCHANGE_REFERENCE.md.
-    if (
-      config.server.keyboardInteractive === true &&
-      config.server.password !== undefined
-    )
-      connectOptions["tryKeyboard"] = true;
+    if (includeCredentials) {
+      if (config.server.password !== undefined)
+        connectOptions["password"] = config.server.password;
+      if (config.server.privateKey !== undefined)
+        connectOptions["privateKey"] = config.server.privateKey;
+      if (config.server.privateKeyPassphrase !== undefined)
+        connectOptions["passphrase"] = config.server.privateKeyPassphrase;
+      // Offer the keyboard-interactive auth method alongside `password` for a
+      // server that disables the direct `password` method but accepts the same
+      // password over keyboard-interactive (ssh2 tries password first, then
+      // keyboard-interactive, exactly as a GUI SFTP client does). The transport
+      // adapter reads this flag to install a handler that answers the server's
+      // prompts with `password`; gated on a password being present so the handler
+      // always has a value to answer with (the schema also refines this). Nothing
+      // is installed unless the operator opted in, so default behavior is
+      // unchanged. See SSH2SFTPClientAdapter.connect and docs/EXCHANGE_REFERENCE.md.
+      if (
+        config.server.keyboardInteractive === true &&
+        config.server.password !== undefined
+      )
+        connectOptions["tryKeyboard"] = true;
+    }
     // serverConnectTimeoutMs for SFTP is enforced by ssh2 via readyTimeout, not a
     // Promise.race wrapper -- the per-attempt deadline is equivalent. Always set:
     // the schema defaults the field to DEFAULT_SERVER_CONNECT_TIMEOUT_MS, and the
@@ -1490,7 +1504,9 @@ export class FileSyncConnection extends EventEmitter<Events, never> {
   async probeHostKeyFingerprint(
     config: SFTPConnectionConfig,
   ): Promise<PresentedHostKey> {
-    const connectOptions = this.buildSftpConnectOptions(config);
+    const connectOptions = this.buildSftpConnectOptions(config, {
+      includeCredentials: false,
+    });
     let captured: PresentedHostKey | undefined;
     let captureError: unknown;
     let connectError: unknown;

--- a/packages/core/test/fileSyncConnection.test.ts
+++ b/packages/core/test/fileSyncConnection.test.ts
@@ -1047,6 +1047,54 @@ test("probeHostKeyFingerprint returns the presented key without authenticating",
   expect(conn.connected).toBe(false);
 });
 
+test("probeHostKeyFingerprint sends no credential, so an unresolved @path never reaches ssh2", async () => {
+  // Regression: the probe refuses before authenticating and runs before @path
+  // credential refs are resolved, so it must pass NO credential to ssh2. A
+  // literal "@/secrets/id_rsa" left in privateKey would otherwise hit ssh2's
+  // eager privateKey parse at connect time and abort with "Unsupported key
+  // format" -- surfacing as "could not read the server's host key" -- before the
+  // host key is ever read.
+  const blob = ed25519Blob();
+  const { client } = makeMockClient();
+  let captured: Record<string, unknown> | undefined;
+  client.connect = (options: Record<string, unknown>) => {
+    captured = options;
+    const verifier = options["hostVerifier"] as (
+      b: Buffer,
+      verify: (permitted: boolean) => void,
+    ) => void;
+    return new Promise<void>((resolve, reject) => {
+      verifier(blob, (permitted: boolean) =>
+        permitted
+          ? resolve()
+          : reject(new Error("Host denied (verification failed)")),
+      );
+    });
+  };
+  const conn = new FileSyncConnection(client, { verbose: -1 });
+  const presented = await conn.probeHostKeyFingerprint({
+    channel: "sftp",
+    server: {
+      host: "sftp.example.org",
+      username: "roberts",
+      privateKey: "@/secrets/id_rsa",
+      privateKeyPassphrase: "@/secrets/pass",
+    },
+  });
+  // The host key is still read: dropping credentials leaves host-key negotiation
+  // unchanged.
+  expect(presented.keyType).toBe("ssh-ed25519");
+  // No credential -- the unresolved @path included -- reached ssh2.
+  expect(captured).toBeDefined();
+  expect(captured?.["privateKey"]).toBeUndefined();
+  expect(captured?.["passphrase"]).toBeUndefined();
+  expect(captured?.["password"]).toBeUndefined();
+  expect(captured?.["tryKeyboard"]).toBeUndefined();
+  // The non-secret fields the probe DOES need are still present.
+  expect(captured?.["host"]).toBe("sftp.example.org");
+  expect(captured?.["username"]).toBe("roberts");
+});
+
 test("probeHostKeyFingerprint throws when the host presents no key", async () => {
   // A connect that fails before presenting a key (here, a no-verifier resolve)
   // leaves nothing captured, so the probe throws rather than returning a bogus


### PR DESCRIPTION
## Summary

The trust-on-first-use SSH host-key probe handed its private key to ssh2 before `@path` credential references were resolved, so a key supplied as `@path` (the documented, recommended form) aborted the probe with "Unsupported key format" before the host key could be read -- breaking every first-use SFTP connection that uses an `@path` key. The probe refuses before authenticating, so it needs no credential; this stops it from carrying one, restoring the documented "verify the host key before sending any credential" behavior.

## Changes

- packages/core/src/connection/fileSyncConnection.ts: gate the credential fields (`password`, `privateKey`, `passphrase`, `tryKeyboard`) in `buildSftpConnectOptions` behind a required `includeCredentials` flag; `open()` passes `true`, `probeHostKeyFingerprint` passes `false`.
- packages/core/test/fileSyncConnection.test.ts: regression test asserting the probe sends no credential (an unresolved `@path` never reaches ssh2) while still reading the host key and forwarding the non-secret `host`/`username`.

## Test plan

Ran: `npx vitest run packages/core/test/fileSyncConnection.test.ts` (320 passed), `npm run test` across all workspaces (core, cli, web) green, and `npm run typecheck && npm run lint && npm run format` clean.
New tests cover: the probe omits `privateKey`/`passphrase`/`password`/`tryKeyboard` from the ssh2 connect options while still reading the host key; the credentialed `open()` path retains them (existing coverage in the same file).

## Background

The probe runs before `resolveConnectionCredentials`: `establishHostKeyTrust` executes on the original connection, and only the live-use clone is resolved afterward, so `server.privateKey` can still be a literal `@/path` at probe time. ssh2 parses `privateKey` eagerly at connect time, so it threw before the host key was read. Credentials never influence host-key algorithm negotiation (KEXINIT precedes userauth), so the probe still observes the same key the credentialed connect enforces -- no pin-vs-enforce gap.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; docs/CLI.md already states SFTP "verifies the server's SSH host key before sending any credential", which this fix restores conformance with.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: fixes unreleased code (the first-use host-key probe does not exist in v0.1.0), so no released operator- or reviewer-visible behavior changes.
- [x] Security review -- independent multi-role cold review (host-key trust / MITM, credential path, invariant durability) plus maintainer triage: net security improvement, no findings. The probe now presents no credential to a not-yet-trusted server.
