### PR TITLE
Add many-to-one vector to PSI fixture

### DIFF
--- a/packages/core/test/psiIntersectionVectors.test.ts
+++ b/packages/core/test/psiIntersectionVectors.test.ts
@@ -154,6 +154,7 @@ test("the fixture covers every consolidated source", () => {
     "empty-key-all-empty-column-no-match",
     "empty-key-carried-forward-later-round",
     "empty-key-duplicate-dropped-unique-still-matches",
+    "many-to-one-duplicate-entity-cascade",
   ]);
 });
 

--- a/packages/core/test/vectors/generate-psi-intersection-vectors.mjs
+++ b/packages/core/test/vectors/generate-psi-intersection-vectors.mjs
@@ -441,6 +441,36 @@ const scenarios = [
     starterKeys: [["", "", "Alice"]],
     joinerKeys: [["", "Alice"]],
   },
+  {
+    name: "many-to-one-duplicate-entity-cascade",
+    description:
+      "linkViaPSI many-to-one: the joiner (the 'many' party) holds two intake " +
+      "rows for the same entity 'E1' (a re-registered record) alongside two " +
+      "singleton entities 'E2' and 'E3', against the starter's (the 'one' " +
+      "party) one row per entity. Round 0 drops both 'E1' joiner rows as a " +
+      "within-round duplicate on the joiner's own side and matches only the " +
+      "unique 'E2' and 'E3' rows; round 1's secondary key then resolves ONE of " +
+      "the two surviving 'E1' duplicates by tie-breaking against the starter's " +
+      "carried-forward value, leaving the other permanently unmatched despite " +
+      "genuinely sharing the entity. This pins today's behavior of the branch " +
+      "linkViaPSI shares between 'one-to-one' and 'many-to-one' " +
+      "(protocol.cardinality is read only to select this branch, never again " +
+      "inside it): given this dataset, 'many-to-one' and 'one-to-one' produce " +
+      "the byte-identical projection asserted here, because neither cardinality " +
+      "yet implements the fan-out consolidation ('deduplicate', " +
+      "EXCHANGE_REFERENCE.md) that would let both 'E1' rows validly link to the " +
+      "same starter row. The vector exists to fail the day that split lands.",
+    method: "linkViaPSI",
+    cardinality: "many-to-one",
+    starterKeys: [
+      ["E1", "E2", "E3"],
+      ["C2", "x", "y"],
+    ],
+    joinerKeys: [
+      ["E1", "E1", "E2", "E3"],
+      ["C1", "C2", "x", "y"],
+    ],
+  },
 ];
 
 async function project(scenario) {

--- a/packages/core/test/vectors/psi-intersection-vectors.json
+++ b/packages/core/test/vectors/psi-intersection-vectors.json
@@ -224,6 +224,28 @@
       "joinerKeys": [["", "Alice"]],
       "starter": [[2], [1]],
       "joiner": [[1], [2]]
+    },
+    {
+      "name": "many-to-one-duplicate-entity-cascade",
+      "description": "linkViaPSI many-to-one: the joiner (the 'many' party) holds two intake rows for the same entity 'E1' (a re-registered record) alongside two singleton entities 'E2' and 'E3', against the starter's (the 'one' party) one row per entity. Round 0 drops both 'E1' joiner rows as a within-round duplicate on the joiner's own side and matches only the unique 'E2' and 'E3' rows; round 1's secondary key then resolves ONE of the two surviving 'E1' duplicates by tie-breaking against the starter's carried-forward value, leaving the other permanently unmatched despite genuinely sharing the entity. This pins today's behavior of the branch linkViaPSI shares between 'one-to-one' and 'many-to-one' (protocol.cardinality is read only to select this branch, never again inside it): given this dataset, 'many-to-one' and 'one-to-one' produce the byte-identical projection asserted here, because neither cardinality yet implements the fan-out consolidation ('deduplicate', EXCHANGE_REFERENCE.md) that would let both 'E1' rows validly link to the same starter row. The vector exists to fail the day that split lands.",
+      "method": "linkViaPSI",
+      "cardinality": "many-to-one",
+      "starterKeys": [
+        ["E1", "E2", "E3"],
+        ["C2", "x", "y"]
+      ],
+      "joinerKeys": [
+        ["E1", "E1", "E2", "E3"],
+        ["C1", "C2", "x", "y"]
+      ],
+      "starter": [
+        [0, 1, 2],
+        [1, 2, 3]
+      ],
+      "joiner": [
+        [1, 2, 3],
+        [0, 1, 2]
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Close the PSI-engine fixture's cardinality coverage gap: every existing linkViaPSI vector runs one-to-one, so the engine's behavior for a many-to-one-shaped dataset was unanchored against a fork bump, engine swap, or a future split of the shared cardinality branch. Adds one generator scenario and its regenerated vector pinning both intersection membership and the association projection.

Implements [209241395](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=209241395).

## Changes

- packages/core/test/vectors/generate-psi-intersection-vectors.mjs: add the many-to-one-duplicate-entity-cascade scenario (joiner holds two rows for one entity plus two singletons; a second linkage key resolves one duplicate by tie-break).
- packages/core/test/vectors/psi-intersection-vectors.json: regenerated; purely additive (+22 lines), all 12 existing vectors byte-unchanged.
- packages/core/test/psiIntersectionVectors.test.ts: add the new vector's name to the fixture-coverage guard list.

## Test plan

Ran: `npx vitest run packages/core/test/psiIntersectionVectors.test.ts` (14 passed), `npm test -w packages/core` (65 files / 2153 tests passed), and root typecheck, lint, format.
New tests cover: the intersection and association projection linkViaPSI produces under cardinality many-to-one for a dataset with duplicated local linkage-key values, including the duplicate-drop and second-key tie-break behavior.

## Background

linkViaPSI reads protocol.cardinality once, to select the shared one-to-one/many-to-one branch, and never again inside it, so the two cardinalities currently produce byte-identical projections (verified empirically while authoring the vector). The vector therefore pins today's aliased duplicate-drop behavior on a genuinely many-to-one-shaped dataset; its description records this and the vector exists to fail the day the branch is split into distinct algorithms.

## Out of scope / follow-on

- Deriving the run cardinality from the parties' deduplicate terms -- [200737364](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=200737364), in progress separately.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: test-fixture-only diff; no doc describes the fixture's vector inventory (TESTING.md's vector mentions are the browser suite's cross-implementation vectors, untouched here)
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test-only change, nothing operator- or reviewer-visible
- [x] Security review -- n/a: no cryptographic code or inputs touched; adds a known-answer vector for an existing, already-covered engine path