### PR TITLE
Design schedule shape and run-window coordination

### DIFF
--- a/docs/MANAGED_EXCHANGE.md
+++ b/docs/MANAGED_EXCHANGE.md
@@ -210,18 +210,41 @@ and a two-sided absence are the same benign outcome from each present party's
 point of view. There is no "who retries" question to answer: neither party
 retries early, and both simply meet again at the next window.
 
-A single miss is unremarkable and needs no operator attention -- a laptop closed
-for the evening, a machine mid-reboot at the window. What matters is a
-**pattern** of misses, which means the partnership is no longer meeting: the
-partner has stopped running the exchange, the schedules have drifted apart, or a
-machine's clock is far enough off that its windows never overlap. That is a
-coordination problem, and it is resolved **out-of-band, where the schedule was
-agreed** -- not by the app guessing. The record counts consecutive misses since
-the last success (see
+That bookkeeping is **one-sided by construction, and deliberately so**:
+"whoever showed up records the miss" means the escalating surface below fires
+on the party that keeps showing up -- exactly the party positioned to reach out
+-- while a persistently absent party's runtime may never be awake to see
+anything. The asymmetry is accepted because reconciliation needs only one side
+to raise it, over the channel where the schedule was agreed. Nor is the absent
+side left permanently ignorant: a runtime that wakes to find windows fully
+elapsed counts each one as a miss and lands on the next live window (the
+catch-up rule; see
+[MANAGED_EXCHANGE_RECORD.md](spec/MANAGED_EXCHANGE_RECORD.md#catch-up-on-wake)),
+so its own repeated-miss surface fires at that wake -- it learns late, but it
+does learn.
+
+A single miss is unremarkable and demands no action -- a laptop closed for the
+evening, a machine mid-reboot at the window. What matters is a **pattern** of
+misses, which means the partnership is no longer meeting: the partner has
+stopped running the exchange, the schedules have drifted apart, or a machine's
+clock is far enough off that its windows never overlap. That is a coordination
+problem, and it is resolved **out-of-band, where the schedule was agreed** --
+not by the app guessing. The record counts consecutive misses since the last
+success (see
 [MANAGED_EXCHANGE_RECORD.md](spec/MANAGED_EXCHANGE_RECORD.md#the-schedule-object)),
-and past a small threshold the next visit's surface and the between-visit
-notification say plainly: "this exchange has missed its last N runs -- check
-with your partner."
+and at **two consecutive misses** the next visit's surface and the between-visit
+notification escalate to the coordination prompt, which names **both** checks:
+check with your partner, and check this machine's own clock -- a wrong local
+time source produces exactly this pattern, and a no-IT operator pointed only at
+the partner would never look at their own machine.
+
+The threshold is a window count, not a wall-clock age, so it is deliberately
+**cadence-relative**: two misses on a monthly partnership means roughly two
+months before the escalated state. That is accepted because each miss already
+fires its own moment-anchored notification at its window (see [The between-visit
+notification](#the-between-visit-notification)), so the operator is not in the
+dark in the interim -- the threshold gates only the escalated
+coordination-problem framing, not the operator's first knowledge of a miss.
 
 #### Repeated misses surface, they do not auto-pause
 
@@ -246,10 +269,10 @@ persona this feature serves the two failure modes are not symmetric:
 The honest cost of not pausing is that the miss surface must itself be
 trustworthy: if it read as noise the operator learned to ignore, endless quiet
 retries would mask a dead partnership just as a silent pause would. That is why
-the miss surface is **moment-anchored and escalating** -- silent for a single
-miss, an actionable state and a notification only once the pattern is real --
-rather than a standing warning the operator clicks through (the same discipline
-the backup surfaces follow; see [Moment-anchored backup
+the miss surface is **moment-anchored and escalating** -- one informational
+note per miss at its window, the actionable coordination state only once the
+pattern is real -- rather than a standing warning the operator clicks through
+(the same discipline the backup surfaces follow; see [Moment-anchored backup
 surfaces](#moment-anchored-backup-surfaces)).
 
 The operator retains an explicit, manual control either way: a recurring
@@ -271,7 +294,7 @@ It is a concept-level surface here, not a wire or storage design: it reads the
 same run bookkeeping the next-visit surfaces read and says the same things, just
 sooner.
 
-Three moments are worth a notification, and each maps to a state the design
+Four moments are worth a notification, and each maps to a state the design
 already defines:
 
 - **This ran, and your backup is now stale.** An unattended run rotates the
@@ -283,21 +306,36 @@ already defines:
   wires to the **existing** derived backup state and its transition; it does not
   introduce a second persistence-status track (see [Surviving storage
   eviction](#surviving-storage-eviction)).
-- **This needs you: repeated misses.** Once the consecutive-miss count crosses
-  the threshold above, the notification carries the coordination prompt so the
-  operator learns the partnership stopped meeting without having to open the app
-  to find out.
+- **This did not run: a missed window.** Each miss fires one quiet,
+  informational notification at its window -- the run the operator expected did
+  not happen, said honestly at its moment, with the next planned window named;
+  no action is demanded, because the retry is automatic. A runtime that wakes to
+  find windows already elapsed surfaces its accrued misses **once**, at the wake
+  (the catch-up rule; see
+  [MANAGED_EXCHANGE_RECORD.md](spec/MANAGED_EXCHANGE_RECORD.md#catch-up-on-wake)),
+  not one notification per slept-through window. Once the consecutive-miss count
+  crosses the escalation threshold, the copy becomes the coordination prompt --
+  check with your partner, and check this machine's own clock -- and further
+  misses stop firing individually while that state stands (the in-app state
+  carries it), so a dead partnership on a short cadence does not become a daily
+  nag.
+- **This needs you: the input file is missing or was rejected.** A benign
+  pre-run input failure on an unattended run -- the handle's file gone at run
+  start, or a refresh the column-shape guard rejects -- means no scheduled run
+  can succeed until the operator re-points the handle or drops a conforming
+  file, so it is actionable at its moment (see [The input file each
+  run](#the-input-file-each-run)).
 - **This needs you: a run failed with no benign explanation.** A handshake that
   ran and failed closed with no recorded benign cause (the Tier-2 case; see
   [Telling a desync from an attack](#telling-a-desync-from-an-attack)) is the
   one failure that needs the operator's out-of-band confirmation work, so it is
   worth surfacing between visits rather than waiting for the next visit.
 
-Every other outcome stays quiet: a single miss, a benign input miss, a
-successful run whose backup the operator will refresh at their next visit
-anyway. The notification follows the same moment-anchored discipline as the
-in-app surfaces -- it fires only when its condition is true and actionable, so
-it does not become the standing nag the whole surface design avoids.
+Everything else stays quiet, and nothing repeats: each notification fires once
+at its state's transition, and a condition already surfaced is carried by the
+in-app state rather than re-announced at every subsequent wake -- the same
+moment-anchored discipline as the in-app surfaces, so the notification never
+becomes the standing nag the whole surface design avoids.
 
 Because the notification is a concept over states the record already carries, a
 platform without OS notifications loses only the *sooner* prompt: every one of

--- a/docs/MANAGED_EXCHANGE.md
+++ b/docs/MANAGED_EXCHANGE.md
@@ -8,14 +8,16 @@ This document describes the **managed exchange** lifecycle for the hosted web
 application: how a two-party PPRL exchange, once set up, runs again on an agreed
 schedule from the browser -- unattended where the platform allows -- without
 re-authoring the terms or re-establishing a shared secret. It covers the
-automation goal and its platform envelope, the durability and crash-consistency
-contract for the rotating secret, the single-device ownership invariant and its
-rationale, how a party tells a rotation desync from an attack (and a missed run
-window from either) and recovers, how the design survives silent browser
-storage eviction, the moment-anchored backup surfaces that keep an operator
-honestly informed without training click-through, and the one-action deletion
-of an exchange's stored information. It opens with who the feature serves; the
-failure machinery follows.
+automation goal and its platform envelope, the agreed schedule and the run
+windows two runners meet in (with the retry policy for a missed one), the
+durability and crash-consistency contract for the rotating secret, the
+single-device ownership invariant and its rationale, how a party tells a
+rotation desync from an attack (and a missed run window from either) and
+recovers, how the design survives silent browser storage eviction, the
+moment-anchored backup surfaces and the between-visit OS notification that keep
+an operator honestly informed without training click-through, and the
+one-action deletion of an exchange's stored information. It opens with who the
+feature serves; the failure machinery follows.
 
 It is the operational and conceptual counterpart to two companion documents: the
 **managed exchange record** field-by-field shape in
@@ -127,11 +129,179 @@ attack](#a-missed-window-is-neither-desync-nor-attack)). The record persists
 the agreed schedule and the retry bookkeeping
 ([MANAGED_EXCHANGE_RECORD.md](spec/MANAGED_EXCHANGE_RECORD.md)).
 
-Scope: this document fixes the automation goal, the platform envelope, and what
-the record persists to support them; the detailed scheduling and
-window-coordination design (run windows, retry policy, notification surfaces)
-is later, separately-designed work and is neither foreclosed nor duplicated
-here.
+The run windows both runners meet in, the retry policy for a missed one, and
+the between-visit notification surface are designed under [The schedule and its
+run windows](#the-schedule-and-its-run-windows) below; the record's closed
+field layout for them is in
+[MANAGED_EXCHANGE_RECORD.md](spec/MANAGED_EXCHANGE_RECORD.md#the-schedule-object).
+
+## The schedule and its run windows
+
+An unattended run takes two runners awake at the same time, and neither runner
+can reach a server to be told when the other is ready. The schedule is what lets
+both arrive at the same moment without any live coordination: it is a recurrence
+and a window width both parties agree once, out-of-band, and then each runner
+executes locally against its own clock.
+
+### Where the schedule is agreed, and where it lives
+
+The schedule is **partnership-level agreement, coordinated out-of-band**,
+exactly as the linkage terms and the setup secret are (see
+[SECURITY_DESIGN.md](SECURITY_DESIGN.md#invitation-contents-and-confidentiality)).
+The two operators decide a cadence and a window together over their trusted
+channel, and each enters it locally when saving the exchange as recurring. It is
+**not** minted into the exchange-file document and **not** carried on the
+invitation wire: the document is the shared terms-and-locator config a terms
+change would force a re-invite to alter, and a reschedule is neither a terms
+change nor a credential, so the schedule is a local record field instead (the
+`schedule` object; see
+[MANAGED_EXCHANGE_RECORD.md](spec/MANAGED_EXCHANGE_RECORD.md#the-schedule-object)).
+Nothing about the schedule is ever sent to a server or to the partner over the
+wire; there is no server-side coordination anywhere in the design.
+
+The cost of local-only entry is that each side types the same values by hand, so
+a mistyped cadence or window on one side produces windows that never overlap.
+That failure is benign and self-announcing: it shows up as mutual missed windows
+(below), which the operators resolve out-of-band where they agreed the schedule
+in the first place -- the same channel, the same reconciliation as any other
+schedule drift.
+
+### When a window opens and closes
+
+The recurrence is an anchor instant plus a whole-day interval, and each window
+stays open for the agreed width. Both parties persist the same anchor and
+interval, so both compute the same window opens independently. The closed field
+layout is in
+[MANAGED_EXCHANGE_RECORD.md](spec/MANAGED_EXCHANGE_RECORD.md#the-schedule-object).
+
+For an unattended handshake to happen inside a window, both runners must be
+**awake and in the window at the same time**: each installed app runtime, kept
+running since OS login, wakes at its own computed window open, derives the
+rendezvous id from the current secret, and waits for the peer for the window's
+duration. If both are present and the handshake completes, the run proceeds
+through rotate-and-persist and the data exchange (see [The second
+run](#the-second-run-end-to-end)). If the window elapses with no completed
+handshake -- the peer never arrived, or arrived and left before this side did --
+the window is recorded as **missed** and the runner advances to the next planned
+window.
+
+The window width is deliberately generous -- hours, not minutes -- for two
+reasons. It absorbs clock skew between the two machines (the runners never
+exchange a clock reading, so a wide window is what guarantees overlap despite
+small clock differences; the honest bound is in
+[MANAGED_EXCHANGE_RECORD.md](spec/MANAGED_EXCHANGE_RECORD.md#clock-skew-and-the-window-width)),
+and it absorbs the ordinary slack of two independently-kept machines -- a laptop
+that woke late, an app launched a few minutes after login. A missed window is
+never desync and never an attack: nothing authenticated and nothing failed
+closed, because there was no peer to fail against (see [A missed window is
+neither desync nor attack](#a-missed-window-is-neither-desync-nor-attack)).
+
+### Retry and repeated misses
+
+The retry policy is **retry at the next agreed window**, and nothing sooner.
+A miss does not trigger an off-schedule retry, a backoff, or an immediate
+re-attempt: the next opportunity is simply the next window the recurrence
+defines, because a sooner retry would need the partner's runner to also be
+awake off-schedule, which the whole point of an agreed window is to avoid. When
+both parties miss (neither runner ran), both advance to the next window and try
+again there; when only one misses, the present party records a miss and also
+advances -- so **whoever showed up records the miss**, and a one-sided absence
+and a two-sided absence are the same benign outcome from each present party's
+point of view. There is no "who retries" question to answer: neither party
+retries early, and both simply meet again at the next window.
+
+A single miss is unremarkable and needs no operator attention -- a laptop closed
+for the evening, a machine mid-reboot at the window. What matters is a
+**pattern** of misses, which means the partnership is no longer meeting: the
+partner has stopped running the exchange, the schedules have drifted apart, or a
+machine's clock is far enough off that its windows never overlap. That is a
+coordination problem, and it is resolved **out-of-band, where the schedule was
+agreed** -- not by the app guessing. The record counts consecutive misses since
+the last success (see
+[MANAGED_EXCHANGE_RECORD.md](spec/MANAGED_EXCHANGE_RECORD.md#the-schedule-object)),
+and past a small threshold the next visit's surface and the between-visit
+notification say plainly: "this exchange has missed its last N runs -- check
+with your partner."
+
+#### Repeated misses surface, they do not auto-pause
+
+A design question this raises: after enough consecutive misses, should the app
+**automatically pause** the schedule (stop attempting until the operator
+re-enables it), or only **surface** the problem and keep attempting on cadence?
+
+This design chooses **surface-only, no auto-pause**, because for the no-IT
+persona this feature serves the two failure modes are not symmetric:
+
+- **Auto-pausing is silent, and the persona visits rarely.** A paused schedule
+  stops trying with no visible signal, so a partnership that quietly stopped
+  attempting is indistinguishable from a healthy one until the next in-person
+  visit -- which may be weeks away. A silently paused schedule is a silently
+  dead partnership.
+- **Continuing to attempt costs almost nothing.** Each attempt against a partner
+  who has gone away is one runner waking, deriving a rendezvous id, and waiting
+  out a window against a peer that never arrives: no wire traffic to a server,
+  no secret exposure (the secret does not rotate on a miss), and no data read
+  (the input guard and connection come only after a peer is found).
+
+The honest cost of not pausing is that the miss surface must itself be
+trustworthy: if it read as noise the operator learned to ignore, endless quiet
+retries would mask a dead partnership just as a silent pause would. That is why
+the miss surface is **moment-anchored and escalating** -- silent for a single
+miss, an actionable state and a notification only once the pattern is real --
+rather than a standing warning the operator clicks through (the same discipline
+the backup surfaces follow; see [Moment-anchored backup
+surfaces](#moment-anchored-backup-surfaces)).
+
+The operator retains an explicit, manual control either way: a recurring
+exchange can be paused or its schedule edited from its detail surface at any
+time, and deleting the exchange stops all attempts (see [Deleting a managed
+exchange](#deleting-a-managed-exchange)). What the design declines to do is make
+that pause decision *for* the operator on a heuristic, because the failure mode
+of a wrong automatic pause (a silently dead partnership) is worse for this
+persona than the failure mode of not pausing (cheap, visible, ignorable
+retries).
+
+### The between-visit notification
+
+Between visits the operator is not watching the app, so the "this ran / this
+needs you" surface is an **OS-level notification** from the installed app -- the
+platform's own notification, shown from the same app runtime that executes the
+runs, the concept that reaches an operator who is not looking at a browser tab.
+It is a concept-level surface here, not a wire or storage design: it reads the
+same run bookkeeping the next-visit surfaces read and says the same things, just
+sooner.
+
+Three moments are worth a notification, and each maps to a state the design
+already defines:
+
+- **This ran, and your backup is now stale.** An unattended run rotates the
+  secret with nobody present, which flips the derived backup state to "backup
+  needed" (see [Moment-anchored backup surfaces](#moment-anchored-backup-surfaces)).
+  The notification prompts the **re-export** at that moment rather than letting
+  the standing backup silently drift stale until the next visit -- the
+  between-visit form of the attended run's "download updated backup" step. It
+  wires to the **existing** derived backup state and its transition; it does not
+  introduce a second persistence-status track (see [Surviving storage
+  eviction](#surviving-storage-eviction)).
+- **This needs you: repeated misses.** Once the consecutive-miss count crosses
+  the threshold above, the notification carries the coordination prompt so the
+  operator learns the partnership stopped meeting without having to open the app
+  to find out.
+- **This needs you: a run failed with no benign explanation.** A handshake that
+  ran and failed closed with no recorded benign cause (the Tier-2 case; see
+  [Telling a desync from an attack](#telling-a-desync-from-an-attack)) is the
+  one failure that needs the operator's out-of-band confirmation work, so it is
+  worth surfacing between visits rather than waiting for the next visit.
+
+Every other outcome stays quiet: a single miss, a benign input miss, a
+successful run whose backup the operator will refresh at their next visit
+anyway. The notification follows the same moment-anchored discipline as the
+in-app surfaces -- it fires only when its condition is true and actionable, so
+it does not become the standing nag the whole surface design avoids.
+
+Because the notification is a concept over states the record already carries, a
+platform without OS notifications loses only the *sooner* prompt: every one of
+these states is still carried honestly to the operator's next in-app visit.
 
 ## The second run, end to end
 
@@ -151,9 +321,9 @@ does that the one-shot flow cannot. On the first-class path the second run is
    below, unchanged by nobody watching.
 5. **The outcome lands in the run bookkeeping**, and the next visit's surfaces
    carry it: the results, the refreshed-backup prompt, or the failure state.
-   An OS-level notification from the installed app is the natural "this ran /
-   this needs you" surface between visits; its design belongs to the later
-   scheduling and installed-app work.
+   An OS-level notification from the installed app is the "this ran / this needs
+   you" surface between visits (see [The between-visit
+   notification](#the-between-visit-notification)).
 
 The **attended re-run** -- the degradations' path, available on any platform --
 is the same run with the operator present: open the app (the exchange shows
@@ -368,7 +538,8 @@ the run bookkeeping (a `"missed"` outcome; see
 the next agreed window, and it never enters the desync/attack framing below --
 exactly as expiry never does. Only a handshake that actually ran and failed
 reaches that framing. A pattern of missed windows is a coordination problem,
-resolved out-of-band where the schedule itself was agreed.
+resolved out-of-band where the schedule itself was agreed -- surfaced, not
+auto-paused (see [Retry and repeated misses](#retry-and-repeated-misses)).
 
 ### The grace window
 
@@ -572,10 +743,10 @@ so taking it there keeps that path green and quiet. An unattended scheduled run
 rotates the secret with nobody present, so a scheduled exchange's standing
 export goes stale between visits **by design**; the backup state carries that
 honestly -- actionable at the next visit, a state, not a nag -- and an OS-level
-notification from the installed app is the concept for prompting a re-export
-sooner (its design belongs to the later scheduling and installed-app work). The
-frame throughout: every honest statement appears at the moment it becomes true
-and actionable.
+notification from the installed app prompts a re-export sooner (see [The
+between-visit notification](#the-between-visit-notification)). The frame
+throughout: every honest statement appears at the moment it becomes true and
+actionable.
 
 The in-browser copy is treated as convenience and the exported credential
 file as the durability of record, so an operator is never surprised by a silent

--- a/docs/spec/MANAGED_EXCHANGE_RECORD.md
+++ b/docs/spec/MANAGED_EXCHANGE_RECORD.md
@@ -97,7 +97,7 @@ are the standing definition of the managed exchange.
 | `sharedSecret` | string (base64url, 43 chars / 32 bytes) | The **current** rotated shared secret, matching `SHARED_SECRET_REGEX` (see [EXCHANGE_FILE.md](EXCHANGE_FILE.md)) -- the `.psilink.key` analog the exchange-file document deliberately never carries. This is the one at-rest secret in the record. Rotated after every successful run and re-persisted before the run is treated as succeeded (see [Persist-before-success ordering](#persist-before-success-ordering)). |
 | `expires` | string (ISO 8601, UTC `Z`) or absent | The instant after which `sharedSecret` must not be used; the recovery when it lapses is re-invite. Absent means no bound is in force. The record inherits the CLI key file's **consumer** semantics for `expires` -- one field, one meaning to every consumer (see [Two sources, one `expires`](../SECURITY_DESIGN.md#two-sources-one-expires), a citation about meaning, not sourcing) -- while its **provenance** is single-source: only the max-age stamp below writes it, the invitation's setup lifetime having been consumed at provisioning. |
 | `tokenMaxAgeDays` | integer or absent | The operator's max-token-age policy for this exchange, the browser analog of the CLI `authentication.token_max_age_days`, and like it **off by default**: absent means no bound is in force, and a record is created with it absent unless the operator sets one. When set, each successful run stamps `expires` this many days out onto the rotated secret. The reason to opt in is a dormant partnership: rotation caps exposure only for an exchange that actually runs, so an idle stored secret has no automatic exposure bound without it (see [The primary controls](../SECURITY_DESIGN.md#the-primary-controls)). |
-| `schedule` | object or absent | The partnership-agreed run schedule the unattended path executes: the agreed recurrence and run window -- the schedule is partnership-level agreement, coordinated out-of-band exactly as the terms are -- plus the retry bookkeeping for a missed window (the next planned attempt). Closed shape: timestamps, durations, and enums, no free text, under the same no-narrative constraint as `lastRun`. Absent for an exchange run attended-only. The exact field layout is fixed by the later scheduling design work, within the security-review gate; this record commits to carrying it. |
+| `schedule` | object or absent | The partnership-agreed run schedule the unattended path executes: the agreed recurrence and run window -- the schedule is partnership-level agreement, coordinated out-of-band exactly as the terms are -- plus the retry bookkeeping for a missed window (the next planned attempt). Closed shape: timestamps, durations, and enums, no free text, under the same no-narrative constraint as `lastRun`. Absent for an exchange run attended-only. The field-by-field layout is in [The `schedule` object](#the-schedule-object). |
 | `lastRun` | object or absent | Run bookkeeping the backup state and the tiered desync UX read (see [MANAGED_EXCHANGE.md](../MANAGED_EXCHANGE.md)): `at` (ISO 8601 UTC), `outcome` (`"succeeded"` \| `"failed"` \| `"desynced"` \| `"missed"`), and, for a non-succeeded outcome, an optional `failureKind` (`"auth"` \| `"transport"` \| `"storage"` \| `"input"` \| `"cancelled"`). A `"missed"` outcome records an agreed window that passed without a completed handshake (a runner no-show on either side); it is benign, retried at the next window, and never routed through the desync/attack framing (see [MANAGED_EXCHANGE.md](../MANAGED_EXCHANGE.md#a-missed-window-is-neither-desync-nor-attack)). An `"input"` failure records a benign pre-run input problem -- the handle's file missing at run start, or contents the column-shape guard rejects -- detected before any connection, likewise never routed through that framing. Every field is a timestamp or a closed enum -- there is deliberately **no free-text field**, so the record structurally cannot carry a match result, a count, or a row value; the constraint is the type, not a prose promise. |
 
 Everything in this table except `sharedSecret` is non-secret but not
@@ -168,6 +168,61 @@ That evolution path -- reject, re-invite, re-create -- is also how the shape
 grows: a future schema revision adds its fields under a new `schemaVersion`,
 rather than the v1 record carrying speculative, structurally always-absent
 seams.
+
+### The schedule object
+
+The optional `schedule` object carries the partnership-agreed run cadence, the
+run window the two runners meet in, and the miss bookkeeping the retry policy
+reads. It is present only when the operator saved the exchange as recurring;
+an attended-only exchange omits it. Every field is a timestamp, an integer
+duration, or a closed enum -- no free text, the same no-narrative constraint
+`lastRun` carries -- so the object cannot accumulate the schedule narrative the
+metadata-at-rest analysis did not cover (see
+[Metadata at rest](../SECURITY_DESIGN.md#metadata-at-rest-presence-and-shape)).
+
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `anchor` | string (ISO 8601, UTC `Z`) | The instant of the first agreed window's open, the phase the recurrence counts from. Both parties persist the **same** `anchor`, agreed out-of-band with the rest of the schedule, so both runners compute the same window opens. Stored UTC; a local-time cadence ("09:00 Tuesdays") is resolved to UTC at save and re-resolved only when the operator edits the schedule, so a daylight-saving shift does not silently move an unattended window. |
+| `intervalDays` | integer, at least 1 | The recurrence period in whole days: the run window opens every `intervalDays` after `anchor`. A whole-day integer covers the daily, weekly, and monthly-approximated (for example 28- or 30-day) cadences the persona runs; sub-day cadences are out of scope for a partnership coordinated out-of-band, and calendar-month recurrence (the drifting "1st of the month") is deliberately not modeled -- an integer period keeps both runners' window computation identical without a shared calendar library. |
+| `windowSeconds` | integer, at least 1 | The run window's width: window *n* is open from `anchor + n * intervalDays` for `windowSeconds`. The width is chosen to dwarf realistic clock skew between the two machines (see [Clock skew](#clock-skew-and-the-window-width)); a several-hour width is the intended range, not a several-minute one. |
+| `nextWindow` | string (ISO 8601, UTC `Z`) | The open instant of the next window the runner plans to attempt. Derived from `anchor`, `intervalDays`, and the run bookkeeping (advanced past a completed or missed window), it is persisted rather than recomputed so a reader -- the runtime waking, or a next-visit surface -- sees the planned attempt without replaying history. After a miss it is the **next** window, never a sooner off-schedule retry: retry-at-next-window is the whole retry policy (see [MANAGED_EXCHANGE.md](../MANAGED_EXCHANGE.md#retry-and-repeated-misses)). |
+| `consecutiveMisses` | integer, at least 0 | The count of consecutive agreed windows that ended in a runner no-show (a `lastRun.outcome` of `"missed"`). A `"succeeded"` outcome resets it to 0; a `"missed"` outcome increments it; **any other outcome leaves it unchanged**, because only a no-show signals the two runners are not meeting. A handshake that ran and failed (`"failed"`/`"desynced"`) means the partnership *did* meet, so it is a desync/attack question, not a coordination-drift one; a benign pre-peer `"input"` failure is likewise not a partner no-show. It drives only the surfacing of a repeated-miss coordination problem (see [MANAGED_EXCHANGE.md](../MANAGED_EXCHANGE.md#retry-and-repeated-misses)); it never pauses the schedule and never changes `nextWindow`'s cadence. |
+
+The object holds no operator-facing recurrence label, no timezone name, and no
+window-outcome history: `anchor` plus `intervalDays` plus `windowSeconds` fully
+determine every past and future window, and `lastRun` already carries the most
+recent outcome. A per-window outcome log would be exactly the narrative the
+no-free-text constraint excludes, and it is unnecessary -- `consecutiveMisses`
+is the only cross-window state the retry policy needs.
+
+The schedule is a **local-only** field, not part of the persisted
+`exchangeFile` document: a reschedule is neither a terms change nor a credential,
+so it must not force the re-invite a document change requires (see [Record
+shape](#record-shape)), and the CLI would carry it inertly. Each party enters it
+locally at save-as-recurring, agreed out-of-band exactly as the terms and the
+setup secret are (see
+[SECURITY_DESIGN.md](../SECURITY_DESIGN.md#invitation-contents-and-confidentiality)).
+Normatively: neither the invitation wire format nor the exchange-file document
+carries the schedule, and no schedule field is ever sent to a server or to the
+partner over the wire. Two parties who enter mismatched values never share an
+overlapping window and record mutual misses until they reconcile out-of-band --
+a benign coordination failure, never a desync or an attack. The operational
+framing is in
+[MANAGED_EXCHANGE.md](../MANAGED_EXCHANGE.md#where-the-schedule-is-agreed-and-where-it-lives).
+
+### Clock skew and the window width
+
+The two runners never exchange a clock reading; each opens and closes its window
+by its own machine clock against the shared `anchor` and `intervalDays`, so an
+overlapping window depends on both clocks agreeing closely enough. The mitigation
+is width, not synchronization: `windowSeconds` is chosen to dwarf realistic skew
+(a several-hour window against the seconds-to-minutes skew of a machine with any
+working time source), so two reasonably-set clocks overlap comfortably and only a
+grossly wrong clock on one side turns a scheduled run into a benign miss. The
+design adds no time-sync protocol; a persistently miss-producing clock is a
+local operational problem the miss surfacing (see
+[MANAGED_EXCHANGE.md](../MANAGED_EXCHANGE.md#retry-and-repeated-misses)) points
+the operator at, resolved by fixing the machine's time source, not by the app.
 
 ### Re-supplied each run
 

--- a/docs/spec/MANAGED_EXCHANGE_RECORD.md
+++ b/docs/spec/MANAGED_EXCHANGE_RECORD.md
@@ -184,9 +184,9 @@ metadata-at-rest analysis did not cover (see
 | ----- | ---- | ----- |
 | `anchor` | string (ISO 8601, UTC `Z`) | The instant of the first agreed window's open, the phase the recurrence counts from. Both parties persist the **same** `anchor`, agreed out-of-band with the rest of the schedule, so both runners compute the same window opens. Stored UTC; a local-time cadence ("09:00 Tuesdays") is resolved to UTC at save and re-resolved only when the operator edits the schedule, so a daylight-saving shift does not silently move an unattended window. |
 | `intervalDays` | integer, at least 1 | The recurrence period in whole days: the run window opens every `intervalDays` after `anchor`. A whole-day integer covers the daily, weekly, and monthly-approximated (for example 28- or 30-day) cadences the persona runs; sub-day cadences are out of scope for a partnership coordinated out-of-band, and calendar-month recurrence (the drifting "1st of the month") is deliberately not modeled -- an integer period keeps both runners' window computation identical without a shared calendar library. |
-| `windowSeconds` | integer, at least 1 | The run window's width: window *n* is open from `anchor + n * intervalDays` for `windowSeconds`. The width is chosen to dwarf realistic clock skew between the two machines (see [Clock skew](#clock-skew-and-the-window-width)); a several-hour width is the intended range, not a several-minute one. |
-| `nextWindow` | string (ISO 8601, UTC `Z`) | The open instant of the next window the runner plans to attempt. Derived from `anchor`, `intervalDays`, and the run bookkeeping (advanced past a completed or missed window), it is persisted rather than recomputed so a reader -- the runtime waking, or a next-visit surface -- sees the planned attempt without replaying history. After a miss it is the **next** window, never a sooner off-schedule retry: retry-at-next-window is the whole retry policy (see [MANAGED_EXCHANGE.md](../MANAGED_EXCHANGE.md#retry-and-repeated-misses)). |
-| `consecutiveMisses` | integer, at least 0 | The count of consecutive agreed windows that ended in a runner no-show (a `lastRun.outcome` of `"missed"`). A `"succeeded"` outcome resets it to 0; a `"missed"` outcome increments it; **any other outcome leaves it unchanged**, because only a no-show signals the two runners are not meeting. A handshake that ran and failed (`"failed"`/`"desynced"`) means the partnership *did* meet, so it is a desync/attack question, not a coordination-drift one; a benign pre-peer `"input"` failure is likewise not a partner no-show. It drives only the surfacing of a repeated-miss coordination problem (see [MANAGED_EXCHANGE.md](../MANAGED_EXCHANGE.md#retry-and-repeated-misses)); it never pauses the schedule and never changes `nextWindow`'s cadence. |
+| `windowSeconds` | integer, at least 1 | The run window's width: window *n* is open from `anchor + n * intervalDays` for `windowSeconds`. The width is chosen to dwarf realistic clock skew between the two machines (see [Clock skew](#clock-skew-and-the-window-width)); a several-hour width is the intended range, not a several-minute one. The structural floor is one second, but schedule entry enforces a UX-level minimum on the order of an hour: width is the only skew mitigation the design has, so a seconds-wide window would guarantee perpetual self-inflicted misses. |
+| `nextWindow` | string (ISO 8601, UTC `Z`) | The open instant of the next window the runner plans to attempt. Derived from `anchor`, `intervalDays`, and the run bookkeeping (advanced past a completed or missed window), it is persisted rather than recomputed so a reader -- the runtime waking, or a next-visit surface -- sees the planned attempt without replaying history. After a miss it is the **next** window, never a sooner off-schedule retry: retry-at-next-window is the whole retry policy (see [MANAGED_EXCHANGE.md](../MANAGED_EXCHANGE.md#retry-and-repeated-misses)). A runtime that wakes to find it in the past applies the catch-up rule below before anything else (see [Catch-up on wake](#catch-up-on-wake)). |
+| `consecutiveMisses` | integer, at least 0 | The count of consecutive agreed windows that passed without a completed handshake, **regardless of which side was absent**: a window this runner sat out waiting for a peer that never arrived counts exactly as one this runner itself slept through (the latter recorded retroactively; see [Catch-up on wake](#catch-up-on-wake)). A `"succeeded"` outcome resets it to 0; a `"missed"` outcome increments it; **any other outcome leaves it unchanged**, because only a no-show signals the two runners are not meeting. A handshake that ran and failed (`"failed"`/`"desynced"`) means the partnership *did* meet, so it is a desync/attack question, not a coordination-drift one; a benign pre-peer `"input"` failure is likewise not a partner no-show. It drives only the surfacing of a repeated-miss coordination problem, whose escalated state fires at **two** consecutive misses (see [MANAGED_EXCHANGE.md](../MANAGED_EXCHANGE.md#retry-and-repeated-misses)); it never pauses the schedule and never changes `nextWindow`'s cadence. |
 
 The object holds no operator-facing recurrence label, no timezone name, and no
 window-outcome history: `anchor` plus `intervalDays` plus `windowSeconds` fully
@@ -209,6 +209,35 @@ overlapping window and record mutual misses until they reconcile out-of-band --
 a benign coordination failure, never a desync or an attack. The operational
 framing is in
 [MANAGED_EXCHANGE.md](../MANAGED_EXCHANGE.md#where-the-schedule-is-agreed-and-where-it-lives).
+
+#### Catch-up on wake
+
+A runner does not tick while its machine sleeps, so a runtime can wake -- a
+laptop reopened after a week on a daily cadence, the app relaunched after a
+reboot -- with `nextWindow` in the past and one or more windows fully elapsed.
+On wake, before attempting anything, the runner applies one catch-up rule:
+
+- Every fully-elapsed, unattempted window counts as **one miss each**:
+  `consecutiveMisses` is incremented by the count, and `lastRun` records the
+  most recent elapsed window as `"missed"`.
+- `nextWindow` advances past every fully-elapsed window to the first window not
+  yet closed: if the current instant falls inside that window, the runner
+  attempts it immediately; otherwise `nextWindow` is the first window opening
+  after the current instant.
+
+The rule keeps both fields honest. `consecutiveMisses` reflects the true count
+of elapsed misses whichever side was absent, and the runner lands on a live
+window rather than replaying stale past ones. Crossing the two-miss escalation
+threshold during catch-up fires the repeated-miss surface at the wake -- which
+is how a persistently absent party learns of a miss pattern late rather than
+never (see
+[MANAGED_EXCHANGE.md](../MANAGED_EXCHANGE.md#retry-and-repeated-misses)).
+
+The import path is the rule's second consumer: an imported backup carries the
+snapshot's `nextWindow`, typically in the past by the time the artifact is
+restored, and the first wake after an import applies the same catch-up --
+elapsed windows counted, `nextWindow` advanced to a live window -- before any
+attempt.
 
 ### Clock skew and the window width
 


### PR DESCRIPTION
## Summary

Settle the managed exchange's schedule design so the record's schedule field and the unattended runner can be implemented against a reviewed shape: a closed five-field schedule object (anchor, interval, window width, next window, consecutive-miss counter), run-window semantics with an explicit catch-up rule for a runtime that slept through windows, a surface-only retry posture (no auto-pause -- a silently paused schedule is a silently dead partnership for an operator who visits rarely), and the between-visit OS-notification concept wired to the existing backup-state machinery. Docs only; the runner item implements against this.

Implements [213135477](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=213135477).

## Changes

- docs/spec/MANAGED_EXCHANGE_RECORD.md: the schedule object's field layout (all timestamps/integers, local-only, never minted or sent on the wire), the catch-up-on-wake rule (also governing imported backups), consecutiveMisses semantics (counts windows without a completed handshake regardless of which side was absent; succeeded resets, non-miss outcomes leave it unchanged), the two-miss escalation constant, the hour-order UX minimum over the structural window-width floor, and the clock-skew paragraph.
- docs/MANAGED_EXCHANGE.md: where the schedule is agreed and lives (out-of-band, local-only), window open/close semantics and what both runners must satisfy, retry-at-next-window with the owned one-sided miss surface, the escalated coordination prompt naming both the partner and this machine's clock, and the four moment-anchored notification moments (backup-stale, missed window, input failure, unexplained failure).

## Test plan

Ran: mechanical link/anchor validation over both files (all resolve), ASCII sweep, `npm run check:contributing`, `npm run format`.
New tests cover: n/a -- docs-only design; the runner item encodes these semantics as checks and tests.

## Background

One independent design review (combined product and security lens): sound-with-fixes, with two majors (the catch-up rule was unspecified; the miss surface's deliberate one-sidedness was presented as symmetric) and three minors, all folded in. The reviewer verified consistency with the settled managed-exchange design: closed shape, metadata-at-rest, the persisted-vs-document split, and export/import semantics.

## Out of scope / follow-on

- The unattended runner implementing these semantics -- the Scheduled exchanges epic's next item.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- docs/MANAGED_EXCHANGE.md (conceptual) and docs/spec/MANAGED_EXCHANGE_RECORD.md (field layout and rules); no other page describes scheduling
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: doc-only design work, nothing operator-visible ships
- [x] Security review -- n/a for code (no control surface touched); the design was independently reviewed (product + security lens, findings folded in) and lands within the managed-exchange program's security-review-gated design set