### PR TITLE
Read the managed input through a persisted handle

### DIFF
--- a/apps/web/src/psi/managedExchangeRecord.ts
+++ b/apps/web/src/psi/managedExchangeRecord.ts
@@ -388,6 +388,28 @@ export function applyManagedExchangeLastRun(
   return parseManagedExchangeRecord({ ...record, lastRun });
 }
 
+/**
+ * Apply an input-file handle to a record, producing a validated new record with
+ * only `inputFileHandle` changed -- the document, the secret, and the bookkeeping
+ * are carried through untouched. A `FileSystemFileHandle` sets (or re-points) the
+ * handle; `null` drops it. This is the field-scoped write the save flow uses to
+ * persist a handle and the surfaces use to re-point one after a missing-file
+ * failure; separate from a rotation or a local edit so persisting a handle cannot
+ * carry a stale secret or a stale document back over a concurrent write. The input
+ * record is not mutated.
+ *
+ * @throws {ZodError} if the resulting record is invalid.
+ */
+export function applyManagedExchangeInputHandle(
+  record: ManagedExchangeRecord,
+  handle: FileSystemFileHandle | null,
+): ManagedExchangeRecord {
+  const next: ManagedExchangeRecord = { ...record };
+  if (handle === null) delete next.inputFileHandle;
+  else next.inputFileHandle = handle;
+  return parseManagedExchangeRecord(next);
+}
+
 /** The local fields an operator may edit in place without a re-invite: the
  * display label, the run schedule, and the max-token-age policy. A change to the
  * agreed terms is a re-invite, not an in-place record edit, so the document and

--- a/apps/web/src/psi/managedExchangeRun.ts
+++ b/apps/web/src/psi/managedExchangeRun.ts
@@ -3,12 +3,20 @@
  * section: the Web Locks single-writer acquisition and the strict-durability,
  * field-scoped store write that the pure ordering logic in
  * {@link ./managedRunRotate.ts} drives. This is the seam the future managed-
- * exchange runner calls -- it passes its handshake and data-exchange phases in and
- * cannot get the persist-before-success ordering wrong, because the data-exchange
- * phase is a callback this module invokes only after the durable persist resolves.
+ * exchange runner calls -- it passes its input-guard, handshake, and data-exchange
+ * phases in and cannot get the ordering wrong: the input guard gates the handshake
+ * (its result is the handshake's argument), and the data-exchange phase is a
+ * callback this module invokes only after the durable persist resolves.
  *
- * Two invariants this module owns (normative in docs/MANAGED_EXCHANGE.md and
+ * Three invariants this module owns (normative in docs/MANAGED_EXCHANGE.md and
  * docs/spec/MANAGED_EXCHANGE_RECORD.md):
+ *
+ * - **Input guard before connection.** The input file is acquired and its columns
+ *   validated against the standing terms BEFORE the handshake opens any connection;
+ *   the guard's result is the handshake's argument, so a runner cannot reorder the
+ *   guard after the handshake. A benign input rejection (missing file, gone
+ *   permission, unsatisfiable columns) records the `"input"` bookkeeping and
+ *   re-raises with no connection attempted, never through desync/attack framing.
  *
  * - **Single-writer exclusion.** A Web Locks lock keyed to the record's id is held
  *   from "begin this run" through "rotated secret durably persisted", so a second
@@ -29,6 +37,7 @@
 
 import {
   RotationPersistError,
+  failedRun,
   runRotationCriticalSection,
   succeededRun,
 } from "./managedRunRotate";
@@ -36,6 +45,7 @@ import {
   persistManagedExchangeRotation,
   recordManagedExchangeLastRun,
 } from "./managedExchangeStore";
+import { ManagedInputError } from "./managedInputGuard";
 
 import type { ManagedExchangeLastRun } from "./managedExchangeRecord";
 import type { RotationWriteBack } from "./managedRunRotate";
@@ -103,17 +113,31 @@ export async function withManagedExchangeLock<T>(
   });
 }
 
-/** The handshake and data-exchange phases the runner supplies to
+/** The input, handshake, and data-exchange phases the runner supplies to
  * {@link runManagedExchange}, plus the record's rotation policy. The persist and
  * lock are this module's; the runner cannot reach the data exchange before the
- * persist resolves. */
-export interface ManagedExchangeRunPhases<THandshake, TExchange> {
+ * persist resolves, nor the handshake before the input is acquired and validated. */
+export interface ManagedExchangeRunPhases<TInput, THandshake, TExchange> {
   /** The record whose secret this run rotates. Its `id` keys the lock and the
    * field-scoped store writes; `tokenMaxAgeDays` restamps `expires`. */
   record: { id: string; tokenMaxAgeDays?: number };
+  /**
+   * Acquire and validate the input file BEFORE any connection: read it through the
+   * persisted handle (or the re-selected file), then reject a missing file, a gone
+   * permission, or a column shape the standing terms cannot satisfy as a benign
+   * pre-run `"input"` failure (the `acquireValidatedManagedInput` seam in
+   * {@link ./managedInputHandle.ts} raises a {@link ManagedInputError} for each).
+   * Its result is handed to {@link handshake}, so the handshake -- and the
+   * connection it opens -- is structurally unreachable until the guard passes: a
+   * runner cannot reorder the guard after the handshake.
+   */
+  acquireInput: () => Promise<TInput>;
   /** Run the authenticated handshake and yield the rotated secret (from the
-   * `AuthResult`) plus whatever the data exchange needs. Runs inside the lock. */
-  handshake: () => Promise<{ rotatedSecret: string; handshake: THandshake }>;
+   * `AuthResult`) plus whatever the data exchange needs. Runs inside the lock, after
+   * the input guard passed; receives the acquired input. */
+  handshake: (
+    input: TInput,
+  ) => Promise<{ rotatedSecret: string; handshake: THandshake }>;
   /** Begin and complete the data exchange -- reachable only after the durable
    * persist resolves. Receives the handshake's carried value. */
   dataExchange: (handshake: THandshake) => Promise<TExchange>;
@@ -137,49 +161,79 @@ export interface ManagedExchangeRunResult<TExchange> {
 
 /**
  * Run a managed exchange's run+rotate critical section: the seam the future runner
- * calls. The single-writer lock is held across the handshake and the durable,
- * field-scoped rotation write -- exactly "begin this run" through "rotated secret
- * durably persisted". The data exchange then runs AFTER the lock releases, and on
- * its completion the `succeeded` outcome is recorded. The data exchange still
- * cannot begin before the persist resolves: it consumes the gate the locked
+ * calls. The single-writer lock is held across the input guard, the handshake, and
+ * the durable, field-scoped rotation write -- "begin this run" through "rotated
+ * secret durably persisted". The data exchange then runs AFTER the lock releases,
+ * and on its completion the `succeeded` outcome is recorded. The data exchange
+ * still cannot begin before the persist resolves: it consumes the gate the locked
  * section resolves only after the persist commits, so the ordering is structural,
  * not the caller's to uphold, and the lock is not held for the (potentially long)
  * data exchange.
+ *
+ * The input guard runs FIRST, before the handshake opens any connection: its
+ * result is the handshake's argument, so a runner structurally cannot reorder the
+ * guard after the handshake. A benign {@link ManagedInputError} (a missing file, a
+ * gone permission, or a column shape the standing terms cannot satisfy) records the
+ * `"input"`-kind `lastRun` inside the lock, best-effort, and re-raises without a
+ * handshake -- never routed through desync/attack framing, and no connection is
+ * attempted.
  *
  * A persist failure after rotation records a `storage`-kind `lastRun` inside the
  * lock, best-effort (so the next handshake failure surfaces through the benign
  * tier, not the attack framing) and re-raises, without beginning the data
  * exchange. A handshake or data-exchange failure propagates unchanged for the
- * runner to classify and record; this module owns only the two outcomes the
- * critical section itself decides (succeeded, and the storage failure). Because
- * the bookkeeping tail runs outside the lock, its write is monotonic on `at` (see
- * {@link recordManagedExchangeLastRun}): a slow run's stale tail cannot mask a
- * newer run's recorded outcome. The success stamp is likewise an unlocked,
- * individually failable write: if it fails after a completed exchange, the NEXT
- * run's tiering degrades to the stricter Tier-2 surface -- an operator
+ * runner to classify and record; this module owns only the outcomes the critical
+ * section itself decides (succeeded, the storage failure, and the benign input
+ * failure). Because the bookkeeping tail runs outside the lock, its write is
+ * monotonic on `at` (see {@link recordManagedExchangeLastRun}): a slow run's stale
+ * tail cannot mask a newer run's recorded outcome. The success stamp is likewise an
+ * unlocked, individually failable write: if it fails after a completed exchange,
+ * the NEXT run's tiering degrades to the stricter Tier-2 surface -- an operator
  * inconvenience, not a correctness break (the rotated secret is already durable).
  *
  * @throws {ManagedExchangeLockUnavailableError} if `lock.ifAvailable` is set and a
  *   run is already in progress on this device.
+ * @throws {ManagedInputError} if the input guard rejects (a missing file, a gone
+ *   permission, or an unsatisfiable column shape); the benign `"input"` `lastRun`
+ *   is recorded best-effort before this propagates, and no connection was made.
  * @throws {RotationPersistError} if the rotation write fails; the `storage`
  *   `lastRun` is recorded best-effort before this propagates, and the error
  *   carries it either way -- a bookkeeping-write failure never replaces this
  *   error.
  */
-export async function runManagedExchange<THandshake, TExchange>(
-  phases: ManagedExchangeRunPhases<THandshake, TExchange>,
+export async function runManagedExchange<TInput, THandshake, TExchange>(
+  phases: ManagedExchangeRunPhases<TInput, THandshake, TExchange>,
 ): Promise<ManagedExchangeRunResult<TExchange>> {
   const { record } = phases;
   const now = phases.now ?? Date.now;
 
-  // The locked window: handshake through rotated-secret-durably-persisted. The
+  // The locked window: input guard through rotated-secret-durably-persisted. The
   // gate is resolvable only once the persist has committed.
   const gate = await withManagedExchangeLock(
     record.id,
     async () => {
+      // The input guard runs before the handshake opens any connection. A benign
+      // input rejection records the `input` bookkeeping inside the lock (this run's
+      // record until the lock releases), then re-raises with no handshake attempted.
+      let input: TInput;
+      try {
+        input = await phases.acquireInput();
+      } catch (error) {
+        if (error instanceof ManagedInputError) {
+          // Best-effort, for the same reason the storage tier is below: a failed
+          // bookkeeping write must not replace the ManagedInputError the runner
+          // classifies on.
+          try {
+            await recordLastRun(record.id, failedRun(now(), "failed", "input"));
+          } catch {
+            // Swallowed: the ManagedInputError still reaches the runner on the rethrow.
+          }
+        }
+        throw error;
+      }
       try {
         return await runRotationCriticalSection<THandshake>({
-          handshake: phases.handshake,
+          handshake: () => phases.handshake(input),
           persist: (writeBack: RotationWriteBack) =>
             persistRotation(record.id, writeBack),
           tokenMaxAgeDays: record.tokenMaxAgeDays,

--- a/apps/web/src/psi/managedExchangeStore.ts
+++ b/apps/web/src/psi/managedExchangeStore.ts
@@ -22,6 +22,7 @@
  */
 
 import {
+  applyManagedExchangeInputHandle,
   applyManagedExchangeLastRun,
   applyManagedExchangeLocalEdits,
   applyManagedExchangeRotation,
@@ -325,6 +326,33 @@ export async function recordManagedExchangeLastRun(
       throw new Error(`no managed exchange with id ${id}`);
     const existing = parseManagedExchangeRecord(stored);
     return applyManagedExchangeLastRun(existing, lastRun);
+  });
+}
+
+/**
+ * Persist an input-file handle onto the stored record, or drop it with `null`,
+ * advancing only `inputFileHandle` and nothing else. The read, the field-scoped
+ * application through {@link applyManagedExchangeInputHandle} (which re-validates),
+ * and the write-back run inside one strict-durability readwrite transaction
+ * ({@link readModifyWriteRecord}), so persisting a handle applies to the freshest
+ * stored record and is structurally incapable of carrying a stale secret or a
+ * stale document back over a concurrent rotation write. This is the write the save
+ * flow uses to persist the handle at save-as-recurring or first run, and the write
+ * the surfaces use to re-point a handle after a missing-file failure.
+ *
+ * @throws {Error} if no record with `id` exists.
+ * @throws {ZodError} if the stored value is not a valid v1 record or the result is
+ *   invalid; the transaction aborts and nothing is written.
+ */
+export async function persistManagedExchangeInputHandle(
+  id: string,
+  handle: FileSystemFileHandle | null,
+): Promise<ManagedExchangeRecord> {
+  return readModifyWriteRecord(id, (stored) => {
+    if (stored === undefined)
+      throw new Error(`no managed exchange with id ${id}`);
+    const existing = parseManagedExchangeRecord(stored);
+    return applyManagedExchangeInputHandle(existing, handle);
   });
 }
 

--- a/apps/web/src/psi/managedInputGuard.ts
+++ b/apps/web/src/psi/managedInputGuard.ts
@@ -1,0 +1,106 @@
+/**
+ * The pure, platform-free half of the managed (recurring) exchange's run-start
+ * input guard: deciding whether a read input's columns can back the standing
+ * terms, and classifying an input-acquisition failure into the benign `"input"`
+ * bookkeeping -- so both decisions are unit-testable in Node without a file handle,
+ * a permission prompt, or a database. The platform half (reading the file through
+ * the persisted `FileSystemFileHandle`, the read/query permission layer, and the
+ * handle persistence) is in {@link ./managedInputHandle.ts}.
+ *
+ * Both decisions run BEFORE any connection on every run path -- unattended,
+ * one-action, and re-selection -- and each produces a benign `"input"`-kind
+ * failure, never the desync/attack framing (see docs/MANAGED_EXCHANGE.md, "The
+ * input file each run", and docs/spec/MANAGED_EXCHANGE_RECORD.md, the
+ * `inputFileHandle` and `lastRun` rows). The column check reuses core's
+ * {@link assessLinkageSatisfiability}, the same column-shape verdict the CLI
+ * pre-flight and the web intake surfaces block on, rather than re-deriving it.
+ */
+
+import { assessLinkageSatisfiability } from "@psilink/core";
+
+import type { ExchangeSpec, LinkageField } from "@psilink/core";
+
+/**
+ * Why the run-start input could not back the standing terms. Both variants are a
+ * benign pre-run problem the runner records as an `"input"`-kind failure and never
+ * routes through desync/attack framing:
+ *
+ * - `"acquire"` -- the file could not be read at run start: the entry is missing
+ *   (deleted, moved, or renamed away), the read permission is gone, or no handle
+ *   is held where one is required. The underlying error is carried for the caller
+ *   to surface (sanitized) and log.
+ * - `"columns"` -- the file was read, but its columns cannot satisfy any of the
+ *   standing terms' linkage keys, so an exchange would match nothing and yield a
+ *   result byte-indistinguishable from a legitimately empty intersection. The
+ *   linkage fields the columns cannot produce are carried so the caller can name
+ *   the missing field types.
+ */
+export type ManagedInputRejection =
+  | {
+      /** The input could not be read at run start (missing file, gone permission,
+       * or an absent required handle). */
+      reason: "acquire";
+      /** The underlying acquisition error, for the caller to surface and log. */
+      cause: unknown;
+    }
+  | {
+      /** The input was read but its columns satisfy none of the standing terms'
+       * linkage keys (`satisfiableKeyCount === 0`). */
+      reason: "columns";
+      /** The standing terms' linkage fields the read columns cannot produce, so
+       * the caller can name the missing field types. */
+      unsatisfied: Array<LinkageField>;
+    };
+
+/**
+ * Raised when the run-start input cannot back the standing terms, carrying the
+ * {@link ManagedInputRejection} that discriminates the benign cause. Distinct from
+ * a handshake or data-exchange failure so the runner routes it to the `"input"`
+ * failure tier and knows no connection was ever attempted. Its base `message` is a
+ * fixed, non-sensitive summary suitable for a log line; the partner-influenced
+ * detail (the unsatisfied field names) rides {@link rejection} for the caller to
+ * sanitize before display.
+ */
+export class ManagedInputError extends Error {
+  /** The discriminated benign cause. */
+  readonly rejection: ManagedInputRejection;
+  constructor(rejection: ManagedInputRejection) {
+    super(
+      rejection.reason === "acquire"
+        ? "managed exchange input could not be read at run start"
+        : "managed exchange input satisfies no standing linkage keys",
+      rejection.reason === "acquire" ? { cause: rejection.cause } : undefined,
+    );
+    this.name = "ManagedInputError";
+    this.rejection = rejection;
+  }
+}
+
+/**
+ * Validate a read input's `columns` against a record's standing terms' column
+ * shape, the guard every run path applies before any connection. Reuses core's
+ * {@link assessLinkageSatisfiability} over the persisted document's linkage terms,
+ * standardization, and metadata, so the verdict matches an exchange that would run
+ * from exactly those terms -- the same block signal (`satisfiableKeyCount === 0`)
+ * the CLI pre-flight and the web intake surfaces use, never a re-derivation.
+ *
+ * Returns `undefined` when the columns satisfy at least one key (the input is
+ * accepted); returns a `"columns"` {@link ManagedInputRejection} carrying the
+ * unproducible linkage fields when none can, so the run is rejected as a benign
+ * pre-run problem rather than run to a silent empty intersection. The check is over
+ * column SHAPE, not row values (see {@link assessLinkageSatisfiability}): it can
+ * only over-accept a same-shaped wrong file, never wrongly block a conforming one.
+ */
+export function assessManagedInputColumns(
+  exchangeFile: ExchangeSpec,
+  columns: ReadonlyArray<string>,
+): ManagedInputRejection | undefined {
+  const { satisfiableKeyCount, unsatisfied } = assessLinkageSatisfiability(
+    [...columns],
+    exchangeFile.linkageTerms,
+    exchangeFile.standardization,
+    exchangeFile.metadata,
+  );
+  if (satisfiableKeyCount > 0) return undefined;
+  return { reason: "columns", unsatisfied };
+}

--- a/apps/web/src/psi/managedInputGuard.ts
+++ b/apps/web/src/psi/managedInputGuard.ts
@@ -26,9 +26,10 @@ import type { ExchangeSpec, LinkageField } from "@psilink/core";
  * routes through desync/attack framing:
  *
  * - `"acquire"` -- the file could not be read at run start: the entry is missing
- *   (deleted, moved, or renamed away), the read permission is gone, or no handle
- *   is held where one is required. The underlying error is carried for the caller
- *   to surface (sanitized) and log.
+ *   (deleted, moved, or renamed away), the read permission is gone, no handle is
+ *   held where one is required, or the file is unreadable or malformed (the CSV
+ *   parse fails). The underlying error is carried for the caller to surface
+ *   (sanitized) and log.
  * - `"columns"` -- the file was read, but its columns cannot satisfy any of the
  *   standing terms' linkage keys, so an exchange would match nothing and yield a
  *   result byte-indistinguishable from a legitimately empty intersection. The
@@ -38,7 +39,8 @@ import type { ExchangeSpec, LinkageField } from "@psilink/core";
 export type ManagedInputRejection =
   | {
       /** The input could not be read at run start (missing file, gone permission,
-       * or an absent required handle). */
+       * an absent required handle, or an unreadable/malformed file the CSV parse
+       * rejects). */
       reason: "acquire";
       /** The underlying acquisition error, for the caller to surface and log. */
       cause: unknown;

--- a/apps/web/src/psi/managedInputHandle.ts
+++ b/apps/web/src/psi/managedInputHandle.ts
@@ -1,0 +1,257 @@
+/**
+ * The input-file handle lifecycle for a managed (recurring) exchange: the platform
+ * layer the save flow, the runner, and the future management surfaces call to
+ * persist a live pointer to the operator's input file, read the input through it at
+ * each run start, check and request read permission where the platform offers it,
+ * detect platform support, and re-point (replace) the handle. It is the pointer
+ * side of the no-second-copy invariant: the record holds a `FileSystemFileHandle`,
+ * never file content, and every run reads through the handle with `getFile()` at
+ * run start rather than retaining a `File` across runs, so dropping the current
+ * period's extract over the same name is the data-refresh workflow (see
+ * docs/MANAGED_EXCHANGE.md, "The input file each run", and
+ * docs/spec/MANAGED_EXCHANGE_RECORD.md, the `inputFileHandle` row).
+ *
+ * The pure column-shape guard and the input-rejection classification are in
+ * {@link ./managedInputGuard.ts}; this module composes them with the platform reads
+ * so a run-start acquisition failure (missing file, gone permission, no handle
+ * where one is required) or a column-shape rejection each surfaces as the same
+ * benign {@link ManagedInputError}, before any connection, on every run path.
+ *
+ * The permission layer is a non-standard File System Access extension
+ * (`queryPermission` / `requestPermission`) the DOM lib does not type and some
+ * handle sources (a picker handle) offer while others (an origin-private-file-
+ * system handle) do not. It is reached through {@link browserHandleReadPermission},
+ * which feature-detects the methods and treats their absence as an already-usable
+ * grant, so a handle without the extension reads through without prompting -- and
+ * the {@link HandleReadPermissionQuery} seam stays injectable for tests that cannot
+ * summon a real picker grant.
+ */
+
+import {
+  ManagedInputError,
+  assessManagedInputColumns,
+} from "./managedInputGuard";
+import { loadCSVFileOffMainThread } from "./csvParseController";
+
+import type { ExchangeSpec } from "@psilink/core";
+
+/**
+ * Whether the File System Access API's file handles exist in this runtime, so a
+ * managed exchange can persist a live pointer to the operator's input file
+ * (Chromium) rather than re-selecting it each attended run (Safari, Firefox). A
+ * `false` here is what routes the save flow to persist no handle and the runner to
+ * re-selection; it never throws, so it is safe under SSR and on older engines.
+ */
+export function fileSystemAccessSupported(): boolean {
+  return typeof globalThis.FileSystemFileHandle !== "undefined";
+}
+
+/**
+ * The read-permission state a handle reports: `"granted"` reads through without a
+ * prompt, `"denied"` cannot be read, and `"prompt"` needs an operator gesture to
+ * grant. Mirrors the `PermissionState` the File System Access permission methods
+ * return. A handle whose source does not implement the permission extension is
+ * treated as `"granted"` -- there is no separate permission to hold, so the read is
+ * governed only by whether the file still exists.
+ */
+export type HandleReadPermissionState = "granted" | "denied" | "prompt";
+
+/** The `queryPermission` / `requestPermission` extension a File System Access
+ * handle MAY carry (a picker handle does; an origin-private-file-system handle does
+ * not). Declared locally because the DOM lib does not type these non-standard
+ * methods; a handle is narrowed to it by {@link handleReadPermission} through a
+ * runtime feature check rather than an unchecked cast. */
+interface FileSystemHandlePermission {
+  queryPermission?: (descriptor: {
+    mode: "read" | "readwrite";
+  }) => Promise<HandleReadPermissionState>;
+  requestPermission?: (descriptor: {
+    mode: "read" | "readwrite";
+  }) => Promise<HandleReadPermissionState>;
+}
+
+/** The one operation the permission layer performs, factored into a seam so a run
+ * path can query without prompting (the unattended path) or request with a gesture
+ * (the attended path), and so a test can inject a permission outcome a real
+ * origin-private-file-system handle cannot report (it implements neither method).
+ * The default is {@link browserHandleReadPermission}, the feature-detecting
+ * platform implementation. */
+export interface HandleReadPermissionQuery {
+  /** Report the handle's current read-permission state WITHOUT prompting -- the
+   * only check the unattended path may make, since a scheduled run has no operator
+   * to answer a prompt. */
+  query: (handle: FileSystemFileHandle) => Promise<HandleReadPermissionState>;
+  /** Prompt for read permission where the state is `"prompt"`, returning the state
+   * after the operator answers. Called only on an attended path (a gesture is
+   * present). */
+  request: (handle: FileSystemFileHandle) => Promise<HandleReadPermissionState>;
+}
+
+/**
+ * The platform permission layer: feature-detects the handle's non-standard
+ * `queryPermission` / `requestPermission` methods and, when they are absent (an
+ * origin-private-file-system handle, a runtime without the extension), reports
+ * `"granted"` -- there is no separate read permission to hold, so the read is
+ * governed only by whether the file still exists. Never prompts on `query`; prompts
+ * on `request` only where the method exists.
+ */
+export const browserHandleReadPermission: HandleReadPermissionQuery = {
+  query: (handle) => {
+    const permission = handle as unknown as FileSystemHandlePermission;
+    if (permission.queryPermission === undefined)
+      return Promise.resolve("granted");
+    return permission.queryPermission({ mode: "read" });
+  },
+  request: (handle) => {
+    const permission = handle as unknown as FileSystemHandlePermission;
+    if (permission.requestPermission === undefined)
+      return Promise.resolve("granted");
+    return permission.requestPermission({ mode: "read" });
+  },
+};
+
+/** Raised when a handle is held but its read permission cannot be secured for a
+ * run: the unattended path found a non-`"granted"` state (it must not prompt), or
+ * an attended request was denied. Carried as the `cause` of the benign
+ * {@link ManagedInputError} `"acquire"` rejection, so a gone permission records the
+ * same benign `"input"` failure as a missing file, never desync/attack framing. */
+export class HandleReadPermissionError extends Error {
+  /** The permission state that blocked the read. */
+  readonly state: HandleReadPermissionState;
+  constructor(state: HandleReadPermissionState) {
+    super(`managed exchange input handle read permission is ${state}`);
+    this.name = "HandleReadPermissionError";
+    this.state = state;
+  }
+}
+
+/** How a run acquires its input-file read permission: an unattended (scheduled)
+ * run may only proceed on an EXISTING grant and must never prompt; an attended run
+ * may request the grant with the operator's gesture. */
+export type ManagedRunAttendance = "unattended" | "attended";
+
+/**
+ * Secure read permission for `handle` for a run of the given `attendance`, or throw
+ * {@link HandleReadPermissionError}. The unattended path queries only: a
+ * non-`"granted"` state throws, because a scheduled run has no operator to answer a
+ * prompt (the spec's "the unattended path can only proceed on an existing grant --
+ * it must not prompt"). The attended path may additionally request where the state
+ * is `"prompt"`, so a one-action re-run is at most one permission gesture.
+ */
+export async function ensureHandleReadPermission(
+  handle: FileSystemFileHandle,
+  attendance: ManagedRunAttendance,
+  permission: HandleReadPermissionQuery = browserHandleReadPermission,
+): Promise<void> {
+  const current = await permission.query(handle);
+  if (current === "granted") return;
+  // A scheduled run has nobody present to answer a prompt, so it proceeds only on
+  // an already-granted permission and fails benignly on any other state.
+  if (attendance === "unattended") throw new HandleReadPermissionError(current);
+  if (current === "denied") throw new HandleReadPermissionError("denied");
+  const afterPrompt = await permission.request(handle);
+  if (afterPrompt !== "granted")
+    throw new HandleReadPermissionError(afterPrompt);
+}
+
+/** A read input for one run: the `File` read through the handle at run start (never
+ * retained across runs) and its CSV column names, the two the column-shape guard
+ * and the exchange consume. */
+export interface AcquiredManagedInput {
+  /** The `File` read through the handle at THIS run start (a point-in-time
+   * reference; never persisted or retained across runs). */
+  file: File;
+  /** The read file's CSV column names, for the column-shape guard and the
+   * exchange. */
+  columns: Array<string>;
+}
+
+/** How a run supplies its input file, per platform and path. `handle` reads through
+ * a persisted `FileSystemFileHandle` (the unattended and one-action paths, and a
+ * re-point); `file` takes an operator-selected `File` directly (the re-selection
+ * path on a browser without the API). Exactly one is set. */
+export type ManagedInputSource =
+  | {
+      /** Read through a persisted handle at run start (`getFile()` per run). */
+      kind: "handle";
+      handle: FileSystemFileHandle;
+      /** The run's attendance, gating whether a gone permission may be re-prompted
+       * (attended) or must fail benignly (unattended). */
+      attendance: ManagedRunAttendance;
+    }
+  | {
+      /** An operator-selected file on a browser without the API (re-selection). */
+      kind: "file";
+      file: File;
+    };
+
+/**
+ * Read a run's input through its source and parse its column names, throwing a
+ * benign {@link ManagedInputError} `"acquire"` rejection on any failure BEFORE the
+ * column guard or any connection: a missing entry (the file deleted, moved, or
+ * renamed away, so `getFile()` rejects), a gone or refused read permission, or an
+ * unreadable file. The `File` is read at THIS run start and never retained across
+ * runs. On the handle path, permission is secured first (queried for an unattended
+ * run, requestable for an attended one).
+ *
+ * @throws {ManagedInputError} an `"acquire"` rejection carrying the underlying
+ *   error, so the runner records the benign `"input"` failure and knows no
+ *   connection was attempted.
+ */
+export async function acquireManagedInput(
+  source: ManagedInputSource,
+  permission: HandleReadPermissionQuery = browserHandleReadPermission,
+): Promise<AcquiredManagedInput> {
+  let file: File;
+  try {
+    if (source.kind === "handle") {
+      await ensureHandleReadPermission(
+        source.handle,
+        source.attendance,
+        permission,
+      );
+      // getFile() reads whatever file currently exists at the handle's path -- a
+      // missing entry rejects here, the clean not-found the benign input state
+      // rests on. The File is this run's point-in-time reference; it is never
+      // retained past the run.
+      file = await source.handle.getFile();
+    } else {
+      file = source.file;
+    }
+  } catch (cause) {
+    throw new ManagedInputError({ reason: "acquire", cause });
+  }
+
+  let columns: Array<string>;
+  try {
+    const parsed = await loadCSVFileOffMainThread(file);
+    columns = parsed.meta.fields ?? [];
+  } catch (cause) {
+    throw new ManagedInputError({ reason: "acquire", cause });
+  }
+  return { file, columns };
+}
+
+/**
+ * Acquire and validate a run's input against the record's standing terms in one
+ * step, the guard every run path applies before any connection. Reads the input
+ * through {@link acquireManagedInput} (missing file, gone permission, and
+ * unreadable file all surface as a benign `"acquire"` rejection), then rejects an
+ * input whose columns cannot satisfy the standing terms' column shape as a benign
+ * `"columns"` rejection ({@link assessManagedInputColumns}) -- never silently
+ * linked, never routed through desync/attack framing. Returns the read `File` and
+ * its columns when the input is accepted, for the runner to feed the exchange.
+ *
+ * @throws {ManagedInputError} an `"acquire"` or `"columns"` rejection, both benign
+ *   `"input"`-kind failures detected before any connection.
+ */
+export async function acquireValidatedManagedInput(
+  exchangeFile: ExchangeSpec,
+  source: ManagedInputSource,
+  permission: HandleReadPermissionQuery = browserHandleReadPermission,
+): Promise<AcquiredManagedInput> {
+  const acquired = await acquireManagedInput(source, permission);
+  const rejection = assessManagedInputColumns(exchangeFile, acquired.columns);
+  if (rejection !== undefined) throw new ManagedInputError(rejection);
+  return acquired;
+}

--- a/apps/web/test/browser/managedExchangeRun.test.ts
+++ b/apps/web/test/browser/managedExchangeRun.test.ts
@@ -210,6 +210,7 @@ describe("runManagedExchange: persist-before-success end to end", () => {
 
     const result = await runManagedExchange({
       record: created,
+      acquireInput: () => Promise.resolve(undefined),
       handshake: () => {
         order.push("handshake");
         return Promise.resolve({ rotatedSecret, handshake: "carried" });
@@ -253,6 +254,7 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     try {
       await runManagedExchange({
         record: created,
+        acquireInput: () => Promise.resolve(undefined),
         handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
         dataExchange: () => Promise.resolve("done"),
       });
@@ -273,6 +275,7 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     const rotatedSecret = generateSharedSecret();
     await runManagedExchange({
       record: created,
+      acquireInput: () => Promise.resolve(undefined),
       handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
       dataExchange: () => Promise.resolve("done"),
     });
@@ -291,6 +294,7 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     const rotationAt = Date.parse("2026-07-14T12:00:00.000Z");
     await runManagedExchange({
       record: created,
+      acquireInput: () => Promise.resolve(undefined),
       handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
       dataExchange: () => Promise.resolve("done"),
       now: () => rotationAt,
@@ -308,6 +312,7 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     const rotatedSecret = generateSharedSecret();
     await runManagedExchange({
       record: created,
+      acquireInput: () => Promise.resolve(undefined),
       handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
       dataExchange: () => Promise.resolve("done"),
     });
@@ -352,6 +357,7 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     try {
       await runManagedExchange({
         record: created,
+        acquireInput: () => Promise.resolve(undefined),
         handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
         dataExchange: () => {
           dataExchangeRan = true;
@@ -407,6 +413,7 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     try {
       await runManagedExchange({
         record: created,
+        acquireInput: () => Promise.resolve(undefined),
         handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
         dataExchange: () => {
           dataExchangeRan = true;
@@ -445,6 +452,7 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     // first's committed secret, never reverting it.
     const first = runManagedExchange({
       record: created,
+      acquireInput: () => Promise.resolve(undefined),
       handshake: () =>
         Promise.resolve({ rotatedSecret: firstRotated, handshake: "1" }),
       dataExchange: async () => {
@@ -463,6 +471,7 @@ describe("runManagedExchange: persist-before-success end to end", () => {
 
       second = runManagedExchange({
         record: { id: created.id },
+        acquireInput: () => Promise.resolve(undefined),
         handshake: () =>
           Promise.resolve({ rotatedSecret: secondRotated, handshake: "2" }),
         dataExchange: () => Promise.resolve("2"),
@@ -487,6 +496,7 @@ describe("runManagedExchange: persist-before-success end to end", () => {
 
     const error: unknown = await runManagedExchange({
       record: created,
+      acquireInput: () => Promise.resolve(undefined),
       handshake: () => Promise.resolve({ rotatedSecret, handshake: "c" }),
       dataExchange: () => Promise.reject(failure),
     }).then(
@@ -521,6 +531,7 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     // second run completes fully in between, recording the newer outcome.
     const first = runManagedExchange({
       record: created,
+      acquireInput: () => Promise.resolve(undefined),
       handshake: () =>
         Promise.resolve({
           rotatedSecret: generateSharedSecret(),
@@ -538,6 +549,7 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     try {
       await runManagedExchange({
         record: { id: created.id },
+        acquireInput: () => Promise.resolve(undefined),
         handshake: () =>
           Promise.resolve({
             rotatedSecret: generateSharedSecret(),

--- a/apps/web/test/browser/managedExchangeRun.test.ts
+++ b/apps/web/test/browser/managedExchangeRun.test.ts
@@ -15,6 +15,7 @@ import {
   createManagedExchange,
   getManagedExchange,
 } from "@psi/managedExchangeStore";
+import { ManagedInputError } from "@psi/managedInputGuard";
 import { RotationPersistError } from "@psi/managedRunRotate";
 import { composeManagedExchangeFile } from "@psi/managedExchangeRecord";
 
@@ -433,6 +434,69 @@ describe("runManagedExchange: persist-before-success end to end", () => {
     expect(dataExchangeRan).toBe(false);
     // Nothing committed: the old secret is retained and no bookkeeping landed
     // (the write failed; the evidence travels on the error instead).
+    const stored = await getManagedExchange(created.id);
+    expect(stored?.sharedSecret).toBe(created.sharedSecret);
+    expect(stored?.lastRun).toBeUndefined();
+  });
+
+  test("a total storage fault still surfaces the ManagedInputError, not the bookkeeping failure", async () => {
+    const created = await createManagedExchange(newExchange());
+    let handshakeRan = false;
+
+    // Fail EVERY readwrite the run opens: the input tier's best-effort `input`
+    // bookkeeping write fails alongside the input rejection. The second rejection
+    // must not replace the ManagedInputError -- the runner's classification
+    // depends on the original propagating, exactly as in the storage tier above.
+    const realTransaction = IDBDatabase.prototype.transaction;
+    IDBDatabase.prototype.transaction = function (
+      this: IDBDatabase,
+      storeNames: string | Array<string>,
+      mode?: IDBTransactionMode,
+      options?: IDBTransactionOptions,
+    ) {
+      const transaction = realTransaction.call(this, storeNames, mode, options);
+      if (mode === "readwrite") {
+        queueMicrotask(() => {
+          try {
+            transaction.abort();
+          } catch {
+            // Already settled; nothing to abort.
+          }
+        });
+      }
+      return transaction;
+    };
+
+    const inputFailure = new ManagedInputError({
+      reason: "acquire",
+      cause: new Error("the entry was not found"),
+    });
+    let error: unknown;
+    try {
+      await runManagedExchange({
+        record: created,
+        acquireInput: () => Promise.reject(inputFailure),
+        handshake: () => {
+          handshakeRan = true;
+          return Promise.resolve({
+            rotatedSecret: generateSharedSecret(),
+            handshake: "c",
+          });
+        },
+        dataExchange: () => Promise.resolve("done"),
+      });
+    } catch (reason) {
+      error = reason;
+    } finally {
+      IDBDatabase.prototype.transaction = realTransaction;
+    }
+
+    // The exact instance survives the failed bookkeeping write -- not wrapped,
+    // not replaced by the bookkeeping rejection.
+    expect(error).toBe(inputFailure);
+    // No connection was attempted and nothing committed: the guard failed before
+    // the handshake, the pre-run secret is intact, and no bookkeeping landed.
+    expect(handshakeRan).toBe(false);
     const stored = await getManagedExchange(created.id);
     expect(stored?.sharedSecret).toBe(created.sharedSecret);
     expect(stored?.lastRun).toBeUndefined();

--- a/apps/web/test/browser/managedInputHandle.test.ts
+++ b/apps/web/test/browser/managedInputHandle.test.ts
@@ -1,0 +1,513 @@
+/// <reference types="@vitest/browser-playwright/context" />
+/// <reference types="vite/client" />
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  assembleExchangeSpec,
+  connectionFromLocator,
+  generateSharedSecret,
+  getDefaultLinkageTerms,
+} from "@psilink/core";
+
+import {
+  HandleReadPermissionError,
+  acquireManagedInput,
+  acquireValidatedManagedInput,
+  ensureHandleReadPermission,
+  fileSystemAccessSupported,
+} from "@psi/managedInputHandle";
+import {
+  clearManagedExchanges,
+  createManagedExchange,
+  getManagedExchange,
+  persistManagedExchangeInputHandle,
+} from "@psi/managedExchangeStore";
+import { ManagedInputError } from "@psi/managedInputGuard";
+import { composeManagedExchangeFile } from "@psi/managedExchangeRecord";
+import { runManagedExchange } from "@psi/managedExchangeRun";
+
+import type { ExchangeSpec, WebRTCExchangeLocator } from "@psilink/core";
+import type {
+  HandleReadPermissionQuery,
+  HandleReadPermissionState,
+} from "@psi/managedInputHandle";
+import type { NewManagedExchange } from "@psi/managedExchangeRecord";
+
+// The platform half of the input-file handle lifecycle, exercised against real
+// Chromium: reading a File through a FileSystemFileHandle at run start (real
+// getFile, via the origin-private file system), the read-through-not-snapshot
+// property, the benign missing-file and column-shape failures, and the run-seam
+// composition (the input guard gating the handshake). The permission layer is
+// injected: an origin-private-file-system handle implements neither queryPermission
+// nor requestPermission, so its real behavior is the always-granted feature-detect
+// fallback; the non-granted and prompt cases can only be covered by injection, and
+// are, in the "permission layer" block below. The pure column-shape verdict and the
+// input-rejection classification are unit-tested in test/unit/managedInputGuard.test.ts.
+
+const webrtcLocator: WebRTCExchangeLocator = {
+  channel: "webrtc",
+  host: "signaling.example.org",
+  port: 3000,
+  path: "/api/",
+};
+
+const linkageTerms = getDefaultLinkageTerms("County Health Dept");
+
+/** The standing exchange-file document a managed record persists. */
+function standingExchangeFile(): ExchangeSpec {
+  return assembleExchangeSpec({
+    connection: connectionFromLocator(webrtcLocator),
+    linkageTerms,
+  });
+}
+
+function newExchange(
+  overrides: Partial<NewManagedExchange> = {},
+): NewManagedExchange {
+  return {
+    label: "Riverbend quarterly",
+    exchangeFile: composeManagedExchangeFile({
+      connection: webrtcLocator,
+      linkageTerms,
+    }),
+    side: "inviter",
+    sharedSecret: generateSharedSecret(),
+    ...overrides,
+  };
+}
+
+const CONFORMING_HEADER = "ssn,first_name,last_name,date_of_birth\n";
+const CONFORMING_ROW = "123456789,ADA,LOVELACE,01/01/1990\n";
+const DRIFTED_CSV = "unrelated_a,unrelated_b\n1,2\n";
+
+/** Write `content` to an origin-private-file-system file and return its handle.
+ * OPFS handles are structured-cloneable and support getFile(), so they stand in
+ * for a picker handle for everything except the permission extension. */
+async function writeOpfsFile(
+  name: string,
+  content: string,
+): Promise<FileSystemFileHandle> {
+  const root = await navigator.storage.getDirectory();
+  const handle = await root.getFileHandle(name, { create: true });
+  const writable = await handle.createWritable();
+  await writable.write(content);
+  await writable.close();
+  return handle;
+}
+
+/** A permission seam that reports a fixed state and records whether it prompted,
+ * so the unattended-never-prompts and attended-prompts paths can be asserted
+ * against a handle that (being OPFS) implements no real permission extension. */
+function fakePermission(
+  queryState: HandleReadPermissionState,
+  requestState: HandleReadPermissionState = "granted",
+): HandleReadPermissionQuery & { requested: boolean } {
+  const seam = {
+    requested: false,
+    query: () => Promise.resolve(queryState),
+    request: () => {
+      seam.requested = true;
+      return Promise.resolve(requestState);
+    },
+  };
+  return seam;
+}
+
+const OPFS_NAMES: Array<string> = [];
+async function trackedOpfsFile(
+  name: string,
+  content: string,
+): Promise<FileSystemFileHandle> {
+  OPFS_NAMES.push(name);
+  return writeOpfsFile(name, content);
+}
+
+beforeEach(async () => {
+  await clearManagedExchanges();
+});
+
+afterEach(async () => {
+  await clearManagedExchanges();
+  const root = await navigator.storage.getDirectory();
+  for (const name of OPFS_NAMES.splice(0)) {
+    try {
+      await root.removeEntry(name);
+    } catch {
+      // Already gone (a test that removed the entry itself).
+    }
+  }
+});
+
+describe("fileSystemAccessSupported", () => {
+  test("is true in Chromium, which has FileSystemFileHandle", () => {
+    expect(fileSystemAccessSupported()).toBe(true);
+  });
+});
+
+describe("read through the handle at run start", () => {
+  test("getFile picks up replaced contents at the same path", async () => {
+    const handle = await trackedOpfsFile(
+      "managed-input.csv",
+      CONFORMING_HEADER + CONFORMING_ROW,
+    );
+    const first = await acquireManagedInput({
+      kind: "handle",
+      handle,
+      attendance: "unattended",
+    });
+    expect(first.columns).toEqual([
+      "ssn",
+      "first_name",
+      "last_name",
+      "date_of_birth",
+    ]);
+
+    // Drop the next period's extract over the same name -- the data-refresh
+    // workflow -- and the same handle reads the new contents, no re-selection.
+    const writable = await handle.createWritable();
+    await writable.write("email_address\nada@example.org\n");
+    await writable.close();
+
+    const second = await acquireManagedInput({
+      kind: "handle",
+      handle,
+      attendance: "unattended",
+    });
+    expect(second.columns).toEqual(["email_address"]);
+  });
+
+  test("a missing file fails as a benign acquire rejection", async () => {
+    const handle = await trackedOpfsFile(
+      "managed-input.csv",
+      CONFORMING_HEADER + CONFORMING_ROW,
+    );
+    // Remove the entry the handle points at: getFile now rejects with a not-found,
+    // the clean missing-input state -- never a desync or attack.
+    const root = await navigator.storage.getDirectory();
+    await root.removeEntry("managed-input.csv");
+
+    const error: unknown = await acquireManagedInput({
+      kind: "handle",
+      handle,
+      attendance: "unattended",
+    }).then(
+      () => {
+        throw new Error("the acquire should have rejected");
+      },
+      (reason: unknown) => reason,
+    );
+    expect(error).toBeInstanceOf(ManagedInputError);
+    expect((error as ManagedInputError).rejection.reason).toBe("acquire");
+  });
+});
+
+describe("acquireValidatedManagedInput: column-shape guard on each path", () => {
+  test("accepts a conforming file read through a handle", async () => {
+    const handle = await trackedOpfsFile(
+      "managed-input.csv",
+      CONFORMING_HEADER + CONFORMING_ROW,
+    );
+    const acquired = await acquireValidatedManagedInput(
+      standingExchangeFile(),
+      {
+        kind: "handle",
+        handle,
+        attendance: "unattended",
+      },
+    );
+    expect(acquired.columns[0]).toBe("ssn");
+  });
+
+  test("rejects a drifted file read through a handle (columns rejection)", async () => {
+    const handle = await trackedOpfsFile("drifted.csv", DRIFTED_CSV);
+    const error: unknown = await acquireValidatedManagedInput(
+      standingExchangeFile(),
+      { kind: "handle", handle, attendance: "unattended" },
+    ).then(
+      () => {
+        throw new Error("the validated acquire should have rejected");
+      },
+      (reason: unknown) => reason,
+    );
+    expect(error).toBeInstanceOf(ManagedInputError);
+    expect((error as ManagedInputError).rejection.reason).toBe("columns");
+  });
+
+  test("rejects a drifted re-selected file (the no-API path)", async () => {
+    // The re-selection path supplies a File directly rather than a handle; the
+    // same column guard applies.
+    const file = new File([DRIFTED_CSV], "drifted.csv", { type: "text/csv" });
+    const error: unknown = await acquireValidatedManagedInput(
+      standingExchangeFile(),
+      { kind: "file", file },
+    ).then(
+      () => {
+        throw new Error("the validated acquire should have rejected");
+      },
+      (reason: unknown) => reason,
+    );
+    expect(error).toBeInstanceOf(ManagedInputError);
+    expect((error as ManagedInputError).rejection.reason).toBe("columns");
+  });
+
+  test("accepts a conforming re-selected file", async () => {
+    const file = new File([CONFORMING_HEADER + CONFORMING_ROW], "input.csv", {
+      type: "text/csv",
+    });
+    const acquired = await acquireValidatedManagedInput(
+      standingExchangeFile(),
+      {
+        kind: "file",
+        file,
+      },
+    );
+    expect(acquired.columns[0]).toBe("ssn");
+  });
+});
+
+describe("permission layer (injected)", () => {
+  test("the unattended path proceeds on an existing grant, never prompting", async () => {
+    const handle = await trackedOpfsFile(
+      "managed-input.csv",
+      CONFORMING_HEADER,
+    );
+    const permission = fakePermission("granted");
+    await ensureHandleReadPermission(handle, "unattended", permission);
+    expect(permission.requested).toBe(false);
+  });
+
+  test("the unattended path fails on a non-granted state without prompting", async () => {
+    const handle = await trackedOpfsFile(
+      "managed-input.csv",
+      CONFORMING_HEADER,
+    );
+    const permission = fakePermission("prompt");
+    await expect(
+      ensureHandleReadPermission(handle, "unattended", permission),
+    ).rejects.toBeInstanceOf(HandleReadPermissionError);
+    // A scheduled run has nobody to answer a prompt, so it must not request.
+    expect(permission.requested).toBe(false);
+  });
+
+  test("the attended path prompts when the state is prompt and proceeds on grant", async () => {
+    const handle = await trackedOpfsFile(
+      "managed-input.csv",
+      CONFORMING_HEADER,
+    );
+    const permission = fakePermission("prompt", "granted");
+    await ensureHandleReadPermission(handle, "attended", permission);
+    expect(permission.requested).toBe(true);
+  });
+
+  test("the attended path fails when the operator denies the prompt", async () => {
+    const handle = await trackedOpfsFile(
+      "managed-input.csv",
+      CONFORMING_HEADER,
+    );
+    const permission = fakePermission("prompt", "denied");
+    await expect(
+      ensureHandleReadPermission(handle, "attended", permission),
+    ).rejects.toBeInstanceOf(HandleReadPermissionError);
+    expect(permission.requested).toBe(true);
+  });
+
+  test("a denied state fails the unattended acquire as a benign acquire rejection", async () => {
+    const handle = await trackedOpfsFile(
+      "managed-input.csv",
+      CONFORMING_HEADER,
+    );
+    const permission = fakePermission("denied");
+    const error: unknown = await acquireManagedInput(
+      { kind: "handle", handle, attendance: "unattended" },
+      permission,
+    ).then(
+      () => {
+        throw new Error("the acquire should have rejected");
+      },
+      (reason: unknown) => reason,
+    );
+    expect(error).toBeInstanceOf(ManagedInputError);
+    expect((error as ManagedInputError).rejection.reason).toBe("acquire");
+    expect((error as ManagedInputError).cause).toBeInstanceOf(
+      HandleReadPermissionError,
+    );
+  });
+});
+
+describe("handle persistence and re-point", () => {
+  test("no handle is persisted where none is supplied (the unsupported-platform shape)", async () => {
+    // On a browser without the API the save flow supplies no handle; the record
+    // carries none, and the first run re-selects the file.
+    const created = await createManagedExchange(newExchange());
+    expect(created.inputFileHandle).toBeUndefined();
+    expect(
+      (await getManagedExchange(created.id))?.inputFileHandle,
+    ).toBeUndefined();
+  });
+
+  test("an imported record re-acquires a handle by re-point (the post-import path)", async () => {
+    // An imported record carries no handle (the export omits it); the first run
+    // after import re-acquires one by selection, persisted through the re-point
+    // write.
+    const created = await createManagedExchange(newExchange());
+    expect(created.inputFileHandle).toBeUndefined();
+
+    const handle = await trackedOpfsFile(
+      "managed-input.csv",
+      CONFORMING_HEADER,
+    );
+    const repointed = await persistManagedExchangeInputHandle(
+      created.id,
+      handle,
+    );
+    expect(repointed.inputFileHandle).toBeDefined();
+    const stored = await getManagedExchange(created.id);
+    expect(await stored?.inputFileHandle?.isSameEntry(handle)).toBe(true);
+    // The re-point advanced only the handle; the secret and document are intact.
+    expect(stored?.sharedSecret).toBe(created.sharedSecret);
+    expect(stored?.exchangeFile).toEqual(created.exchangeFile);
+  });
+
+  test("re-pointing to a new handle replaces the old one, and null drops it", async () => {
+    const first = await trackedOpfsFile("first.csv", CONFORMING_HEADER);
+    const created = await createManagedExchange(
+      newExchange({ inputFileHandle: first }),
+    );
+    expect(
+      await (
+        await getManagedExchange(created.id)
+      )?.inputFileHandle?.isSameEntry(first),
+    ).toBe(true);
+
+    const second = await trackedOpfsFile("second.csv", CONFORMING_HEADER);
+    await persistManagedExchangeInputHandle(created.id, second);
+    const afterRepoint = await getManagedExchange(created.id);
+    expect(await afterRepoint?.inputFileHandle?.isSameEntry(second)).toBe(true);
+    expect(await afterRepoint?.inputFileHandle?.isSameEntry(first)).toBe(false);
+
+    await persistManagedExchangeInputHandle(created.id, null);
+    expect(
+      (await getManagedExchange(created.id))?.inputFileHandle,
+    ).toBeUndefined();
+  });
+});
+
+describe("run seam composition: the input guard gates the handshake", () => {
+  test("a missing file records a benign input failure and never handshakes", async () => {
+    const handle = await trackedOpfsFile(
+      "managed-input.csv",
+      CONFORMING_HEADER + CONFORMING_ROW,
+    );
+    const created = await createManagedExchange(
+      newExchange({ inputFileHandle: handle }),
+    );
+    const root = await navigator.storage.getDirectory();
+    await root.removeEntry("managed-input.csv");
+
+    let handshakeRan = false;
+    const error: unknown = await runManagedExchange({
+      record: created,
+      acquireInput: () =>
+        acquireValidatedManagedInput(created.exchangeFile, {
+          kind: "handle",
+          handle,
+          attendance: "unattended",
+        }),
+      handshake: () => {
+        handshakeRan = true;
+        return Promise.resolve({
+          rotatedSecret: generateSharedSecret(),
+          handshake: "c",
+        });
+      },
+      dataExchange: () => Promise.resolve("done"),
+    }).then(
+      () => {
+        throw new Error("the run should have rejected on the missing input");
+      },
+      (reason: unknown) => reason,
+    );
+
+    expect(error).toBeInstanceOf(ManagedInputError);
+    // No connection was attempted: the guard fails before the handshake.
+    expect(handshakeRan).toBe(false);
+    // The benign input failure is recorded, never desync/attack framing.
+    const stored = await getManagedExchange(created.id);
+    expect(stored?.lastRun?.outcome).toBe("failed");
+    expect(stored?.lastRun?.failureKind).toBe("input");
+    // The rotation did not run: the pre-run secret is intact.
+    expect(stored?.sharedSecret).toBe(created.sharedSecret);
+  });
+
+  test("a column-shape rejection records a benign input failure and never handshakes", async () => {
+    const handle = await trackedOpfsFile("drifted.csv", DRIFTED_CSV);
+    const created = await createManagedExchange(
+      newExchange({ inputFileHandle: handle }),
+    );
+
+    let handshakeRan = false;
+    const error: unknown = await runManagedExchange({
+      record: created,
+      acquireInput: () =>
+        acquireValidatedManagedInput(created.exchangeFile, {
+          kind: "handle",
+          handle,
+          attendance: "unattended",
+        }),
+      handshake: () => {
+        handshakeRan = true;
+        return Promise.resolve({
+          rotatedSecret: generateSharedSecret(),
+          handshake: "c",
+        });
+      },
+      dataExchange: () => Promise.resolve("done"),
+    }).then(
+      () => {
+        throw new Error("the run should have rejected on the drifted columns");
+      },
+      (reason: unknown) => reason,
+    );
+
+    expect(error).toBeInstanceOf(ManagedInputError);
+    expect((error as ManagedInputError).rejection.reason).toBe("columns");
+    expect(handshakeRan).toBe(false);
+    const stored = await getManagedExchange(created.id);
+    expect(stored?.lastRun?.failureKind).toBe("input");
+    expect(stored?.sharedSecret).toBe(created.sharedSecret);
+  });
+
+  test("a conforming file passes the guard and reaches the handshake", async () => {
+    const handle = await trackedOpfsFile(
+      "managed-input.csv",
+      CONFORMING_HEADER + CONFORMING_ROW,
+    );
+    const created = await createManagedExchange(
+      newExchange({ inputFileHandle: handle }),
+    );
+    const rotatedSecret = generateSharedSecret();
+
+    // The handshake receives the acquired input, proving the guard gates it.
+    let handshakeColumns: Array<string> | undefined;
+    const result = await runManagedExchange({
+      record: created,
+      acquireInput: () =>
+        acquireValidatedManagedInput(created.exchangeFile, {
+          kind: "handle",
+          handle,
+          attendance: "unattended",
+        }),
+      handshake: (input) => {
+        handshakeColumns = input.columns;
+        return Promise.resolve({ rotatedSecret, handshake: "c" });
+      },
+      dataExchange: () => Promise.resolve("done"),
+    });
+
+    expect(handshakeColumns?.[0]).toBe("ssn");
+    expect(result.exchange).toBe("done");
+    const stored = await getManagedExchange(created.id);
+    expect(stored?.lastRun?.outcome).toBe("succeeded");
+    expect(stored?.sharedSecret).toBe(rotatedSecret);
+  });
+});

--- a/apps/web/test/unit/managedExchangeRecord.test.ts
+++ b/apps/web/test/unit/managedExchangeRecord.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test } from "vitest";
 import {
   MANAGED_EXCHANGE_SCHEMA_VERSION,
   MAX_LABEL_LENGTH,
+  applyManagedExchangeInputHandle,
   applyManagedExchangeLastRun,
   applyManagedExchangeLocalEdits,
   applyManagedExchangeRotation,
@@ -299,6 +300,52 @@ describe("applyManagedExchangeRotation", () => {
     });
     expect(record.sharedSecret).toBe(originalSecret);
     expect(record.expires).toBe("2026-04-06T14:00:00.000Z");
+  });
+});
+
+describe("applyManagedExchangeInputHandle", () => {
+  // A FileSystemFileHandle is an opaque platform object the schema carries through
+  // as an optional unknown (no runtime shape assertion; see the schema note), so a
+  // stand-in object exercises the set path in Node -- the real handle's structured-
+  // clone round-trip is the browser suite's.
+  const fakeHandle = { kind: "file", name: "input.csv" } as unknown as never;
+
+  test("sets the handle, touching nothing else", () => {
+    const record = buildManagedExchangeRecord(
+      newExchange({ tokenMaxAgeDays: 90, schedule }),
+    );
+    const pointed = applyManagedExchangeInputHandle(record, fakeHandle);
+    expect(pointed.inputFileHandle).toBe(fakeHandle);
+    expect(pointed.sharedSecret).toBe(record.sharedSecret);
+    expect(pointed.exchangeFile).toEqual(record.exchangeFile);
+    expect(pointed.label).toBe(record.label);
+    expect(pointed.schedule).toEqual(schedule);
+  });
+
+  test("re-points to a replacement handle", () => {
+    const record = applyManagedExchangeInputHandle(
+      buildManagedExchangeRecord(newExchange()),
+      fakeHandle,
+    );
+    const other = { kind: "file", name: "other.csv" } as unknown as never;
+    expect(applyManagedExchangeInputHandle(record, other).inputFileHandle).toBe(
+      other,
+    );
+  });
+
+  test("a null drops the handle, deleting the key", () => {
+    const record = applyManagedExchangeInputHandle(
+      buildManagedExchangeRecord(newExchange()),
+      fakeHandle,
+    );
+    const dropped = applyManagedExchangeInputHandle(record, null);
+    expect(dropped).not.toHaveProperty("inputFileHandle");
+  });
+
+  test("does not mutate the input record", () => {
+    const record = buildManagedExchangeRecord(newExchange());
+    applyManagedExchangeInputHandle(record, fakeHandle);
+    expect(record.inputFileHandle).toBeUndefined();
   });
 });
 

--- a/apps/web/test/unit/managedInputGuard.test.ts
+++ b/apps/web/test/unit/managedInputGuard.test.ts
@@ -1,0 +1,105 @@
+import {
+  assembleExchangeSpec,
+  connectionFromLocator,
+  getDefaultLinkageTerms,
+} from "@psilink/core";
+import { describe, expect, test } from "vitest";
+
+import {
+  ManagedInputError,
+  assessManagedInputColumns,
+} from "@psi/managedInputGuard";
+
+import type { ExchangeSpec, WebRTCExchangeLocator } from "@psilink/core";
+
+// The pure, platform-free half of the run-start input guard, tested in Node
+// without a file handle, a permission prompt, or a database: the column-shape
+// verdict over a record's standing terms and the benign input-rejection
+// classification. The platform reads (getFile through the handle, the permission
+// layer, and the composed run-start acquisition) are the platform half, tested
+// against real Chromium in test/browser/managedInputHandle.test.ts.
+
+const webrtcLocator: WebRTCExchangeLocator = {
+  channel: "webrtc",
+  host: "signaling.example.org",
+  port: 3000,
+  path: "/api/",
+};
+
+/** A managed exchange-file document whose standing terms are the metadata-aware
+ * defaults for a PII column set, so a conforming input satisfies at least one key
+ * and a drifted one satisfies none -- the same document the record persists. */
+function standingExchangeFile(): ExchangeSpec {
+  return assembleExchangeSpec({
+    connection: connectionFromLocator(webrtcLocator),
+    linkageTerms: getDefaultLinkageTerms("County Health Dept"),
+  });
+}
+
+const standingColumns = ["ssn", "first_name", "last_name", "date_of_birth"];
+
+describe("assessManagedInputColumns: the column-shape guard", () => {
+  test("accepts columns that satisfy at least one standing linkage key", () => {
+    expect(
+      assessManagedInputColumns(standingExchangeFile(), standingColumns),
+    ).toBeUndefined();
+  });
+
+  test("rejects columns that satisfy no standing linkage key", () => {
+    const rejection = assessManagedInputColumns(standingExchangeFile(), [
+      "unrelated_a",
+      "unrelated_b",
+    ]);
+    expect(rejection?.reason).toBe("columns");
+    // The unproducible standing linkage fields are carried for the caller to name.
+    if (rejection?.reason === "columns")
+      expect(rejection.unsatisfied.length).toBeGreaterThan(0);
+  });
+
+  test("rejects an empty column set (a wrong or headerless refresh)", () => {
+    const rejection = assessManagedInputColumns(standingExchangeFile(), []);
+    expect(rejection?.reason).toBe("columns");
+  });
+
+  test("a partial-but-sufficient column set is accepted (shape, not exact match)", () => {
+    // A file missing SSN but carrying name + DOB still satisfies a name-only key,
+    // so the shape guard accepts it -- it blocks only the no-key-can-match case.
+    expect(
+      assessManagedInputColumns(standingExchangeFile(), [
+        "first_name",
+        "last_name",
+        "date_of_birth",
+      ]),
+    ).toBeUndefined();
+  });
+});
+
+describe("ManagedInputError", () => {
+  test("an acquire rejection carries its cause and a non-sensitive message", () => {
+    const cause = new Error("NotFoundError: the entry was not found");
+    const error = new ManagedInputError({ reason: "acquire", cause });
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("ManagedInputError");
+    expect(error.rejection.reason).toBe("acquire");
+    expect(error.cause).toBe(cause);
+    // The base message is a fixed summary, not the partner- or file-influenced
+    // detail (which rides the rejection for the caller to sanitize).
+    expect(error.message).not.toContain("NotFound");
+  });
+
+  test("a columns rejection carries the unsatisfied fields off the message", () => {
+    const rejection = assessManagedInputColumns(standingExchangeFile(), [
+      "nope",
+    ]);
+    if (rejection === undefined) throw new Error("expected a rejection");
+    const error = new ManagedInputError(rejection);
+    expect(error.rejection.reason).toBe("columns");
+    if (error.rejection.reason === "columns")
+      expect(error.rejection.unsatisfied.length).toBeGreaterThan(0);
+    // The message names no field, so a partner-influenced field name cannot leak
+    // through a generic error surface.
+    expect(error.message).toBe(
+      "managed exchange input satisfies no standing linkage keys",
+    );
+  });
+});

--- a/docs/spec/MANAGED_EXCHANGE_RECORD.md
+++ b/docs/spec/MANAGED_EXCHANGE_RECORD.md
@@ -25,9 +25,11 @@ the exchange-file artifact the record is composed from (see
 [PROTOCOL.md](PROTOCOL.md#shared-secret-rotation)). Intended readers are security
 auditors and implementors.
 
-> **Status.** The record store and the run+rotate critical section (the
-> single-writer lock and the persist-before-success write-back) are implemented;
-> the runner, scheduling, and management surfaces that use them are not yet. The
+> **Status.** The record store, the run+rotate critical section (the
+> single-writer lock and the persist-before-success write-back), and the
+> input-acquisition seam (the persisted handle, its permission discipline, and
+> the pre-connection column-shape guard) are implemented; the runner,
+> scheduling, and management surfaces that use them are not yet. The
 > recurring-exchange epic implements against the shape below, security-reviewed
 > at each step because the record persists a rotating credential at rest. The
 > persist-before-success ordering and the single-owner invariant are normative,


### PR DESCRIPTION
## Summary

Implement the managed exchange's input-file seam: where the File System Access API exists, a managed exchange persists a FileSystemFileHandle to the operator's input file -- a live pointer, never a copy -- so each run reads the standing file at run start and replacing the file at the same path is the data-refresh workflow. The run seam gains an input guard structurally ahead of the handshake: a missing file, a revoked permission, an unreadable file, or columns the standing terms cannot satisfy fail as benign input-kind bookkeeping before any connection. The unattended path proceeds only on an existing read grant and never prompts; platforms without the API re-select per run; an imported record carries no handle and re-acquires one by selection.

Implements [213135457](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=213135457).

## Changes

- apps/web/src/psi/managedInputHandle.ts (new): platform half -- support detection, the injectable permission layer (query first; unattended throws on any non-granted state before the request call, which is structurally unreachable on that path), per-run getFile acquisition with File never retained across runs, and the acquire-then-validate composition.
- apps/web/src/psi/managedInputGuard.ts (new): pure half -- the column-shape guard reusing core's assessLinkageSatisfiability over the record's standing terms, and ManagedInputError with a structured rejection (fixed message; field names ride structured data for display-boundary sanitization, the InvitationFileError shape).
- apps/web/src/psi/managedExchangeRun.ts: the run seam gains a required acquireInput phase whose result is the handshake's argument, so the guard cannot be reordered after the handshake; an input rejection records benign "input" lastRun bookkeeping best-effort and re-raises with no connection attempted.
- apps/web/src/psi/managedExchangeRecord.ts + managedExchangeStore.ts: the pure handle applier (set/re-point/drop) and its field-scoped single-transaction store write -- the persist and re-point API the save flow and management surfaces will call (no UI is invented here; the surfaces are later epic items).
- docs/spec/MANAGED_EXCHANGE_RECORD.md: status note names the input seam.

## Test plan

Ran: `npm run typecheck && npm run lint && npm run format`; `npm run test -w apps/web` (1135 passed); `npm run test:browser -w apps/web` (382 passed, real Chromium); `npm run linkcheck`.
New tests cover: read-through-handle picking up replaced contents at the same path; missing-file and unreadable-file acquire rejections; the unattended path failing on a non-granted state without prompting (asserted requested === false) and the attended path requesting; column-shape rejection on the handle, re-selected-file, and run-seam paths with no handshake attempted and the secret intact; no handle persisted where none is supplied; the post-import re-acquisition path; handle persist/re-point/drop round-trips; and the input-tier total-storage-fault analog (the ManagedInputError surfaces unmasked when its bookkeeping write also fails). Permission-denied/prompt outcomes are covered through the injectable permission seam, since real-Chromium OPFS handles do not implement queryPermission; the honest boundary is noted in the module.

## Background

The persisted handle plus a granted read permission extends an in-origin reader's reach to the file's current contents, and the file name enters the store -- the disclosure analyzed and accepted in docs/SECURITY_DESIGN.md ("Metadata at rest: presence and shape"). A focused security review verified this diff stays within that envelope: no input content or row value on any write path, the unattended no-prompt property structural, error shapes carrying structured fields rather than strings, and the guard unbypassable ahead of the handshake. Verdict: ship, no findings.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- docs/spec/MANAGED_EXCHANGE_RECORD.md status note; the handle semantics this implements were already documented normatively and are unchanged
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: infrastructure for a capability not yet user-reachable; the recurring-exchanges headline entry lands when the feature ships
- [x] Security review -- done: focused reviewer pass over the handle-and-grant disclosure surface confirming the diff stays within the envelope docs/SECURITY_DESIGN.md analyzes and accepts (no content at rest, unattended never prompts, structured rejections, guard ahead of handshake); no findings
