### PR TITLE
Save an exchange as recurring on invite and on accept

### DIFF
--- a/apps/web/src/bench/AcceptorBench.tsx
+++ b/apps/web/src/bench/AcceptorBench.tsx
@@ -668,7 +668,11 @@ export function AcceptorBench() {
   // is the inviter's signaling location, not this browser's), and this party's
   // linkage terms are its derived perspective (identity replaced, output/payload
   // mirrored) with its own authored metadata and standardization -- the exact
-  // spec this run used. The secret is the invitation's; the one-shot run discards
+  // spec this run used. The token's disclosed set is persisted as the record's
+  // expectedPayloadColumns (empty = strict receive-nothing; an absent set stays
+  // absent = lazy), exactly as the CLI accept persists it, so a managed re-run
+  // fails closed if the partner transmits a set diverging from what was
+  // consented to here. The secret is the invitation's; the one-shot run discards
   // its own derived rotation, so the record stays coherent at this value until a
   // managed re-run rotates it. Declining is simply not pressing Manage.
   async function manageExchange(choices: ManageOfferChoices) {
@@ -685,6 +689,11 @@ export function AcceptorBench() {
           ),
           metadata: launched.edits.metadata,
           standardization: launched.edits.standardization,
+          ...(invitationToken.disclosedPayloadColumns !== undefined
+            ? {
+                expectedPayloadColumns: invitationToken.disclosedPayloadColumns,
+              }
+            : {}),
         },
         webrtcLocatorFromEndpoint(endpoint),
       );

--- a/apps/web/src/bench/AcceptorBench.tsx
+++ b/apps/web/src/bench/AcceptorBench.tsx
@@ -5,13 +5,20 @@ import { Dropzone } from "@mantine/dropzone";
 import { IconAlertCircle } from "@tabler/icons-react";
 import log from "loglevel";
 
-import { describeDecodeError, sanitizeErrorForDisplay } from "@psilink/core";
+import {
+  deriveAcceptedLinkageTerms,
+  describeDecodeError,
+  sanitizeErrorForDisplay,
+} from "@psilink/core";
 
 import { emptyColumnPositions, unnameableColumnsAlert } from "@psi/columnNames";
+import { capturedInputHandle } from "@psi/managedInputHandle";
+import { createManagedExchange } from "@psi/managedExchangeStore";
 import { loadCSVFileOffMainThread } from "@psi/csvParseController";
 import { prepareAcceptedInvitation } from "@psi/acceptInvitation";
 
 import { deploymentProfile } from "@utils/clientConfig";
+import { whenDiagnostic } from "@utils/diagnostics";
 
 import { InvitationTerms } from "@components/InvitationTerms";
 import { MAX_CSV_FILE_BYTES } from "@components/csvIntake";
@@ -40,12 +47,18 @@ import {
   acceptorLaunchPayload,
   acceptorVerdict,
 } from "./acceptorColumnsModel";
+import {
+  buildManagedDeposit,
+  composeManagedDocument,
+  webrtcLocatorFromEndpoint,
+} from "./manageOfferModel";
 import { AcceptorCleaningStep } from "./AcceptorCleaningStep";
 import { AcceptorColumnsStep } from "./AcceptorColumnsStep";
 import { AcceptorExchangeSection } from "./AcceptorExchangeSection";
 import { BenchShell } from "./BenchShell";
 import { FILE_ASSURANCE_LINE } from "./fileAssurance";
 import { Ledger } from "./Ledger";
+import { ManageExchangeOffer } from "./ManageExchangeOffer";
 import { Problems } from "./Problems";
 import { TopBar } from "./TopBar";
 import { acceptorTimelineSteps } from "./exchangeRun";
@@ -75,6 +88,8 @@ import type { AlertContent } from "@components/csvIntake";
 import type { FieldStepOverride } from "@psi/standardizationAuthoring";
 import type { FileRejection } from "@mantine/dropzone";
 import type { IntakeAlert } from "./YourFileSection";
+import type { ManageOfferChoices } from "./manageOfferModel";
+import type { ManageOfferStatus } from "./ManageExchangeOffer";
 import type { RailStep } from "./inviterModel";
 
 /** Stable empty inputs for {@link useNonEmptyRates} before a file is acquired, so the
@@ -174,7 +189,13 @@ export function AcceptorBench() {
   // so the server-job path submits the exact bytes the browser path parsed (no
   // re-serialization of rawRows). Fixed alongside `acquired` and the committed name.
   const [acceptedFile, setAcceptedFile] = useState<File>();
+  // The File System Access handle the committed file's selection yielded, where
+  // the platform gave one (a drop on Chromium in a secure context); captured so a
+  // managed deposit can persist a reusable pointer to the input without a second
+  // picker dialog. Absent for a click-selected file and a browser without the API.
+  const [sourceHandle, setSourceHandle] = useState<FileSystemFileHandle>();
   const [columnsState, setColumnsState] = useState<AcceptorColumnsState>();
+  const [manageStatus, setManageStatus] = useState<ManageOfferStatus>("idle");
   // The launched exchange (the assembled edits + optional advisory); rendering the
   // minimal run stub the next package replaces.
   const [launched, setLaunched] = useState<AcceptorLaunched>();
@@ -378,6 +399,7 @@ export function AcceptorBench() {
       // edited (the input stays editable; the committed identity does not drift).
       setCommittedName(name);
       setAcceptedFile(file);
+      setSourceHandle(capturedInputHandle(file));
       setAcquired({
         fileName: file.name,
         sizeBytes: file.size,
@@ -635,8 +657,63 @@ export function AcceptorBench() {
   // with every column-step input intact, where the acceptor fixes its settings.
   const backToColumns = () => {
     setLaunched(undefined);
+    setManageStatus("idle");
     goToStep("columns");
   };
+
+  // Deposit a managed-exchange record for this exchange as the acceptor: this
+  // party's own perspective of the terms plus the secret carried in the
+  // invitation link, so the same partnership can run again later. The connection
+  // block is composed from the INVITATION's endpoint (the acceptor's rendezvous
+  // is the inviter's signaling location, not this browser's), and this party's
+  // linkage terms are its derived perspective (identity replaced, output/payload
+  // mirrored) with its own authored metadata and standardization -- the exact
+  // spec this run used. The secret is the invitation's; the one-shot run discards
+  // its own derived rotation, so the record stays coherent at this value until a
+  // managed re-run rotates it. Declining is simply not pressing Manage.
+  async function manageExchange(choices: ManageOfferChoices) {
+    if (decode.status !== "ready" || launched === undefined) return;
+    const { token: invitationToken, endpoint } = decode.invitation;
+    if (endpoint.channel !== "webrtc") return;
+    setManageStatus("depositing");
+    try {
+      const exchangeFile = composeManagedDocument(
+        {
+          linkageTerms: deriveAcceptedLinkageTerms(
+            invitationToken.linkageTerms,
+            committedName,
+          ),
+          metadata: launched.edits.metadata,
+          standardization: launched.edits.standardization,
+        },
+        webrtcLocatorFromEndpoint(endpoint),
+      );
+      await createManagedExchange(
+        buildManagedDeposit(
+          {
+            side: "acceptor",
+            exchangeFile,
+            sharedSecret: invitationToken.sharedSecret,
+            ...(sourceHandle !== undefined
+              ? { inputFileHandle: sourceHandle }
+              : {}),
+            choices,
+          },
+          Date.now(),
+        ),
+      );
+      setManageStatus("deposited");
+    } catch (error) {
+      console.error(
+        "managed exchange deposit failed:",
+        error instanceof Error ? error.name : typeof error,
+      );
+      whenDiagnostic(() =>
+        console.error("managed exchange deposit failed (detail):", error),
+      );
+      setManageStatus("error");
+    }
+  }
 
   const cleaningResetKey =
     editorState?.standardization
@@ -884,15 +961,30 @@ export function AcceptorBench() {
             />
           )}
         {decode.status === "ready" && step === "launched" && (
-          <AcceptorExchangeSection
-            invitation={decode.invitation}
-            run={run}
-            outputs={outputs}
-            failure={failure}
-            warning={launched?.warning}
-            onTryAgain={tryAgain}
-            onFixColumns={backToColumns}
-          />
+          <>
+            <AcceptorExchangeSection
+              invitation={decode.invitation}
+              run={run}
+              outputs={outputs}
+              failure={failure}
+              warning={launched?.warning}
+              onTryAgain={tryAgain}
+              onFixColumns={backToColumns}
+            />
+            {/* The manage offer is webrtc-only (its record composes a webrtc
+                locator from the invitation's endpoint) and is skippable: leaving
+                it untouched keeps the exchange one-time. It stands from launch
+                through completion, so this party can manage the partnership. */}
+            {decode.invitation.endpoint.channel === "webrtc" &&
+              launched !== undefined &&
+              failure === undefined && (
+                <ManageExchangeOffer
+                  status={manageStatus}
+                  handleCaptured={sourceHandle !== undefined}
+                  onManage={(choices) => void manageExchange(choices)}
+                />
+              )}
+          </>
         )}
       </div>
     </BenchShell>

--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -304,6 +304,10 @@ export function InviterBench() {
           ...(invitation.standardization !== undefined
             ? { standardization: invitation.standardization }
             : {}),
+          // The token's own published set (including the strict empty set), so
+          // the persisted send-side commitment is the one the partner locked in
+          // -- never a re-derivation that could drift from it.
+          disclosedPayloadColumns: invitation.disclosedPayloadColumns,
         },
         connection,
       );
@@ -1023,14 +1027,18 @@ export function InviterBench() {
             {/* The manage offer is webrtc-only (its record composes a webrtc
                 locator) and is skippable: leaving it untouched keeps the exchange
                 one-time. It stands from the share screen through completion, so
-                either party can manage the partnership. */}
-            {transport === "browser" && failure === undefined && (
-              <ManageExchangeOffer
-                status={manageStatus}
-                handleCaptured={sourceHandle !== undefined}
-                onManage={(choices) => void manageExchange(choices)}
-              />
-            )}
+                either party can manage the partnership. The sample demo is
+                excluded: a standing record of synthetic terms armed with a real
+                secret is not a partnership to manage. */}
+            {transport === "browser" &&
+              failure === undefined &&
+              !demoActive && (
+                <ManageExchangeOffer
+                  status={manageStatus}
+                  handleCaptured={sourceHandle !== undefined}
+                  onManage={(choices) => void manageExchange(choices)}
+                />
+              )}
           </>
         )}
         {section === "save" && isCliTransport(transport) && (

--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -9,8 +9,14 @@ import {
   sanitizeForDisplay,
 } from "@psilink/core";
 
-import { InvitationFileError, generateInvitation } from "@psi/invitation";
+import {
+  InvitationFileError,
+  generateInvitation,
+  webrtcEndpointFromLocation,
+} from "@psi/invitation";
 import { emptyColumnPositions, unnameableColumnsAlert } from "@psi/columnNames";
+import { capturedInputHandle } from "@psi/managedInputHandle";
+import { createManagedExchange } from "@psi/managedExchangeStore";
 import { fetchSftpRemotes } from "@psi/serverJobExchangeDriver";
 import { invitationLocation } from "@psi/invitationLocation";
 import { loadCSVFileOffMainThread } from "@psi/csvParseController";
@@ -32,6 +38,11 @@ import {
   saveRailNote,
   saveTrustFooter,
 } from "./saveExchangeModel";
+import {
+  buildManagedDeposit,
+  composeManagedDocument,
+  webrtcLocatorFromEndpoint,
+} from "./manageOfferModel";
 import {
   cleaningCoverageProblems,
   editorFromCsv,
@@ -71,6 +82,7 @@ import { CleaningTab } from "./CleaningTab";
 import { InviterExchangeSection } from "./InviterExchangeSection";
 import { KeysTab } from "./KeysTab";
 import { Ledger } from "./Ledger";
+import { ManageExchangeOffer } from "./ManageExchangeOffer";
 import { MatchingSharingSection } from "./MatchingSharingSection";
 import { Problems } from "./Problems";
 import { ReviewCreateSection } from "./ReviewCreateSection";
@@ -93,6 +105,8 @@ import type {
 } from "@psi/invitation";
 import type { DisclosureChoice } from "@psi/metadataEditing";
 import type { IntakeAlert } from "./YourFileSection";
+import type { ManageOfferChoices } from "./manageOfferModel";
+import type { ManageOfferStatus } from "./ManageExchangeOffer";
 import type { SavedExchange } from "./SaveExchangeSection";
 import type { Section } from "./stepRestore";
 import type { SftpRemoteProjection } from "@jobs/jobManager";
@@ -160,6 +174,11 @@ export function InviterBench() {
   const [lastSpineStep, setLastSpineStep] = useState<SpineStep>("file");
   const [acquired, setAcquired] = useState<AcquiredCsv>();
   const [sourceFile, setSourceFile] = useState<File>();
+  // The File System Access handle a drop attached to the selected file, where the
+  // platform yielded one; captured so a managed deposit can persist a reusable
+  // pointer to the input without a second picker dialog. Absent for a
+  // click-selected file, a browser without the API, and the in-memory sample.
+  const [sourceHandle, setSourceHandle] = useState<FileSystemFileHandle>();
   const [editor, setEditor] = useState<InviterEditor>();
   const [intakeAlert, setIntakeAlert] = useState<IntakeAlert>();
   const [reading, setReading] = useState(false);
@@ -177,6 +196,7 @@ export function InviterBench() {
   const [sftpRemotes, setSftpRemotes] = useState<Array<SftpRemoteProjection>>();
   const [sftpRemoteName, setSftpRemoteName] = useState<string>();
   const [demoActive, setDemoActive] = useState(false);
+  const [manageStatus, setManageStatus] = useState<ManageOfferStatus>("idle");
 
   const transport = editor?.transport ?? "browser";
 
@@ -255,7 +275,63 @@ export function InviterBench() {
     );
     setInvitation(undefined);
     setSavedExchange(undefined);
+    setManageStatus("idle");
     goTo("review");
+  }
+
+  // Deposit a managed-exchange record for this exchange as the inviter: the
+  // standing terms plus the secret embedded in the just-minted invitation, so the
+  // same partnership can run again later. The connection block is composed from
+  // this app's own signaling location -- the same window.location source the
+  // invitation's endpoint was built from -- not read back off the encoded token.
+  // The secret is the minted invitation's; the one-shot run that follows discards
+  // its own derived rotation, so the record stays coherent at this value until a
+  // managed re-run rotates it. Declining is simply not pressing Manage, so there
+  // is no discard path here.
+  async function manageExchange(choices: ManageOfferChoices) {
+    if (invitation === undefined || editor === undefined) return;
+    setManageStatus("depositing");
+    try {
+      const connection = webrtcLocatorFromEndpoint(
+        webrtcEndpointFromLocation(invitationLocation()),
+      );
+      const exchangeFile = composeManagedDocument(
+        {
+          linkageTerms: invitation.linkageTerms,
+          ...(invitation.metadata !== undefined
+            ? { metadata: invitation.metadata }
+            : {}),
+          ...(invitation.standardization !== undefined
+            ? { standardization: invitation.standardization }
+            : {}),
+        },
+        connection,
+      );
+      await createManagedExchange(
+        buildManagedDeposit(
+          {
+            side: "inviter",
+            exchangeFile,
+            sharedSecret: invitation.sharedSecret,
+            ...(sourceHandle !== undefined
+              ? { inputFileHandle: sourceHandle }
+              : {}),
+            choices,
+          },
+          Date.now(),
+        ),
+      );
+      setManageStatus("deposited");
+    } catch (error) {
+      console.error(
+        "managed exchange deposit failed:",
+        error instanceof Error ? error.name : typeof error,
+      );
+      whenDiagnostic(() =>
+        console.error("managed exchange deposit failed (detail):", error),
+      );
+      setManageStatus("error");
+    }
   }
 
   // Apply a section arriving from a browser Back/Forward: set the step state
@@ -359,6 +435,7 @@ export function InviterBench() {
   function discardRead(alert: IntakeAlert) {
     setAcquired(undefined);
     setSourceFile(undefined);
+    setSourceHandle(undefined);
     setEditor(undefined);
     setDemoActive(false);
     setIntakeAlert(alert);
@@ -399,6 +476,7 @@ export function InviterBench() {
       const seeded = editorFromCsv(identity, csv);
       setAcquired(csv);
       setSourceFile(file);
+      setSourceHandle(capturedInputHandle(file));
       setEditor(seeded);
       // A fresh file re-seeds the terms and resets the transport to browser;
       // any exchange file saved for the prior read no longer describes them.
@@ -441,12 +519,14 @@ export function InviterBench() {
     setName("");
     setAcquired(undefined);
     setSourceFile(undefined);
+    setSourceHandle(undefined);
     setEditor(undefined);
     setIntakeAlert(undefined);
     setReading(false);
     setDemoActive(false);
     setSavedExchange(undefined);
     setInvitation(undefined);
+    setManageStatus("idle");
     goTo("file");
   }
 
@@ -516,6 +596,7 @@ export function InviterBench() {
       });
       setEditor(sealEditor(editor));
       setInvitation(minted);
+      setManageStatus("idle");
       goTo("share");
     } catch (error) {
       if (error instanceof InvitationFileError) {
@@ -928,16 +1009,29 @@ export function InviterBench() {
           />
         )}
         {section === "share" && invitation !== undefined && (
-          <InviterExchangeSection
-            invitation={invitation}
-            run={run}
-            outputs={outputs}
-            failure={failure}
-            warnings={warnings}
-            partnerAcceptsByCli={isCliTransport(transport)}
-            onTryAgain={tryAgain}
-            onStartOver={startOver}
-          />
+          <>
+            <InviterExchangeSection
+              invitation={invitation}
+              run={run}
+              outputs={outputs}
+              failure={failure}
+              warnings={warnings}
+              partnerAcceptsByCli={isCliTransport(transport)}
+              onTryAgain={tryAgain}
+              onStartOver={startOver}
+            />
+            {/* The manage offer is webrtc-only (its record composes a webrtc
+                locator) and is skippable: leaving it untouched keeps the exchange
+                one-time. It stands from the share screen through completion, so
+                either party can manage the partnership. */}
+            {transport === "browser" && failure === undefined && (
+              <ManageExchangeOffer
+                status={manageStatus}
+                handleCaptured={sourceHandle !== undefined}
+                onManage={(choices) => void manageExchange(choices)}
+              />
+            )}
+          </>
         )}
         {section === "save" && isCliTransport(transport) && (
           <SaveExchangeSection

--- a/apps/web/src/bench/ManageExchangeOffer.tsx
+++ b/apps/web/src/bench/ManageExchangeOffer.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+
+import { Alert, Button, Checkbox, NumberInput, TextInput } from "@mantine/core";
+import { IconCircleCheck } from "@tabler/icons-react";
+
+import {
+  LABEL_GUIDANCE,
+  MAX_LABEL_LENGTH,
+  labelWithinCap,
+  maxAgeCadenceNote,
+} from "./manageOfferModel";
+import styles from "./bench.module.css";
+
+import type { ManageOfferChoices } from "./manageOfferModel";
+
+/** The deposit's progress, driven by the host that owns the store write: `idle`
+ * before the operator commits, `depositing` while the write is in flight,
+ * `deposited` once the record lands, and `error` when the write failed. */
+export type ManageOfferStatus = "idle" | "depositing" | "deposited" | "error";
+
+/**
+ * The "manage this exchange" offer, rendered as its own panel on the inviter's
+ * share surface and the acceptor's completion surface. Declining is simply not
+ * acting: the offer never blocks the one-shot flow, and leaving it untouched
+ * leaves no managed record (the one-shot discard stands). Committing deposits a
+ * managed-exchange record for this party -- the standing terms plus the deposited
+ * secret -- so the same partnership can run again later.
+ *
+ * The panel is presentational: it collects the operator's label and optional
+ * max-age policy and hands them to {@link onManage}; the host owns the async store
+ * write and reports back through {@link status}. The label cap and the max-age
+ * cadence line come from the pure {@link ./manageOfferModel}, so the copy and the
+ * enforcement match the record schema.
+ */
+export function ManageExchangeOffer({
+  status,
+  handleCaptured,
+  onManage,
+}: {
+  status: ManageOfferStatus;
+  /** Whether a File System Access input-file handle was captured from the
+   * operator's selection, so a scheduled re-run can re-read the file without
+   * re-selection. Absent capture is normal (a click-selected file, or a browser
+   * without the API); the panel names which case holds so the operator is not
+   * surprised by a re-selection prompt later. */
+  handleCaptured: boolean;
+  onManage: (choices: ManageOfferChoices) => void;
+}) {
+  const [label, setLabel] = useState("");
+  const [maxAgeEnabled, setMaxAgeEnabled] = useState(false);
+  const [maxAgeDays, setMaxAgeDays] = useState<number>(90);
+
+  if (status === "deposited")
+    return (
+      <div className={styles.callout}>
+        <p className={styles.calloutLead}>
+          <IconCircleCheck
+            size={18}
+            aria-hidden
+            style={{ verticalAlign: "text-bottom", marginRight: 6 }}
+          />
+          This exchange is now managed.
+        </p>
+        <p className={styles.small}>
+          Its terms and secret are stored in this browser so you can run it
+          again with the same partner. Manage or delete it from the
+          recurring-exchange list.
+        </p>
+      </div>
+    );
+
+  const tokenMaxAgeDays =
+    maxAgeEnabled && Number.isInteger(maxAgeDays) && maxAgeDays > 0
+      ? maxAgeDays
+      : undefined;
+  const cadenceNote = maxAgeCadenceNote(tokenMaxAgeDays);
+  const labelValid = labelWithinCap(label);
+  const depositing = status === "depositing";
+  const canManage = labelValid && !depositing;
+
+  return (
+    <div className={styles.callout}>
+      <p className={styles.calloutLead}>Manage this exchange</p>
+      <p className={styles.small}>
+        Store this exchange&apos;s terms and secret in this browser so you can
+        run it again with the same partner, without re-inviting. Skip this to
+        keep the exchange one-time: nothing is stored.
+      </p>
+      <TextInput
+        label="Label"
+        description={LABEL_GUIDANCE}
+        value={label}
+        maxLength={MAX_LABEL_LENGTH}
+        error={
+          labelValid
+            ? undefined
+            : `Keep the label to ${MAX_LABEL_LENGTH} characters or fewer.`
+        }
+        onChange={(event) => setLabel(event.currentTarget.value)}
+        mt="sm"
+      />
+      <Checkbox
+        label="Set a maximum age for the stored secret"
+        description="Off by default. When set, the stored secret lapses if the exchange is not run or renewed within the age you choose."
+        checked={maxAgeEnabled}
+        onChange={(event) => setMaxAgeEnabled(event.currentTarget.checked)}
+        mt="sm"
+      />
+      {maxAgeEnabled && (
+        <NumberInput
+          label="Maximum age in days"
+          value={maxAgeDays}
+          min={1}
+          step={1}
+          allowDecimal={false}
+          onChange={(value) =>
+            setMaxAgeDays(typeof value === "number" ? value : 0)
+          }
+          mt="xs"
+        />
+      )}
+      {cadenceNote !== undefined && (
+        <p className={`${styles.small} ${styles.sub}`}>{cadenceNote}</p>
+      )}
+      <p className={`${styles.small} ${styles.sub}`}>
+        {handleCaptured
+          ? "A scheduled run can re-read your input file from this browser without re-selecting it."
+          : "You will re-select your input file for each run; this browser did not capture a reusable pointer to it."}
+      </p>
+      {status === "error" && (
+        <Alert color="red" title="Could not manage this exchange" mt="sm">
+          The exchange was not stored. Your one-time exchange is unaffected -
+          try again.
+        </Alert>
+      )}
+      <Button
+        mt="sm"
+        loading={depositing}
+        disabled={!canManage}
+        onClick={() =>
+          onManage({
+            label,
+            ...(tokenMaxAgeDays !== undefined ? { tokenMaxAgeDays } : {}),
+          })
+        }
+      >
+        Manage this exchange
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/bench/ManageExchangeOffer.tsx
+++ b/apps/web/src/bench/ManageExchangeOffer.tsx
@@ -6,8 +6,10 @@ import { IconCircleCheck } from "@tabler/icons-react";
 import {
   LABEL_GUIDANCE,
   MAX_LABEL_LENGTH,
+  MAX_TOKEN_MAX_AGE_DAYS,
   labelWithinCap,
   maxAgeCadenceNote,
+  maxAgeDaysError,
 } from "./manageOfferModel";
 import styles from "./bench.module.css";
 
@@ -48,7 +50,10 @@ export function ManageExchangeOffer({
 }) {
   const [label, setLabel] = useState("");
   const [maxAgeEnabled, setMaxAgeEnabled] = useState(false);
-  const [maxAgeDays, setMaxAgeDays] = useState<number>(90);
+  // Held as the NumberInput reports it (a string when cleared or mid-edit), so
+  // an invalid state is representable and can block the deposit rather than
+  // being coerced to a sentinel that silently drops the opted-in bound.
+  const [maxAgeDays, setMaxAgeDays] = useState<number | string>(90);
 
   if (status === "deposited")
     return (
@@ -69,14 +74,19 @@ export function ManageExchangeOffer({
       </div>
     );
 
+  // An enabled policy with an invalid day count blocks the deposit (the field
+  // error below names why): resolving it to "no bound" would silently drop the
+  // opted-in exposure bound the operator asked for.
+  const maxAgeError = maxAgeEnabled ? maxAgeDaysError(maxAgeDays) : undefined;
   const tokenMaxAgeDays =
-    maxAgeEnabled && Number.isInteger(maxAgeDays) && maxAgeDays > 0
+    maxAgeEnabled && maxAgeError === undefined && typeof maxAgeDays === "number"
       ? maxAgeDays
       : undefined;
   const cadenceNote = maxAgeCadenceNote(tokenMaxAgeDays);
   const labelValid = labelWithinCap(label);
   const depositing = status === "depositing";
-  const canManage = labelValid && !depositing;
+  const canManage =
+    labelValid && !depositing && (!maxAgeEnabled || maxAgeError === undefined);
 
   return (
     <div className={styles.callout}>
@@ -111,11 +121,11 @@ export function ManageExchangeOffer({
           label="Maximum age in days"
           value={maxAgeDays}
           min={1}
+          max={MAX_TOKEN_MAX_AGE_DAYS}
           step={1}
           allowDecimal={false}
-          onChange={(value) =>
-            setMaxAgeDays(typeof value === "number" ? value : 0)
-          }
+          error={maxAgeError}
+          onChange={setMaxAgeDays}
           mt="xs"
         />
       )}

--- a/apps/web/src/bench/manageOfferModel.ts
+++ b/apps/web/src/bench/manageOfferModel.ts
@@ -22,7 +22,7 @@
  * "compose then throw away" path here -- a caller that declines never composes.
  */
 
-import { disclosedColumnNames } from "@psilink/core";
+import { MAX_TOKEN_MAX_AGE_DAYS } from "@psilink/core";
 
 import {
   MAX_LABEL_LENGTH,
@@ -69,11 +69,16 @@ export function webrtcLocatorFromEndpoint(
  * {@link MAX_LABEL_LENGTH}). */
 export { MAX_LABEL_LENGTH };
 
+/** The maximum max-token-age policy in days, re-exported at the offer boundary
+ * so the component bounds its input at the same cap the record schema enforces
+ * at write (core's {@link MAX_TOKEN_MAX_AGE_DAYS}). */
+export { MAX_TOKEN_MAX_AGE_DAYS };
+
 /** This party's own exchange-file substance at the completion surface, the parts
  * of the persisted document that are not the connection: the linkage terms this
- * party runs on (its own perspective), and the optional per-party blocks. The
- * connection is supplied separately as a webrtc locator, so this shape is
- * transport-agnostic and identical for both sides. */
+ * party runs on (its own perspective), the optional per-party blocks, and the
+ * payload-column commitments. The connection is supplied separately as a webrtc
+ * locator, so this shape is transport-agnostic and identical for both sides. */
 export interface ManagedExchangeDocumentParts {
   /** This party's linkage terms -- the inviter's minted terms, or the acceptor's
    * derived perspective (identity replaced, output/payload mirrored). */
@@ -82,17 +87,40 @@ export interface ManagedExchangeDocumentParts {
   metadata?: Metadata;
   /** This party's per-party standardization, when authored. */
   standardization?: Standardization;
+  /**
+   * This party's SEND-side disclosure commitment -- the inviter supplies the
+   * token's own `disclosedPayloadColumns` (one source: the set the partner
+   * consented to and locked in, never a re-derivation that could drift from it).
+   * Empty means a strict "sends nothing" commitment; absent means no commitment
+   * on record (the acceptor, whose send commitment rides its mirrored
+   * `payload.send` instead -- see docs/spec/FILE_SYNC.md, "Which mint paths
+   * persist disclosedPayloadColumns").
+   */
+  disclosedPayloadColumns?: Array<string>;
+  /**
+   * This party's RECEIVE-side lock-in -- the acceptor supplies the invitation
+   * token's `disclosedPayloadColumns` (the partner's committed send set, in the
+   * partner's column namespace), so a managed re-run fails CLOSED if the partner
+   * transmits a different set than was consented to at accept, exactly as the
+   * CLI accept persists it (docs/spec/FILE_SYNC.md, "Runtime lock-in"). Empty
+   * means a strict "receive nothing" lock-in; absent means lazy (a token that
+   * carried no set). The inviter omits it: its received set is unknowable at
+   * mint (the CLI inviter crystallizes it only by observing the first exchange).
+   */
+  expectedPayloadColumns?: Array<string>;
 }
 
 /**
  * Compose this party's persisted exchange-file document from its own document
- * parts and the credential-free webrtc locator. The disclosed and expected
- * payload columns are derived from this party's metadata exactly as the
- * downloadable-file mint derives them (`disclosedColumnNames` over the same
- * metadata), so the persisted document's commitments match the run the terms were
- * authored for; both are omitted when there is no metadata to derive them from.
- * The document carries no `authentication` block and no credential by
- * construction (see {@link composeManagedExchangeFile}).
+ * parts and the credential-free webrtc locator. The payload-column commitments
+ * are caller-supplied and carried verbatim -- `disclosedPayloadColumns` is the
+ * token's published set (the inviter's send commitment), and
+ * `expectedPayloadColumns` is the token's set from the partner's side (the
+ * acceptor's receive lock-in) -- never re-derived here, so the persisted
+ * commitment cannot disagree with the one the token carried. An empty array is
+ * a strict commitment and is preserved; only an absent field is omitted. The
+ * document carries no `authentication` block and no credential by construction
+ * (see {@link composeManagedExchangeFile}).
  *
  * @throws {ZodError} if the assembled document fails schema validation (a
  *   malformed locator, an out-of-range port).
@@ -101,10 +129,6 @@ export function composeManagedDocument(
   parts: ManagedExchangeDocumentParts,
   connection: WebRTCExchangeLocator,
 ): ExchangeSpec {
-  const disclosed =
-    parts.metadata !== undefined
-      ? disclosedColumnNames(parts.metadata)
-      : undefined;
   return composeManagedExchangeFile({
     connection,
     linkageTerms: parts.linkageTerms,
@@ -112,13 +136,17 @@ export function composeManagedDocument(
     ...(parts.standardization !== undefined
       ? { standardization: parts.standardization }
       : {}),
-    ...(disclosed !== undefined ? { disclosedPayloadColumns: disclosed } : {}),
+    ...(parts.disclosedPayloadColumns !== undefined
+      ? { disclosedPayloadColumns: parts.disclosedPayloadColumns }
+      : {}),
+    ...(parts.expectedPayloadColumns !== undefined
+      ? { expectedPayloadColumns: parts.expectedPayloadColumns }
+      : {}),
   });
 }
 
 /** The operator's choices on the manage offer: the display label and whether to
- * opt into a max-age policy. The label cap is enforced by
- * {@link buildManagedDeposit}; the schedule is a later surface (a managed re-run
+ * opt into a max-age policy. The schedule is a later surface (a managed re-run
  * item), so it is deliberately not offered here. */
 export interface ManageOfferChoices {
   /** The operator-supplied display label for the partnership. */
@@ -149,16 +177,17 @@ export interface ManagedDepositInputs {
 }
 
 /**
- * Assemble the {@link NewManagedExchange} fields a deposit persists. The label
- * cap is enforced here (rejecting an over-long label before the store write, the
- * same cap {@link buildManagedExchangeRecord} re-checks), and the max-age policy
- * drives `expires`: when the operator opts in, `expires` is stamped `now +
- * tokenMaxAgeDays` through {@link rotationWriteBack} (reusing the run-rotate date
- * math and its guards, not duplicating them), so a creation-time bound is applied
- * exactly as a rotation would restamp it; when they do not, `tokenMaxAgeDays` and
- * `expires` are both absent -- the opt-in default. The invitation's setup lifetime
- * never flows into `expires`: the record's `expires` provenance is single-source
- * (see docs/spec/MANAGED_EXCHANGE_RECORD.md, the `expires` row).
+ * Assemble the {@link NewManagedExchange} fields a deposit persists. The label is
+ * carried verbatim -- its cap is enforced by the record schema at the store write
+ * ({@link buildManagedExchangeRecord}), with {@link labelWithinCap} as the UI
+ * gate. The max-age policy drives `expires`: when the operator opts in, `expires`
+ * is stamped `now + tokenMaxAgeDays` through {@link rotationWriteBack} (reusing
+ * the run-rotate date math and its guards, not duplicating them), so a
+ * creation-time bound is applied exactly as a rotation would restamp it; when
+ * they do not, `tokenMaxAgeDays` and `expires` are both absent -- the opt-in
+ * default. The invitation's setup lifetime never flows into `expires`: the
+ * record's `expires` provenance is single-source (see
+ * docs/spec/MANAGED_EXCHANGE_RECORD.md, the `expires` row).
  *
  * @param now The instant the max-age stamp counts from, injected so the deposit
  *   stays pure and testable.
@@ -191,6 +220,26 @@ export function buildManagedDeposit(
  * operator cooperation, not enforced. */
 export function labelWithinCap(label: string): boolean {
   return label.length <= MAX_LABEL_LENGTH;
+}
+
+/**
+ * Validate an opted-in max-age day count as the operator typed it (a number, or
+ * the string a cleared/partial number input reports), returning the field error
+ * to show, or `undefined` when the value is a usable policy. The offer must not
+ * resolve an enabled-but-invalid count to "no bound": the max-age policy is the
+ * only control bounding a dormant partnership's stored-secret exposure, so a
+ * cleared field silently converting opt-in to no-bound would deposit an unbounded
+ * secret the operator believes is bounded -- an invalid value blocks the deposit
+ * with this error instead. The bounds are the record schema's (a positive integer
+ * at most {@link MAX_TOKEN_MAX_AGE_DAYS}), checked here so an out-of-range value
+ * fails at the field, not as a generic store-write failure after the click.
+ */
+export function maxAgeDaysError(value: number | string): string | undefined {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1)
+    return "Enter a whole number of days.";
+  if (value > MAX_TOKEN_MAX_AGE_DAYS)
+    return `Enter at most ${MAX_TOKEN_MAX_AGE_DAYS} days.`;
+  return undefined;
 }
 
 /**

--- a/apps/web/src/bench/manageOfferModel.ts
+++ b/apps/web/src/bench/manageOfferModel.ts
@@ -1,0 +1,216 @@
+/**
+ * The pure decision half of the "manage this exchange" offer the bench makes at
+ * invite creation (the inviter) and at accept (the acceptor). It composes the
+ * fields a managed-exchange deposit needs -- the credential-free webrtc locator,
+ * this party's exchange-file document, the deposited secret, this party's `side`,
+ * and the optional max-age policy -- from what each completion surface already
+ * holds, and it derives the operator-facing copy (the label cap and the max-age
+ * cadence line). No React, no IndexedDB: the deposit itself (through
+ * {@link createManagedExchange}) and the offer's UI state live in the components,
+ * so the composition and the decline discipline are unit-testable in Node.
+ *
+ * Deposit shape and composition rules are normative in
+ * docs/spec/MANAGED_EXCHANGE_RECORD.md: the record persists this party's whole
+ * exchange-file document verbatim (no `authentication` block), composed from a
+ * credential-free {@link WebRTCExchangeLocator} through the shared schema (see
+ * {@link composeManagedExchangeFile}). The deposited secret is the invitation's
+ * secret -- `sharedSecret` on the inviter's minted invitation, `token.sharedSecret`
+ * on the acceptor's decoded one; the one-shot run that follows discards its own
+ * derived rotation, so both parties' records stay coherent at the deposited value
+ * until a later managed re-run rotates it. Declining leaves no record: the offer
+ * is skipped and the one-shot flow's discard stands, so there is deliberately no
+ * "compose then throw away" path here -- a caller that declines never composes.
+ */
+
+import { disclosedColumnNames } from "@psilink/core";
+
+import {
+  MAX_LABEL_LENGTH,
+  composeManagedExchangeFile,
+} from "@psi/managedExchangeRecord";
+import { rotationWriteBack } from "@psi/managedRunRotate";
+
+import type {
+  ExchangeSpec,
+  Metadata,
+  Standardization,
+  WebRTCEndpoint,
+  WebRTCExchangeLocator,
+} from "@psilink/core";
+import type {
+  ManagedExchangeSide,
+  NewManagedExchange,
+} from "@psi/managedExchangeRecord";
+
+/**
+ * Build the credential-free {@link WebRTCExchangeLocator} the managed record's
+ * connection block is composed from, out of a webrtc {@link WebRTCEndpoint}. The
+ * acceptor's endpoint is the invitation's own endpoint; the inviter's is the one
+ * {@link webrtcEndpointFromLocation} built for the token from this app's location.
+ * Either is already the invitation's `WebRTCEndpointSchema` shape (host/port/path,
+ * no credential), and the locator IS that schema (see
+ * docs/spec/MANAGED_EXCHANGE_RECORD.md, "The connection block") -- so this only
+ * re-shapes it, dropping an absent optional rather than carrying an explicit
+ * `undefined` the composer's strict parse would otherwise reject.
+ */
+export function webrtcLocatorFromEndpoint(
+  endpoint: WebRTCEndpoint,
+): WebRTCExchangeLocator {
+  return {
+    channel: "webrtc",
+    host: endpoint.host,
+    ...(endpoint.port !== undefined ? { port: endpoint.port } : {}),
+    ...(endpoint.path !== undefined ? { path: endpoint.path } : {}),
+  };
+}
+
+/** The maximum operator label length, re-exported at the offer boundary so the
+ * component enforces the same cap the record schema does (see
+ * {@link MAX_LABEL_LENGTH}). */
+export { MAX_LABEL_LENGTH };
+
+/** This party's own exchange-file substance at the completion surface, the parts
+ * of the persisted document that are not the connection: the linkage terms this
+ * party runs on (its own perspective), and the optional per-party blocks. The
+ * connection is supplied separately as a webrtc locator, so this shape is
+ * transport-agnostic and identical for both sides. */
+export interface ManagedExchangeDocumentParts {
+  /** This party's linkage terms -- the inviter's minted terms, or the acceptor's
+   * derived perspective (identity replaced, output/payload mirrored). */
+  linkageTerms: ExchangeSpec["linkageTerms"];
+  /** This party's edited column metadata, when authored. */
+  metadata?: Metadata;
+  /** This party's per-party standardization, when authored. */
+  standardization?: Standardization;
+}
+
+/**
+ * Compose this party's persisted exchange-file document from its own document
+ * parts and the credential-free webrtc locator. The disclosed and expected
+ * payload columns are derived from this party's metadata exactly as the
+ * downloadable-file mint derives them (`disclosedColumnNames` over the same
+ * metadata), so the persisted document's commitments match the run the terms were
+ * authored for; both are omitted when there is no metadata to derive them from.
+ * The document carries no `authentication` block and no credential by
+ * construction (see {@link composeManagedExchangeFile}).
+ *
+ * @throws {ZodError} if the assembled document fails schema validation (a
+ *   malformed locator, an out-of-range port).
+ */
+export function composeManagedDocument(
+  parts: ManagedExchangeDocumentParts,
+  connection: WebRTCExchangeLocator,
+): ExchangeSpec {
+  const disclosed =
+    parts.metadata !== undefined
+      ? disclosedColumnNames(parts.metadata)
+      : undefined;
+  return composeManagedExchangeFile({
+    connection,
+    linkageTerms: parts.linkageTerms,
+    ...(parts.metadata !== undefined ? { metadata: parts.metadata } : {}),
+    ...(parts.standardization !== undefined
+      ? { standardization: parts.standardization }
+      : {}),
+    ...(disclosed !== undefined ? { disclosedPayloadColumns: disclosed } : {}),
+  });
+}
+
+/** The operator's choices on the manage offer: the display label and whether to
+ * opt into a max-age policy. The label cap is enforced by
+ * {@link buildManagedDeposit}; the schedule is a later surface (a managed re-run
+ * item), so it is deliberately not offered here. */
+export interface ManageOfferChoices {
+  /** The operator-supplied display label for the partnership. */
+  label: string;
+  /** The operator's opt-in max-token-age policy in whole days, or `undefined`
+   * for the default (no bound). */
+  tokenMaxAgeDays?: number;
+}
+
+/** Everything a completion surface supplies to turn the offer into a deposit: the
+ * party's side, its composed document, the invitation's secret, an optional
+ * input-file handle where the platform yielded one, and the operator's choices. */
+export interface ManagedDepositInputs {
+  /** This party's side of the partnership. */
+  side: ManagedExchangeSide;
+  /** This party's composed exchange-file document (see
+   * {@link composeManagedDocument}). */
+  exchangeFile: ExchangeSpec;
+  /** The invitation's shared secret -- the inviter's minted `sharedSecret`, the
+   * acceptor's `token.sharedSecret`. The one-shot run discards its rotation, so
+   * this stays the record's live secret until a managed re-run rotates it. */
+  sharedSecret: string;
+  /** An input-file handle pointer, where the File System Access API yielded one;
+   * absent otherwise (the record field is optional). */
+  inputFileHandle?: FileSystemFileHandle;
+  /** The operator's label and opt-in max-age policy. */
+  choices: ManageOfferChoices;
+}
+
+/**
+ * Assemble the {@link NewManagedExchange} fields a deposit persists. The label
+ * cap is enforced here (rejecting an over-long label before the store write, the
+ * same cap {@link buildManagedExchangeRecord} re-checks), and the max-age policy
+ * drives `expires`: when the operator opts in, `expires` is stamped `now +
+ * tokenMaxAgeDays` through {@link rotationWriteBack} (reusing the run-rotate date
+ * math and its guards, not duplicating them), so a creation-time bound is applied
+ * exactly as a rotation would restamp it; when they do not, `tokenMaxAgeDays` and
+ * `expires` are both absent -- the opt-in default. The invitation's setup lifetime
+ * never flows into `expires`: the record's `expires` provenance is single-source
+ * (see docs/spec/MANAGED_EXCHANGE_RECORD.md, the `expires` row).
+ *
+ * @param now The instant the max-age stamp counts from, injected so the deposit
+ *   stays pure and testable.
+ * @throws {RangeError} (from {@link rotationWriteBack}) if `tokenMaxAgeDays` is
+ *   not a positive integer or stamps an expiry outside the representable range.
+ */
+export function buildManagedDeposit(
+  inputs: ManagedDepositInputs,
+  now: number,
+): NewManagedExchange {
+  const { tokenMaxAgeDays } = inputs.choices;
+  const stamp = rotationWriteBack(inputs.sharedSecret, tokenMaxAgeDays, now);
+  return {
+    label: inputs.choices.label,
+    exchangeFile: inputs.exchangeFile,
+    side: inputs.side,
+    sharedSecret: inputs.sharedSecret,
+    ...(inputs.inputFileHandle !== undefined
+      ? { inputFileHandle: inputs.inputFileHandle }
+      : {}),
+    ...(tokenMaxAgeDays !== undefined ? { tokenMaxAgeDays } : {}),
+    ...(stamp.expires !== null ? { expires: stamp.expires } : {}),
+  };
+}
+
+/** Whether the operator's label is within the cap the deposit enforces. Offered
+ * so a component can gate its deposit action on a valid label without catching the
+ * schema's throw. An empty label is permitted (the field has no minimum); the
+ * content guidance -- name the partnership, no sensitive counterparty detail -- is
+ * operator cooperation, not enforced. */
+export function labelWithinCap(label: string): boolean {
+  return label.length <= MAX_LABEL_LENGTH;
+}
+
+/**
+ * The cadence line surfaced when the operator sets a max-age policy, naming the
+ * implication the operator weighs against the partnership's known cadence: the
+ * exchange must run or be renewed within the bound or its stored secret lapses
+ * (see docs/MANAGED_EXCHANGE.md, "Expiry is its own state"). Returns `undefined`
+ * when no policy is set (the default), so a component renders nothing.
+ */
+export function maxAgeCadenceNote(
+  tokenMaxAgeDays: number | undefined,
+): string | undefined {
+  if (tokenMaxAgeDays === undefined) return undefined;
+  const days = tokenMaxAgeDays === 1 ? "1 day" : `${tokenMaxAgeDays} days`;
+  return `This exchange must run or be renewed within ${days}, or its stored secret lapses and you re-invite your partner.`;
+}
+
+/** The operator guidance for the label field: name the partnership without
+ * sensitive counterparty detail. Reuses the spec's settled label-row language --
+ * the label is disclosed to any reader of the store and never sent, so agreement
+ * numbers and contact details do not belong in it. */
+export const LABEL_GUIDANCE =
+  "Name the partnership so you recognize it later. The label is stored in this browser and never sent, but any reader of this browser's storage can see it, so keep agreement numbers, contact details, and other sensitive counterparty information out of it.";

--- a/apps/web/src/psi/invitation.ts
+++ b/apps/web/src/psi/invitation.ts
@@ -147,6 +147,15 @@ export interface GeneratedInvitation {
    * downstream. Local-only.
    */
   standardization?: Standardization;
+  /**
+   * The disclosed-column subset the token carries -- the value already inside
+   * `encoded`, surfaced so a persisting caller (the managed-exchange deposit)
+   * records the SAME send-side commitment the token published rather than
+   * re-deriving one that could drift. Always set, including the EMPTY set (a
+   * strict "sends nothing" commitment, not the absent/lazy case); see
+   * docs/spec/FILE_SYNC.md, "Which mint paths persist disclosedPayloadColumns".
+   */
+  disclosedPayloadColumns: Array<string>;
 }
 
 /** Why {@link generateInvitation} refused to mint an invitation for the given
@@ -530,5 +539,6 @@ export async function generateInvitation(params: {
     columns,
     metadata: params.metadata,
     standardization: params.standardization,
+    disclosedPayloadColumns,
   };
 }

--- a/apps/web/src/psi/managedInputHandle.ts
+++ b/apps/web/src/psi/managedInputHandle.ts
@@ -46,6 +46,38 @@ export function fileSystemAccessSupported(): boolean {
   return typeof globalThis.FileSystemFileHandle !== "undefined";
 }
 
+/** A selected file that MAY carry a File System Access handle. The bench's file
+ * intake (Mantine's Dropzone over `file-selector`) attaches a `handle` to a
+ * dropped file in a secure context on Chromium, so a managed deposit can capture
+ * the operator's existing selection without a second picker dialog; every other
+ * selection path (a click-to-open input, a browser without the API) yields a plain
+ * `File` and no handle. Declared locally because the DOM `File` lib does not type
+ * the `file-selector` extension. */
+interface FileWithOptionalHandle {
+  handle?: FileSystemFileHandle;
+}
+
+/**
+ * Read the File System Access handle a drop attached to `file`, or `undefined`
+ * when the selection path did not yield one. On Chromium in a secure context,
+ * `file-selector` (under the bench's Dropzone) calls
+ * `DataTransferItem.getAsFileSystemHandle()` on a drop and attaches the handle to
+ * the `File`; a click-to-open selection and a browser without the API leave it
+ * absent. The presence of the handle is also gated on
+ * {@link fileSystemAccessSupported}, so a foreign object carrying a `handle`
+ * property on a runtime without the API is not mistaken for a real handle. This is
+ * the capture-at-deposit seam: no extra dialog is shown to obtain a handle the
+ * operator's existing selection already carries, and no handle is persisted when
+ * the selection cannot yield one (the record field is optional).
+ */
+export function capturedInputHandle(
+  file: File,
+): FileSystemFileHandle | undefined {
+  if (!fileSystemAccessSupported()) return undefined;
+  const handle = (file as File & FileWithOptionalHandle).handle;
+  return handle instanceof FileSystemFileHandle ? handle : undefined;
+}
+
 /**
  * The read-permission state a handle reports: `"granted"` reads through without a
  * prompt, `"denied"` cannot be read, and `"prompt"` needs an operator gesture to

--- a/apps/web/test/browser/managedInputHandle.test.ts
+++ b/apps/web/test/browser/managedInputHandle.test.ts
@@ -13,6 +13,7 @@ import {
   HandleReadPermissionError,
   acquireManagedInput,
   acquireValidatedManagedInput,
+  capturedInputHandle,
   ensureHandleReadPermission,
   fileSystemAccessSupported,
 } from "@psi/managedInputHandle";
@@ -509,5 +510,31 @@ describe("run seam composition: the input guard gates the handshake", () => {
     const stored = await getManagedExchange(created.id);
     expect(stored?.lastRun?.outcome).toBe("succeeded");
     expect(stored?.sharedSecret).toBe(rotatedSecret);
+  });
+});
+
+describe("capturedInputHandle", () => {
+  // The bench's Dropzone (over file-selector) attaches a `handle` to a dropped
+  // File in a secure context on Chromium; capturedInputHandle reads it back so a
+  // deposit persists a reusable pointer without a second picker dialog. Here the
+  // handle is a real OPFS FileSystemFileHandle attached the same way file-selector
+  // attaches a picker handle.
+  test("returns a handle attached to the selected file where the API exists", async () => {
+    expect(fileSystemAccessSupported()).toBe(true);
+    const handle = await writeOpfsFile("captured.csv", CONFORMING_HEADER);
+    const file = await handle.getFile();
+    (file as File & { handle?: FileSystemFileHandle }).handle = handle;
+    expect(capturedInputHandle(file)).toBe(handle);
+  });
+
+  test("returns undefined for a plain File with no attached handle", () => {
+    const plain = new File(["a,b\n1,2\n"], "plain.csv", { type: "text/csv" });
+    expect(capturedInputHandle(plain)).toBeUndefined();
+  });
+
+  test("ignores a non-handle value on the handle property", () => {
+    const file = new File(["a,b\n1,2\n"], "spoofed.csv", { type: "text/csv" });
+    (file as File & { handle?: unknown }).handle = { name: "not-a-handle.csv" };
+    expect(capturedInputHandle(file)).toBeUndefined();
   });
 });

--- a/apps/web/test/unit/benchManageOfferModel.test.ts
+++ b/apps/web/test/unit/benchManageOfferModel.test.ts
@@ -1,0 +1,257 @@
+import {
+  connectionFromLocator,
+  deriveAcceptedLinkageTerms,
+  disclosedColumnNames,
+  generateSharedSecret,
+  getDefaultLinkageTerms,
+  inferMetadata,
+} from "@psilink/core";
+import { describe, expect, test } from "vitest";
+
+import {
+  LABEL_GUIDANCE,
+  MAX_LABEL_LENGTH,
+  buildManagedDeposit,
+  composeManagedDocument,
+  labelWithinCap,
+  maxAgeCadenceNote,
+  webrtcLocatorFromEndpoint,
+} from "@bench/manageOfferModel";
+
+import type { ManagedDepositInputs } from "@bench/manageOfferModel";
+import type { WebRTCEndpoint } from "@psilink/core";
+
+// The inviter's own signaling location (window.location-derived) is already the
+// invitation's endpoint shape; the acceptor's endpoint is the invitation's own.
+const inviterEndpoint: WebRTCEndpoint = {
+  channel: "webrtc",
+  host: "signaling.example.org",
+  port: 3000,
+  path: "/api/",
+};
+
+// The acceptor composes from THIS endpoint (the inviter's signaling location
+// carried on the invitation), not from its own browser location.
+const invitationEndpoint: WebRTCEndpoint = {
+  channel: "webrtc",
+  host: "inviter.example.net",
+  port: 8443,
+  path: "/api/",
+};
+
+// ssn/first_name/last_name/dob infer matching keys; program_code is not in the
+// alias map, so it infers a disclosed payload column -- a non-trivial disclosed
+// set for composeManagedDocument to derive.
+const inviterColumns = [
+  "ssn",
+  "first_name",
+  "last_name",
+  "dob",
+  "program_code",
+];
+const inviterMetadata = inferMetadata(inviterColumns);
+const inviterTerms = getDefaultLinkageTerms(
+  "County Health Dept",
+  inviterMetadata,
+);
+
+function depositInputs(
+  overrides: Partial<ManagedDepositInputs> = {},
+): ManagedDepositInputs {
+  return {
+    side: "inviter",
+    exchangeFile: composeManagedDocument(
+      { linkageTerms: inviterTerms, metadata: inviterMetadata },
+      webrtcLocatorFromEndpoint(inviterEndpoint),
+    ),
+    sharedSecret: generateSharedSecret(),
+    choices: { label: "Riverbend quarterly" },
+    ...overrides,
+  };
+}
+
+describe("webrtcLocatorFromEndpoint", () => {
+  test("re-shapes a webrtc endpoint into a credential-free locator", () => {
+    expect(webrtcLocatorFromEndpoint(inviterEndpoint)).toEqual({
+      channel: "webrtc",
+      host: "signaling.example.org",
+      port: 3000,
+      path: "/api/",
+    });
+  });
+
+  test("drops an absent optional rather than carrying an explicit undefined", () => {
+    const bare: WebRTCEndpoint = { channel: "webrtc", host: "peer.example" };
+    const locator = webrtcLocatorFromEndpoint(bare);
+    expect(locator).not.toHaveProperty("port");
+    expect(locator).not.toHaveProperty("path");
+    // The composer's strict parse must accept it, so an absent optional cannot be
+    // an explicit `undefined` key.
+    expect(() =>
+      composeManagedDocument({ linkageTerms: inviterTerms }, locator),
+    ).not.toThrow();
+  });
+});
+
+describe("composeManagedDocument", () => {
+  test("composes a credential-free webrtc document with no authentication block", () => {
+    const doc = composeManagedDocument(
+      { linkageTerms: inviterTerms, metadata: inviterMetadata },
+      webrtcLocatorFromEndpoint(inviterEndpoint),
+    );
+    expect(doc.connection).toEqual(
+      connectionFromLocator(webrtcLocatorFromEndpoint(inviterEndpoint)),
+    );
+    expect(doc.authentication).toBeUndefined();
+    // No credential is representable: the webrtc server carries only host/port/path.
+    expect(JSON.stringify(doc)).not.toContain("username");
+    expect(JSON.stringify(doc)).not.toContain('"key"');
+  });
+
+  test("derives disclosed payload columns from this party's metadata", () => {
+    const doc = composeManagedDocument(
+      { linkageTerms: inviterTerms, metadata: inviterMetadata },
+      webrtcLocatorFromEndpoint(inviterEndpoint),
+    );
+    expect(doc.disclosedPayloadColumns).toEqual(
+      disclosedColumnNames(inviterMetadata),
+    );
+  });
+
+  test("omits disclosed payload columns when there is no metadata", () => {
+    const doc = composeManagedDocument(
+      { linkageTerms: inviterTerms },
+      webrtcLocatorFromEndpoint(inviterEndpoint),
+    );
+    expect(doc).not.toHaveProperty("disclosedPayloadColumns");
+  });
+});
+
+describe("buildManagedDeposit (inviter)", () => {
+  test("deposits side inviter with the invitation's secret and composed document", () => {
+    const secret = generateSharedSecret();
+    const deposit = buildManagedDeposit(
+      depositInputs({ side: "inviter", sharedSecret: secret }),
+      Date.UTC(2026, 6, 15, 12, 0, 0),
+    );
+    expect(deposit.side).toBe("inviter");
+    expect(deposit.sharedSecret).toBe(secret);
+    expect(deposit.exchangeFile.connection.channel).toBe("webrtc");
+    expect(deposit.exchangeFile.authentication).toBeUndefined();
+    expect(deposit.label).toBe("Riverbend quarterly");
+  });
+
+  test("tokenMaxAgeDays and expires are absent unless the operator opts in", () => {
+    const deposit = buildManagedDeposit(
+      depositInputs(),
+      Date.UTC(2026, 6, 15, 12, 0, 0),
+    );
+    expect(deposit).not.toHaveProperty("tokenMaxAgeDays");
+    expect(deposit).not.toHaveProperty("expires");
+  });
+
+  test("an opted-in max age stamps expires N days out (not the invitation lifetime)", () => {
+    const now = Date.UTC(2026, 6, 15, 12, 0, 0);
+    const deposit = buildManagedDeposit(
+      depositInputs({ choices: { label: "labelled", tokenMaxAgeDays: 30 } }),
+      now,
+    );
+    expect(deposit.tokenMaxAgeDays).toBe(30);
+    // The stamp is now + 30 days, from the max-age policy alone; the invitation's
+    // setup lifetime never flows into the record's expires.
+    expect(deposit.expires).toBe(new Date(now + 30 * 86_400_000).toISOString());
+  });
+
+  test("carries an input-file handle only when one is captured", () => {
+    const handle = { name: "records.csv" } as unknown as FileSystemFileHandle;
+    const withHandle = buildManagedDeposit(
+      depositInputs({ inputFileHandle: handle }),
+      Date.now(),
+    );
+    expect(withHandle.inputFileHandle).toBe(handle);
+
+    const without = buildManagedDeposit(depositInputs(), Date.now());
+    expect(without).not.toHaveProperty("inputFileHandle");
+  });
+});
+
+describe("buildManagedDeposit (acceptor)", () => {
+  test("deposits side acceptor composing from the invitation endpoint and derived terms", () => {
+    const acceptorColumns = ["ssn", "first_name", "last_name", "dob"];
+    const acceptorMetadata = inferMetadata(acceptorColumns);
+    // The acceptor's own perspective: identity replaced, output/payload mirrored.
+    const acceptorTerms = deriveAcceptedLinkageTerms(inviterTerms, "Clinic A");
+    const secret = generateSharedSecret();
+    const deposit = buildManagedDeposit(
+      {
+        side: "acceptor",
+        exchangeFile: composeManagedDocument(
+          { linkageTerms: acceptorTerms, metadata: acceptorMetadata },
+          webrtcLocatorFromEndpoint(invitationEndpoint),
+        ),
+        sharedSecret: secret,
+        choices: { label: "Clinic A partnership" },
+      },
+      Date.now(),
+    );
+    expect(deposit.side).toBe("acceptor");
+    expect(deposit.sharedSecret).toBe(secret);
+    // The connection block is composed from the INVITATION's endpoint.
+    expect(deposit.exchangeFile.connection).toEqual(
+      connectionFromLocator(webrtcLocatorFromEndpoint(invitationEndpoint)),
+    );
+    expect(deposit.exchangeFile.linkageTerms.identity).toBe("Clinic A");
+    expect(deposit.exchangeFile.authentication).toBeUndefined();
+  });
+});
+
+describe("the label cap", () => {
+  test("labelWithinCap accepts a label at the cap and rejects one past it", () => {
+    expect(labelWithinCap("x".repeat(MAX_LABEL_LENGTH))).toBe(true);
+    expect(labelWithinCap("x".repeat(MAX_LABEL_LENGTH + 1))).toBe(false);
+    expect(labelWithinCap("")).toBe(true);
+  });
+
+  test("buildManagedDeposit produces a record the store's cap accepts, and rejects an over-long one", () => {
+    const atCap = "x".repeat(MAX_LABEL_LENGTH);
+    expect(() =>
+      buildManagedDeposit(
+        depositInputs({ choices: { label: atCap } }),
+        Date.now(),
+      ),
+    ).not.toThrow();
+    // The deposit itself does not throw on an over-long label (the store's build
+    // enforces the cap), but the field carries it verbatim for that check.
+    const overCap = "x".repeat(MAX_LABEL_LENGTH + 1);
+    const deposit = buildManagedDeposit(
+      depositInputs({ choices: { label: overCap } }),
+      Date.now(),
+    );
+    expect(deposit.label.length).toBe(MAX_LABEL_LENGTH + 1);
+    expect(labelWithinCap(deposit.label)).toBe(false);
+  });
+});
+
+describe("maxAgeCadenceNote", () => {
+  test("names the cadence implication when a policy is set", () => {
+    const note = maxAgeCadenceNote(30);
+    expect(note).toContain("30 days");
+    expect(note).toContain("run or be renewed");
+  });
+
+  test("singularizes one day", () => {
+    expect(maxAgeCadenceNote(1)).toContain("1 day");
+    expect(maxAgeCadenceNote(1)).not.toContain("1 days");
+  });
+
+  test("returns undefined when no policy is set (the default)", () => {
+    expect(maxAgeCadenceNote(undefined)).toBeUndefined();
+  });
+});
+
+describe("the label guidance", () => {
+  test("directs the operator to keep sensitive counterparty detail out", () => {
+    expect(LABEL_GUIDANCE).toContain("Name the partnership");
+    expect(LABEL_GUIDANCE.toLowerCase()).toContain("never sent");
+  });
+});

--- a/apps/web/test/unit/benchManageOfferModel.test.ts
+++ b/apps/web/test/unit/benchManageOfferModel.test.ts
@@ -11,10 +11,12 @@ import { describe, expect, test } from "vitest";
 import {
   LABEL_GUIDANCE,
   MAX_LABEL_LENGTH,
+  MAX_TOKEN_MAX_AGE_DAYS,
   buildManagedDeposit,
   composeManagedDocument,
   labelWithinCap,
   maxAgeCadenceNote,
+  maxAgeDaysError,
   webrtcLocatorFromEndpoint,
 } from "@bench/manageOfferModel";
 
@@ -40,8 +42,8 @@ const invitationEndpoint: WebRTCEndpoint = {
 };
 
 // ssn/first_name/last_name/dob infer matching keys; program_code is not in the
-// alias map, so it infers a disclosed payload column -- a non-trivial disclosed
-// set for composeManagedDocument to derive.
+// alias map, so it infers a disclosed payload column -- a non-trivial published
+// set for the inviter deposit to carry.
 const inviterColumns = [
   "ssn",
   "first_name",
@@ -55,13 +57,21 @@ const inviterTerms = getDefaultLinkageTerms(
   inviterMetadata,
 );
 
+// The set the token publishes -- generateInvitation derives it from this same
+// metadata, so the fixture mirrors the mint (["program_code"] here).
+const tokenDisclosedColumns = disclosedColumnNames(inviterMetadata);
+
 function depositInputs(
   overrides: Partial<ManagedDepositInputs> = {},
 ): ManagedDepositInputs {
   return {
     side: "inviter",
     exchangeFile: composeManagedDocument(
-      { linkageTerms: inviterTerms, metadata: inviterMetadata },
+      {
+        linkageTerms: inviterTerms,
+        metadata: inviterMetadata,
+        disclosedPayloadColumns: tokenDisclosedColumns,
+      },
       webrtcLocatorFromEndpoint(inviterEndpoint),
     ),
     sharedSecret: generateSharedSecret(),
@@ -108,22 +118,43 @@ describe("composeManagedDocument", () => {
     expect(JSON.stringify(doc)).not.toContain('"key"');
   });
 
-  test("derives disclosed payload columns from this party's metadata", () => {
+  test("carries caller-supplied payload commitments verbatim, never re-derived", () => {
     const doc = composeManagedDocument(
+      {
+        linkageTerms: inviterTerms,
+        metadata: inviterMetadata,
+        // Deliberately NOT what this metadata would derive, so the assertion
+        // proves the caller's set is carried as-is (one source: the token).
+        disclosedPayloadColumns: ["program_code", "extra_committed"],
+        expectedPayloadColumns: ["partner_col"],
+      },
+      webrtcLocatorFromEndpoint(inviterEndpoint),
+    );
+    expect(doc.disclosedPayloadColumns).toEqual([
+      "program_code",
+      "extra_committed",
+    ]);
+    expect(doc.expectedPayloadColumns).toEqual(["partner_col"]);
+  });
+
+  test("preserves an EMPTY commitment (strict), distinct from an absent one (lazy)", () => {
+    const strict = composeManagedDocument(
+      {
+        linkageTerms: inviterTerms,
+        disclosedPayloadColumns: [],
+        expectedPayloadColumns: [],
+      },
+      webrtcLocatorFromEndpoint(inviterEndpoint),
+    );
+    expect(strict.disclosedPayloadColumns).toEqual([]);
+    expect(strict.expectedPayloadColumns).toEqual([]);
+
+    const lazy = composeManagedDocument(
       { linkageTerms: inviterTerms, metadata: inviterMetadata },
       webrtcLocatorFromEndpoint(inviterEndpoint),
     );
-    expect(doc.disclosedPayloadColumns).toEqual(
-      disclosedColumnNames(inviterMetadata),
-    );
-  });
-
-  test("omits disclosed payload columns when there is no metadata", () => {
-    const doc = composeManagedDocument(
-      { linkageTerms: inviterTerms },
-      webrtcLocatorFromEndpoint(inviterEndpoint),
-    );
-    expect(doc).not.toHaveProperty("disclosedPayloadColumns");
+    expect(lazy).not.toHaveProperty("disclosedPayloadColumns");
+    expect(lazy).not.toHaveProperty("expectedPayloadColumns");
   });
 });
 
@@ -139,6 +170,12 @@ describe("buildManagedDeposit (inviter)", () => {
     expect(deposit.exchangeFile.connection.channel).toBe("webrtc");
     expect(deposit.exchangeFile.authentication).toBeUndefined();
     expect(deposit.label).toBe("Riverbend quarterly");
+    // The persisted send-side commitment is the token's published set; the
+    // received set is unknowable at mint, so no receive lock-in is persisted.
+    expect(deposit.exchangeFile.disclosedPayloadColumns).toEqual(
+      tokenDisclosedColumns,
+    );
+    expect(deposit.exchangeFile).not.toHaveProperty("expectedPayloadColumns");
   });
 
   test("tokenMaxAgeDays and expires are absent unless the operator opts in", () => {
@@ -176,32 +213,61 @@ describe("buildManagedDeposit (inviter)", () => {
 });
 
 describe("buildManagedDeposit (acceptor)", () => {
-  test("deposits side acceptor composing from the invitation endpoint and derived terms", () => {
-    const acceptorColumns = ["ssn", "first_name", "last_name", "dob"];
-    const acceptorMetadata = inferMetadata(acceptorColumns);
-    // The acceptor's own perspective: identity replaced, output/payload mirrored.
-    const acceptorTerms = deriveAcceptedLinkageTerms(inviterTerms, "Clinic A");
-    const secret = generateSharedSecret();
-    const deposit = buildManagedDeposit(
+  const acceptorColumns = ["ssn", "first_name", "last_name", "dob"];
+  const acceptorMetadata = inferMetadata(acceptorColumns);
+  // The acceptor's own perspective: identity replaced, output/payload mirrored.
+  const acceptorTerms = deriveAcceptedLinkageTerms(inviterTerms, "Clinic A");
+
+  function acceptorDeposit(tokenSet: Array<string> | undefined) {
+    return buildManagedDeposit(
       {
         side: "acceptor",
         exchangeFile: composeManagedDocument(
-          { linkageTerms: acceptorTerms, metadata: acceptorMetadata },
+          {
+            linkageTerms: acceptorTerms,
+            metadata: acceptorMetadata,
+            ...(tokenSet !== undefined
+              ? { expectedPayloadColumns: tokenSet }
+              : {}),
+          },
           webrtcLocatorFromEndpoint(invitationEndpoint),
         ),
-        sharedSecret: secret,
+        sharedSecret: generateSharedSecret(),
         choices: { label: "Clinic A partnership" },
       },
       Date.now(),
     );
+  }
+
+  test("deposits side acceptor composing from the invitation endpoint and derived terms", () => {
+    const deposit = acceptorDeposit(tokenDisclosedColumns);
     expect(deposit.side).toBe("acceptor");
-    expect(deposit.sharedSecret).toBe(secret);
     // The connection block is composed from the INVITATION's endpoint.
     expect(deposit.exchangeFile.connection).toEqual(
       connectionFromLocator(webrtcLocatorFromEndpoint(invitationEndpoint)),
     );
     expect(deposit.exchangeFile.linkageTerms.identity).toBe("Clinic A");
     expect(deposit.exchangeFile.authentication).toBeUndefined();
+  });
+
+  test("locks in the token's disclosed set as expectedPayloadColumns", () => {
+    const deposit = acceptorDeposit(tokenDisclosedColumns);
+    expect(deposit.exchangeFile.expectedPayloadColumns).toEqual(
+      tokenDisclosedColumns,
+    );
+    // The acceptor persists no send-side commitment field: its send commitment
+    // rides the mirrored payload.send (docs/spec/FILE_SYNC.md).
+    expect(deposit.exchangeFile).not.toHaveProperty("disclosedPayloadColumns");
+  });
+
+  test("an EMPTY token set persists as a strict receive-nothing lock-in", () => {
+    const deposit = acceptorDeposit([]);
+    expect(deposit.exchangeFile.expectedPayloadColumns).toEqual([]);
+  });
+
+  test("a token with no set leaves the lock-in absent (lazy)", () => {
+    const deposit = acceptorDeposit(undefined);
+    expect(deposit.exchangeFile).not.toHaveProperty("expectedPayloadColumns");
   });
 });
 
@@ -246,6 +312,30 @@ describe("maxAgeCadenceNote", () => {
 
   test("returns undefined when no policy is set (the default)", () => {
     expect(maxAgeCadenceNote(undefined)).toBeUndefined();
+  });
+});
+
+describe("maxAgeDaysError", () => {
+  test("accepts a positive whole day count up to the schema's cap", () => {
+    expect(maxAgeDaysError(1)).toBeUndefined();
+    expect(maxAgeDaysError(90)).toBeUndefined();
+    expect(maxAgeDaysError(MAX_TOKEN_MAX_AGE_DAYS)).toBeUndefined();
+  });
+
+  test("rejects a cleared field (the input reports a string), not silently no-bound", () => {
+    expect(maxAgeDaysError("")).toBeDefined();
+    expect(maxAgeDaysError("12.")).toBeDefined();
+  });
+
+  test("rejects zero, negatives, and fractions", () => {
+    expect(maxAgeDaysError(0)).toBeDefined();
+    expect(maxAgeDaysError(-7)).toBeDefined();
+    expect(maxAgeDaysError(2.5)).toBeDefined();
+  });
+
+  test("rejects a value past the record schema's cap, naming the bound", () => {
+    const error = maxAgeDaysError(MAX_TOKEN_MAX_AGE_DAYS + 1);
+    expect(error).toContain(String(MAX_TOKEN_MAX_AGE_DAYS));
   });
 });
 

--- a/apps/web/test/unit/benchSaveExchangeModel.test.ts
+++ b/apps/web/test/unit/benchSaveExchangeModel.test.ts
@@ -43,6 +43,7 @@ function invitationStub(
     columns: ["program_code", "dob"],
     metadata,
     standardization: undefined,
+    disclosedPayloadColumns: ["program_code"],
     ...overrides,
   };
 }

--- a/apps/web/test/unit/invitation.test.ts
+++ b/apps/web/test/unit/invitation.test.ts
@@ -419,27 +419,33 @@ describe("generateInvitation", () => {
 
   test("quick path carries the disclosed-columns subset on the token", async () => {
     const disclosed = disclosedColumnNames(inferMetadata(DISCLOSING_COLUMNS));
-    const { encoded } = await generateInvitation({
+    const result = await generateInvitation({
       inviterName: "Org",
       file: csvStream(DISCLOSING_CSV),
       location,
     });
-    const token = await decodeInvitation(encoded);
+    const token = await decodeInvitation(result.encoded);
     // The dedicated wire field carries exactly what preparePayload transmits.
     expect(token.disclosedPayloadColumns).toEqual(disclosed);
+    // The surfaced field is the token's value, so a persisting caller (the
+    // managed-exchange deposit) records the same commitment the token published.
+    expect(result.disclosedPayloadColumns).toEqual(
+      token.disclosedPayloadColumns,
+    );
   });
 
   test("quick path carries an empty disclosed subset when the file discloses nothing", async () => {
     // The web inviter always knows its metadata, so the field is always carried --
     // here the EMPTY set, which locks the acceptor in to "receive nothing" (a later
     // non-empty payload aborts) rather than reconciling lazily.
-    const { encoded } = await generateInvitation({
+    const result = await generateInvitation({
       inviterName: "Org",
       file: csvStream(ALL_COLUMNS_CSV),
       location,
     });
-    const token = await decodeInvitation(encoded);
+    const token = await decodeInvitation(result.encoded);
     expect(token.disclosedPayloadColumns).toEqual([]);
+    expect(result.disclosedPayloadColumns).toEqual([]);
   });
 
   test("summarizeInvitation derives the received set from the carried subset with no payload.send authored", () => {

--- a/docs/spec/MANAGED_EXCHANGE_RECORD.md
+++ b/docs/spec/MANAGED_EXCHANGE_RECORD.md
@@ -26,10 +26,11 @@ the exchange-file artifact the record is composed from (see
 auditors and implementors.
 
 > **Status.** The record store, the run+rotate critical section (the
-> single-writer lock and the persist-before-success write-back), and the
+> single-writer lock and the persist-before-success write-back), the
 > input-acquisition seam (the persisted handle, its permission discipline, and
-> the pre-connection column-shape guard) are implemented; the runner,
-> scheduling, and management surfaces that use them are not yet. The
+> the pre-connection column-shape guard), and the record-creating deposits (the
+> manage offers at invite creation and at accept) are implemented; the runner,
+> scheduling, and list/detail management surfaces that use them are not yet. The
 > recurring-exchange epic implements against the shape below, security-reviewed
 > at each step because the record persists a rotating credential at rest. The
 > persist-before-success ordering and the single-owner invariant are normative,


### PR DESCRIPTION
## Summary

Offer "manage this exchange" at invite creation and at accept, so either party can deposit a managed-exchange record in the browser store from a real flow -- the item that makes managed records exist. The deposit composes this party's exchange-file document from a credential-free webrtc locator through the existing composer (parse result persisted, no authentication block representable), carries the invitation's shared secret and the local side, enforces the 120-char label cap with content guidance, keeps tokenMaxAgeDays opt-in with the cadence implication surfaced, and persists the input-file handle where a drag-drop yielded one. Declining leaves no record.

Implements [212131321](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=212131321).

## Changes

- apps/web/src/bench/manageOfferModel.ts: pure deposit model -- locator reshaping, document composition with caller-supplied payload commitments carried verbatim (never re-derived), deposit assembly reusing rotationWriteBack for the creation-time expires stamp, label/max-age validation, and the offer copy.
- apps/web/src/bench/ManageExchangeOffer.tsx: the offer panel (label, opt-in max-age with field-level validation bounded at the schema cap, capture note, deposit states); presentational only.
- apps/web/src/bench/InviterBench.tsx: offer on the share surface for the browser transport (sample demo excluded); deposit composes from this app's own signaling location and the token's published disclosed set, side inviter.
- apps/web/src/bench/AcceptorBench.tsx: offer on the completion surface for a webrtc invitation; deposit composes from the invitation's endpoint with the token's disclosed set persisted as the receive-side expectedPayloadColumns lock-in (empty = strict, absent = lazy, matching the CLI accept), side acceptor.
- apps/web/src/psi/invitation.ts: GeneratedInvitation surfaces the token's disclosedPayloadColumns so persisting callers record the same commitment the token published (one source).
- apps/web/src/psi/managedInputHandle.ts: capturedInputHandle reads the handle a drop attached to the selected File (instanceof-guarded, gated on API support); no extra picker dialog, no handle persisted where the platform yields none.
- docs/spec/MANAGED_EXCHANGE_RECORD.md: status note now includes the deposit surfaces.
- Tests: benchManageOfferModel.test.ts (deposit composition, commitment carry and empty-vs-absent semantics, expires provenance, label cap, max-age validation), invitation.test.ts (surfaced set equals the decoded token's), managedInputHandle.test.ts (real-handle capture and spoof rejection in the browser).

## Test plan

Ran: `npm run test -w apps/web` (60 files, 1158 unit tests), `npm run test:browser -w apps/web` (full Playwright suite, green after each round), `npm run typecheck && npm run lint && npm run format`.
New tests cover: inviter and acceptor deposit shapes, the acceptor's receive-side lock-in including strict-empty and absent-lazy, verbatim (non-derived) commitment carry, decline-leaves-no-record structure, default-off tokenMaxAgeDays and single-source expires stamping, label cap, max-age field validation bounds, and File System Access handle capture with spoof rejection.

## Background

The offer is deliberately visible from invite creation / accept commit onward, before the one-shot run completes: both offer moments are pre-run by the item's definition, and the deposited record (the invitation's secret plus the standing terms) is valid regardless of the one-shot run's outcome -- the one-shot flow discards its derived rotation on both sides, so records stay coherent at the deposited secret until the first managed re-run rotates it.

## Out of scope / follow-on

- The CLI-transport save surface still re-derives its disclosed set from metadata instead of the newly surfaced one-source field (benign today): [213389526](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=213389526)

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- docs/spec/MANAGED_EXCHANGE_RECORD.md status note updated; the deposit implements behavior MANAGED_EXCHANGE_RECORD.md and MANAGED_EXCHANGE.md already specify at their tiers
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: first slice of the recurring-exchange capability, not yet usable end to end (a saved record cannot be re-run until the re-run item lands); the headline entry belongs to the item that completes the user-visible capability
- [x] Security review -- focused single-reviewer pass (credential-at-rest deposit, disclosure lock-ins, token_max_age_days wiring) within the panel-reviewed managed-record envelope, plus re-verification of the fixes; two three-reviewer rounds with all confirmed findings fixed on-branch