### PR TITLE
Rotate the managed secret under a single writer

### DIFF
--- a/apps/web/src/psi/authenticateExchange.ts
+++ b/apps/web/src/psi/authenticateExchange.ts
@@ -47,9 +47,12 @@ const NON_TRUST_KINDS: ReadonlySet<ConnectionErrorKind> = new Set([
  * flip this to `true`). The 32-byte session key is still derived: it is the
  * fruit of authenticating the peer, and the deferred web-encryption work (board
  * item 195802633) consumes it to key {@link EncryptedMessageConnection} once a
- * relay can force the wrap on. This call discards the rotated secret -- web has
- * no key-file persistence, so web exchanges are single-use (also per
- * docs/SECURITY_DESIGN.md).
+ * relay can force the wrap on. The returned {@link AuthResult} carries the rotated
+ * secret unchanged; what a caller does with it is the caller's, not this
+ * function's: the one-shot flow discards it (single-use, no key-file persistence
+ * -- see docs/SECURITY_DESIGN.md), while a managed exchange feeds it to the
+ * run+rotate write-back (see {@link ./managedExchangeRun.ts}). This function
+ * neither persists nor rotates; it authenticates and returns.
  *
  * Failure handling fails closed. A handshake failure aborts the exchange before
  * any PSI frame is sent (the caller runs this strictly before `runExchange`).

--- a/apps/web/src/psi/managedExchangeRecord.ts
+++ b/apps/web/src/psi/managedExchangeRecord.ts
@@ -326,6 +326,55 @@ export function buildManagedExchangeRecord(
   return parseManagedExchangeRecord(record);
 }
 
+/** The rotation fields a successful run advances on the stored record: the
+ * rotated secret always, and the `expires` bound restamped from the max-age
+ * policy (a string to set it, `null` to clear any standing bound). Deliberately
+ * the only fields {@link applyManagedExchangeRotation} touches, so a rotation
+ * write cannot carry a stale secret or a stale document -- the persist-before-
+ * success write is structurally incapable of it (see
+ * docs/spec/MANAGED_EXCHANGE_RECORD.md, "Persist-before-success ordering"). */
+export interface ManagedExchangeRotation {
+  /** The rotated shared secret (base64url) to persist as the current secret. */
+  sharedSecret: string;
+  /** The restamped bound to set, or `null` to clear any standing bound. */
+  expires: string | null;
+}
+
+/**
+ * Apply a rotation to a record, producing a validated new record with only the
+ * rotated secret and the `expires` bound changed -- the document, the label, the
+ * schedule, the handle, and the bookkeeping are carried through untouched. A
+ * string `expires` sets the bound; `null` clears it (a policy dropped between runs
+ * must not leave a stale bound armed). The result is re-validated through the
+ * schema, so a malformed rotated secret is rejected here. The input record is not
+ * mutated.
+ *
+ * @throws {ZodError} if the rotated record is invalid (a malformed secret).
+ */
+export function applyManagedExchangeRotation(
+  record: ManagedExchangeRecord,
+  rotation: ManagedExchangeRotation,
+): ManagedExchangeRecord {
+  const next: ManagedExchangeRecord = {
+    ...record,
+    sharedSecret: rotation.sharedSecret,
+  };
+  if (rotation.expires === null) delete next.expires;
+  else next.expires = rotation.expires;
+  return parseManagedExchangeRecord(next);
+}
+
+/** Apply a `lastRun` bookkeeping entry to a record, producing a validated new
+ * record with only `lastRun` changed. The document and the secret are carried
+ * through untouched. Separate from a rotation write so the run outcome is recorded
+ * without re-touching the rotated secret. The input record is not mutated. */
+export function applyManagedExchangeLastRun(
+  record: ManagedExchangeRecord,
+  lastRun: ManagedExchangeLastRun,
+): ManagedExchangeRecord {
+  return parseManagedExchangeRecord({ ...record, lastRun });
+}
+
 /** The local fields an operator may edit in place without a re-invite: the
  * display label, the run schedule, and the max-token-age policy. A change to the
  * agreed terms is a re-invite, not an in-place record edit, so the document and

--- a/apps/web/src/psi/managedExchangeRecord.ts
+++ b/apps/web/src/psi/managedExchangeRecord.ts
@@ -367,11 +367,24 @@ export function applyManagedExchangeRotation(
 /** Apply a `lastRun` bookkeeping entry to a record, producing a validated new
  * record with only `lastRun` changed. The document and the secret are carried
  * through untouched. Separate from a rotation write so the run outcome is recorded
- * without re-touching the rotated secret. The input record is not mutated. */
+ * without re-touching the rotated secret. The input record is not mutated.
+ *
+ * Monotonic on `at`: an entry older than the stored one leaves the record
+ * unchanged. Two runs' bookkeeping tails are not serialized by the run+rotate
+ * lock (it covers only handshake through persist), so a slow earlier run's late
+ * write could otherwise land after -- and mask -- a newer run's outcome; the
+ * guard makes the stale write a no-op instead. Compared as parsed instants, not
+ * strings: the schema admits ISO datetimes of varying fractional precision, whose
+ * lexicographic order diverges from chronological. */
 export function applyManagedExchangeLastRun(
   record: ManagedExchangeRecord,
   lastRun: ManagedExchangeLastRun,
 ): ManagedExchangeRecord {
+  if (
+    record.lastRun !== undefined &&
+    Date.parse(record.lastRun.at) > Date.parse(lastRun.at)
+  )
+    return parseManagedExchangeRecord(record);
   return parseManagedExchangeRecord({ ...record, lastRun });
 }
 

--- a/apps/web/src/psi/managedExchangeRun.ts
+++ b/apps/web/src/psi/managedExchangeRun.ts
@@ -125,11 +125,13 @@ export interface ManagedExchangeRunPhases<THandshake, TExchange> {
 }
 
 /** The outcome of a completed managed exchange run: the data-exchange result and
- * the `succeeded` `lastRun` recorded on the store. */
+ * the `succeeded` `lastRun` this run stamped. The store keeps the newest entry
+ * across racing runs' tails (the monotonic guard in the bookkeeping write), so
+ * this is this run's outcome, not necessarily the stored one. */
 export interface ManagedExchangeRunResult<TExchange> {
   /** The data-exchange phase's return value. */
   exchange: TExchange;
-  /** The `succeeded` `lastRun` recorded on the store for this run. */
+  /** The `succeeded` `lastRun` this run stamped. */
   lastRun: ManagedExchangeLastRun;
 }
 
@@ -149,7 +151,10 @@ export interface ManagedExchangeRunResult<TExchange> {
  * attack framing) and re-raises, without beginning the data exchange. A handshake
  * or data-exchange failure propagates unchanged for the runner to classify and
  * record; this module owns only the two outcomes the critical section itself
- * decides (succeeded, and the storage failure).
+ * decides (succeeded, and the storage failure). Because the bookkeeping tail runs
+ * outside the lock, its write is monotonic on `at` (see
+ * {@link recordManagedExchangeLastRun}): a slow run's stale tail cannot mask a
+ * newer run's recorded outcome.
  *
  * @throws {ManagedExchangeLockUnavailableError} if `lock.ifAvailable` is set and a
  *   run is already in progress on this device.

--- a/apps/web/src/psi/managedExchangeRun.ts
+++ b/apps/web/src/psi/managedExchangeRun.ts
@@ -147,19 +147,24 @@ export interface ManagedExchangeRunResult<TExchange> {
  * data exchange.
  *
  * A persist failure after rotation records a `storage`-kind `lastRun` inside the
- * lock (so the next handshake failure surfaces through the benign tier, not the
- * attack framing) and re-raises, without beginning the data exchange. A handshake
- * or data-exchange failure propagates unchanged for the runner to classify and
- * record; this module owns only the two outcomes the critical section itself
- * decides (succeeded, and the storage failure). Because the bookkeeping tail runs
- * outside the lock, its write is monotonic on `at` (see
+ * lock, best-effort (so the next handshake failure surfaces through the benign
+ * tier, not the attack framing) and re-raises, without beginning the data
+ * exchange. A handshake or data-exchange failure propagates unchanged for the
+ * runner to classify and record; this module owns only the two outcomes the
+ * critical section itself decides (succeeded, and the storage failure). Because
+ * the bookkeeping tail runs outside the lock, its write is monotonic on `at` (see
  * {@link recordManagedExchangeLastRun}): a slow run's stale tail cannot mask a
- * newer run's recorded outcome.
+ * newer run's recorded outcome. The success stamp is likewise an unlocked,
+ * individually failable write: if it fails after a completed exchange, the NEXT
+ * run's tiering degrades to the stricter Tier-2 surface -- an operator
+ * inconvenience, not a correctness break (the rotated secret is already durable).
  *
  * @throws {ManagedExchangeLockUnavailableError} if `lock.ifAvailable` is set and a
  *   run is already in progress on this device.
  * @throws {RotationPersistError} if the rotation write fails; the `storage`
- *   `lastRun` is recorded before this propagates.
+ *   `lastRun` is recorded best-effort before this propagates, and the error
+ *   carries it either way -- a bookkeeping-write failure never replaces this
+ *   error.
  */
 export async function runManagedExchange<THandshake, TExchange>(
   phases: ManagedExchangeRunPhases<THandshake, TExchange>,
@@ -186,8 +191,18 @@ export async function runManagedExchange<THandshake, TExchange>(
         // failure to the benign tier. Record it inside the lock (the record is
         // this run's until the lock releases), then re-raise for the runner. Every
         // other failure is the runner's to classify and record.
-        if (error instanceof RotationPersistError)
-          await recordLastRun(record.id, error.lastRun);
+        if (error instanceof RotationPersistError) {
+          // Best-effort: the storage subsystem that just failed the rotation
+          // persist may fail this write too, and a second storage rejection must
+          // never replace the RotationPersistError -- the runner's instanceof
+          // classification, and the storage lastRun the error itself carries,
+          // depend on the original propagating.
+          try {
+            await recordLastRun(record.id, error.lastRun);
+          } catch {
+            // Swallowed: error.lastRun still reaches the runner on the rethrow.
+          }
+        }
         throw error;
       }
     },

--- a/apps/web/src/psi/managedExchangeRun.ts
+++ b/apps/web/src/psi/managedExchangeRun.ts
@@ -1,0 +1,218 @@
+/**
+ * The platform half of the managed (recurring) exchange's run+rotate critical
+ * section: the Web Locks single-writer acquisition and the strict-durability,
+ * field-scoped store write that the pure ordering logic in
+ * {@link ./managedRunRotate.ts} drives. This is the seam the future managed-
+ * exchange runner calls -- it passes its handshake and data-exchange phases in and
+ * cannot get the persist-before-success ordering wrong, because the data-exchange
+ * phase is a callback this module invokes only after the durable persist resolves.
+ *
+ * Two invariants this module owns (normative in docs/MANAGED_EXCHANGE.md and
+ * docs/spec/MANAGED_EXCHANGE_RECORD.md):
+ *
+ * - **Single-writer exclusion.** A Web Locks lock keyed to the record's id is held
+ *   from "begin this run" through "rotated secret durably persisted", so a second
+ *   same-origin context (a second tab, or a tab and a scheduled run) cannot double-
+ *   rotate and desync the two parties. The lock is a same-profile liveness guard,
+ *   auto-released when the holding context is destroyed; it is taken WITHOUT
+ *   `steal: true` (a steal would defeat the single-writer property it exists to
+ *   provide). It does not and cannot guard a second device or profile -- the
+ *   durable single-owner property rests on migration-not-sync export semantics,
+ *   not on the lock.
+ *
+ * - **Persist-before-success.** The rotated secret is written durably (a strict-
+ *   durability transaction awaited to `complete`) BEFORE the data exchange begins.
+ *   {@link runRotationCriticalSection} enforces the ordering, resolving the gate the
+ *   data exchange needs only after the persist commits; {@link persistManagedExchangeRotation}
+ *   is the durable, field-scoped write it awaits.
+ */
+
+import {
+  RotationPersistError,
+  runRotationCriticalSection,
+  succeededRun,
+} from "./managedRunRotate";
+import {
+  persistManagedExchangeRotation,
+  recordManagedExchangeLastRun,
+} from "./managedExchangeStore";
+
+import type { ManagedExchangeLastRun } from "./managedExchangeRecord";
+import type { RotationWriteBack } from "./managedRunRotate";
+
+/** Namespace prefix for the Web Locks name, so a managed-exchange run lock cannot
+ * collide with any other same-origin lock name. The record's id is appended. */
+const MANAGED_EXCHANGE_LOCK_PREFIX = "psilink-managed-exchange:";
+
+/** The Web Locks name for a managed record's run+rotate critical section. */
+export function managedExchangeLockName(id: string): string {
+  return `${MANAGED_EXCHANGE_LOCK_PREFIX}${id}`;
+}
+
+/**
+ * Raised when the run+rotate lock for a record cannot be acquired without
+ * waiting -- another same-origin context already holds it. The runner treats this
+ * as "a run is already in progress on this device", not a failure of this run.
+ * Only raised on the non-blocking (`ifAvailable`) acquisition path.
+ */
+export class ManagedExchangeLockUnavailableError extends Error {
+  constructor(id: string) {
+    super(`a run is already in progress for managed exchange ${id}`);
+    this.name = "ManagedExchangeLockUnavailableError";
+  }
+}
+
+/** How the run+rotate lock is acquired when a second context already holds it. */
+export interface ManagedExchangeLockOptions {
+  /**
+   * When `true`, do not queue behind a held lock: if another same-origin context
+   * holds it, fail immediately with {@link ManagedExchangeLockUnavailableError}
+   * rather than waiting. When `false` (the default), queue and run when the holder
+   * releases -- either is a valid single-writer discipline; the runner chooses per
+   * whether a scheduled run should wait out an attended one or defer to it.
+   */
+  ifAvailable?: boolean;
+}
+
+/**
+ * Hold the run+rotate single-writer lock for `id` across `critical`, releasing it
+ * when `critical` settles (the Web Locks API releases the lock when the callback's
+ * promise resolves or rejects). The lock is taken WITHOUT `steal: true`: a steal
+ * would let a second context wrench the lock away mid-run, defeating the single-
+ * writer property. With `ifAvailable`, a lock held by another context yields a
+ * `null` grant, which this raises as {@link ManagedExchangeLockUnavailableError}
+ * rather than running `critical` unguarded.
+ *
+ * @throws {ManagedExchangeLockUnavailableError} if `ifAvailable` is set and the
+ *   lock is already held.
+ */
+export async function withManagedExchangeLock<T>(
+  id: string,
+  critical: () => Promise<T>,
+  options: ManagedExchangeLockOptions = {},
+): Promise<T> {
+  const name = managedExchangeLockName(id);
+  const request: LockOptions = { mode: "exclusive" };
+  if (options.ifAvailable === true) request.ifAvailable = true;
+  return globalThis.navigator.locks.request(name, request, async (lock) => {
+    // `ifAvailable` yields a null grant when the lock is held; without it the
+    // grant is guaranteed non-null (the request queued). Never a steal, so a
+    // granted lock is exclusively this run's until `critical` settles.
+    if (lock === null) throw new ManagedExchangeLockUnavailableError(id);
+    return critical();
+  });
+}
+
+/** The handshake and data-exchange phases the runner supplies to
+ * {@link runManagedExchange}, plus the record's rotation policy. The persist and
+ * lock are this module's; the runner cannot reach the data exchange before the
+ * persist resolves. */
+export interface ManagedExchangeRunPhases<THandshake, TExchange> {
+  /** The record whose secret this run rotates. Its `id` keys the lock and the
+   * field-scoped store writes; `tokenMaxAgeDays` restamps `expires`. */
+  record: { id: string; tokenMaxAgeDays?: number };
+  /** Run the authenticated handshake and yield the rotated secret (from the
+   * `AuthResult`) plus whatever the data exchange needs. Runs inside the lock. */
+  handshake: () => Promise<{ rotatedSecret: string; handshake: THandshake }>;
+  /** Begin and complete the data exchange -- reachable only after the durable
+   * persist resolves. Receives the handshake's carried value. */
+  dataExchange: (handshake: THandshake) => Promise<TExchange>;
+  /** Lock acquisition discipline (queue vs. fail-fast). */
+  lock?: ManagedExchangeLockOptions;
+  /** The clock, injected so a test can pin the rotation and bookkeeping stamps.
+   * Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/** The outcome of a completed managed exchange run: the data-exchange result and
+ * the `succeeded` `lastRun` recorded on the store. */
+export interface ManagedExchangeRunResult<TExchange> {
+  /** The data-exchange phase's return value. */
+  exchange: TExchange;
+  /** The `succeeded` `lastRun` recorded on the store for this run. */
+  lastRun: ManagedExchangeLastRun;
+}
+
+/**
+ * Run a managed exchange's run+rotate critical section: the seam the future runner
+ * calls. The single-writer lock is held across the handshake and the durable,
+ * field-scoped rotation write -- exactly "begin this run" through "rotated secret
+ * durably persisted". The data exchange then runs AFTER the lock releases, and on
+ * its completion the `succeeded` outcome is recorded. The data exchange still
+ * cannot begin before the persist resolves: it consumes the gate the locked
+ * section resolves only after the persist commits, so the ordering is structural,
+ * not the caller's to uphold, and the lock is not held for the (potentially long)
+ * data exchange.
+ *
+ * A persist failure after rotation records a `storage`-kind `lastRun` inside the
+ * lock (so the next handshake failure surfaces through the benign tier, not the
+ * attack framing) and re-raises, without beginning the data exchange. A handshake
+ * or data-exchange failure propagates unchanged for the runner to classify and
+ * record; this module owns only the two outcomes the critical section itself
+ * decides (succeeded, and the storage failure).
+ *
+ * @throws {ManagedExchangeLockUnavailableError} if `lock.ifAvailable` is set and a
+ *   run is already in progress on this device.
+ * @throws {RotationPersistError} if the rotation write fails; the `storage`
+ *   `lastRun` is recorded before this propagates.
+ */
+export async function runManagedExchange<THandshake, TExchange>(
+  phases: ManagedExchangeRunPhases<THandshake, TExchange>,
+): Promise<ManagedExchangeRunResult<TExchange>> {
+  const { record } = phases;
+  const now = phases.now ?? Date.now;
+
+  // The locked window: handshake through rotated-secret-durably-persisted. The
+  // gate is resolvable only once the persist has committed.
+  const gate = await withManagedExchangeLock(
+    record.id,
+    async () => {
+      try {
+        return await runRotationCriticalSection<THandshake>({
+          handshake: phases.handshake,
+          persist: (writeBack: RotationWriteBack) =>
+            persistRotation(record.id, writeBack),
+          tokenMaxAgeDays: record.tokenMaxAgeDays,
+          now,
+        });
+      } catch (error) {
+        // A persist failure after rotation is the one failure this section records
+        // itself: the `storage` bookkeeping is what steers the next handshake
+        // failure to the benign tier. Record it inside the lock (the record is
+        // this run's until the lock releases), then re-raise for the runner. Every
+        // other failure is the runner's to classify and record.
+        if (error instanceof RotationPersistError)
+          await recordLastRun(record.id, error.lastRun);
+        throw error;
+      }
+    },
+    phases.lock,
+  );
+
+  // Lock released: the peer-visible data exchange runs outside the single-writer
+  // window, then the success outcome is recorded.
+  const exchange = await phases.dataExchange(gate.handshake);
+  const lastRun = succeededRun(now());
+  await recordLastRun(record.id, lastRun);
+  return { exchange, lastRun };
+}
+
+/** The durable, field-scoped rotation write the ordering awaits before the data
+ * exchange. Split out so the write target is one call site. */
+async function persistRotation(
+  id: string,
+  writeBack: RotationWriteBack,
+): Promise<void> {
+  await persistManagedExchangeRotation(id, {
+    sharedSecret: writeBack.sharedSecret,
+    expires: writeBack.expires,
+  });
+}
+
+/** Record a run's `lastRun` bookkeeping on the store. */
+async function recordLastRun(
+  id: string,
+  lastRun: ManagedExchangeLastRun,
+): Promise<void> {
+  await recordManagedExchangeLastRun(id, lastRun);
+}

--- a/apps/web/src/psi/managedExchangeStore.ts
+++ b/apps/web/src/psi/managedExchangeStore.ts
@@ -22,14 +22,18 @@
  */
 
 import {
+  applyManagedExchangeLastRun,
   applyManagedExchangeLocalEdits,
+  applyManagedExchangeRotation,
   buildManagedExchangeRecord,
   parseManagedExchangeRecord,
 } from "./managedExchangeRecord";
 
 import type {
+  ManagedExchangeLastRun,
   ManagedExchangeLocalEdits,
   ManagedExchangeRecord,
+  ManagedExchangeRotation,
   NewManagedExchange,
 } from "./managedExchangeRecord";
 
@@ -268,6 +272,57 @@ export async function updateManagedExchangeLocalFields(
       throw new Error(`no managed exchange with id ${id}`);
     const existing = parseManagedExchangeRecord(stored);
     return applyManagedExchangeLocalEdits(existing, edits);
+  });
+}
+
+/**
+ * Persist a rotation to the stored record: advance the rotated secret and the
+ * `expires` bound, and nothing else. The read, the field-scoped application
+ * through {@link applyManagedExchangeRotation} (which re-validates), and the
+ * write-back run inside one strict-durability readwrite transaction
+ * ({@link readModifyWriteRecord}), so the rotation applies to the freshest stored
+ * record and the write is structurally incapable of carrying a stale secret or a
+ * stale document. This is the durable write the persist-before-success ordering
+ * awaits before the data exchange begins (see docs/spec/MANAGED_EXCHANGE_RECORD.md).
+ *
+ * @throws {Error} if no record with `id` exists.
+ * @throws {ZodError} if the stored value is not a valid v1 record or the rotation
+ *   produces an invalid one; the transaction aborts and nothing is written.
+ */
+export async function persistManagedExchangeRotation(
+  id: string,
+  rotation: ManagedExchangeRotation,
+): Promise<ManagedExchangeRecord> {
+  return readModifyWriteRecord(id, (stored) => {
+    if (stored === undefined)
+      throw new Error(`no managed exchange with id ${id}`);
+    const existing = parseManagedExchangeRecord(stored);
+    return applyManagedExchangeRotation(existing, rotation);
+  });
+}
+
+/**
+ * Record a run's `lastRun` bookkeeping on the stored record, leaving the rotated
+ * secret and the document untouched. The read, the field-scoped application
+ * through {@link applyManagedExchangeLastRun}, and the write-back run inside one
+ * strict-durability readwrite transaction, so recording an outcome cannot revert a
+ * concurrent rotation write. Separate from {@link persistManagedExchangeRotation}
+ * so the run outcome is recorded (succeeded after the data exchange, or a
+ * `storage` failure when the rotation persist itself failed) without re-touching
+ * the secret.
+ *
+ * @throws {Error} if no record with `id` exists.
+ * @throws {ZodError} if the stored value or the resulting record is invalid.
+ */
+export async function recordManagedExchangeLastRun(
+  id: string,
+  lastRun: ManagedExchangeLastRun,
+): Promise<ManagedExchangeRecord> {
+  return readModifyWriteRecord(id, (stored) => {
+    if (stored === undefined)
+      throw new Error(`no managed exchange with id ${id}`);
+    const existing = parseManagedExchangeRecord(stored);
+    return applyManagedExchangeLastRun(existing, lastRun);
   });
 }
 

--- a/apps/web/src/psi/managedExchangeStore.ts
+++ b/apps/web/src/psi/managedExchangeStore.ts
@@ -309,7 +309,9 @@ export async function persistManagedExchangeRotation(
  * concurrent rotation write. Separate from {@link persistManagedExchangeRotation}
  * so the run outcome is recorded (succeeded after the data exchange, or a
  * `storage` failure when the rotation persist itself failed) without re-touching
- * the secret.
+ * the secret. The application is monotonic on `at` (see
+ * {@link applyManagedExchangeLastRun}): a write staler than the stored entry is a
+ * no-op, so a slow run's late bookkeeping tail cannot mask a newer run's outcome.
  *
  * @throws {Error} if no record with `id` exists.
  * @throws {ZodError} if the stored value or the resulting record is invalid.

--- a/apps/web/src/psi/managedRunRotate.ts
+++ b/apps/web/src/psi/managedRunRotate.ts
@@ -1,0 +1,213 @@
+/**
+ * The pure ordering and decision half of the managed (recurring) exchange's
+ * run+rotate critical section: the IndexedDB-free, Web-Locks-free logic that
+ * decides what the rotation writes back, restamps `expires` from the max-age
+ * policy, and records the run's `lastRun` bookkeeping -- so the persist-before-
+ * success sequence and its decisions are unit-testable in Node without a database
+ * or a real lock. The platform half (the Web Locks acquisition and the strict-
+ * durability, field-scoped store write) is in {@link ./managedExchangeRun.ts}.
+ *
+ * Normative sequence: docs/spec/MANAGED_EXCHANGE_RECORD.md, "Persist-before-
+ * success ordering". Within one run: the handshake yields the `AuthResult`; the
+ * rotated `sharedSecret` (and `expires`, restamped from `tokenMaxAgeDays` when a
+ * policy is set) is durably persisted and the write awaited; only then does the
+ * data exchange begin, and only on its completion is the run recorded succeeded.
+ * {@link runRotationCriticalSection} is the locked window (handshake through
+ * persist); it resolves a gate whose carried value the data exchange needs, so the
+ * data exchange is unreachable until the persist resolves even though the caller
+ * runs it after releasing the lock -- the ordering is a property of the control
+ * flow, not the caller's discipline.
+ */
+
+import type {
+  ManagedExchangeFailureKind,
+  ManagedExchangeLastRun,
+} from "./managedExchangeRecord";
+
+/** Milliseconds in a day, for restamping a rotated secret's `expires` from the
+ * max-age policy. Mirrors the CLI key file's `MS_PER_DAY`. */
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * The rotation write-back: the fields a successful handshake advances on the
+ * stored record, and nothing else. Structurally scoped to the rotation fields so
+ * a whole-record write cannot ride along and carry a stale secret or a stale
+ * document back over a concurrent write -- the field-scoped write the store
+ * applies inside one transaction consumes exactly this shape.
+ *
+ * `expires` is a three-way decision, not an optional: `{ expires: string }`
+ * restamps a bound when a max-age policy is set, `{ expires: null }` clears any
+ * standing bound when no policy is set (a policy dropped between runs must not
+ * leave a stale bound armed), and it is `null` rather than absent so the write
+ * distinguishes "clear it" from "leave it untouched".
+ */
+export interface RotationWriteBack {
+  /** The rotated shared secret to persist as the record's current secret. */
+  sharedSecret: string;
+  /** The restamped bound (`now + tokenMaxAgeDays`) when a policy is set, or
+   * `null` to clear any standing bound when no policy is set. */
+  expires: string | null;
+}
+
+/**
+ * Compute the rotation write-back for a run: the rotated secret always, plus the
+ * `expires` decision. When `tokenMaxAgeDays` is set, `expires` is restamped to
+ * `now + tokenMaxAgeDays` days (ISO 8601 UTC) so the rotated secret cannot outlive
+ * the operator's max-age policy; when it is absent, `expires` is `null` so any
+ * standing bound is cleared. This mirrors the CLI's `buildRotatedKeyFile`,
+ * including its guards against a non-positive-integer age (a caller bypassing the
+ * config schema) and a computed expiry outside the representable date range.
+ *
+ * `now` is a parameter, not read internally, so the stamp reflects the actual
+ * moment of rotation and the function stays pure for testing.
+ *
+ * @throws {RangeError} if `tokenMaxAgeDays` is not a positive integer, or if
+ *   `now + tokenMaxAgeDays` days falls outside the supported date range.
+ */
+export function rotationWriteBack(
+  rotatedSecret: string,
+  tokenMaxAgeDays: number | undefined,
+  now: number,
+): RotationWriteBack {
+  if (tokenMaxAgeDays === undefined)
+    return { sharedSecret: rotatedSecret, expires: null };
+  // Belt-and-suspenders, mirroring the CLI key file's guard: the record schema
+  // already enforces a positive integer, but a caller bypassing it could pass 0,
+  // a negative, or a float, stamping an expiry that is immediately expired or on a
+  // sub-day boundary. Reject it before it reaches the store.
+  if (!Number.isInteger(tokenMaxAgeDays) || tokenMaxAgeDays <= 0)
+    throw new RangeError(
+      "rotationWriteBack: tokenMaxAgeDays must be a positive integer; got " +
+        String(tokenMaxAgeDays),
+    );
+  const expires = new Date(now + tokenMaxAgeDays * MS_PER_DAY);
+  if (Number.isNaN(expires.getTime()) || expires.getUTCFullYear() > 9999)
+    throw new RangeError(
+      "rotationWriteBack: tokenMaxAgeDays is too large; the computed expiry is " +
+        "outside the supported date range",
+    );
+  return { sharedSecret: rotatedSecret, expires: expires.toISOString() };
+}
+
+/** Record a run that completed the data exchange. The `lastRun` the tiered
+ * desync UX and the backup state read as green: `succeeded`, no `failureKind`. */
+export function succeededRun(at: number): ManagedExchangeLastRun {
+  return { at: new Date(at).toISOString(), outcome: "succeeded" };
+}
+
+/**
+ * Record a run that rotated the secret but failed to persist it. This is
+ * structured `failureKind: "storage"` bookkeeping precisely so the next handshake
+ * failure surfaces through the benign Tier-1 framing (a recorded persist failure
+ * explains a desync) rather than the attack framing -- see
+ * docs/MANAGED_EXCHANGE.md, "Telling a desync from an attack".
+ */
+export function storageFailureRun(at: number): ManagedExchangeLastRun {
+  return {
+    at: new Date(at).toISOString(),
+    outcome: "failed",
+    failureKind: "storage",
+  };
+}
+
+/** Record a non-succeeded run with the given outcome and failure kind. Used for
+ * the failure paths the runner classifies (an `auth`/`security` handshake
+ * failure, a `transport` drop, a benign `input` problem, a `cancelled` run);
+ * `succeededRun` and `storageFailureRun` are the two the critical section itself
+ * decides. */
+export function failedRun(
+  at: number,
+  outcome: Exclude<ManagedExchangeLastRun["outcome"], "succeeded">,
+  failureKind: ManagedExchangeFailureKind,
+): ManagedExchangeLastRun {
+  return { at: new Date(at).toISOString(), outcome, failureKind };
+}
+
+/** Raised when the rotation write-back fails to persist, carrying the `lastRun`
+ * bookkeeping the caller records. Distinct from a handshake or data-exchange
+ * failure so the runner can route it to the `storage` failure tier and know the
+ * data exchange never began. */
+export class RotationPersistError extends Error {
+  /** The `storage`-kind `lastRun` to record for this failed run. */
+  readonly lastRun: ManagedExchangeLastRun;
+  constructor(at: number, cause: unknown) {
+    super("failed to persist the rotated shared secret", { cause });
+    this.name = "RotationPersistError";
+    this.lastRun = storageFailureRun(at);
+  }
+}
+
+/** The locked half of a run: the handshake and the durable persist, plus the
+ * seams the platform half injects. This is exactly the window the single-writer
+ * lock covers -- "begin this run" through "rotated secret durably persisted" --
+ * and it is testable in Node with the persist seam faked. */
+export interface ManagedRotationCriticalSection<THandshake> {
+  /**
+   * Run the authenticated handshake and yield the rotated secret (from the
+   * `AuthResult`) plus whatever the data-exchange phase needs. Runs inside the
+   * lock; a throw here aborts the run before any persist or data exchange.
+   */
+  handshake: () => Promise<{ rotatedSecret: string; handshake: THandshake }>;
+  /**
+   * Durably persist the rotation write-back and await the write's completion.
+   * The platform half opens a strict-durability, field-scoped transaction; a
+   * throw here means the secret did not persist and the data exchange must not
+   * begin (a `RotationPersistError` is raised in its place).
+   */
+  persist: (writeBack: RotationWriteBack) => Promise<void>;
+  /** The operator's max-age policy for this record, or `undefined` for no bound.
+   * Restamps `expires` on the write-back when set. */
+  tokenMaxAgeDays: number | undefined;
+  /** The instant of rotation, injected so the stamp reflects the caller's clock
+   * and the sequence stays pure for testing. */
+  now: () => number;
+}
+
+/**
+ * The result of the locked critical section: the handshake's carried value and a
+ * `proceed` gate. `proceed` -- the data exchange -- is only obtainable once the
+ * rotated secret is durably persisted, so a caller structurally cannot begin the
+ * data exchange before the persist resolves, even though the caller runs it AFTER
+ * releasing the lock (the lock covers only through persist, per the spec's window).
+ */
+export interface ManagedRotationGate<THandshake> {
+  /** The handshake's carried value, to hand to the data-exchange phase. */
+  handshake: THandshake;
+}
+
+/**
+ * Run the locked half of one run's persist-before-success sequence: the window the
+ * single-writer lock holds.
+ *
+ * 1. `handshake()` yields the `AuthResult`'s rotated secret.
+ * 2. The rotation write-back (the rotated secret, `expires` restamped from the
+ *    policy) is computed and `persist()`ed, awaited to completion. A persist
+ *    failure raises a {@link RotationPersistError} carrying the `storage`-kind
+ *    `lastRun`.
+ *
+ * It resolves only after the persist commits, and returns the {@link ManagedRotationGate}
+ * whose carried handshake value the data exchange consumes -- so the data exchange
+ * (which the caller runs after releasing the lock) is unreachable until the persist
+ * has resolved. The lock window is exactly this function: begin-run through rotated-
+ * secret-durably-persisted, no wider (the data exchange does not hold the lock).
+ *
+ * @throws {RotationPersistError} if the rotation write-back fails to persist.
+ */
+export async function runRotationCriticalSection<THandshake>(
+  section: ManagedRotationCriticalSection<THandshake>,
+): Promise<ManagedRotationGate<THandshake>> {
+  const { rotatedSecret, handshake } = await section.handshake();
+
+  const writeBack = rotationWriteBack(
+    rotatedSecret,
+    section.tokenMaxAgeDays,
+    section.now(),
+  );
+  try {
+    await section.persist(writeBack);
+  } catch (error) {
+    throw new RotationPersistError(section.now(), error);
+  }
+
+  return { handshake };
+}

--- a/apps/web/test/browser/managedExchangeRun.test.ts
+++ b/apps/web/test/browser/managedExchangeRun.test.ts
@@ -175,6 +175,21 @@ describe("single-writer lock", () => {
     expect(seenOptions[0]?.mode).toBe("exclusive");
   });
 
+  test("the lock releases when the critical section rejects", async () => {
+    await expect(
+      withManagedExchangeLock("record-a", () =>
+        Promise.reject(new Error("run failed inside the lock")),
+      ),
+    ).rejects.toThrow("run failed inside the lock");
+    // A failed run must not strand the lock; ifAvailable would refuse (not
+    // wait) if it were still held.
+    await expect(
+      withManagedExchangeLock("record-a", () => Promise.resolve("ran"), {
+        ifAvailable: true,
+      }),
+    ).resolves.toBe("ran");
+  });
+
   test("the lock name is namespaced to the record id", () => {
     expect(managedExchangeLockName("abc")).toBe("psilink-managed-exchange:abc");
   });
@@ -399,6 +414,84 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     // The second rotation advanced the secret without reverting the first's write.
     expect((await getManagedExchange(created.id))?.sharedSecret).toBe(
       secondRotated,
+    );
+  });
+
+  test("a data-exchange failure propagates unchanged, with the rotation kept and no success recorded", async () => {
+    const created = await createManagedExchange(newExchange());
+    const rotatedSecret = generateSharedSecret();
+    const failure = new Error("data channel dropped mid-exchange");
+
+    const error: unknown = await runManagedExchange({
+      record: created,
+      handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
+      dataExchange: () => Promise.reject(failure),
+    }).then(
+      () => {
+        throw new Error(
+          "the run should have rejected with the exchange failure",
+        );
+      },
+      (reason: unknown) => reason,
+    );
+
+    // The exact instance propagates -- not wrapped, not re-tagged -- for the
+    // runner to classify and record.
+    expect(error).toBe(failure);
+    const stored = await getManagedExchange(created.id);
+    // The rotation is real even though the exchange then failed: both parties
+    // rotated at handshake completion, so the persisted secret must stay rotated.
+    expect(stored?.sharedSecret).toBe(rotatedSecret);
+    // No succeeded outcome was recorded; the failure bookkeeping is the runner's.
+    expect(stored?.lastRun).toBeUndefined();
+  });
+
+  test("a slow run's stale success tail cannot mask a newer run's outcome", async () => {
+    const created = await createManagedExchange(newExchange());
+    const earlierRunAt = Date.parse("2026-07-14T12:00:00.000Z");
+    const laterRunAt = Date.parse("2026-07-14T13:00:00.000Z");
+    const firstInExchange = deferred<void>();
+    const releaseFirst = deferred<void>();
+
+    // The first run rotates, releases the lock, and parks in its data exchange;
+    // its success bookkeeping will land last, stamped with the older clock. The
+    // second run completes fully in between, recording the newer outcome.
+    const first = runManagedExchange({
+      record: created,
+      handshake: () =>
+        Promise.resolve({
+          rotatedSecret: generateSharedSecret(),
+          handshake: "1",
+        }),
+      dataExchange: async () => {
+        firstInExchange.resolve();
+        await releaseFirst.promise;
+        return "1";
+      },
+      now: () => earlierRunAt,
+    });
+
+    await firstInExchange.promise;
+    try {
+      await runManagedExchange({
+        record: { id: created.id },
+        handshake: () =>
+          Promise.resolve({
+            rotatedSecret: generateSharedSecret(),
+            handshake: "2",
+          }),
+        dataExchange: () => Promise.resolve("2"),
+        now: () => laterRunAt,
+      });
+    } finally {
+      releaseFirst.resolve();
+      await first;
+    }
+
+    // The first run's tail wrote after the second's, but with an older stamp:
+    // the monotonic bookkeeping write no-ops, keeping the newer run's outcome.
+    expect((await getManagedExchange(created.id))?.lastRun?.at).toBe(
+      new Date(laterRunAt).toISOString(),
     );
   });
 });

--- a/apps/web/test/browser/managedExchangeRun.test.ts
+++ b/apps/web/test/browser/managedExchangeRun.test.ts
@@ -15,6 +15,7 @@ import {
   createManagedExchange,
   getManagedExchange,
 } from "@psi/managedExchangeStore";
+import { RotationPersistError } from "@psi/managedRunRotate";
 import { composeManagedExchangeFile } from "@psi/managedExchangeRecord";
 
 import type { NewManagedExchange } from "@psi/managedExchangeRecord";
@@ -200,9 +201,12 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     const created = await createManagedExchange(newExchange());
     const rotatedSecret = generateSharedSecret();
     const order: Array<string> = [];
-    // The stored secret as seen at the moment the data exchange begins -- it must
-    // already be the rotated one, proving the persist resolved first.
-    let secretAtDataExchange: string | undefined;
+    // The stored record as seen at the moment the data exchange begins -- the
+    // secret must already be the rotated one (the persist resolved first), and
+    // no success stamp may exist yet (it is recorded only after the data
+    // exchange completes).
+    let storedAtDataExchange:
+      Awaited<ReturnType<typeof getManagedExchange>> | undefined;
 
     const result = await runManagedExchange({
       record: created,
@@ -212,14 +216,15 @@ describe("runManagedExchange: persist-before-success end to end", () => {
       },
       dataExchange: async (carried: string) => {
         order.push("dataExchange");
-        secretAtDataExchange = (await getManagedExchange(created.id))
-          ?.sharedSecret;
+        storedAtDataExchange = await getManagedExchange(created.id);
         return `exchanged:${carried}`;
       },
     });
 
     expect(order).toEqual(["handshake", "dataExchange"]);
-    expect(secretAtDataExchange).toBe(rotatedSecret);
+    expect(storedAtDataExchange?.sharedSecret).toBe(rotatedSecret);
+    // No success stamp during the data exchange: succeeded lands strictly after.
+    expect(storedAtDataExchange?.lastRun).toBeUndefined();
     expect(result.exchange).toBe("exchanged:carried");
     // The success outcome landed on the store.
     const stored = await getManagedExchange(created.id);
@@ -315,9 +320,10 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     const rotatedSecret = generateSharedSecret();
     let dataExchangeRan = false;
 
-    // Force the rotation persist to fail by aborting every readwrite transaction
-    // the run opens. The put's own transaction abort surfaces as a rejected
-    // persist, which the ordering turns into the storage-tier failure.
+    // Force the rotation persist to fail by aborting the FIRST readwrite
+    // transaction the run opens, sparing the follow-up bookkeeping write. The
+    // put's own transaction abort surfaces as a rejected persist, which the
+    // ordering turns into the storage-tier failure.
     const realTransaction = IDBDatabase.prototype.transaction;
     let failNextReadwrite = true;
     IDBDatabase.prototype.transaction = function (
@@ -358,7 +364,7 @@ describe("runManagedExchange: persist-before-success end to end", () => {
       IDBDatabase.prototype.transaction = realTransaction;
     }
 
-    expect(error).toBeDefined();
+    expect(error).toBeInstanceOf(RotationPersistError);
     expect(dataExchangeRan).toBe(false);
     // The record still holds the pre-rotation secret (the rotation did not commit),
     // and the run is recorded as a benign-tier storage failure.
@@ -366,6 +372,63 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     expect(stored?.sharedSecret).toBe(created.sharedSecret);
     expect(stored?.lastRun?.outcome).toBe("failed");
     expect(stored?.lastRun?.failureKind).toBe("storage");
+  });
+
+  test("a total storage fault still surfaces the RotationPersistError, not the bookkeeping failure", async () => {
+    const created = await createManagedExchange(newExchange());
+    const rotatedSecret = generateSharedSecret();
+    let dataExchangeRan = false;
+
+    // Fail EVERY readwrite the run opens: the rotation persist fails, and so
+    // does the in-catch storage bookkeeping write. The second rejection must not
+    // replace the RotationPersistError -- the runner's classification, and the
+    // storage lastRun the error carries, depend on the original propagating.
+    const realTransaction = IDBDatabase.prototype.transaction;
+    IDBDatabase.prototype.transaction = function (
+      this: IDBDatabase,
+      storeNames: string | Array<string>,
+      mode?: IDBTransactionMode,
+      options?: IDBTransactionOptions,
+    ) {
+      const transaction = realTransaction.call(this, storeNames, mode, options);
+      if (mode === "readwrite") {
+        queueMicrotask(() => {
+          try {
+            transaction.abort();
+          } catch {
+            // Already settled; nothing to abort.
+          }
+        });
+      }
+      return transaction;
+    };
+
+    let error: unknown;
+    try {
+      await runManagedExchange({
+        record: created,
+        handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
+        dataExchange: () => {
+          dataExchangeRan = true;
+          return Promise.resolve("done");
+        },
+      });
+    } catch (reason) {
+      error = reason;
+    } finally {
+      IDBDatabase.prototype.transaction = realTransaction;
+    }
+
+    // The original error survives the failed bookkeeping write, still carrying
+    // the storage lastRun for the runner to classify on.
+    expect(error).toBeInstanceOf(RotationPersistError);
+    expect((error as RotationPersistError).lastRun.failureKind).toBe("storage");
+    expect(dataExchangeRan).toBe(false);
+    // Nothing committed: the old secret is retained and no bookkeeping landed
+    // (the write failed; the evidence travels on the error instead).
+    const stored = await getManagedExchange(created.id);
+    expect(stored?.sharedSecret).toBe(created.sharedSecret);
+    expect(stored?.lastRun).toBeUndefined();
   });
 
   test("two contended runs serialize: the second sees the first's rotated secret", async () => {

--- a/apps/web/test/browser/managedExchangeRun.test.ts
+++ b/apps/web/test/browser/managedExchangeRun.test.ts
@@ -1,0 +1,404 @@
+/// <reference types="@vitest/browser-playwright/context" />
+/// <reference types="vite/client" />
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { generateSharedSecret, getDefaultLinkageTerms } from "@psilink/core";
+
+import {
+  ManagedExchangeLockUnavailableError,
+  managedExchangeLockName,
+  runManagedExchange,
+  withManagedExchangeLock,
+} from "@psi/managedExchangeRun";
+import {
+  clearManagedExchanges,
+  createManagedExchange,
+  getManagedExchange,
+} from "@psi/managedExchangeStore";
+import { composeManagedExchangeFile } from "@psi/managedExchangeRecord";
+
+import type { NewManagedExchange } from "@psi/managedExchangeRecord";
+import type { WebRTCExchangeLocator } from "@psilink/core";
+
+// The platform half of the run+rotate critical section, exercised against real
+// Chromium (real Web Locks and real IndexedDB): the single-writer lock's exclusion
+// under contention, the no-steal property, the strict-durability field-scoped
+// rotation write, and the persist-before-success wiring end to end. The pure
+// ordering and decision logic is unit-tested in Node without either platform in
+// test/unit/managedRunRotate.test.ts.
+
+const linkageTerms = getDefaultLinkageTerms("County Health Dept");
+
+const webrtcLocator: WebRTCExchangeLocator = {
+  channel: "webrtc",
+  host: "signaling.example.org",
+  port: 3000,
+  path: "/api/",
+};
+
+function newExchange(
+  overrides: Partial<NewManagedExchange> = {},
+): NewManagedExchange {
+  return {
+    label: "Riverbend quarterly",
+    exchangeFile: composeManagedExchangeFile({
+      connection: webrtcLocator,
+      linkageTerms,
+    }),
+    side: "inviter",
+    sharedSecret: generateSharedSecret(),
+    ...overrides,
+  };
+}
+
+/** A deferred promise, so a test can hold a lock open until it chooses to release
+ * it and observe a contending acquisition wait or fail. */
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(async () => {
+  await clearManagedExchanges();
+});
+
+afterEach(async () => {
+  await clearManagedExchanges();
+});
+
+describe("single-writer lock", () => {
+  test("a second acquisition waits for the first to release", async () => {
+    const id = "record-a";
+    const order: Array<string> = [];
+    const firstHeld = deferred<void>();
+    const release = deferred<void>();
+
+    const first = withManagedExchangeLock(id, async () => {
+      order.push("first-enter");
+      firstHeld.resolve();
+      await release.promise;
+      order.push("first-exit");
+    });
+
+    // Only start contending once the first holder is confirmed inside the lock.
+    await firstHeld.promise;
+    const second = withManagedExchangeLock(id, () => {
+      order.push("second-enter");
+      return Promise.resolve();
+    });
+
+    try {
+      // Give the second acquisition a chance to (wrongly) barge in; it must not.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(order).toEqual(["first-enter"]);
+    } finally {
+      // Release even if the assertion above throws, so a failing test cannot
+      // strand the exclusive lock for the rest of the page's life.
+      release.resolve();
+      await Promise.all([first, second]);
+    }
+    // The second entered only after the first released -- serialized, not raced.
+    expect(order).toEqual(["first-enter", "first-exit", "second-enter"]);
+  });
+
+  test("distinct record ids do not contend", async () => {
+    const held = deferred<void>();
+    const release = deferred<void>();
+    const first = withManagedExchangeLock("record-a", async () => {
+      held.resolve();
+      await release.promise;
+    });
+    await held.promise;
+    try {
+      // A different id's lock is a different name, so it runs immediately.
+      await expect(
+        withManagedExchangeLock("record-b", () => Promise.resolve("ran")),
+      ).resolves.toBe("ran");
+    } finally {
+      release.resolve();
+      await first;
+    }
+  });
+
+  test("ifAvailable refuses rather than waits when the lock is held", async () => {
+    const id = "record-a";
+    const held = deferred<void>();
+    const release = deferred<void>();
+    const first = withManagedExchangeLock(id, async () => {
+      held.resolve();
+      await release.promise;
+    });
+    await held.promise;
+
+    try {
+      await expect(
+        withManagedExchangeLock(id, () => Promise.resolve("ran"), {
+          ifAvailable: true,
+        }),
+      ).rejects.toBeInstanceOf(ManagedExchangeLockUnavailableError);
+    } finally {
+      release.resolve();
+      await first;
+    }
+  });
+
+  test("the lock is taken without steal (a concurrent steal is not requested)", async () => {
+    // Prove the no-steal property structurally: intercept navigator.locks.request
+    // and assert the run+rotate acquisition never passes `steal: true`. A steal
+    // would wrench the lock from a live holder, defeating single-writer exclusion.
+    const realRequest = navigator.locks.request.bind(navigator.locks);
+    const seenOptions: Array<LockOptions | undefined> = [];
+    // The overloads of request() make a faithful wrapper verbose; the run path
+    // always calls the (name, options, callback) form, which is all we assert.
+    (navigator.locks as unknown as { request: unknown }).request = (
+      name: string,
+      options: LockOptions,
+      callback: (lock: Lock | null) => Promise<unknown>,
+    ) => {
+      seenOptions.push(options);
+      return realRequest(name, options, callback);
+    };
+    try {
+      await withManagedExchangeLock("record-a", () => Promise.resolve("ran"));
+    } finally {
+      (navigator.locks as unknown as { request: typeof realRequest }).request =
+        realRequest;
+    }
+    expect(seenOptions).toHaveLength(1);
+    expect(seenOptions[0]?.steal).toBeUndefined();
+    expect(seenOptions[0]?.mode).toBe("exclusive");
+  });
+
+  test("the lock name is namespaced to the record id", () => {
+    expect(managedExchangeLockName("abc")).toBe("psilink-managed-exchange:abc");
+  });
+});
+
+describe("runManagedExchange: persist-before-success end to end", () => {
+  test("persists the rotated secret durably before the data exchange begins", async () => {
+    const created = await createManagedExchange(newExchange());
+    const rotatedSecret = generateSharedSecret();
+    const order: Array<string> = [];
+    // The stored secret as seen at the moment the data exchange begins -- it must
+    // already be the rotated one, proving the persist resolved first.
+    let secretAtDataExchange: string | undefined;
+
+    const result = await runManagedExchange({
+      record: created,
+      handshake: () => {
+        order.push("handshake");
+        return Promise.resolve({ rotatedSecret, handshake: "carried" });
+      },
+      dataExchange: async (carried: string) => {
+        order.push("dataExchange");
+        secretAtDataExchange = (await getManagedExchange(created.id))
+          ?.sharedSecret;
+        return `exchanged:${carried}`;
+      },
+    });
+
+    expect(order).toEqual(["handshake", "dataExchange"]);
+    expect(secretAtDataExchange).toBe(rotatedSecret);
+    expect(result.exchange).toBe("exchanged:carried");
+    // The success outcome landed on the store.
+    const stored = await getManagedExchange(created.id);
+    expect(stored?.sharedSecret).toBe(rotatedSecret);
+    expect(stored?.lastRun?.outcome).toBe("succeeded");
+  });
+
+  test("the rotation write uses a strict-durability transaction", async () => {
+    const created = await createManagedExchange(newExchange());
+    const rotatedSecret = generateSharedSecret();
+
+    // Observe the durability of the readwrite transactions the run opens: the
+    // persist-before-success write requests strict durability (OS writeback before
+    // complete), the renderer-crash-consistency the secret at rest relies on.
+    const realTransaction = IDBDatabase.prototype.transaction;
+    const durabilities: Array<IDBTransactionDurability | undefined> = [];
+    IDBDatabase.prototype.transaction = function (
+      this: IDBDatabase,
+      storeNames: string | Array<string>,
+      mode?: IDBTransactionMode,
+      options?: IDBTransactionOptions,
+    ) {
+      if (mode === "readwrite") durabilities.push(options?.durability);
+      return realTransaction.call(this, storeNames, mode, options);
+    };
+    try {
+      await runManagedExchange({
+        record: created,
+        handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
+        dataExchange: () => Promise.resolve("done"),
+      });
+    } finally {
+      IDBDatabase.prototype.transaction = realTransaction;
+    }
+
+    // Every readwrite the run opened (the rotation persist and the lastRun record)
+    // is strict; none defaulted to relaxed durability.
+    expect(durabilities.length).toBeGreaterThanOrEqual(1);
+    for (const durability of durabilities) expect(durability).toBe("strict");
+  });
+
+  test("the rotation write is field-scoped: it advances the secret, not the label", async () => {
+    const created = await createManagedExchange(
+      newExchange({ label: "original label" }),
+    );
+    const rotatedSecret = generateSharedSecret();
+    await runManagedExchange({
+      record: created,
+      handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
+      dataExchange: () => Promise.resolve("done"),
+    });
+    const stored = await getManagedExchange(created.id);
+    // The rotation advanced only the secret; the document and label are intact.
+    expect(stored?.sharedSecret).toBe(rotatedSecret);
+    expect(stored?.label).toBe("original label");
+    expect(stored?.exchangeFile).toEqual(created.exchangeFile);
+  });
+
+  test("restamps expires from tokenMaxAgeDays on a successful run", async () => {
+    const created = await createManagedExchange(
+      newExchange({ tokenMaxAgeDays: 90 }),
+    );
+    const rotatedSecret = generateSharedSecret();
+    const rotationAt = Date.parse("2026-07-14T12:00:00.000Z");
+    await runManagedExchange({
+      record: created,
+      handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
+      dataExchange: () => Promise.resolve("done"),
+      now: () => rotationAt,
+    });
+    const stored = await getManagedExchange(created.id);
+    expect(stored?.expires).toBe(
+      new Date(rotationAt + 90 * 86_400_000).toISOString(),
+    );
+  });
+
+  test("no policy clears any standing expires bound on rotation", async () => {
+    const created = await createManagedExchange(
+      newExchange({ expires: "2026-09-01T00:00:00.000Z" }),
+    );
+    const rotatedSecret = generateSharedSecret();
+    await runManagedExchange({
+      record: created,
+      handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
+      dataExchange: () => Promise.resolve("done"),
+    });
+    // A record with no max-age policy must not keep a stale bound armed.
+    expect((await getManagedExchange(created.id))?.expires).toBeUndefined();
+  });
+
+  test("a persist failure records a storage failure and never begins the data exchange", async () => {
+    const created = await createManagedExchange(newExchange());
+    const rotatedSecret = generateSharedSecret();
+    let dataExchangeRan = false;
+
+    // Force the rotation persist to fail by aborting every readwrite transaction
+    // the run opens. The put's own transaction abort surfaces as a rejected
+    // persist, which the ordering turns into the storage-tier failure.
+    const realTransaction = IDBDatabase.prototype.transaction;
+    let failNextReadwrite = true;
+    IDBDatabase.prototype.transaction = function (
+      this: IDBDatabase,
+      storeNames: string | Array<string>,
+      mode?: IDBTransactionMode,
+      options?: IDBTransactionOptions,
+    ) {
+      const transaction = realTransaction.call(this, storeNames, mode, options);
+      if (mode === "readwrite" && failNextReadwrite) {
+        failNextReadwrite = false;
+        // Abort on the next microtask, after the store.get/put are queued, so the
+        // rotation's read-modify-write transaction fails as a storage error.
+        queueMicrotask(() => {
+          try {
+            transaction.abort();
+          } catch {
+            // Already settled; nothing to abort.
+          }
+        });
+      }
+      return transaction;
+    };
+
+    let error: unknown;
+    try {
+      await runManagedExchange({
+        record: created,
+        handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
+        dataExchange: () => {
+          dataExchangeRan = true;
+          return Promise.resolve("done");
+        },
+      });
+    } catch (reason) {
+      error = reason;
+    } finally {
+      IDBDatabase.prototype.transaction = realTransaction;
+    }
+
+    expect(error).toBeDefined();
+    expect(dataExchangeRan).toBe(false);
+    // The record still holds the pre-rotation secret (the rotation did not commit),
+    // and the run is recorded as a benign-tier storage failure.
+    const stored = await getManagedExchange(created.id);
+    expect(stored?.sharedSecret).toBe(created.sharedSecret);
+    expect(stored?.lastRun?.outcome).toBe("failed");
+    expect(stored?.lastRun?.failureKind).toBe("storage");
+  });
+
+  test("two contended runs serialize: the second sees the first's rotated secret", async () => {
+    const created = await createManagedExchange(newExchange());
+    const firstRotated = generateSharedSecret();
+    const secondRotated = generateSharedSecret();
+    const firstInExchange = deferred<void>();
+    const releaseFirst = deferred<void>();
+
+    // The first run parks inside its data exchange (after it has rotated and
+    // persisted, and released the lock). The second run then rotates from the
+    // freshest stored record. Because the lock covers rotation+persist, the two
+    // rotations cannot interleave: the second's field-scoped write lands on the
+    // first's committed secret, never reverting it.
+    const first = runManagedExchange({
+      record: created,
+      handshake: () =>
+        Promise.resolve({ rotatedSecret: firstRotated, handshake: "1" }),
+      dataExchange: async () => {
+        firstInExchange.resolve();
+        await releaseFirst.promise;
+        return "1";
+      },
+    });
+
+    await firstInExchange.promise;
+    let second: Promise<unknown> = Promise.resolve();
+    try {
+      const secretBeforeSecond = (await getManagedExchange(created.id))
+        ?.sharedSecret;
+      expect(secretBeforeSecond).toBe(firstRotated);
+
+      second = runManagedExchange({
+        record: { id: created.id },
+        handshake: () =>
+          Promise.resolve({ rotatedSecret: secondRotated, handshake: "2" }),
+        dataExchange: () => Promise.resolve("2"),
+      });
+    } finally {
+      // Unpark the first run even if an assertion above throws, so neither run
+      // hangs the suite.
+      releaseFirst.resolve();
+      await Promise.all([first, second]);
+    }
+
+    // The second rotation advanced the secret without reverting the first's write.
+    expect((await getManagedExchange(created.id))?.sharedSecret).toBe(
+      secondRotated,
+    );
+  });
+});

--- a/apps/web/test/browser/managedExchangeStore.test.ts
+++ b/apps/web/test/browser/managedExchangeStore.test.ts
@@ -13,7 +13,9 @@ import {
   getManagedExchange,
   listManagedExchanges,
   openManagedExchangeDatabase,
+  persistManagedExchangeRotation,
   putManagedExchange,
+  recordManagedExchangeLastRun,
   requestPersistentStorage,
   updateManagedExchangeLocalFields,
 } from "@psi/managedExchangeStore";
@@ -226,6 +228,113 @@ describe("single-transaction local edits", () => {
       }),
     ).rejects.toThrow();
     expect((await getManagedExchange(created.id))?.label).toBe(created.label);
+  });
+});
+
+describe("field-scoped rotation write", () => {
+  test("advances the secret and expires, leaving the document and label untouched", async () => {
+    const created = await createManagedExchange(
+      newExchange({ label: "Riverbend quarterly" }),
+    );
+    const rotatedSecret = generateSharedSecret();
+    const rotated = await persistManagedExchangeRotation(created.id, {
+      sharedSecret: rotatedSecret,
+      expires: "2026-10-06T14:00:00.000Z",
+    });
+    expect(rotated.sharedSecret).toBe(rotatedSecret);
+    expect(rotated.expires).toBe("2026-10-06T14:00:00.000Z");
+    expect(rotated.label).toBe("Riverbend quarterly");
+    expect(rotated.exchangeFile).toEqual(created.exchangeFile);
+    expect((await getManagedExchange(created.id))?.sharedSecret).toBe(
+      rotatedSecret,
+    );
+  });
+
+  test("a null expires clears any standing bound", async () => {
+    const created = await createManagedExchange(
+      newExchange({ expires: "2026-04-06T14:00:00.000Z" }),
+    );
+    const rotatedSecret = generateSharedSecret();
+    const rotated = await persistManagedExchangeRotation(created.id, {
+      sharedSecret: rotatedSecret,
+      expires: null,
+    });
+    expect(rotated.expires).toBeUndefined();
+    expect((await getManagedExchange(created.id))?.expires).toBeUndefined();
+  });
+
+  test("a rotation cannot carry a stale label over a concurrent local edit", async () => {
+    // The store holds a rotation write and a label edit as two field-scoped
+    // read-modify-writes, each reading the freshest record inside its own
+    // transaction. A rotation applied after a label edit keeps the new label -- the
+    // rotation write is structurally incapable of reverting a field it does not
+    // touch, the property the persist-before-success write depends on.
+    const created = await createManagedExchange(newExchange());
+    await updateManagedExchangeLocalFields(created.id, {
+      label: "edited after create",
+    });
+    const rotatedSecret = generateSharedSecret();
+    const rotated = await persistManagedExchangeRotation(created.id, {
+      sharedSecret: rotatedSecret,
+      expires: null,
+    });
+    expect(rotated.sharedSecret).toBe(rotatedSecret);
+    expect(rotated.label).toBe("edited after create");
+  });
+
+  test("a malformed rotated secret aborts and writes nothing", async () => {
+    const created = await createManagedExchange(newExchange());
+    await expect(
+      persistManagedExchangeRotation(created.id, {
+        sharedSecret: "not-a-secret",
+        expires: null,
+      }),
+    ).rejects.toThrow();
+    expect((await getManagedExchange(created.id))?.sharedSecret).toBe(
+      created.sharedSecret,
+    );
+  });
+
+  test("rotating a missing id rejects", async () => {
+    await expect(
+      persistManagedExchangeRotation("no-such-id", {
+        sharedSecret: generateSharedSecret(),
+        expires: null,
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("field-scoped lastRun write", () => {
+  test("records the outcome, leaving the secret and document untouched", async () => {
+    const created = await createManagedExchange(newExchange());
+    const updated = await recordManagedExchangeLastRun(created.id, {
+      at: "2026-07-14T12:00:00.000Z",
+      outcome: "succeeded",
+    });
+    expect(updated.lastRun).toEqual({
+      at: "2026-07-14T12:00:00.000Z",
+      outcome: "succeeded",
+    });
+    expect(updated.sharedSecret).toBe(created.sharedSecret);
+    expect(updated.exchangeFile).toEqual(created.exchangeFile);
+  });
+
+  test("recording an outcome cannot revert a concurrent rotation write", async () => {
+    const created = await createManagedExchange(newExchange());
+    const rotatedSecret = generateSharedSecret();
+    await persistManagedExchangeRotation(created.id, {
+      sharedSecret: rotatedSecret,
+      expires: null,
+    });
+    const updated = await recordManagedExchangeLastRun(created.id, {
+      at: "2026-07-14T12:00:00.000Z",
+      outcome: "failed",
+      failureKind: "storage",
+    });
+    // The lastRun read the freshest record: the rotated secret survives.
+    expect(updated.sharedSecret).toBe(rotatedSecret);
+    expect(updated.lastRun?.failureKind).toBe("storage");
   });
 });
 

--- a/apps/web/test/unit/managedExchangeRecord.test.ts
+++ b/apps/web/test/unit/managedExchangeRecord.test.ts
@@ -8,7 +8,9 @@ import { describe, expect, test } from "vitest";
 import {
   MANAGED_EXCHANGE_SCHEMA_VERSION,
   MAX_LABEL_LENGTH,
+  applyManagedExchangeLastRun,
   applyManagedExchangeLocalEdits,
+  applyManagedExchangeRotation,
   buildManagedExchangeRecord,
   composeManagedExchangeFile,
   parseManagedExchangeRecord,
@@ -16,6 +18,7 @@ import {
 } from "@psi/managedExchangeRecord";
 
 import type {
+  ManagedExchangeLastRun,
   ManagedExchangeSchedule,
   NewManagedExchange,
 } from "@psi/managedExchangeRecord";
@@ -233,5 +236,145 @@ describe("applyManagedExchangeLocalEdits", () => {
         label: "x".repeat(MAX_LABEL_LENGTH + 1),
       }),
     ).toThrow();
+  });
+});
+
+describe("applyManagedExchangeRotation", () => {
+  test("a string expires sets the bound; the secret advances", () => {
+    const record = buildManagedExchangeRecord(newExchange());
+    const rotatedSecret = generateSharedSecret();
+    const rotated = applyManagedExchangeRotation(record, {
+      sharedSecret: rotatedSecret,
+      expires: "2026-10-06T14:00:00.000Z",
+    });
+    expect(rotated.sharedSecret).toBe(rotatedSecret);
+    expect(rotated.expires).toBe("2026-10-06T14:00:00.000Z");
+  });
+
+  test("a null expires deletes the key, not merely sets it undefined", () => {
+    const record = buildManagedExchangeRecord(
+      newExchange({ expires: "2026-04-06T14:00:00.000Z" }),
+    );
+    const rotated = applyManagedExchangeRotation(record, {
+      sharedSecret: generateSharedSecret(),
+      expires: null,
+    });
+    expect(rotated).not.toHaveProperty("expires");
+  });
+
+  test("touches only the rotation fields; everything else survives", () => {
+    const record = buildManagedExchangeRecord(
+      newExchange({ tokenMaxAgeDays: 90, schedule }),
+    );
+    const rotated = applyManagedExchangeRotation(record, {
+      sharedSecret: generateSharedSecret(),
+      expires: null,
+    });
+    expect(rotated.id).toBe(record.id);
+    expect(rotated.label).toBe(record.label);
+    expect(rotated.exchangeFile).toEqual(record.exchangeFile);
+    expect(rotated.side).toBe(record.side);
+    expect(rotated.tokenMaxAgeDays).toBe(90);
+    expect(rotated.schedule).toEqual(schedule);
+  });
+
+  test("rejects a malformed rotated secret at this pure layer", () => {
+    const record = buildManagedExchangeRecord(newExchange());
+    expect(() =>
+      applyManagedExchangeRotation(record, {
+        sharedSecret: "not-a-secret",
+        expires: null,
+      }),
+    ).toThrow();
+  });
+
+  test("does not mutate the input record", () => {
+    const record = buildManagedExchangeRecord(
+      newExchange({ expires: "2026-04-06T14:00:00.000Z" }),
+    );
+    const originalSecret = record.sharedSecret;
+    applyManagedExchangeRotation(record, {
+      sharedSecret: generateSharedSecret(),
+      expires: null,
+    });
+    expect(record.sharedSecret).toBe(originalSecret);
+    expect(record.expires).toBe("2026-04-06T14:00:00.000Z");
+  });
+});
+
+describe("applyManagedExchangeLastRun", () => {
+  const olderRun: ManagedExchangeLastRun = {
+    at: "2026-07-14T12:00:00.000Z",
+    outcome: "succeeded",
+  };
+  const newerRun: ManagedExchangeLastRun = {
+    at: "2026-07-14T13:00:00.000Z",
+    outcome: "failed",
+    failureKind: "storage",
+  };
+
+  test("records an outcome, leaving the secret and document untouched", () => {
+    const record = buildManagedExchangeRecord(newExchange());
+    const updated = applyManagedExchangeLastRun(record, olderRun);
+    expect(updated.lastRun).toEqual(olderRun);
+    expect(updated.sharedSecret).toBe(record.sharedSecret);
+    expect(updated.exchangeFile).toEqual(record.exchangeFile);
+    // The input record is not mutated.
+    expect(record).not.toHaveProperty("lastRun");
+  });
+
+  test("a newer entry overwrites an older stored one", () => {
+    const record = applyManagedExchangeLastRun(
+      buildManagedExchangeRecord(newExchange()),
+      olderRun,
+    );
+    expect(applyManagedExchangeLastRun(record, newerRun).lastRun).toEqual(
+      newerRun,
+    );
+  });
+
+  test("an entry staler than the stored one is a no-op", () => {
+    const record = applyManagedExchangeLastRun(
+      buildManagedExchangeRecord(newExchange()),
+      newerRun,
+    );
+    const applied = applyManagedExchangeLastRun(record, olderRun);
+    expect(applied.lastRun).toEqual(newerRun);
+  });
+
+  test("an entry with the same instant overwrites (only strictly-staler no-ops)", () => {
+    const record = applyManagedExchangeLastRun(
+      buildManagedExchangeRecord(newExchange()),
+      olderRun,
+    );
+    const sameInstant: ManagedExchangeLastRun = {
+      at: olderRun.at,
+      outcome: "missed",
+    };
+    expect(applyManagedExchangeLastRun(record, sameInstant).lastRun).toEqual(
+      sameInstant,
+    );
+  });
+
+  test("staleness compares instants, not strings, across ISO precisions", () => {
+    // A whole-second ISO stamp sorts lexicographically AFTER a fractional stamp
+    // of a later instant ("...00Z" > "...00.500Z" as strings); the guard must
+    // still treat it as the older instant and keep the newer entry.
+    const fractionalNewer: ManagedExchangeLastRun = {
+      at: "2026-07-14T12:00:00.500Z",
+      outcome: "failed",
+      failureKind: "storage",
+    };
+    const wholeSecondOlder: ManagedExchangeLastRun = {
+      at: "2026-07-14T12:00:00Z",
+      outcome: "succeeded",
+    };
+    const record = applyManagedExchangeLastRun(
+      buildManagedExchangeRecord(newExchange()),
+      fractionalNewer,
+    );
+    expect(
+      applyManagedExchangeLastRun(record, wholeSecondOlder).lastRun,
+    ).toEqual(fractionalNewer);
   });
 });

--- a/apps/web/test/unit/managedRunRotate.test.ts
+++ b/apps/web/test/unit/managedRunRotate.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "vitest";
+import { generateSharedSecret } from "@psilink/core";
+
+import {
+  RotationPersistError,
+  failedRun,
+  rotationWriteBack,
+  runRotationCriticalSection,
+  storageFailureRun,
+  succeededRun,
+} from "@psi/managedRunRotate";
+
+import type { ManagedRotationCriticalSection } from "@psi/managedRunRotate";
+
+// The pure ordering and decision half of the run+rotate critical section, tested
+// in Node without a database or a real Web Lock: the persist-before-data-exchange
+// sequence (with the persist and lock seams faked), the `expires` restamp from the
+// max-age policy, and the `lastRun` bookkeeping. The strict-durability transaction,
+// the single-writer lock, and the no-steal property are the platform half, tested
+// against real Chromium in test/browser/managedExchangeRun.test.ts.
+
+// A fixed rotation instant and a day in ms, so the expected restamp is a plain
+// arithmetic check rather than a re-derivation of the function under test.
+const ROTATION_AT = Date.parse("2026-07-14T12:00:00.000Z");
+const MS_PER_DAY = 86_400_000;
+
+describe("rotationWriteBack: the expires restamp", () => {
+  test("with no policy, clears any standing bound (expires: null)", () => {
+    const secret = generateSharedSecret();
+    const writeBack = rotationWriteBack(secret, undefined, ROTATION_AT);
+    expect(writeBack).toEqual({ sharedSecret: secret, expires: null });
+  });
+
+  test("with a policy, restamps expires to now + tokenMaxAgeDays days", () => {
+    const secret = generateSharedSecret();
+    const writeBack = rotationWriteBack(secret, 90, ROTATION_AT);
+    expect(writeBack.sharedSecret).toBe(secret);
+    expect(writeBack.expires).toBe(
+      new Date(ROTATION_AT + 90 * MS_PER_DAY).toISOString(),
+    );
+  });
+
+  test("rejects a non-positive-integer age (a schema-bypassing caller)", () => {
+    const secret = generateSharedSecret();
+    expect(() => rotationWriteBack(secret, 0, ROTATION_AT)).toThrow(RangeError);
+    expect(() => rotationWriteBack(secret, -1, ROTATION_AT)).toThrow(
+      RangeError,
+    );
+    expect(() => rotationWriteBack(secret, 1.5, ROTATION_AT)).toThrow(
+      RangeError,
+    );
+  });
+
+  test("rejects an age whose computed expiry overflows the date range", () => {
+    const secret = generateSharedSecret();
+    // Far beyond year 9999 from the epoch.
+    expect(() => rotationWriteBack(secret, 100_000_000, ROTATION_AT)).toThrow(
+      RangeError,
+    );
+  });
+});
+
+describe("lastRun bookkeeping builders", () => {
+  test("succeededRun records a green outcome with no failureKind", () => {
+    expect(succeededRun(ROTATION_AT)).toEqual({
+      at: new Date(ROTATION_AT).toISOString(),
+      outcome: "succeeded",
+    });
+  });
+
+  test("storageFailureRun records a benign-tier storage failure", () => {
+    // The `storage` kind is what steers the next handshake failure to the benign
+    // Tier-1 framing rather than the attack framing.
+    expect(storageFailureRun(ROTATION_AT)).toEqual({
+      at: new Date(ROTATION_AT).toISOString(),
+      outcome: "failed",
+      failureKind: "storage",
+    });
+  });
+
+  test("failedRun records the runner-classified outcomes", () => {
+    expect(failedRun(ROTATION_AT, "desynced", "auth")).toEqual({
+      at: new Date(ROTATION_AT).toISOString(),
+      outcome: "desynced",
+      failureKind: "auth",
+    });
+  });
+});
+
+/** A locked critical section whose phases record the order they fire into
+ * `order`, so a test can assert the persist ran strictly after the handshake. The
+ * persist and handshake outcomes are configurable to drive the failure paths. */
+function tracedSection(
+  order: Array<string>,
+  overrides: Partial<ManagedRotationCriticalSection<string>> = {},
+): ManagedRotationCriticalSection<string> {
+  const rotatedSecret = generateSharedSecret();
+  return {
+    handshake: () => {
+      order.push("handshake");
+      return Promise.resolve({ rotatedSecret, handshake: "carried" });
+    },
+    persist: () => {
+      order.push("persist");
+      return Promise.resolve();
+    },
+    tokenMaxAgeDays: undefined,
+    now: () => ROTATION_AT,
+    ...overrides,
+  };
+}
+
+describe("runRotationCriticalSection: persist-before-gate ordering", () => {
+  test("persists the rotation and resolves the gate only after the persist", async () => {
+    const order: Array<string> = [];
+    const gate = await runRotationCriticalSection(tracedSection(order));
+
+    // The gate the data exchange consumes is resolved strictly after the persist,
+    // so a caller cannot begin the data exchange before the secret is durable.
+    expect(order).toEqual(["handshake", "persist"]);
+    expect(gate.handshake).toBe("carried");
+  });
+
+  test("the persist receives the restamped write-back when a policy is set", async () => {
+    const order: Array<string> = [];
+    const seen: Array<{ sharedSecret: string; expires: string | null }> = [];
+    const rotatedSecret = generateSharedSecret();
+    await runRotationCriticalSection(
+      tracedSection(order, {
+        tokenMaxAgeDays: 30,
+        handshake: () => {
+          order.push("handshake");
+          return Promise.resolve({ rotatedSecret, handshake: "carried" });
+        },
+        persist: (writeBack) => {
+          order.push("persist");
+          seen.push(writeBack);
+          return Promise.resolve();
+        },
+      }),
+    );
+    expect(seen).toHaveLength(1);
+    expect(seen[0].sharedSecret).toBe(rotatedSecret);
+    expect(seen[0].expires).toBe(
+      new Date(ROTATION_AT + 30 * MS_PER_DAY).toISOString(),
+    );
+  });
+
+  test("a persist failure aborts the section and carries storage bookkeeping", async () => {
+    const order: Array<string> = [];
+    const section = tracedSection(order, {
+      persist: () => {
+        order.push("persist");
+        return Promise.reject(new Error("quota exceeded"));
+      },
+    });
+
+    const error: unknown = await runRotationCriticalSection(section).then(
+      () => {
+        throw new Error(
+          "the section should have rejected on the persist failure",
+        );
+      },
+      (reason: unknown) => reason,
+    );
+
+    // The section rejects at the persist: no gate is resolved, so the data
+    // exchange the caller would run next is unreachable.
+    expect(order).toEqual(["handshake", "persist"]);
+    expect(error).toBeInstanceOf(RotationPersistError);
+    expect((error as RotationPersistError).lastRun).toEqual(
+      storageFailureRun(ROTATION_AT),
+    );
+    // The original cause is preserved for diagnostics.
+    expect((error as RotationPersistError).cause).toBeInstanceOf(Error);
+  });
+
+  test("a handshake failure aborts before any persist", async () => {
+    const order: Array<string> = [];
+    const section = tracedSection(order, {
+      handshake: () => {
+        order.push("handshake");
+        return Promise.reject(new Error("handshake failed closed"));
+      },
+    });
+
+    await expect(runRotationCriticalSection(section)).rejects.toThrow(
+      "handshake failed closed",
+    );
+    // The persist never ran.
+    expect(order).toEqual(["handshake"]);
+  });
+});

--- a/docs/spec/MANAGED_EXCHANGE_RECORD.md
+++ b/docs/spec/MANAGED_EXCHANGE_RECORD.md
@@ -25,11 +25,13 @@ the exchange-file artifact the record is composed from (see
 [PROTOCOL.md](PROTOCOL.md#shared-secret-rotation)). Intended readers are security
 auditors and implementors.
 
-> **Status.** The managed exchange record is not yet implemented. The
-> recurring-exchange epic implements against the shape below, and that
-> implementation is gated on security review because it persists a rotating
-> credential at rest. The persist-before-success ordering and the single-owner
-> invariant are normative for that implementation, not aspirational.
+> **Status.** The record store and the run+rotate critical section (the
+> single-writer lock and the persist-before-success write-back) are implemented;
+> the runner, scheduling, and management surfaces that use them are not yet. The
+> recurring-exchange epic implements against the shape below, security-reviewed
+> at each step because the record persists a rotating credential at rest. The
+> persist-before-success ordering and the single-owner invariant are normative,
+> not aspirational.
 
 ## What the record is, and what it deliberately is not
 


### PR DESCRIPTION
## Summary

Implement the run+rotate critical section for managed (recurring) exchanges: the seam the future runner calls to run a handshake, durably persist the rotated shared secret before the data exchange begins, and record run bookkeeping -- under a Web Locks single-writer lock so two same-origin contexts cannot double-rotate and desync the parties. The persist-before-success ordering is structural: the data exchange consumes a gate that resolves only after the strict-durability write commits.

Implements [212131250](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=212131250).

## Changes

- apps/web/src/psi/managedRunRotate.ts (new): the pure ordering half -- the rotation write-back (rotated secret plus a three-way expires decision: restamped from tokenMaxAgeDays, or null-cleared when no policy is set, mirroring the CLI's buildRotatedKeyFile including its guards), lastRun builders, RotationPersistError, and runRotationCriticalSection, whose gate the data exchange needs and which resolves only post-persist.
- apps/web/src/psi/managedExchangeRun.ts (new): the platform half and the runner's front door -- withManagedExchangeLock (exclusive, never stolen, keyed to the record id, ifAvailable optionally refusing instead of queuing) and runManagedExchange (lock held exactly from run start through the rotated secret's durable persist per the spec; the data exchange runs after release but remains unreachable pre-persist; a persist failure records storage-kind lastRun best-effort inside the lock and always rethrows the classifiable error).
- apps/web/src/psi/managedExchangeStore.ts: persistManagedExchangeRotation and recordManagedExchangeLastRun -- field-scoped read-modify-writes inside one strict-durability transaction, so neither can carry a stale secret or document.
- apps/web/src/psi/managedExchangeRecord.ts: pure appliers for rotation and lastRun; the lastRun applier is monotonic (a stamp older than the stored one is a no-op, compared as instants since the schema admits mixed ISO precision), so a slow run's stale tail cannot mask a newer run's outcome.
- apps/web/src/psi/authenticateExchange.ts: doc-only -- the one-shot flow still discards the rotated secret; the managed path consumes it from the same returned AuthResult.
- docs/spec/MANAGED_EXCHANGE_RECORD.md: status note updated (store and critical section implemented; runner and surfaces not yet).

## Test plan

Ran: `npm run typecheck && npm run lint && npm run format`; `npm run test -w apps/web` (1122 passed); `npm run test:browser -w apps/web` (357 passed, real Chromium has Web Locks and IndexedDB); `npm run linkcheck`.
New tests cover: persist-before-data-exchange ordering end to end (stored secret already rotated when the data exchange reads it; success stamp absent until the exchange completes); strict-durability transaction observed; contended same-id runs serializing without reverting the first rotation; distinct ids not contending; ifAvailable refusal; a structural no-steal assertion; lock release on a failed critical section; expires restamp and null-clear; the monotonic lastRun guard including cross-precision stamps; a data-exchange rejection propagating unchanged with the rotation kept and no success recorded; and a total storage outage (every readwrite failing) still yielding the classifiable RotationPersistError with the old secret retained.

## Background

Security-review-gated surface (secret lifecycle). A three-role panel (rotation-desync, browser platform, crash/failure ordering) reviewed the branch: the ordering, lock discipline, gate, and expires semantics were verified sound and CLI-faithful; the one converged fix (a double storage fault masking the classifiable error and losing the benign-tier steering evidence) is applied here with a discriminating test. One informational observation was routed to the board for a doc decision. The lock is a same-profile liveness guard only; the durable single-owner property rests on migration-not-sync export semantics (a later epic item).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- docs/spec/MANAGED_EXCHANGE_RECORD.md status note; the persist-before-success and durability contracts this implements were already documented and unchanged; docs/MANAGED_EXCHANGE.md's lifecycle status remains accurate (no live flow calls the seam yet)
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: infrastructure for a capability not yet user-reachable; the recurring-exchanges headline entry lands when the feature ships
- [x] Security review -- done: role-specialized panel (rotation-desync, browser platform, crash ordering) over the secret-lifecycle surface; the converged double-fault finding is fixed in this diff with a negative-checked test, and the lock-name observability note is filed on the board
