### PR TITLE
Widen lobby text below the action cards

### DIFF
--- a/apps/web/src/bench/bench.module.css
+++ b/apps/web/src/bench/bench.module.css
@@ -949,6 +949,16 @@
   margin: 1.8rem 0 1.2rem 0;
 }
 
+/* Below-cards copy should read at the cards' width, not the standing
+   68ch prose measure (.page p): the general-sibling combinator only
+   reaches markup after .lobbyActions inside .lobby, so the tagline and
+   file-assurance line above the cards keep their narrower measure, and
+   no other .page using .sub/.small/.howItWorks is affected. */
+.lobby .lobbyActions ~ p,
+.lobby .lobbyActions ~ .howItWorks p {
+  max-width: none;
+}
+
 .actionCard {
   background: var(--bench-column);
   border: 2px solid var(--bench-rule);


### PR DESCRIPTION
## Summary

The landing page's text below the two action cards read at the page-wide 68ch prose measure -- about 80% of the width the card grid takes. A scoped sibling rule lifts the cap for exactly the paragraphs and how-it-works block that follow the cards, so they align with the cards' width; the tagline and file-assurance line above the cards keep their narrower measure, and no other page changes.

## Changes

- apps/web/src/bench/bench.module.css: one rule after .lobbyActions -- `.lobby .lobbyActions ~ p, .lobby .lobbyActions ~ .howItWorks p { max-width: none; }` -- following the stylesheet's existing out-specify-`.page p` idiom.

## Test plan

Ran: `npm run test:browser -w apps/web -- benchVerify.test.ts bench.test.ts themeContrast.test.ts benchAccept.test.ts` (109 tests), `npm run typecheck && npm run lint && npm run format`.
New tests cover: n/a -- a width-only CSS change with no behavior to pin; the lobby's existing browser coverage passes unchanged.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed, width-only styling
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: UI polish
- [x] Security review -- n/a: none of the security-relevant surfaces touched; a CSS max-width rule