### PR TITLE
Fold the bench to a narrow-viewport layout

### DIFF
--- a/apps/web/src/bench/AcceptorBench.tsx
+++ b/apps/web/src/bench/AcceptorBench.tsx
@@ -544,6 +544,7 @@ export function AcceptorBench() {
         ).map((row) => ({
           label: row.label,
           muted: row.muted,
+          shareBar: row.shareBar,
           value: Array.isArray(row.value) ? (
             <>
               {row.value.map((line, index) => (

--- a/apps/web/src/bench/BenchShell.tsx
+++ b/apps/web/src/bench/BenchShell.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from "react";
+
 import { BenchPage } from "./BenchPage";
 import styles from "./bench.module.css";
 import { useNarrowBench } from "./narrowViewport";
@@ -17,7 +19,12 @@ import type { ReactNode } from "react";
  * At or below the narrow cut-over the ledger is placed AHEAD of the work
  * column in the DOM, so its collapsible share bar (see {@link Ledger}) is the
  * page's first interactive element -- a focus/DOM-order commitment CSS
- * reordering alone cannot make.
+ * reordering alone cannot make. The two regions render as a keyed array so a
+ * live breakpoint crossing (docking, rotation, devtools) is a reconciler MOVE:
+ * both subtrees keep their instances and local state (in-progress fields,
+ * reveal toggles, live-region identity). The browser does drop focus when the
+ * node containing the focused element moves -- inherent to the DOM move, not
+ * something keying can prevent.
  */
 export function BenchShell({
   topBar,
@@ -40,22 +47,22 @@ export function BenchShell({
         : topBar === undefined
           ? `${styles.grid} ${styles.gridLedger}`
           : `${styles.grid} ${styles.gridLedger} ${styles.gridUnderBar}`;
-  const work = <main className={styles.work}>{children}</main>;
+  const work = (
+    <main key="work" className={styles.work}>
+      {children}
+    </main>
+  );
+  const ledgerRegion =
+    ledger === undefined ? undefined : (
+      <Fragment key="ledger">{ledger}</Fragment>
+    );
   return (
     <BenchPage>
       {topBar}
       <div className={gridClass}>
-        {narrow && ledger !== undefined ? (
-          <>
-            {ledger}
-            {work}
-          </>
-        ) : (
-          <>
-            {work}
-            {ledger}
-          </>
-        )}
+        {narrow && ledgerRegion !== undefined
+          ? [ledgerRegion, work]
+          : [work, ledgerRegion]}
       </div>
     </BenchPage>
   );

--- a/apps/web/src/bench/BenchShell.tsx
+++ b/apps/web/src/bench/BenchShell.tsx
@@ -1,5 +1,6 @@
 import { BenchPage } from "./BenchPage";
 import styles from "./bench.module.css";
+import { useNarrowBench } from "./narrowViewport";
 
 import type { ReactNode } from "react";
 
@@ -12,6 +13,11 @@ import type { ReactNode } from "react";
  * `ledger` collapses to the single-column "plain" layout {@link
  * VerifyReceiptBench} uses; omitting only the ledger keeps the work column
  * alone under the top bar.
+ *
+ * At or below the narrow cut-over the ledger is placed AHEAD of the work
+ * column in the DOM, so its collapsible share bar (see {@link Ledger}) is the
+ * page's first interactive element -- a focus/DOM-order commitment CSS
+ * reordering alone cannot make.
  */
 export function BenchShell({
   topBar,
@@ -22,6 +28,7 @@ export function BenchShell({
   ledger?: ReactNode;
   children: ReactNode;
 }) {
+  const narrow = useNarrowBench();
   // gridUnderBar raises the ledger's sticky offset above the stuck top bar;
   // a ledger with no bar (a generic layout this shell permits even though no
   // current bench composes it) keeps the plain offset.
@@ -33,12 +40,22 @@ export function BenchShell({
         : topBar === undefined
           ? `${styles.grid} ${styles.gridLedger}`
           : `${styles.grid} ${styles.gridLedger} ${styles.gridUnderBar}`;
+  const work = <main className={styles.work}>{children}</main>;
   return (
     <BenchPage>
       {topBar}
       <div className={gridClass}>
-        <main className={styles.work}>{children}</main>
-        {ledger}
+        {narrow && ledger !== undefined ? (
+          <>
+            {ledger}
+            {work}
+          </>
+        ) : (
+          <>
+            {work}
+            {ledger}
+          </>
+        )}
       </div>
     </BenchPage>
   );

--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -732,6 +732,7 @@ export function InviterBench() {
             label: row.label,
             reference: row.reference,
             muted: row.muted,
+            shareBar: row.shareBar,
             value: Array.isArray(row.value) ? (
               <>
                 {row.value.map((line, index) => (

--- a/apps/web/src/bench/Ledger.tsx
+++ b/apps/web/src/bench/Ledger.tsx
@@ -7,34 +7,16 @@ import { useNarrowBench } from "./narrowViewport";
 import type { RailFact } from "./inviterModel";
 import type { ReactNode } from "react";
 
-/** The narrow share bar condenses the ledger to three headline disclosure
- * facts: the primary outbound row, the matched-on keys, and the expiry -- the
- * mock's subset. The inviter sends and the acceptor receives, so the primary
- * row is "You will send" when present and the receive row otherwise (either
- * tense). Labels are model-authored constants; a producer that renames one of
- * these must update the matching list here -- a share-bar row silently
- * dropping is a review tell. */
-const SHARE_BAR_SENT_LABEL = "You will send";
-const SHARE_BAR_RECEIVED_LABELS: ReadonlyArray<string> = [
-  "You will receive",
-  "You received",
-];
-const SHARE_BAR_MATCHED_LABEL = "Matched on";
-const SHARE_BAR_EXPIRES_LABEL = "Expires";
-
-/** The share bar's rows in ledger order: the primary outbound fact, matched-on,
- * and expires. Falls back to the leading rows if a producer's labels do not
- * match, so the bar is never empty. */
+/** The narrow share bar's rows in ledger order: the headline disclosure facts
+ * each row producer marked `shareBar` -- the producer declares its own
+ * condensed subset, so a relabel cannot silently drop a row from the trust
+ * surface. The leading-rows fallback is a best-effort backstop only, keeping
+ * the bar non-empty should a producer mark nothing; the unit suite pins each
+ * producer's marked subset, so it is not a guarantee anything relies on. */
 function shareBarRows(
   rows: ReadonlyArray<LedgerRow>,
 ): ReadonlyArray<LedgerRow> {
-  const hasSend = rows.some((row) => row.label === SHARE_BAR_SENT_LABEL);
-  const headline = rows.filter((row) => {
-    if (row.label === SHARE_BAR_MATCHED_LABEL) return true;
-    if (row.label === SHARE_BAR_EXPIRES_LABEL) return true;
-    if (hasSend) return row.label === SHARE_BAR_SENT_LABEL;
-    return SHARE_BAR_RECEIVED_LABELS.includes(row.label);
-  });
+  const headline = rows.filter((row) => row.shareBar === true);
   return headline.length > 0 ? headline : rows.slice(0, 3);
 }
 
@@ -43,13 +25,15 @@ function shareBarRows(
  * bench's monospace data voice, and an optional reference to the spine step
  * that owns the value ("Step 2"). `muted` is the named empty state ("None",
  * "Nothing - matching only"), rendered in the placeholder voice; with neither
- * the row shows the em-dash "not decided yet" mark.
+ * the row shows the em-dash "not decided yet" mark. `shareBar` carries the
+ * producer's marker for the narrow condensed bar (see {@link shareBarRows}).
  */
 export interface LedgerRow {
   label: string;
   value?: ReactNode;
   muted?: string;
   reference?: string;
+  shareBar?: boolean;
 }
 
 const FACT_TONE_CLASS = {

--- a/apps/web/src/bench/Ledger.tsx
+++ b/apps/web/src/bench/Ledger.tsx
@@ -1,7 +1,42 @@
+import { useState } from "react";
+
+import { DisclosureSection } from "../components/DisclosureSection";
 import styles from "./bench.module.css";
+import { useNarrowBench } from "./narrowViewport";
 
 import type { RailFact } from "./inviterModel";
 import type { ReactNode } from "react";
+
+/** The narrow share bar condenses the ledger to three headline disclosure
+ * facts: the primary outbound row, the matched-on keys, and the expiry -- the
+ * mock's subset. The inviter sends and the acceptor receives, so the primary
+ * row is "You will send" when present and the receive row otherwise (either
+ * tense). Labels are model-authored constants; a producer that renames one of
+ * these must update the matching list here -- a share-bar row silently
+ * dropping is a review tell. */
+const SHARE_BAR_SENT_LABEL = "You will send";
+const SHARE_BAR_RECEIVED_LABELS: ReadonlyArray<string> = [
+  "You will receive",
+  "You received",
+];
+const SHARE_BAR_MATCHED_LABEL = "Matched on";
+const SHARE_BAR_EXPIRES_LABEL = "Expires";
+
+/** The share bar's rows in ledger order: the primary outbound fact, matched-on,
+ * and expires. Falls back to the leading rows if a producer's labels do not
+ * match, so the bar is never empty. */
+function shareBarRows(
+  rows: ReadonlyArray<LedgerRow>,
+): ReadonlyArray<LedgerRow> {
+  const hasSend = rows.some((row) => row.label === SHARE_BAR_SENT_LABEL);
+  const headline = rows.filter((row) => {
+    if (row.label === SHARE_BAR_MATCHED_LABEL) return true;
+    if (row.label === SHARE_BAR_EXPIRES_LABEL) return true;
+    if (hasSend) return row.label === SHARE_BAR_SENT_LABEL;
+    return SHARE_BAR_RECEIVED_LABELS.includes(row.label);
+  });
+  return headline.length > 0 ? headline : rows.slice(0, 3);
+}
 
 /**
  * One row of the disclosure ledger: an uppercase label, the value in the
@@ -42,12 +77,32 @@ function CustomizeFactValue({ entry }: { entry: RailFact }) {
  * plain button per optional surface (normal tab order, no menu semantics),
  * pairing the surface's label with its quiet fact. The open tab's row carries
  * `aria-current="true"` and the accent style; a surface not yet reachable
- * (no file read) renders its row disabled.
+ * (no file read) renders its row disabled. `groupNote` is the line above the
+ * rows -- the "Customize" heading on the wide ledger, the "Filled in from your
+ * file." note inside the narrow disclosure whose toggle already reads
+ * "Customize".
  */
-function LedgerCustomize({ facts }: { facts: ReadonlyArray<RailFact> }) {
+function LedgerCustomize({
+  facts,
+  groupNote,
+}: {
+  facts: ReadonlyArray<RailFact>;
+  /** The line above the rows. Absent on the wide ledger (the uppercase
+   * "Customize" heading); the narrow disclosure passes the softer "Filled in
+   * from your file." note, its toggle already carrying the "Customize" name. */
+  groupNote?: string;
+}) {
   return (
     <div className={styles.ledgerCustomize}>
-      <p className={styles.ledgerGroupLabel}>Customize</p>
+      <p
+        className={
+          groupNote === undefined
+            ? styles.ledgerGroupLabel
+            : styles.customizeGroupNote
+        }
+      >
+        {groupNote ?? "Customize"}
+      </p>
       <ul>
         {facts.map((entry) => (
           <li key={entry.label}>
@@ -74,6 +129,60 @@ function LedgerCustomize({ facts }: { facts: ReadonlyArray<RailFact> }) {
   );
 }
 
+/** The sealed-terms tag and sample-data notice shown under the ledger title:
+ * standing trust state that survives every viewport, so it renders above the
+ * disclosures on a narrow layout too. */
+function LedgerStanding({
+  tag,
+  demoNotice,
+}: {
+  tag?: string;
+  demoNotice?: { label: string; onClear?: () => void };
+}) {
+  return (
+    <>
+      {tag !== undefined && <span className={styles.sealedTag}>{tag}</span>}
+      {demoNotice !== undefined && (
+        <div className={styles.demoNotice}>
+          <span>{demoNotice.label}</span>
+          {demoNotice.onClear !== undefined && (
+            <button
+              type="button"
+              className={styles.demoClear}
+              onClick={demoNotice.onClear}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+/** The ledger's fact rows as a definition list. */
+function LedgerRows({ rows }: { rows: ReadonlyArray<LedgerRow> }) {
+  return (
+    <dl>
+      {rows.map((row) => (
+        <div key={row.label} className={styles.ledgerRow}>
+          <dt>
+            {row.label}
+            {row.reference !== undefined && (
+              <span className={styles.ledgerRef}>{row.reference}</span>
+            )}
+          </dt>
+          <dd>
+            {row.value ?? (
+              <span className={styles.dash}>{row.muted ?? "\u2014"}</span>
+            )}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
 /**
  * The standing disclosure ledger on the bench's right: always visible,
  * filling in as the exchange takes shape -- the running answer to "what leaves
@@ -81,6 +190,12 @@ function LedgerCustomize({ facts }: { facts: ReadonlyArray<RailFact> }) {
  * the terms are editable it also hosts the Customize group's surface rows
  * ({@link LedgerCustomize}); the hosting bench withholds `customize` once the
  * terms seal or the run launches.
+ *
+ * At or below the narrow cut-over the aside folds to a collapsible "What you
+ * will share" bar (a condensed three-row subset plus the trust footer) and,
+ * when editable, a separate Customize disclosure. The hosting {@link
+ * BenchShell} pins this aside ahead of the work column at that width, making
+ * the share bar the page's first interactive element.
  */
 export function Ledger({
   title = "This exchange",
@@ -106,43 +221,87 @@ export function Ledger({
   customize?: ReadonlyArray<RailFact>;
   footer?: ReactNode;
 }) {
+  const narrow = useNarrowBench();
+  if (narrow) {
+    return (
+      <NarrowLedger
+        title={title}
+        tag={tag}
+        demoNotice={demoNotice}
+        rows={rows}
+        customize={customize}
+        footer={footer}
+      />
+    );
+  }
   return (
     <aside className={styles.ledger} aria-label={title}>
       <h2>{title}</h2>
-      {tag !== undefined && <span className={styles.sealedTag}>{tag}</span>}
-      {demoNotice !== undefined && (
-        <div className={styles.demoNotice}>
-          <span>{demoNotice.label}</span>
-          {demoNotice.onClear !== undefined && (
-            <button
-              type="button"
-              className={styles.demoClear}
-              onClick={demoNotice.onClear}
-            >
-              Clear
-            </button>
-          )}
-        </div>
-      )}
-      <dl>
-        {rows.map((row) => (
-          <div key={row.label} className={styles.ledgerRow}>
-            <dt>
-              {row.label}
-              {row.reference !== undefined && (
-                <span className={styles.ledgerRef}>{row.reference}</span>
-              )}
-            </dt>
-            <dd>
-              {row.value ?? (
-                <span className={styles.dash}>{row.muted ?? "\u2014"}</span>
-              )}
-            </dd>
-          </div>
-        ))}
-      </dl>
+      <LedgerStanding tag={tag} demoNotice={demoNotice} />
+      <LedgerRows rows={rows} />
       {customize !== undefined && <LedgerCustomize facts={customize} />}
       {footer !== undefined && <p className={styles.trust}>{footer}</p>}
+    </aside>
+  );
+}
+
+/**
+ * The ledger at a narrow viewport: a collapsible "What you will share" bar
+ * over the condensed top rows plus the trust footer, and -- while the terms
+ * are editable -- a separate Customize disclosure holding the same surface
+ * rows. Both default collapsed but present, one tap from their contents.
+ * Still an `<aside>` named by the ledger title, so the trust landmark survives
+ * the fold. The share bar comes first so it is the page's first interactive
+ * element ahead of the sample notice's Clear action; the standing tag and
+ * sample notice follow it, always visible.
+ */
+function NarrowLedger({
+  title,
+  tag,
+  demoNotice,
+  rows,
+  customize,
+  footer,
+}: {
+  title: string;
+  tag?: string;
+  demoNotice?: { label: string; onClear?: () => void };
+  rows: ReadonlyArray<LedgerRow>;
+  customize?: ReadonlyArray<RailFact>;
+  footer?: ReactNode;
+}) {
+  const [shareOpen, setShareOpen] = useState(false);
+  const [customizeOpen, setCustomizeOpen] = useState(false);
+  return (
+    <aside className={styles.narrowLedger} aria-label={title}>
+      <div className={styles.shareBar}>
+        <DisclosureSection
+          label="What you will share"
+          headingOrder={2}
+          open={shareOpen}
+          onToggle={setShareOpen}
+        >
+          <div className={styles.shareBarBody}>
+            <LedgerRows rows={shareBarRows(rows)} />
+            {footer !== undefined && <p className={styles.trust}>{footer}</p>}
+          </div>
+        </DisclosureSection>
+      </div>
+      {customize !== undefined && (
+        <div className={styles.customizeDisclosure}>
+          <DisclosureSection
+            label="Customize"
+            open={customizeOpen}
+            onToggle={setCustomizeOpen}
+          >
+            <LedgerCustomize
+              facts={customize}
+              groupNote="Filled in from your file."
+            />
+          </DisclosureSection>
+        </div>
+      )}
+      <LedgerStanding tag={tag} demoNotice={demoNotice} />
     </aside>
   );
 }

--- a/apps/web/src/bench/TopBar.tsx
+++ b/apps/web/src/bench/TopBar.tsx
@@ -1,6 +1,7 @@
 import { Stepper } from "@mantine/core";
 
 import styles from "./bench.module.css";
+import { useNarrowBench } from "./narrowViewport";
 
 import type { RailStep } from "./inviterModel";
 
@@ -52,10 +53,39 @@ function BenchStepper({ steps }: { steps: ReadonlyArray<RailStep> }) {
 }
 
 /**
+ * The narrow-viewport spine: the full Stepper compresses to a one-line strip
+ * naming the current position ("Step 2 of 3 - Matching & sharing"), the USWDS
+ * step-indicator small variant. The strip is plain text -- no step is a link
+ * here -- so it never precedes the collapsible share bar as an interactive
+ * element. The "N/M" badge is a decorative echo, hidden from assistive tech
+ * since the sentence already carries the position.
+ */
+function StepStrip({ steps }: { steps: ReadonlyArray<RailStep> }) {
+  // activeIndex returns steps.length when every step is done, so clamp to the
+  // last real step before naming it.
+  const position = Math.min(activeIndex(steps), steps.length - 1);
+  const humanPosition = position + 1;
+  return (
+    <p className={styles.stepStrip}>
+      <span>
+        Step {humanPosition} of {steps.length} - {steps[position].label}
+      </span>
+      <span className={styles.mono} aria-hidden="true">
+        {humanPosition}/{steps.length}
+      </span>
+    </p>
+  );
+}
+
+/**
  * The bench's top bar: the wordmark, a `<nav>` landmark named by `navLabel`
  * wrapping the required-spine or protocol-timeline Stepper, and the
  * right-aligned transport note -- pure wayfinding; the optional Customize
  * surfaces live on the disclosure ledger. See {@link BenchShell}.
+ *
+ * At or below the narrow cut-over the Stepper compresses to a {@link
+ * StepStrip}; the switch is by conditional render, not `display`, so only one
+ * spine is ever in the accessibility tree.
  */
 export function TopBar({
   navLabel,
@@ -68,11 +98,12 @@ export function TopBar({
    * directory"), shown once the exchange's channel is fixed. */
   transportNote?: string;
 }) {
+  const narrow = useNarrowBench();
   return (
     <div className={styles.topBar}>
       <div className={styles.wordmark}>psilink</div>
       <nav aria-label={navLabel} className={styles.topBarNav}>
-        <BenchStepper steps={steps} />
+        {narrow ? <StepStrip steps={steps} /> : <BenchStepper steps={steps} />}
       </nav>
       {transportNote !== undefined && (
         <p className={styles.topBarNote}>{transportNote}</p>

--- a/apps/web/src/bench/acceptorModel.ts
+++ b/apps/web/src/bench/acceptorModel.ts
@@ -122,11 +122,15 @@ function acceptorResultsGoTo(output: LinkageTerms["output"]): string {
 
 /** One row of the acceptor's disclosure ledger: the value renders in the data
  * voice, `muted` in the empty-state voice, `value` may be a multi-line list (the
- * per-key matched-on rows). */
+ * per-key matched-on rows). `shareBar` marks the row as one of the headline
+ * disclosure facts the narrow viewport's condensed "What you will share" bar
+ * keeps -- declared here by the producer, so a relabel can never silently drop
+ * a row from that trust surface. */
 export interface AcceptorLedgerRow {
   label: string;
   value?: string | ReadonlyArray<string>;
   muted?: string;
+  shareBar?: boolean;
 }
 
 /** The forward-reference wording the pre-file send rows carry, before any file is
@@ -146,12 +150,16 @@ function acceptorSendRow(
   label: string,
   disclosure: ReadonlyArray<string> | undefined,
 ): AcceptorLedgerRow {
+  // Whatever its tense, the outbound row is the share bar's headline fact --
+  // what leaves (or left) this machine.
   if (disclosure === undefined)
-    return { label, muted: ACCEPTOR_SEND_FORWARD_REFERENCE };
-  if (disclosure.length === 0) return { label, muted: "No additional columns" };
+    return { label, muted: ACCEPTOR_SEND_FORWARD_REFERENCE, shareBar: true };
+  if (disclosure.length === 0)
+    return { label, muted: "No additional columns", shareBar: true };
   return {
     label,
     value: disclosure.map((name) => sanitizeForDisplay(name)).join(", "),
+    shareBar: true,
   };
 }
 
@@ -208,14 +216,16 @@ export function acceptorLedgerRows(
           value: summary.linkageKeys.map(
             (key, index) => `${index + 1}. ${key.name}`,
           ),
+          shareBar: true,
         }
-      : { label: "Matched on", muted: "No keys" },
+      : { label: "Matched on", muted: "No keys", shareBar: true },
     {
       label: "Expires",
       value:
         summary.expires !== undefined
           ? dateTimeLabel(new Date(summary.expires))
           : "No expiry",
+      shareBar: true,
     },
     {
       label: "Results go to",
@@ -282,15 +292,18 @@ export function acceptorDoneLedgerRows(
         )} matched rows${receivedSuffix}`;
   return [
     acceptorSendRow("You sent", disclosedColumnNames(metadata)),
-    { label: "You received", value: receivedValue },
+    // The expiry row is gone (the invitation is consumed), so the settled
+    // condensed subset is what left, what arrived, and what matched.
+    { label: "You received", value: receivedValue, shareBar: true },
     summary.linkageKeys.length > 0
       ? {
           label: "Matched on",
           value: summary.linkageKeys.map(
             (key, index) => `${index + 1}. ${key.name}`,
           ),
+          shareBar: true,
         }
-      : { label: "Matched on", muted: "No keys" },
+      : { label: "Matched on", muted: "No keys", shareBar: true },
     {
       label: "Results went to",
       value: acceptorResultsGoTo(token.linkageTerms.output),

--- a/apps/web/src/bench/bench.module.css
+++ b/apps/web/src/bench/bench.module.css
@@ -995,3 +995,58 @@
     display: none;
   }
 }
+
+/* ---------- narrow-viewport information architecture ----------
+   Kept in sync with NARROW_BENCH_MAX_WIDTH (narrowViewport.ts): the JS
+   useMediaQuery that switches the DOM presentation and these styles read the
+   same width, so they cannot disagree about the cut-over. The step strip, the
+   share bar, and the Customize disclosure are conditionally rendered above
+   this width, so their classes never apply to the wide layout. */
+@media (max-width: 600px) {
+  .topBarNav {
+    flex: 1;
+    overflow-x: visible;
+  }
+
+  .stepStrip {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin: 0;
+    background: var(--bench-column);
+    border: 1px solid var(--bench-rule);
+    border-radius: 2px;
+    padding: 8px 12px;
+    font-size: 13.5px;
+    font-weight: 650;
+  }
+
+  .narrowLedger {
+    min-width: 0;
+  }
+
+  .shareBar,
+  .customizeDisclosure {
+    border: 1px solid var(--bench-rule);
+    background: var(--bench-column);
+    border-radius: 8px;
+    padding: 10px 12px;
+    margin: 12px 0;
+  }
+
+  .shareBarBody {
+    padding-top: 8px;
+    font-size: 13.5px;
+  }
+
+  .shareBarBody .trust {
+    margin-top: 10px;
+  }
+
+  .customizeGroupNote {
+    font-size: 12px;
+    color: var(--bench-faint);
+    margin: 8px 0 4px 0;
+  }
+}

--- a/apps/web/src/bench/inviterModel.ts
+++ b/apps/web/src/bench/inviterModel.ts
@@ -649,12 +649,16 @@ export const RESULTS_DIRECTION_LABELS: Record<OutputDirection, string> = {
 
 /** One disclosure-ledger row: `value` renders in the data voice, `muted`
  * renders in the empty-state voice ("None", "Nothing"), neither renders the
- * em-dash placeholder. */
+ * em-dash placeholder. `shareBar` marks the row as one of the headline
+ * disclosure facts the narrow viewport's condensed "What you will share" bar
+ * keeps -- declared here by the producer, so a relabel can never silently
+ * drop a row from that trust surface. */
 export interface InviterLedgerRow {
   label: string;
   reference?: string;
   value?: string | ReadonlyArray<string>;
   muted?: string;
+  shareBar?: boolean;
 }
 
 /** What a completed exchange settled, folded into the ledger: the invitation
@@ -681,10 +685,10 @@ export function inviterLedgerRows(
 ): Array<InviterLedgerRow> {
   if (editor === undefined) {
     return [
-      { label: "You will send", reference: "Step 2" },
+      { label: "You will send", reference: "Step 2", shareBar: true },
       { label: "You will receive", reference: "Step 2" },
-      { label: "Matched on", reference: "Step 2" },
-      { label: "Expires", reference: "Step 3" },
+      { label: "Matched on", reference: "Step 2", shareBar: true },
+      { label: "Expires", reference: "Step 3", shareBar: true },
       { label: "Results go to", reference: "Step 3" },
       { label: "Agreement" },
       { label: "Transport", reference: "Step 3" },
@@ -694,11 +698,17 @@ export function inviterLedgerRows(
   const keys = enabledKeys(editor.draft);
   return [
     sent.length > 0
-      ? { label: "You will send", reference: "Step 2", value: sent.join(", ") }
+      ? {
+          label: "You will send",
+          reference: "Step 2",
+          value: sent.join(", "),
+          shareBar: true,
+        }
       : {
           label: "You will send",
           reference: "Step 2",
           muted: "Nothing - matching only",
+          shareBar: true,
         },
     {
       label: "You will receive",
@@ -715,8 +725,14 @@ export function inviterLedgerRows(
           label: "Matched on",
           reference: "Step 2",
           value: keys.map((key, index) => `${index + 1}. ${key.name}`),
+          shareBar: true,
         }
-      : { label: "Matched on", reference: "Step 2", muted: "No keys" },
+      : {
+          label: "Matched on",
+          reference: "Step 2",
+          muted: "No keys",
+          shareBar: true,
+        },
     {
       label: "Expires",
       reference: "Step 3",
@@ -726,6 +742,7 @@ export function inviterLedgerRows(
           : expiresIso !== undefined
             ? dateTimeLabel(new Date(expiresIso))
             : lifetimeLabel(editor.draft.lifetimeSeconds),
+      shareBar: true,
     },
     {
       label: "Results go to",

--- a/apps/web/src/bench/narrowViewport.ts
+++ b/apps/web/src/bench/narrowViewport.ts
@@ -1,0 +1,29 @@
+import { useMediaQuery } from "@mantine/hooks";
+
+/**
+ * The width at or below which the bench switches to its narrow-viewport
+ * information architecture: the top-bar stepper compresses to a step strip,
+ * the standing ledger folds to a collapsible "What you will share" bar pinned
+ * as the page's first interactive element, and the Customize surfaces fold
+ * behind their own disclosure. Above it the wide work/ledger layout holds.
+ *
+ * The media query and the {@link useNarrowBench} hook that drive the two
+ * presentations both read this one value, so the CSS styling and the DOM-order
+ * switch cannot disagree about where the cut-over is.
+ */
+export const NARROW_BENCH_MAX_WIDTH = 600;
+
+/** The `max-width` media query for {@link NARROW_BENCH_MAX_WIDTH}. */
+export const NARROW_BENCH_MEDIA_QUERY = `(max-width: ${NARROW_BENCH_MAX_WIDTH}px)`;
+
+/**
+ * Whether the bench is at or below {@link NARROW_BENCH_MAX_WIDTH}. Reads the
+ * real viewport on the first render (`getInitialValueInEffect: false`), which
+ * the bench routes can do because they render client-only -- so the narrow IA
+ * paints without a wide-layout flash rather than settling after an effect.
+ */
+export function useNarrowBench(): boolean {
+  return useMediaQuery(NARROW_BENCH_MEDIA_QUERY, false, {
+    getInitialValueInEffect: false,
+  });
+}

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -182,8 +182,8 @@ afterEach(async () => {
   csvLoadHarness.resolve = undefined;
   lifecycleHarness.calls.length = 0;
   // The bench reads the viewport width to choose its wide vs narrow layout, so
-  // a test that narrows the page must not leak that width into the next: reset
-  // to a wide default (above the one-column and the narrow cut-overs).
+  // a test that narrows the page must not leak that width into the next:
+  // restore the browser project's configured wide default (vite.config.ts).
   await page.viewport(1280, 800);
 });
 
@@ -2296,14 +2296,19 @@ describe("bench at a narrow viewport", () => {
 
     // The first focusable control on the page is the share bar's toggle: it
     // sits ahead of every work-column control in DOM order, so tabbing from the
-    // document start reaches it first.
+    // document start reaches it first. "Interactive" means tab-reachable
+    // (tabIndex >= 0), enabled, and laid out -- excluding, e.g., the hidden
+    // tabindex="-1" measurement textarea Mantine's autosize input parks on
+    // document.body.
     const focusable = Array.from(
       document.querySelectorAll<HTMLElement>(
-        'button, a[href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        "button, a[href], input, select, textarea, [tabindex]",
       ),
     ).filter(
       (element) =>
-        element.offsetParent !== null || element === document.activeElement,
+        element.tabIndex >= 0 &&
+        !element.matches(":disabled") &&
+        element.offsetParent !== null,
     );
     const shareToggle = page.getByRole("button", {
       name: "What you will share",

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -2352,4 +2352,39 @@ describe("bench at a narrow viewport", () => {
     await page.getByRole("button", { name: "Customize" }).click();
     expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(400);
   });
+
+  test("a live breakpoint crossing preserves the work column's state", async () => {
+    // Mounted wide (the project's default viewport) and sealed, with
+    // component-local state armed in the work column: the reveal toggle's
+    // open textarea, whose state lives inside the copy row, not the bench.
+    await createSealedInvitation();
+    const reveal = page.getByRole("button", { name: "Show full link" });
+    await reveal.click();
+    await expect.element(reveal).toHaveAttribute("aria-expanded", "true");
+    const revealArea = document.querySelector(
+      `.${styles.revealArea}`,
+    ) as HTMLTextAreaElement;
+    expect(revealArea).not.toBeNull();
+    const deepLink = revealArea.value;
+
+    // Crossing to narrow reorders the regions as a keyed move, not a
+    // remount: the reveal stays open, on the very same DOM node, while the
+    // ledger folds to the share bar.
+    await page.viewport(400, 800);
+    await expect
+      .element(page.getByRole("button", { name: "What you will share" }))
+      .toBeInTheDocument();
+    await expect.element(reveal).toHaveAttribute("aria-expanded", "true");
+    expect(document.querySelector(`.${styles.revealArea}`)).toBe(revealArea);
+    expect(revealArea.value).toBe(deepLink);
+
+    // And back out to wide: the full ledger aside returns, the reveal still
+    // open on the same node.
+    await page.viewport(1280, 800);
+    await expect
+      .element(page.getByRole("heading", { name: "This exchange" }))
+      .toBeInTheDocument();
+    await expect.element(reveal).toHaveAttribute("aria-expanded", "true");
+    expect(document.querySelector(`.${styles.revealArea}`)).toBe(revealArea);
+  });
 });

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -167,7 +167,7 @@ function mount(content: ReactNode) {
   root.render(createElement(MantineProvider, null, content));
 }
 
-afterEach(() => {
+afterEach(async () => {
   // Backstop for the fake-Date test below: a failure between useFakeTimers and
   // its finally must not leak a frozen clock into the rest of the suite.
   vi.useRealTimers();
@@ -181,6 +181,10 @@ afterEach(() => {
   csvLoadHarness.lastSignal = undefined;
   csvLoadHarness.resolve = undefined;
   lifecycleHarness.calls.length = 0;
+  // The bench reads the viewport width to choose its wide vs narrow layout, so
+  // a test that narrows the page must not leak that width into the next: reset
+  // to a wide default (above the one-column and the narrow cut-overs).
+  await page.viewport(1280, 800);
 });
 
 // Walk the spine to a sealed invitation: name, file, straight through to
@@ -2194,5 +2198,153 @@ describe("inviter bench", () => {
     } finally {
       downloads.restore();
     }
+  });
+});
+
+describe("bench at a narrow viewport", () => {
+  const SAMPLE_CSV = new File(
+    [
+      "client_id,first_name,last_name,dob,program_code\n" +
+        "1,Ann,Lee,01/02/1990,A\n2,Bo,Ray,03/04/1985,B\n",
+    ],
+    "clients.csv",
+    { type: "text/csv" },
+  );
+
+  // Mount already narrow so the layout hook renders the small-viewport IA from
+  // the first paint, read the sample file so the ledger fills and the Customize
+  // surfaces become reachable, then walk to Matching & sharing (spine step 2).
+  async function reachMatchingSharingNarrow() {
+    await page.viewport(400, 800);
+    mount(createElement(InviterBench));
+    await expect.element(page.getByLabelText("Your name")).toBeInTheDocument();
+    await userEvent.fill(page.getByLabelText("Your name"), "Dana Okafor");
+    const fileInput = document.querySelector('input[type="file"]');
+    await userEvent.upload(
+      page.elementLocator(fileInput as HTMLElement),
+      SAMPLE_CSV,
+    );
+    await expect.element(page.getByText("clients.csv")).toBeInTheDocument();
+    await page
+      .getByRole("button", { name: "Continue to matching & sharing" })
+      .click();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Matching & sharing");
+  }
+
+  test("the spine compresses to a step strip naming the current position", async () => {
+    await reachMatchingSharingNarrow();
+
+    // The setup nav no longer renders the full Mantine Stepper (no step-label
+    // nodes, the selector the wide-layout tests read); it carries the one-line
+    // step strip naming step 2 of the three-step spine.
+    const nav = document.querySelector('nav[aria-label="Exchange setup"]');
+    expect(nav).not.toBeNull();
+    expect(
+      (nav as Element).querySelectorAll(".mantine-Stepper-stepLabel"),
+    ).toHaveLength(0);
+    expect((nav as Element).textContent).toContain(
+      "Step 2 of 3 - Matching & sharing",
+    );
+
+    // The decorative "N/M" badge is hidden from assistive tech -- the sentence
+    // already carries the position.
+    const badge = (nav as Element).querySelector('[aria-hidden="true"]');
+    expect(badge?.textContent).toBe("2/3");
+  });
+
+  test("the Customize tabs fold behind a disclosure keeping each fact value", async () => {
+    await reachMatchingSharingNarrow();
+
+    // The optional surfaces are behind a collapsed "Customize" disclosure, not
+    // the standing ledger group.
+    const customizeToggle = page.getByRole("button", { name: "Customize" });
+    await expect.element(customizeToggle).toBeInTheDocument();
+    await expect
+      .element(customizeToggle)
+      .toHaveAttribute("aria-expanded", "false");
+
+    // The group note and each surface's right-aligned fact are inside it.
+    await customizeToggle.click();
+    await expect
+      .element(customizeToggle)
+      .toHaveAttribute("aria-expanded", "true");
+    await expect
+      .element(page.getByText("Filled in from your file."))
+      .toBeInTheDocument();
+    const cleaningRow = page.getByRole("button", { name: /Cleaning/ });
+    await expect.element(cleaningRow).toBeInTheDocument();
+    expect((cleaningRow.element() as HTMLElement).textContent).toMatch(
+      /Cleaning.*field/,
+    );
+    const keysRow = page.getByRole("button", { name: /Matching keys/ });
+    expect((keysRow.element() as HTMLElement).textContent).toMatch(
+      /Matching keys.*key/,
+    );
+
+    // Opening the disclosure reaches each tab: the Matching keys surface opens
+    // its work column.
+    await keysRow.click();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Matching keys");
+  });
+
+  test("the share bar is the first interactive element and collapses", async () => {
+    await reachMatchingSharingNarrow();
+
+    // The first focusable control on the page is the share bar's toggle: it
+    // sits ahead of every work-column control in DOM order, so tabbing from the
+    // document start reaches it first.
+    const focusable = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        'button, a[href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter(
+      (element) =>
+        element.offsetParent !== null || element === document.activeElement,
+    );
+    const shareToggle = page.getByRole("button", {
+      name: "What you will share",
+    });
+    await expect.element(shareToggle).toBeInTheDocument();
+    // It is the very first focusable control in the document -- nothing
+    // interactive precedes the trust surface at any viewport.
+    expect(focusable[0]).toBe(shareToggle.element() as HTMLElement);
+    // And it precedes the first work-column control in DOM order.
+    const firstWorkControl = document.querySelector<HTMLElement>(
+      `main.${styles.work} button, main.${styles.work} select, main.${styles.work} input`,
+    );
+    expect(firstWorkControl).not.toBeNull();
+    expect(
+      focusable.indexOf(shareToggle.element() as HTMLElement),
+    ).toBeLessThan(focusable.indexOf(firstWorkControl as HTMLElement));
+
+    // Present but collapsed: one tap reveals the condensed subset.
+    await expect.element(shareToggle).toHaveAttribute("aria-expanded", "false");
+    await shareToggle.click();
+    await expect.element(shareToggle).toHaveAttribute("aria-expanded", "true");
+
+    // The share bar shows the condensed three-row subset, not the ledger's full
+    // seven rows.
+    const shareBar = document.querySelector(`.${styles.shareBar}`) as Element;
+    const rows = Array.from(
+      shareBar.querySelectorAll(`.${styles.ledgerRow}`),
+    ).map((row) => row.querySelector("dt")?.childNodes[0].textContent);
+    expect(rows).toEqual(["You will send", "Matched on", "Expires"]);
+
+    // Collapsing again reports the closed state.
+    await shareToggle.click();
+    await expect.element(shareToggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("the narrow layout holds without horizontal overflow", async () => {
+    await reachMatchingSharingNarrow();
+
+    // Expanding both disclosures must not push the document past the viewport.
+    await page.getByRole("button", { name: "What you will share" }).click();
+    await page.getByRole("button", { name: "Customize" }).click();
+    expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(400);
   });
 });

--- a/apps/web/test/browser/benchAccept.test.ts
+++ b/apps/web/test/browser/benchAccept.test.ts
@@ -1193,6 +1193,59 @@ describe("acceptor bench: run and completion", () => {
     expect(another?.getAttribute("href")).toBe("/");
   });
 
+  test("at a narrow viewport the settled share bar keeps the You sent row", async () => {
+    // The condensed "What you will share" bar selects rows by the producers'
+    // shareBar markers, so the settled ledger's past-tense relabel ("You
+    // sent") cannot drop the one row naming what was disclosed to the partner.
+    await page.viewport(400, 800);
+    try {
+      await reachRun();
+      const call = lifecycleCall(0);
+      call.onStages(stagesFor(preparedWith("cascade", 2), "acceptor"));
+      call.onStage("waiting for peer");
+      call.onStage("confirming protocol");
+      call.onResult({
+        resultsUrl: URL.createObjectURL(new Blob(["a,b\n"])),
+        matchedRecordCount: 1847,
+        record: {
+          recordUrl: URL.createObjectURL(new Blob(["{}"])),
+          recordFileName: "psilink-record-2026-07-08T14-32.json",
+          keysUrl: URL.createObjectURL(new Blob(["{}"])),
+          keysFileName: "psilink-record-2026-07-08T14-32.keys.json",
+        },
+      });
+      await expect
+        .element(page.getByRole("heading", { level: 1 }))
+        .toHaveTextContent("Exchange complete");
+
+      const shareToggle = page.getByRole("button", {
+        name: "What you will share",
+      });
+      await expect.element(shareToggle).toBeInTheDocument();
+      await shareToggle.click();
+      await expect
+        .element(shareToggle)
+        .toHaveAttribute("aria-expanded", "true");
+
+      // The settled condensed subset: what left, what arrived, what matched.
+      const shareBar = document.querySelector(`.${styles.shareBar}`) as Element;
+      const rows = Array.from(
+        shareBar.querySelectorAll(`.${styles.ledgerRow}`),
+      ).map((row) => row.querySelector("dt")?.textContent);
+      expect(rows).toEqual(["You sent", "You received", "Matched on"]);
+      const sentRow = Array.from(
+        shareBar.querySelectorAll(`.${styles.ledgerRow}`),
+      ).find((row) => row.querySelector("dt")?.textContent === "You sent");
+      // This run disclosed no extra columns, and the row says so rather than
+      // disappearing.
+      expect(sentRow?.querySelector("dd")?.textContent).toBe(
+        "No additional columns",
+      );
+    } finally {
+      await page.viewport(1280, 800);
+    }
+  });
+
   test("the settled ledger's You sent names the launched disclosed column", async () => {
     // The full flow with an extra unrecognized `comment` column against a run token
     // whose terms request no payload from the acceptor. The column transmits (infers

--- a/apps/web/test/unit/benchAcceptorModel.test.ts
+++ b/apps/web/test/unit/benchAcceptorModel.test.ts
@@ -244,6 +244,13 @@ describe("acceptor ledger rows", () => {
     const rows = acceptorLedgerRows(makeToken({ legalAgreement: undefined }));
     expect(rowMuted(rows, "Agreement")).toBe("None");
   });
+
+  test("the narrow share bar's marked subset is send, matched on, expires", () => {
+    const marked = acceptorLedgerRows(makeToken(), DISCLOSING_METADATA)
+      .filter((row) => row.shareBar === true)
+      .map((row) => row.label);
+    expect(marked).toEqual(["You will send", "Matched on", "Expires"]);
+  });
 });
 
 describe("acceptor completion ledger", () => {
@@ -316,6 +323,19 @@ describe("acceptor completion ledger", () => {
     );
     // No received columns, so no suffix -- just the count.
     expect(rowValue(rows, "You received")).toBe("0 matched rows");
+  });
+
+  test("the settled share-bar subset keeps the past-tense disclosure row", () => {
+    // The expiry row is consumed with the invitation, so the settled condensed
+    // subset is what left, what arrived, and what matched -- "You sent" first.
+    const marked = acceptorDoneLedgerRows(
+      makeToken(),
+      { matchedRecordCount: 1847 },
+      DISCLOSING_METADATA,
+    )
+      .filter((row) => row.shareBar === true)
+      .map((row) => row.label);
+    expect(marked).toEqual(["You sent", "You received", "Matched on"]);
   });
 });
 

--- a/apps/web/test/unit/benchInviterModel.test.ts
+++ b/apps/web/test/unit/benchInviterModel.test.ts
@@ -119,6 +119,26 @@ describe("spine derivation from the read file", () => {
     }
   });
 
+  test("the narrow share bar's marked subset holds across every phase", () => {
+    const marked = (rows: ReturnType<typeof inviterLedgerRows>) =>
+      rows.filter((row) => row.shareBar === true).map((row) => row.label);
+    const subset = ["You will send", "Matched on", "Expires"];
+    expect(marked(inviterLedgerRows(undefined))).toEqual(subset);
+    expect(marked(inviterLedgerRows(editorFromCsv("Dana", csv)))).toEqual(
+      subset,
+    );
+    // Settled (outcome present): the labels hold, so the subset does too.
+    expect(
+      marked(
+        inviterLedgerRows(
+          editorFromCsv("Dana", csv),
+          "2026-07-08T19:32:00.000Z",
+          { matchedRecordCount: 3 },
+        ),
+      ),
+    ).toEqual(subset);
+  });
+
   test("rail facts count the derived cleaning and keys", () => {
     const editor = editorFromCsv("Dana", csv);
     const facts = inviterRailFacts(editor);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -190,6 +190,13 @@ export default defineConfig((_configEnv) => {
               }),
               headless: true,
               enabled: true,
+              // Vitest's default viewport is phone-sized (414x896), below the
+              // bench's narrow cut-over (NARROW_BENCH_MAX_WIDTH), which would
+              // silently flip every suite into the narrow layout. Pin the
+              // project to a wide desktop viewport so the wide layout is the
+              // deterministic default; a narrow-layout test opts in with
+              // page.viewport and restores this default afterwards.
+              viewport: { width: 1280, height: 800 },
               instances: [{ browser: "chromium" }],
             },
           },


### PR DESCRIPTION
## Summary

Implement the redesign mock's narrow-viewport information architecture for the bench (design/web-redesign/proposal-c.html, the 400px screen): at or below the cut-over the top bar's stepper compresses to a step strip naming the current position, the standing disclosure ledger folds to a collapsible "What you will share" bar placed ahead of the work column in the DOM so it is the page's first interactive element, and the Customize surfaces fold behind their own disclosure keeping each tab's fact value and the group note. Wide layout is unchanged.

Implements [211682454](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=211682454).

## Changes

- apps/web/src/bench/narrowViewport.ts (new): the single cut-over source -- NARROW_BENCH_MAX_WIDTH (600), its media query, and useNarrowBench() (first-render-accurate since the bench routes are client-only), so the CSS stage and the DOM-order switch cannot disagree.
- apps/web/src/bench/TopBar.tsx: at narrow, a StepStrip ("Step N of M - <label>", plain text, aria-hidden numeric badge) conditionally replaces the Stepper, so only one spine exists in the accessibility tree.
- apps/web/src/bench/Ledger.tsx: at narrow, a NarrowLedger renders the "What you will share" disclosure (condensed rows + trust footer) and, while editable, a "Customize" disclosure with the "Filled in from your file." note and each surface's right-aligned fact -- reusing the existing DisclosureSection semantics. The condensed subset is selected by an explicit shareBar marker each row producer declares per role and phase (inviter setup/settled, acceptor setup/settled), so a relabel can never silently drop a disclosure row; a first-rows fallback keeps the bar non-empty as a backstop.
- apps/web/src/bench/BenchShell.tsx: at narrow the ledger renders ahead of the work column as keyed children, making the share bar the first interactive element while a live breakpoint crossing moves rather than remounts the regions (component state survives; focus inside a moved region blurs, inherent to any reorder).
- apps/web/src/bench/inviterModel.ts + acceptorModel.ts: LedgerRow gains the shareBar marker; producers declare their condensed subsets.
- apps/web/src/bench/bench.module.css: a <=600px stage styling the three presentations; the existing 1080px and 560px stages untouched.
- apps/web/vite.config.ts: the browser test project pins a 1280x800 default viewport -- vitest's 414-wide phone default sits below the new cut-over and silently flipped every suite that never set a viewport into the narrow layout.
- Tests: browser pins for the step strip, the Customize fold with facts, the share bar as first interactive element with collapse/expand, no horizontal overflow at 400px with both disclosures open, the acceptor's settled share bar keeping "You sent", and state surviving a live breakpoint crossing on the identical DOM node; unit pins for every producer's marked subset.

## Test plan

Ran: `npm run typecheck && npm run lint && npm run format`; `npm run test -w apps/web` (1104 passed); `npm run test:browser -w apps/web` (340 passed, twice, stable).
New tests cover: the three narrow behaviors, the settled-state share-bar subsets per role, the first-interactive-element commitment, overflow, and cross-breakpoint state preservation.

## Background

Three interpretation calls the item left open, resolved mock-faithfully and flagged for maintainer review:
- Cut-over width: 600px rather than the suggested 480px -- the code already tightens the top bar at a 560px stage, and 600 aligns the narrow IA with that existing phone treatment instead of stranding 481-600px viewports in a tightened-but-not-narrow hybrid. One constant drives JS and CSS; trivial to change.
- Scope across rail states: uniform -- both benches compose the same shell/top-bar/ledger, so the inviter and acceptor spines and the post-create protocol timelines all get the compressed treatment with no per-bench code.
- Share bar contents: the mock's condensed subset (outbound disclosure, matched-on, expires; the settled acceptor shows sent/received/matched-on). The bar ships collapsed per the acceptance criterion's "collapsed but present" wording, though the mock's markup carries `open`.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: docs/DESIGN.md describes the bench's regions and flows, not per-viewport presentation; no docs/spec page covers bench layout
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: UI refinement within the already-listed web product, below the pre-release major-feature bar
- [x] Security review -- n/a: presentational layout and disclosure folding only; what the condensed trust bar displays is pinned per role and phase by the new subset tests, and nothing changes what is disclosed on the wire, logged, or persisted
