### PR TITLE
Remove leftover work-column width caps

### DIFF
--- a/apps/web/src/bench/bench.module.css
+++ b/apps/web/src/bench/bench.module.css
@@ -50,6 +50,15 @@
   max-width: 68ch;
 }
 
+/* Reading-measure cap is for standing prose (lobby copy, the how-it-works
+   blurb) only: lifted inside .work so work-column paragraphs -- guidance
+   next to a form surface that must track the surface's own width -- fill
+   the container instead. The descendant selector out-specifies .page p;
+   a bare .work p would tie and depend on source order. */
+.page .work p {
+  max-width: none;
+}
+
 /* Excludes a Mantine Button rendered as an anchor (component={Link}): a filled
    Button's label color is --button-color (routed to the per-scheme contrast
    color by the theme, see theme.ts FILLED_PRIMARY_CONTRAST), and this rule's
@@ -406,7 +415,6 @@
   background: var(--bench-field-bg);
   padding: 22px 24px;
   text-align: center;
-  max-width: 640px;
   cursor: pointer;
 }
 
@@ -427,7 +435,6 @@
   border: 1px solid var(--bench-rule);
   border-radius: 8px;
   padding: 12px 16px;
-  max-width: 640px;
   margin: 12px 0;
 }
 
@@ -453,7 +460,6 @@
   border-radius: 8px;
   padding: 12px 16px;
   margin: 1.1rem 0;
-  max-width: 640px;
 }
 
 .callout p {
@@ -469,7 +475,6 @@
   border-radius: 8px;
   padding: 12px 16px;
   margin: 1.4rem 0;
-  max-width: 640px;
 }
 
 .stateLabel {
@@ -483,7 +488,6 @@
 
 .tableScroll {
   overflow-x: auto;
-  max-width: 640px;
 }
 
 .benchTable {
@@ -530,7 +534,6 @@
   list-style: none;
   margin: 0.8rem 0;
   padding: 0;
-  max-width: 640px;
 }
 
 .guidedKeys li {
@@ -575,7 +578,6 @@
   border-radius: 8px;
   padding: 12px 16px;
   margin: 10px 0;
-  max-width: 640px;
 }
 
 .radioCardSelected {
@@ -623,7 +625,6 @@
   border: 0;
   padding: 0;
   margin: 1.2rem 0;
-  max-width: 640px;
 }
 
 .fieldset legend {
@@ -671,7 +672,6 @@
 
 .copyRow {
   margin: 1.1rem 0;
-  max-width: 640px;
 }
 
 .copyBox {
@@ -737,7 +737,6 @@
   border: 1px solid var(--bench-rule);
   border-radius: 8px;
   padding: 16px 20px;
-  max-width: 640px;
   margin: 1.2rem 0;
 }
 
@@ -849,7 +848,6 @@
   border-left: 6px solid var(--bench-accent);
   border-radius: 8px;
   padding: 20px 24px;
-  max-width: 640px;
   margin: 1.2rem 0;
 }
 
@@ -865,7 +863,6 @@
   gap: 14px;
   padding: 12px 0;
   border-bottom: 1px solid var(--bench-rule-soft);
-  max-width: 640px;
   flex-wrap: wrap;
 }
 


### PR DESCRIPTION
## Summary

Finishes what the previous slice's blanket-cap removal only started: twelve element-level 640px caps from the narrow-column era still stopped most work-column surfaces -- the dropzone included -- from growing with their container. All twelve are removed, and the global 68ch paragraph reading measure is scoped out of the work column with a selector that structurally out-specifies it rather than winning by source order. An independent audit agent enumerated every remaining width constraint and measured the major surfaces at runtime; page-level containers, lobby prose, and three intrinsically small widgets (a date input, a two-element picker, popover copy) are the only surviving bounds, each justified.

## Changes

- apps/web/src/bench/bench.module.css: max-width 640px removed from .dropzone, .fileCard, .callout, .stateInset, .tableScroll, .guidedKeys, .radioCard, .fieldset, .copyRow, .statusPanel, .donePanel, .dlRow; the .work paragraph-measure override becomes .page .work p (out-specifies .page p; a bare .work p ties at (0,1,1) and would depend on source order).

## Test plan

Ran: root `npm run typecheck` and `npm run lint`; apps/web unit suite (1049 passed); full Playwright browser suite (304 passed, including the 400px no-overflow assertion). Runtime measurement at 1280px and 1000px: no horizontal overflow; dropzone, answers table, radio cards, guided keys, and panels measured at the work column's full content width. Verified in screenshots across steps 1-3, the Customize tabs, and the acceptor columns step.
New tests cover: n/a -- CSS-only removal; the existing 400px no-overflow test guards the regression direction that matters.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed; no doc describes element widths
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: visual layout polish only, nothing an operator, deployer, or security reviewer acts on
- [x] Security review -- n/a: CSS widths only; no disclosure, credential, authentication, or bounds surface touched