### PR TITLE
Add credential-free webrtc exchange locator

### DIFF
--- a/docs/spec/MANAGED_EXCHANGE_RECORD.md
+++ b/docs/spec/MANAGED_EXCHANGE_RECORD.md
@@ -119,20 +119,23 @@ party's side lives in the local `side` field, not the document (see [Role: a
 local `side` field](#role-a-local-side-field-not-the-document)). The full shared schema **can** represent those
 credential-bearing fields, so the guarantee comes from composition, exactly as
 in the mint layer: the record composer assembles the connection from a
-credential-free locator input and persists the schema's parse result. The mint
-layer's credential-free input union covers only the file-sync channels today (a
-webrtc exchange is coordinated live, not from a downloadable file), so this
-schema requires three concrete pieces of implementation work: a new
-credential-free `WebRTCExchangeLocator` type (`host`/`port`/`path` only); a
-`webrtc` arm in `connectionFromLocator`, the locator-to-connection expansion in
-`packages/core/src/config/exchangeFile.ts`; and the composition guarantee
-extending to the nested `server` object's two credential fields
-(`server.username` and the PeerJS `server.key`), which the flat file-sync
-locators never had to exclude. Prefer composing the webrtc locator from the
+credential-free locator input and persists the schema's parse result. The
+downloadable-file mint path's credential-free input union covers only the
+file-sync channels (a webrtc exchange is coordinated live, not from a
+downloadable file), so core carries the composer's webrtc arm as three
+distinct pieces: a credential-free `WebRTCExchangeLocator` type
+(`host`/`port`/`path` only); a `webrtc` arm in `connectionFromLocator`, the
+locator-to-connection expansion in `packages/core/src/config/exchangeFile.ts`;
+and the composition guarantee extending to the nested `server` object's two
+credential fields (`server.username` and the PeerJS `server.key`), which the
+flat file-sync locators never had to exclude. The webrtc locator is the
 invitation's endpoint schema (`WebRTCEndpointSchema`,
 `packages/core/src/config/invitation.ts`), which is already credential-free by
-schema, so there is one locator source of truth rather than two. The
-composition rule, not a strip pass, is the enforcement.
+schema, so there is one locator source of truth rather than two, and the
+locator-to-connection expansion validates through it -- rejecting any field
+outside the allowlist rather than letting the non-strict webrtc connection
+schema silently strip it. The composition rule, not a strip pass, is the
+enforcement.
 
 #### Role: a local `side` field, not the document
 

--- a/packages/core/src/config/exchangeFile.ts
+++ b/packages/core/src/config/exchangeFile.ts
@@ -8,6 +8,8 @@ import type { Metadata } from "./metadata.js";
 import type { Standardization } from "./standardization.js";
 import { snakeizeKeys } from "../utils/camelizeKeys.js";
 import { PLACEHOLDER_SSH_USERNAME } from "./endpointProducer.js";
+import { WebRTCEndpointSchema } from "./invitation.js";
+import type { WebRTCEndpoint } from "./invitation.js";
 
 // --- Locator-only connection description -------------------------------------
 
@@ -66,15 +68,46 @@ export interface FiledropExchangeLocator {
 }
 
 /**
- * A credential-free connection description for a web-composed exchange,
- * discriminated by `channel`. Carries ONLY locator fields -- by construction no
- * credential (username/password/private key/fingerprint) is representable, so the
- * minted file cannot leak one even if a caller tried. Deliberately covers only
- * the file-sync channels the browser mints a downloadable config for (`sftp`,
- * `filedrop`); a webrtc exchange is coordinated live, not from a minted file.
+ * The credential-free WebRTC locator a web-composed exchange config carries:
+ * WHERE the PeerJS peer-coordination server is (`host`/optional `port`/optional
+ * `path`), never HOW to reach it privately. It is the invitation's
+ * {@link WebRTCEndpoint} -- one locator type, not a second parallel definition --
+ * so the endpoint the code carries and the connection block a managed record
+ * persists agree on the credential-free shape by construction.
+ *
+ * By composition NO credential is representable: the type carries no PeerJS
+ * `server.key`, no `server.username`, and no `turn`, `ice_provision`, or
+ * `provider_options` entry (a TURN entry carries relay credentials and the
+ * provider map is opaque and `@`-file-pathed). The full webrtc connection block
+ * CAN represent those fields, so the guarantee is the composition rule --
+ * {@link connectionFromLocator} expands only these locator fields and
+ * {@link WebRTCEndpointSchema} rejects any other -- not a runtime strip.
+ */
+export type WebRTCExchangeLocator = WebRTCEndpoint;
+
+/**
+ * A credential-free connection description the browser mints a DOWNLOADABLE
+ * exchange config from, discriminated by `channel`. Carries ONLY locator fields
+ * -- by construction no credential (username/password/private key/fingerprint)
+ * is representable, so the minted file cannot leak one even if a caller tried.
+ * Deliberately covers only the file-sync channels a downloadable config targets
+ * (`sftp`, `filedrop`); a webrtc exchange is coordinated live, not from a minted
+ * file, so {@link WebRTCExchangeLocator} is intentionally NOT a member here --
+ * this narrowness is what keeps {@link mintExchangeFile}'s surface file-sync-only
+ * (see the mint-surface guard test).
  */
 export type ExchangeFileConnection =
   SftpExchangeLocator | FiledropExchangeLocator;
+
+/**
+ * The full credential-free locator union {@link connectionFromLocator} expands:
+ * the file-sync {@link ExchangeFileConnection} channels plus
+ * {@link WebRTCExchangeLocator}. Broader than {@link ExchangeFileConnection}
+ * because the locator-to-connection expansion also serves the managed-record
+ * composer, which composes a live webrtc connection block; the downloadable-file
+ * mint path stays on the narrower file-sync-only {@link ExchangeFileConnection}.
+ */
+export type ExchangeLocator = ExchangeFileConnection | WebRTCExchangeLocator;
 
 // --- Mint --------------------------------------------------------------------
 
@@ -164,15 +197,36 @@ export function mintExchangeFile(input: ExchangeFileInput): string {
 }
 
 /**
- * Expand a credential-free {@link ExchangeFileConnection} into the CLI's
+ * Expand a credential-free {@link ExchangeLocator} into the CLI's
  * {@link ConnectionConfig} shape. The single-vs-split directory form is carried
- * through verbatim; the schema (applied by {@link mintExchangeFile}) enforces the
- * both-or-neither and mutual-exclusion rules. For SFTP the placeholder username
- * is seeded -- the one identity field a locator cannot carry.
+ * through verbatim; the schema (applied by {@link mintExchangeFile}, or by the
+ * managed-record composer for the webrtc arm) enforces the both-or-neither and
+ * mutual-exclusion rules. For SFTP the placeholder username is seeded -- the one
+ * identity field a locator cannot carry.
+ *
+ * For WebRTC the guarantee extends into the nested `server` object, which the
+ * flat file-sync locators never had to exclude: the expansion copies only the
+ * {@link WebRTCEndpointSchema}-validated `host`/`port`/`path` into `server`, so
+ * neither the PeerJS `server.key` nor `server.username`, and no sibling `turn`,
+ * `ice_provision`, or `provider_options` entry, is representable in the result.
+ * The locator is validated through {@link WebRTCEndpointSchema} first, so a
+ * type-bypassed caller's unexpected key is rejected (the strict object) rather
+ * than silently stripped by the webrtc connection schema's non-strict object.
  */
-function connectionFromLocator(
-  locator: ExchangeFileConnection,
+export function connectionFromLocator(
+  locator: ExchangeLocator,
 ): ConnectionConfig {
+  if (locator.channel === "webrtc") {
+    const endpoint = WebRTCEndpointSchema.parse(locator);
+    return {
+      channel: "webrtc",
+      server: {
+        host: endpoint.host,
+        ...(endpoint.port !== undefined ? { port: endpoint.port } : {}),
+        ...(endpoint.path !== undefined ? { path: endpoint.path } : {}),
+      },
+    };
+  }
   if (locator.channel === "sftp") {
     return {
       channel: "sftp",

--- a/packages/core/src/config/invitation.ts
+++ b/packages/core/src/config/invitation.ts
@@ -164,7 +164,18 @@ export const MAX_ENDPOINT_PATH_LENGTH = 4096;
 // ZodType<T> and break the union (same rationale as connection.ts). Strict
 // objects enforce the locator allowlist, so any credential field is rejected;
 // type safety is enforced at the ConnectionEndpointSchema level instead.
-const WebRTCEndpointSchema = z.strictObject(
+/**
+ * The credential-free WebRTC signaling-locator schema: `channel`/`host`/`port`/
+ * `path` only, `z.strictObject` so any field outside that allowlist -- a PeerJS
+ * `key`, a `server.username`, a `turn` entry -- is rejected rather than
+ * stripped. Exported (unlike its sftp/filedrop siblings) as the single locator
+ * source of truth the exchange-file mint layer composes a webrtc connection
+ * block from, so the invitation endpoint and the composed connection agree on
+ * the credential-free shape by construction rather than by two parallel
+ * definitions. See {@link WebRTCEndpoint} for the aligned interface and
+ * `connectionFromLocator` in exchangeFile.ts for the consumer.
+ */
+export const WebRTCEndpointSchema = z.strictObject(
   {
     channel: z.literal("webrtc"),
     host: z.string().min(1).max(MAX_ENDPOINT_HOST_LENGTH),

--- a/packages/core/test/exchangeFile.test.ts
+++ b/packages/core/test/exchangeFile.test.ts
@@ -2,8 +2,14 @@ import { ZodError } from "zod";
 import { expect, test } from "vitest";
 import { parse as parseYaml } from "yaml";
 
-import { mintExchangeFile } from "../src/config/exchangeFile";
-import type { ExchangeFileInput } from "../src/config/exchangeFile";
+import {
+  mintExchangeFile,
+  connectionFromLocator,
+} from "../src/config/exchangeFile";
+import type {
+  ExchangeFileInput,
+  WebRTCExchangeLocator,
+} from "../src/config/exchangeFile";
 import { PLACEHOLDER_SSH_USERNAME } from "../src/config/endpointProducer";
 import {
   parseExchangeSpec,
@@ -280,4 +286,123 @@ test("mintExchangeFile: camelize(parse(mint(x))) equals the schema parse of the 
     metadata: baseMetadata,
   });
   expect(viaYaml).toEqual(expected);
+});
+
+// --- WebRTC locator expansion (the managed-record composer's arm) ------------
+
+// The credential fields the webrtc connection block CAN carry but the locator
+// arm must never emit -- the nested server credentials the flat file-sync
+// locators never had to exclude, plus the credential-bearing siblings.
+const forbiddenWebrtcKeys = [
+  "username",
+  "key",
+  "turn",
+  "iceProvision",
+  "providerOptions",
+  "provision",
+];
+
+test("connectionFromLocator: a webrtc locator expands to a valid webrtc connection block", () => {
+  const connection = connectionFromLocator({
+    channel: "webrtc",
+    host: "peer.example.org",
+    port: 9000,
+    path: "/psilink",
+  });
+  // The expansion is exactly the credential-free server locator, nothing more.
+  expect(connection).toEqual({
+    channel: "webrtc",
+    server: { host: "peer.example.org", port: 9000, path: "/psilink" },
+  });
+  // And it validates as the shared exchange-file schema's own connection would:
+  // the parse result (not the raw input) is what a composer persists.
+  const spec = ExchangeSpecSchema.parse({
+    connection,
+    linkageTerms: baseTerms,
+  });
+  expect(spec.connection).toEqual(connection);
+});
+
+test("connectionFromLocator: a minimal webrtc locator omits absent optional fields", () => {
+  const connection = connectionFromLocator({
+    channel: "webrtc",
+    host: "peer.example.org",
+  });
+  // Absent port/path are omitted keys, not explicit undefined the persist step
+  // would render, exactly as the file-sync arms and the mint layer treat them.
+  expect(connection).toEqual({
+    channel: "webrtc",
+    server: { host: "peer.example.org" },
+  });
+  expect(
+    connection.channel === "webrtc" && connection.server,
+  ).not.toHaveProperty("port");
+  expect(
+    connection.channel === "webrtc" && connection.server,
+  ).not.toHaveProperty("path");
+});
+
+test("connectionFromLocator: no credential field appears in a webrtc expansion, including the nested server", () => {
+  const connection = connectionFromLocator({
+    channel: "webrtc",
+    host: "peer.example.org",
+    port: 9000,
+    path: "/psilink",
+  });
+  if (connection.channel !== "webrtc")
+    throw new Error("expected webrtc connection");
+  // The nested server object is where the PeerJS key and username would live;
+  // assert neither is present, and no credential-bearing sibling either.
+  for (const forbidden of forbiddenWebrtcKeys) {
+    expect(connection.server).not.toHaveProperty(forbidden);
+    expect(connection).not.toHaveProperty(forbidden);
+  }
+  // The server object carries ONLY the three locator fields.
+  expect(Object.keys(connection.server).sort()).toEqual(
+    ["host", "path", "port"].sort(),
+  );
+});
+
+test("connectionFromLocator: a webrtc locator carrying an unexpected key is rejected", () => {
+  // A type-bypassed caller cannot smuggle a credential through: the locator is
+  // validated by the invitation's strict WebRTCEndpointSchema, which rejects any
+  // field outside the allowlist rather than letting the non-strict webrtc
+  // connection schema silently strip it into the persisted block.
+  const rogue = {
+    channel: "webrtc",
+    host: "peer.example.org",
+    key: "peerjs-secret-api-key",
+  } as unknown as WebRTCExchangeLocator;
+  expect(() => connectionFromLocator(rogue)).toThrow(ZodError);
+});
+
+test("connectionFromLocator: a webrtc locator with a nested server credential is rejected", () => {
+  // `server.username` on the locator (rather than at the top level) is likewise
+  // outside the flat locator allowlist and rejected, not stripped.
+  const rogue = {
+    channel: "webrtc",
+    host: "peer.example.org",
+    username: "someone",
+  } as unknown as WebRTCExchangeLocator;
+  expect(() => connectionFromLocator(rogue)).toThrow(ZodError);
+});
+
+// --- Mint surface stays file-sync-only ---------------------------------------
+
+test("mintExchangeFile: a webrtc locator is not an admissible mint input (compile-time guard)", () => {
+  // The downloadable-file mint path is file-sync-only: a webrtc exchange is
+  // coordinated live, not from a minted file. This is enforced structurally --
+  // ExchangeFileInput.connection is the file-sync-only ExchangeFileConnection,
+  // which does not include WebRTCExchangeLocator -- and this @ts-expect-error is
+  // that guard as a check: if webrtc ever became assignable to the mint input,
+  // the suppression would go unused and typecheck would fail here, flagging the
+  // silent widening the union addition must not cause.
+  const input = {
+    // @ts-expect-error webrtc is deliberately outside the mint's locator input
+    connection: { channel: "webrtc", host: "peer.example.org" },
+    linkageTerms: baseTerms,
+  } satisfies ExchangeFileInput;
+  // Reference `input` so it is not an unused binding; the assertion under test is
+  // the compile-time @ts-expect-error above, not a runtime property.
+  expect(input.linkageTerms).toBe(baseTerms);
 });

--- a/packages/core/test/exchangeFile.test.ts
+++ b/packages/core/test/exchangeFile.test.ts
@@ -377,14 +377,39 @@ test("connectionFromLocator: a webrtc locator carrying an unexpected key is reje
 });
 
 test("connectionFromLocator: a webrtc locator with a nested server credential is rejected", () => {
-  // `server.username` on the locator (rather than at the top level) is likewise
-  // outside the flat locator allowlist and rejected, not stripped.
-  const rogue = {
-    channel: "webrtc",
-    host: "peer.example.org",
-    username: "someone",
-  } as unknown as WebRTCExchangeLocator;
-  expect(() => connectionFromLocator(rogue)).toThrow(ZodError);
+  // A whole `server` object on the locator is outside the flat locator
+  // allowlist, so a credential nested inside it is rejected, not stripped.
+  for (const server of [{ username: "someone" }, { key: "peerjs-secret" }]) {
+    const rogue = {
+      channel: "webrtc",
+      host: "peer.example.org",
+      server,
+    } as unknown as WebRTCExchangeLocator;
+    expect(() => connectionFromLocator(rogue)).toThrow(ZodError);
+  }
+});
+
+test("connectionFromLocator: every credential-bearing webrtc key is rejected in both casings", () => {
+  // The strict locator schema runs on the raw input, before any camelize
+  // transform, so snake_case aliases cannot slip past it either.
+  const hostileEntries: Array<[string, unknown]> = [
+    ["username", "someone"],
+    ["key", "peerjs-secret"],
+    ["turn", [{ urls: "turn:t.example.org" }]],
+    ["iceProvision", { mode: "static" }],
+    ["ice_provision", { mode: "static" }],
+    ["providerOptions", { secure: true }],
+    ["provider_options", { secure: true }],
+    ["options", { debug: 3 }],
+  ];
+  for (const [hostileKey, value] of hostileEntries) {
+    const rogue = {
+      channel: "webrtc",
+      host: "peer.example.org",
+      [hostileKey]: value,
+    } as unknown as WebRTCExchangeLocator;
+    expect(() => connectionFromLocator(rogue)).toThrow(ZodError);
+  }
 });
 
 // --- Mint surface stays file-sync-only ---------------------------------------


### PR DESCRIPTION
## Summary

The managed exchange record persists a webrtc connection block that must be credential-free by composition, but core's mint-layer locator union covered only the file-sync channels. The invitation's strict WebRTCEndpointSchema is now exported as the single locator source of truth, an ExchangeLocator union adds a WebRTCExchangeLocator member alongside the file-sync-only mint input, and connectionFromLocator gains a webrtc arm that validates the raw locator through the strict schema -- rejecting rather than stripping unexpected keys, before any camelize transform -- and constructs the nested server object exclusively from host, port, and path, so neither server credential field is representable in any expansion, for any caller, including one that bypasses TypeScript types. The downloadable-file mint input stays structurally file-sync-only, enforced by a compile-time guard.

Implements [213135444](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=213135444).

## Changes

- packages/core/src/config/invitation.ts: WebRTCEndpointSchema exported (was module-private) as the single locator source of truth.
- packages/core/src/config/exchangeFile.ts: WebRTCExchangeLocator type alias, the ExchangeLocator union, and the webrtc arm in connectionFromLocator (strict validation, allowlist-only server construction); connectionFromLocator exported for the record composer.
- packages/core/test/exchangeFile.test.ts: expansion validity, credential-key absence sweep (including the nested server object), nested-server and top-level credential rejection, table-driven rejection of every credential-bearing key in camel and snake casings, unknown-key rejection, and the compile-time mint-surface guard (@ts-expect-error that fails typecheck if the mint input ever widens).
- docs/spec/MANAGED_EXCHANGE_RECORD.md: the composition-pieces passage re-tensed -- the core pieces now exist; the record composer that consumes them remains future work.

## Test plan

Ran: full root unit fan-out (core, cli, web -- all pass), the exchangeFile test file (19 pass), typecheck, lint, format.
New tests cover: locator expansion, structural credential exclusion at both nesting levels and in both casings, unknown-key rejection, and the mint-surface guard as a live compile-time check.

## Background

Review pipeline: one light-review round (three reviewers, zero findings, unanimous no-simpler-shape) and a focused security verification of the credential-freedom guarantee -- verdict sound, confirmed by hostile plain-JS probes and a mutation test of the compile-time guard, including the strip-vs-reject boundary and type-erasure paths. Its two test-hygiene findings (a mislabeled nested-server test, missing cased rejection coverage) are fixed in the final commit.

## Out of scope / follow-on

- The managed-record composer that consumes this arm -- [212131321](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=212131321), sequenced later in the epic.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- docs/spec/MANAGED_EXCHANGE_RECORD.md composition passage updated; no overview-tier behavior changed
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: @psilink/core reshape with apps-only consumers; no operator-visible behavior changes (the composer that would use this arm is not yet built)
- [x] Security review -- focused independent verification of the credential-free-composition guarantee (strip-vs-reject at the strict schema, nested-server allowlist, snake/camel casing order, type-erasure and mint-surface probes): verdict sound; test-hygiene findings folded in