### PR TITLE
Clamp restored bench steps to live backing state

### DIFF
--- a/apps/web/src/bench/AcceptorBench.tsx
+++ b/apps/web/src/bench/AcceptorBench.tsx
@@ -49,6 +49,7 @@ import { Ledger } from "./Ledger";
 import { Problems } from "./Problems";
 import { TopBar } from "./TopBar";
 import { acceptorTimelineSteps } from "./exchangeRun";
+import { restorablePosition } from "./stepRestore";
 import styles from "./bench.module.css";
 import { useAcceptorExchange } from "./useAcceptorExchange";
 import { useStepHistory } from "./useStepHistory";
@@ -269,16 +270,23 @@ export function AcceptorBench() {
   // the cursor). The bench stays mounted, so the loaded file, the confirmed
   // columns, and every in-progress edit survive the transition untouched. A
   // token naming no live step (a stale entry from before a deploy renamed one)
-  // is ignored rather than rendered as an empty work column.
-  function restorePosition(token: string) {
-    if (token === "columns:cleaning") {
+  // is ignored rather than rendered as an empty work column. A position whose
+  // backing state is gone (a `launched` entry left behind by a back-to-columns
+  // recovery) clamps to a step that can still render; the settled token is
+  // returned so the hook rewrites the dead entry.
+  function restorePosition(token: string): string | void {
+    const settled = restorablePosition(token, {
+      hasLaunch: launched !== undefined,
+    });
+    if (settled === "columns:cleaning") {
       setColumnsSection("cleaning");
       setStep("columns");
-      return;
+      return settled;
     }
-    if (!isAcceptorStep(token)) return;
+    if (!isAcceptorStep(settled)) return;
     setColumnsSection("columns");
-    setStep(token);
+    setStep(settled);
+    return settled;
   }
 
   const { pushStep } = useStepHistory("review", restorePosition);

--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -77,6 +77,7 @@ import { ReviewCreateSection } from "./ReviewCreateSection";
 import { SaveExchangeSection } from "./SaveExchangeSection";
 import { TopBar } from "./TopBar";
 import { YourFileSection } from "./YourFileSection";
+import { restorableSection } from "./stepRestore";
 import { selectExchangeDriver } from "./exchangeDriverSelection";
 import { sftpEndpointForRemote } from "./sftpRemoteChoice";
 import { timelineSteps } from "./exchangeRun";
@@ -84,12 +85,7 @@ import { useInviterExchange } from "./useInviterExchange";
 import { useStepHistory } from "./useStepHistory";
 import { useUnloadGuard } from "./useUnloadGuard";
 
-import type {
-  AcquiredCsv,
-  InviterEditor,
-  RailStep,
-  SpineTarget,
-} from "./inviterModel";
+import type { AcquiredCsv, InviterEditor, RailStep } from "./inviterModel";
 import type { CliTransport, SaveExchangeFields } from "./saveExchangeModel";
 import type {
   ConnectionEndpointRequest,
@@ -98,11 +94,11 @@ import type {
 import type { DisclosureChoice } from "@psi/metadataEditing";
 import type { IntakeAlert } from "./YourFileSection";
 import type { SavedExchange } from "./SaveExchangeSection";
+import type { Section } from "./stepRestore";
 import type { SftpRemoteProjection } from "@jobs/jobManager";
 
 import type { CSVRow, SemanticType, Standardization } from "@psilink/core";
 
-type Section = SpineTarget | "share" | "save";
 type SpineStep = "file" | "columns" | "review";
 
 /** Stable empty inputs for {@link useNonEmptyRates} before a file is acquired,
@@ -265,14 +261,22 @@ export function InviterBench() {
   // Apply a section arriving from a browser Back/Forward: set the step state
   // without pushing a new history entry (the browser already moved the cursor).
   // The bench stays mounted throughout, so the loaded file, the derived terms,
-  // and every in-progress edit survive the transition untouched.
-  function restoreSection(next: Section) {
-    if (isSpineStep(next)) setLastSpineStep(next);
-    setSection(next);
+  // and every in-progress edit survive the transition untouched. A section whose
+  // backing state is gone (a `share` entry left behind by a start-over) clamps
+  // to a step that can still render; the settled section is returned so the hook
+  // rewrites the dead entry.
+  function restoreSection(next: Section): Section {
+    const settled = restorableSection(next, {
+      hasInvitation: invitation !== undefined,
+      isCliTransport: isCliTransport(transport),
+    });
+    if (isSpineStep(settled)) setLastSpineStep(settled);
+    setSection(settled);
+    return settled;
   }
 
   const { pushStep } = useStepHistory("file", (step) => {
-    if (isSection(step)) restoreSection(step);
+    if (isSection(step)) return restoreSection(step);
   });
 
   // The unload guard arms once a file is loaded and disarms once the exchange is

--- a/apps/web/src/bench/stepRestore.ts
+++ b/apps/web/src/bench/stepRestore.ts
@@ -1,0 +1,51 @@
+/**
+ * The restore-clamp predicates for the two benches: given a step a history entry
+ * names and the backing state the bench currently holds, the step that can
+ * actually render. A browser Back can land on an entry whose work column reads
+ * state a later action cleared -- an inviter `share` entry a start-over emptied
+ * of its invitation, an acceptor `launched` entry a back-to-columns recovery
+ * emptied of its launch -- and rendering it would leave the operator on a blank
+ * or bogus column. The invariant these encode: a step is restored only when the
+ * state its work column requires still exists, else it clamps to the nearest
+ * step whose backing state the clearing action left intact.
+ *
+ * Pure and dependency-free so the clamp is the tested boundary, pinned without
+ * mounting either bench.
+ */
+
+import type { SpineTarget } from "./inviterModel";
+
+/** The inviter bench's work-column sections: the required spine, the Customize
+ * tabs, and the two terminal surfaces. */
+export type Section = SpineTarget | "share" | "save";
+
+/** The backing state the inviter's guarded sections read: `share` renders only
+ * with a live invitation, `save` only under a CLI transport. */
+export interface SectionPreconditions {
+  hasInvitation: boolean;
+  isCliTransport: boolean;
+}
+
+/** The section to restore for `requested`: the section itself when its backing
+ * state still exists, else `review` -- the nearest step whose state (the loaded
+ * file and derived terms) a start-over leaves intact. */
+export function restorableSection(
+  requested: Section,
+  preconditions: SectionPreconditions,
+): Section {
+  if (requested === "share" && !preconditions.hasInvitation) return "review";
+  if (requested === "save" && !preconditions.isCliTransport) return "review";
+  return requested;
+}
+
+/** The position token to restore for `token`: the token itself when its backing
+ * state still exists, else `columns` -- the nearest step whose state (the
+ * acquired file and confirmed columns) a back-to-columns recovery leaves intact.
+ * `launched` reads the run the launch drives, which that recovery clears. */
+export function restorablePosition(
+  token: string,
+  preconditions: { hasLaunch: boolean },
+): string {
+  if (token === "launched" && !preconditions.hasLaunch) return "columns";
+  return token;
+}

--- a/apps/web/src/bench/useStepHistory.ts
+++ b/apps/web/src/bench/useStepHistory.ts
@@ -21,6 +21,14 @@ import {
  * step; a `popstate` that leaves the bench (Back from the first step, an
  * unrelated route) is left to proceed as ordinary navigation.
  *
+ * A restore may be clamped: the step the entry names can require backing state
+ * the bench no longer holds (its work column would render blank), so `onRestore`
+ * returns the step it actually settled on. When that differs from the entry's
+ * step, the hook rewrites the current entry's marker to the settled step with
+ * `replaceState` -- so a later Back does not land on the same dead entry again --
+ * keeping the router's index and key, since Back already moved the cursor and
+ * only the bench marker is stale.
+ *
  * On mount the hook marks the current history entry as the bench's FIRST step
  * (via `replaceState`, so it adds no entry). That baseline is what makes Back
  * from a later step land on the first step in place, while Back from the first
@@ -32,12 +40,14 @@ import {
  * @param onRestore - applies a step arriving from Back/Forward; must set the
  *   step state WITHOUT pushing a new entry (the browser already moved the
  *   cursor), and must validate the step against its own union, ignoring a
- *   foreign one (a stale entry from before a deploy renamed a step). The hook
- *   keeps a live ref to it, so an inline closure is fine.
+ *   foreign one (a stale entry from before a deploy renamed a step). Returns the
+ *   step it settled on so the hook can rewrite a clamped entry; return the
+ *   passed step (or nothing) when it was applied unchanged. The hook keeps a
+ *   live ref to it, so an inline closure is fine.
  */
 export function useStepHistory(
   initialStep: string,
-  onRestore: (step: string) => void,
+  onRestore: (step: string) => string | void,
 ): {
   pushStep: (step: string) => void;
 } {
@@ -70,7 +80,12 @@ export function useStepHistory(
       // or an unrelated route). Let the browser navigate normally -- nothing to
       // restore, and the component unmounts as it always did.
       if (step === undefined) return;
-      restoreRef.current(step);
+      const settled = restoreRef.current(step);
+      if (settled !== undefined && settled !== step)
+        window.history.replaceState(
+          benchStepState(settled, window.history.state),
+          "",
+        );
     }
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -937,6 +937,46 @@ describe("inviter bench", () => {
       .toBeInTheDocument();
   });
 
+  test("Back after a start-over lands on review, not a blank share column", async () => {
+    // Reaching the share screen pushes a `share` history entry; start-over then
+    // clears the invitation the share work column reads and routes to a fresh
+    // review. The `share` entry is now backed by nothing -- pressing Back must
+    // not restore a blank share column.
+    await createSealedInvitation();
+    lifecycleCall(0).onError({
+      category: "security",
+      error: new Error("kex failed"),
+    });
+    await page
+      .getByRole("button", { name: "Start over with a fresh invitation" })
+      .click();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Review & create");
+
+    // Back lands on the clamped review, not the dead `share` entry: the heading
+    // is Review & create and the share surface never appears.
+    window.history.back();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Review & create");
+    expect(page.getByText("Share this invitation").query()).toBeNull();
+    await expect
+      .element(page.getByText("Ready to create."))
+      .toBeInTheDocument();
+    // The entry was rewritten to review, so Forward then Back does not resurrect
+    // the dead share entry either.
+    window.history.forward();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Review & create");
+    window.history.back();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Review & create");
+    expect(page.getByText("Share this invitation").query()).toBeNull();
+  });
+
   test("the unload prompt arms with the file and disarms once the invitation exists", async () => {
     // A cancelable beforeunload dispatched at the window is answered by the
     // same listener the browser consults on a real unload; dispatchEvent

--- a/apps/web/test/browser/benchAccept.test.ts
+++ b/apps/web/test/browser/benchAccept.test.ts
@@ -27,6 +27,7 @@ import {
 } from "@bench/acceptorColumnsModel";
 import { AcceptorBench } from "@bench/AcceptorBench";
 import { AcceptorColumnsStep } from "@bench/AcceptorColumnsStep";
+import { BENCH_STEP_STATE_KEY } from "@bench/stepHistory";
 import { BenchLobby } from "@bench/BenchLobby";
 import { stagesFor } from "@bench/exchangeRun";
 import styles from "@bench/bench.module.css";
@@ -1424,6 +1425,63 @@ describe("acceptor bench: run and completion", () => {
     await expect
       .element(page.getByRole("heading", { name: "Confirm your columns" }))
       .toBeInTheDocument();
+  });
+
+  test("Back after a back-to-columns recovery lands on columns, not the dead run surface", async () => {
+    // Reaching the run pushes a `launched` history entry; the config-failure
+    // recovery then clears the launch that entry's work column reads and pushes
+    // a fresh columns entry. The `launched` entry is now backed by nothing --
+    // pressing Back must not restore a bogus in-progress surface for a run
+    // that is not running.
+    await reachRun();
+    lifecycleCall(0).onError({
+      category: "config",
+      error: new Error("standardization output name contradicts the terms"),
+    });
+    await page.getByRole("button", { name: "Back to your columns" }).click();
+    await expect
+      .element(page.getByRole("heading", { name: "Confirm your columns" }))
+      .toBeInTheDocument();
+
+    // Back lands on the clamped columns step, and the dead entry's marker was
+    // rewritten to columns (it read `launched` when Back arrived on it).
+    window.history.back();
+    await vi.waitFor(() => {
+      expect(
+        (window.history.state as Record<string, unknown>)[BENCH_STEP_STATE_KEY],
+      ).toBe("columns");
+    });
+    await expect
+      .element(page.getByRole("heading", { name: "Confirm your columns" }))
+      .toBeInTheDocument();
+    expect(
+      page.getByRole("heading", { name: "Exchange in progress" }).query(),
+    ).toBeNull();
+
+    // Forward then Back does not resurrect the dead entry either. Both entries
+    // now carry the same columns marker, so each move is awaited on its own
+    // popstate rather than a state change.
+    const nextPopState = () =>
+      new Promise<void>((resolve) => {
+        window.addEventListener("popstate", () => resolve(), { once: true });
+      });
+    let landed = nextPopState();
+    window.history.forward();
+    await landed;
+    await expect
+      .element(page.getByRole("heading", { name: "Confirm your columns" }))
+      .toBeInTheDocument();
+    landed = nextPopState();
+    window.history.back();
+    await landed;
+    await expect
+      .element(page.getByRole("heading", { name: "Confirm your columns" }))
+      .toBeInTheDocument();
+    expect(
+      page.getByRole("heading", { name: "Exchange in progress" }).query(),
+    ).toBeNull();
+    // The discarded launch never restarted the run.
+    expect(lifecycleHarness.calls).toHaveLength(1);
   });
 
   test("an output failure offers no re-run, only a fresh setup", async () => {

--- a/apps/web/test/unit/benchStepRestore.test.ts
+++ b/apps/web/test/unit/benchStepRestore.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+
+import { restorablePosition, restorableSection } from "@bench/stepRestore";
+
+describe("restorableSection", () => {
+  // A start-over clears the invitation but leaves the loaded file and terms, so
+  // a `share` entry Back lands on clamps to review rather than a blank column.
+  test("clamps share to review when the invitation is gone", () => {
+    expect(
+      restorableSection("share", {
+        hasInvitation: false,
+        isCliTransport: false,
+      }),
+    ).toBe("review");
+  });
+
+  test("keeps share when the invitation is still present", () => {
+    expect(
+      restorableSection("share", {
+        hasInvitation: true,
+        isCliTransport: false,
+      }),
+    ).toBe("share");
+  });
+
+  // The save surface renders only under a CLI transport; a fresh file resets the
+  // transport to browser, stranding a `save` entry the same way.
+  test("clamps save to review when the transport is not a CLI transport", () => {
+    expect(
+      restorableSection("save", {
+        hasInvitation: false,
+        isCliTransport: false,
+      }),
+    ).toBe("review");
+  });
+
+  test("keeps save under a CLI transport", () => {
+    expect(
+      restorableSection("save", { hasInvitation: false, isCliTransport: true }),
+    ).toBe("save");
+  });
+
+  test("restores a step with intact backing state unchanged", () => {
+    for (const step of ["file", "columns", "review", "cleaning"] as const)
+      expect(
+        restorableSection(step, {
+          hasInvitation: false,
+          isCliTransport: false,
+        }),
+      ).toBe(step);
+  });
+});
+
+describe("restorablePosition", () => {
+  // A back-to-columns recovery discards the launch but keeps the acquired file
+  // and confirmed columns, so a `launched` entry Back lands on clamps to columns
+  // rather than a run surface backed by nothing.
+  test("clamps launched to columns when the launch is gone", () => {
+    expect(restorablePosition("launched", { hasLaunch: false })).toBe(
+      "columns",
+    );
+  });
+
+  test("keeps launched when the launch is still present", () => {
+    expect(restorablePosition("launched", { hasLaunch: true })).toBe(
+      "launched",
+    );
+  });
+
+  test("restores a step with intact backing state unchanged", () => {
+    for (const token of ["review", "consent", "columns", "columns:cleaning"])
+      expect(restorablePosition(token, { hasLaunch: false })).toBe(token);
+  });
+});


### PR DESCRIPTION
## Summary

Pressing browser Back could land the bench on a step whose work column reads state a later action cleared, rendering blank or bogus: the inviter's share entry after a start-over emptied its invitation, and the acceptor's launched entry after a back-to-columns recovery emptied its launch. Step restoration now validates the entry's render precondition and clamps to the nearest step whose backing state survives, and a clamped restore rewrites the dead history entry in place so a later Back cannot land on it again.

Implements [213034437](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=213034437).

## Changes

- apps/web/src/bench/stepRestore.ts (new): pure clamp predicates encoding the invariant that a step is restored only when the state its work column requires still exists -- share and save clamp to review, launched clamps to columns. The Section type moves here so the predicate and the component share it.
- apps/web/src/bench/useStepHistory.ts: onRestore now returns the step it settled on; when that differs from the entry's step, the hook rewrites the entry with replaceState (preserving the router's own state), so Back does not revisit the dead entry and no entry is pushed.
- apps/web/src/bench/InviterBench.tsx + AcceptorBench.tsx: restore callbacks route through the predicates with live state (invitation, CLI transport, launch).
- apps/web/test/unit/benchStepRestore.test.ts (new): the clamp matrix -- gone-state clamps, intact-state restores unchanged.
- apps/web/test/browser/bench.test.ts + benchAccept.test.ts: full regression walks on both benches -- start-over/recovery, Back lands on a live step, the rewritten entry holds across Forward and Back, and the discarded launch never restarts a run.

## Test plan

Ran: `npm run typecheck && npm run lint && npm run format`; `npm run test -w apps/web` (1085 passed); `npm run test:browser -w apps/web` (318 passed, real Chromium).
New tests cover: the restore-clamp matrix for share/save/launched with backing state gone and intact; browser-level Back-after-start-over on the inviter and Back-after-recovery on the acceptor, including the history-entry rewrite proof.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed (docs describe the step flows, not history-entry restoration mechanics)
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: bug fix, not a major feature
- [x] Security review -- n/a: bench UI step-restoration only; the rewritten history state carries an opaque step name, and the existing browser test pins that navigation writes no file data to history
