### PR TITLE
Add create and delete to the recurring list

### DIFF
--- a/apps/web/src/bench/SavedExchanges.tsx
+++ b/apps/web/src/bench/SavedExchanges.tsx
@@ -302,17 +302,24 @@ function DeleteExchangeButton({
 }) {
   const [confirming, setConfirming] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [deleteFailed, setDeleteFailed] = useState(false);
   const named = label === "" ? "this exchange" : `"${label}"`;
 
   function confirmDelete() {
     setDeleting(true);
+    setDeleteFailed(false);
     void (async () => {
       try {
         await deleteManagedExchange(id);
         onDeleted();
+        setConfirming(false);
+      } catch {
+        // A rejected delete (transaction abort, quota, a blocked open) leaves the
+        // row standing: keep the modal open and surface the failure so the operator
+        // can retry rather than the row silently vanishing from confirm.
+        setDeleteFailed(true);
       } finally {
         setDeleting(false);
-        setConfirming(false);
       }
     })();
   }
@@ -349,6 +356,12 @@ function DeleteExchangeButton({
             yourself if you no longer want it. It remains a credential until the
             partnership rotates past it.
           </p>
+        )}
+        {deleteFailed && (
+          <Alert color="red" title="That exchange could not be removed" mb="sm">
+            Removing it from this browser failed. Nothing was deleted; try
+            again.
+          </Alert>
         )}
         <div className={styles.savedRowActions} style={{ marginTop: "1rem" }}>
           <Button variant="default" onClick={() => setConfirming(false)}>
@@ -461,8 +474,8 @@ function RecoveryListing({ reload }: { reload: () => void }) {
           </div>
           <DeleteExchangeButton
             id={row.id}
-            label={row.unreadable ? "" : row.label}
-            backedUp={false}
+            label={row.deleteLabel}
+            backedUp={row.backedUp}
             onDeleted={reload}
           />
         </li>

--- a/apps/web/src/bench/SavedExchanges.tsx
+++ b/apps/web/src/bench/SavedExchanges.tsx
@@ -330,7 +330,10 @@ function DeleteExchangeButton({
         variant="subtle"
         color="red"
         disabled={deleting}
-        onClick={() => setConfirming(true)}
+        onClick={() => {
+          setDeleteFailed(false);
+          setConfirming(true);
+        }}
       >
         Delete
       </Button>

--- a/apps/web/src/bench/SavedExchanges.tsx
+++ b/apps/web/src/bench/SavedExchanges.tsx
@@ -1,10 +1,19 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-import { Alert, Anchor, Button, FileButton, Loader } from "@mantine/core";
+import {
+  Alert,
+  Anchor,
+  Button,
+  FileButton,
+  Loader,
+  Modal,
+} from "@mantine/core";
 import { Link, useNavigate } from "@tanstack/react-router";
 
 import {
+  deleteManagedExchange,
   listManagedExchanges,
+  listManagedExchangesDiagnostic,
   openManagedExchangeDatabase,
   requestPersistentStorage,
 } from "@psi/managedExchangeStore";
@@ -15,16 +24,24 @@ import { listManagedLocalState } from "@psi/managedLocalState";
 import { BenchLobby } from "./BenchLobby";
 import { BenchPage } from "./BenchPage";
 import { loadSavedExchanges } from "./savedExchangesLoad";
+import { recoveryRows } from "./savedExchangesRecovery";
 import styles from "./bench.module.css";
 
+import type { RecoveryRow } from "./savedExchangesRecovery";
 import type { SavedExchangeRow } from "./savedExchangesModel";
 import type { SavedExchangesLoad } from "./savedExchangesLoad";
 
-/** Run the managed-exchange home load once on mount, cancelling its state write if
- * the component unmounts before the reads settle. Returns `undefined` while the read
- * is in flight, then one of the {@link SavedExchangesLoad} outcomes. */
-function useSavedExchangesLoad(): SavedExchangesLoad | undefined {
+/** Run the managed-exchange home load on mount and on demand, cancelling its state
+ * write if the component unmounts before the reads settle. Returns the current
+ * {@link SavedExchangesLoad} (or `undefined` while a read is in flight) and a
+ * `reload` that re-runs the load -- the delete affordance calls it so a delete that
+ * removes the offending record recovers a now-readable list to the normal surface. */
+function useSavedExchangesLoad(): {
+  load: SavedExchangesLoad | undefined;
+  reload: () => void;
+} {
   const [load, setLoad] = useState<SavedExchangesLoad>();
+  const [nonce, setNonce] = useState(0);
   useEffect(() => {
     let live = true;
     void loadSavedExchanges({
@@ -38,8 +55,12 @@ function useSavedExchangesLoad(): SavedExchangesLoad | undefined {
     return () => {
       live = false;
     };
+  }, [nonce]);
+  const reload = useCallback(() => {
+    setLoad(undefined);
+    setNonce((current) => current + 1);
   }, []);
-  return load;
+  return { load, reload };
 }
 
 /**
@@ -59,7 +80,7 @@ function useSavedExchangesLoad(): SavedExchangesLoad | undefined {
  * `/saved` so the empty state's restore-from-backup affordance stays discoverable.
  */
 export function SavedExchangesHome() {
-  const load = useSavedExchangesLoad();
+  const { load, reload } = useSavedExchangesLoad();
 
   if (load === undefined)
     return (
@@ -74,7 +95,7 @@ export function SavedExchangesHome() {
     (load.kind === "ready" && load.rows.length === 0)
   )
     return <BenchLobby />;
-  return <SavedExchangesSurface load={load} />;
+  return <SavedExchangesSurface load={load} reload={reload} />;
 }
 
 /**
@@ -102,11 +123,11 @@ export function SavedExchangesHome() {
  * handoff date.
  */
 export function SavedExchanges() {
-  const load = useSavedExchangesLoad();
+  const { load, reload } = useSavedExchangesLoad();
 
   if (load?.kind === "unavailable") return <StorageUnavailable />;
 
-  return <SavedExchangesSurface load={load} />;
+  return <SavedExchangesSurface load={load} reload={reload} />;
 }
 
 /** The list surface itself: the loading loader, the exchanges, the designed empty
@@ -116,11 +137,11 @@ export function SavedExchanges() {
  * receives it. */
 function SavedExchangesSurface({
   load,
+  reload,
 }: {
   load: Exclude<SavedExchangesLoad, { kind: "unavailable" }> | undefined;
+  reload: () => void;
 }) {
-  const navigate = useNavigate();
-
   return (
     <BenchPage>
       <main className={styles.lobby}>
@@ -133,48 +154,80 @@ function SavedExchangesSurface({
         {load === undefined ? (
           <Loader />
         ) : load.kind === "failed" ? (
-          <SavedExchangesFailed />
+          <SavedExchangesFailed reload={reload} />
         ) : load.rows.length === 0 ? (
           <SavedExchangesEmpty />
         ) : (
-          <>
-            <ul className={styles.savedList}>
-              {load.rows.map((row) => (
-                <li key={row.id} className={styles.savedRow}>
-                  <div className={styles.savedRowMain}>
-                    <span className={styles.savedRowLabel}>
-                      {row.label === "" ? "(unnamed exchange)" : row.label}
-                    </span>
-                    <span className={`${styles.small} ${styles.sub}`}>
-                      {row.sideLabel} - {row.status}
-                    </span>
-                    <BackupLine row={row} />
-                  </div>
-                  <Button
-                    variant={row.spentAsOf === undefined ? "default" : "subtle"}
-                    onClick={() =>
-                      void navigate({
-                        to: "/saved/$id",
-                        params: { id: row.id },
-                      })
-                    }
-                  >
-                    {row.spentAsOf === undefined ? "Run" : "Open"}
-                  </Button>
-                </li>
-              ))}
-            </ul>
-            <p className={`${styles.sub} ${styles.small}`}>
-              Need a one-off instead?{" "}
-              <Anchor inherit component={Link} to="/quick">
-                Set up or accept an exchange
-              </Anchor>{" "}
-              without saving it here.
-            </p>
-          </>
+          <SavedExchangesList rows={load.rows} reload={reload} />
         )}
       </main>
     </BenchPage>
+  );
+}
+
+/** The populated run list: a row per stored exchange with a run/open action and the
+ * always-available delete, above a first-class create entry into the invite/configure
+ * flow (where saving as recurring happens at share time) and the one-off quick-path
+ * alternative. Deleting a row calls `reload`, so the list reflects the removal without
+ * a page navigation. */
+function SavedExchangesList({
+  rows,
+  reload,
+}: {
+  rows: Array<SavedExchangeRow>;
+  reload: () => void;
+}) {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <ul className={styles.savedList}>
+        {rows.map((row) => (
+          <li key={row.id} className={styles.savedRow}>
+            <div className={styles.savedRowMain}>
+              <span className={styles.savedRowLabel}>
+                {row.label === "" ? "(unnamed exchange)" : row.label}
+              </span>
+              <span className={`${styles.small} ${styles.sub}`}>
+                {row.sideLabel} - {row.status}
+              </span>
+              <BackupLine row={row} />
+            </div>
+            <div className={styles.savedRowActions}>
+              <Button
+                variant={row.spentAsOf === undefined ? "default" : "subtle"}
+                onClick={() =>
+                  void navigate({
+                    to: "/saved/$id",
+                    params: { id: row.id },
+                  })
+                }
+              >
+                {row.spentAsOf === undefined ? "Run" : "Open"}
+              </Button>
+              <DeleteExchangeButton
+                id={row.id}
+                label={row.label}
+                backedUp={row.backup.kind === "backed-up"}
+                onDeleted={reload}
+              />
+            </div>
+          </li>
+        ))}
+      </ul>
+      <p>
+        <Button component={Link} to="/exchange" variant="default">
+          Set up a recurring exchange
+        </Button>
+      </p>
+      <p className={`${styles.sub} ${styles.small}`}>
+        Need a one-off instead?{" "}
+        <Anchor inherit component={Link} to="/quick">
+          Set up or accept an exchange
+        </Anchor>{" "}
+        without saving it here.
+      </p>
+    </>
   );
 }
 
@@ -226,6 +279,90 @@ function BackupLine({ row }: { row: SavedExchangeRow }) {
   );
 }
 
+/** The always-available per-row delete: a first-class action with one simple confirm.
+ * The confirm names the exchange, and -- only when a backup was exported (the row's
+ * backed-up state) -- carries the custody note that the exported file remains a
+ * credential the operator disposes of; a never-exported exchange needs no such note.
+ * Deletion removes everything the browser holds for the exchange in one step
+ * ({@link deleteManagedExchange}); it is local and unilateral, so the confirm says the
+ * partner is not notified. On success it calls {@link onDeleted} so the list reflects
+ * the removal. */
+function DeleteExchangeButton({
+  id,
+  label,
+  backedUp,
+  onDeleted,
+}: {
+  id: string;
+  label: string;
+  /** Whether a backup was exported for this exchange (the custody note shows only
+   * then; a never-exported exchange has nothing under the operator's custody). */
+  backedUp: boolean;
+  onDeleted: () => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const named = label === "" ? "this exchange" : `"${label}"`;
+
+  function confirmDelete() {
+    setDeleting(true);
+    void (async () => {
+      try {
+        await deleteManagedExchange(id);
+        onDeleted();
+      } finally {
+        setDeleting(false);
+        setConfirming(false);
+      }
+    })();
+  }
+
+  return (
+    <>
+      <Button
+        variant="subtle"
+        color="red"
+        disabled={deleting}
+        onClick={() => setConfirming(true)}
+      >
+        Delete
+      </Button>
+      <Modal
+        opened={confirming}
+        onClose={() => setConfirming(false)}
+        title="Remove from this browser"
+        centered
+        transitionProps={{ duration: 0 }}
+      >
+        <p>
+          Delete {named}? This removes everything this browser holds for it --
+          the terms, the stored secret, and its run history -- in one step. It
+          cannot be undone here.
+        </p>
+        <p className={`${styles.small} ${styles.sub}`}>
+          This only removes your copy: your partner is not notified, and their
+          own copy stands until they remove it or you re-invite.
+        </p>
+        {backedUp && (
+          <p className={`${styles.small} ${styles.sub}`}>
+            A backup file you exported stays in your custody -- delete it
+            yourself if you no longer want it. It remains a credential until the
+            partnership rotates past it.
+          </p>
+        )}
+        <div className={styles.savedRowActions} style={{ marginTop: "1rem" }}>
+          <Button variant="default" onClick={() => setConfirming(false)}>
+            Cancel
+          </Button>
+          <Button color="red" loading={deleting} onClick={confirmDelete}>
+            Delete
+          </Button>
+        </div>
+      </Modal>
+    </>
+  );
+}
+
 /** The first-run empty state: a designed surface, not a blank list. It explains what a
  * managed exchange is, offers creating one and accepting a recurring invitation into the
  * quick path, and carries the standing import affordance for post-eviction recovery. A
@@ -257,23 +394,80 @@ function SavedExchangesEmpty() {
   );
 }
 
-/** The read-failed surface: the list opened but its records could not be read, so it
- * cannot show them. The read rejects wholesale on any single invalid record
- * ({@link listManagedExchanges}), so a fresh import cannot mend the list here -- the bad
- * record still fails the read. What the import can still do is store the exchange it
- * carries and take the operator straight to its run surface, sidestepping the unreadable
- * list. The copy is honest about that: the same restore affordance the empty state
- * carries, under a lead that does not promise the list will then display. */
-function SavedExchangesFailed() {
+/** The read-failed surface: the list opened but its records could not be read, so the
+ * normal list ({@link listManagedExchanges}) rejects wholesale on the one offending
+ * record. This surface adds a recovery listing built from a separate diagnostic read
+ * ({@link listManagedExchangesDiagnostic}) that never rejects wholesale: each stored
+ * entry appears with its label and side/date when parseable, or "Unreadable record"
+ * when not, each with the same one-step delete-by-key. Discarding the offending record
+ * and reloading lets a now-readable list recover to the normal surface. A fresh import
+ * still cannot mend the list while the bad record stands, so the restore-from-backup
+ * affordance stays as a way straight to a run surface. */
+function SavedExchangesFailed({ reload }: { reload: () => void }) {
   return (
     <>
       <p className={styles.sub}>
-        Your recurring exchanges could not be read from this browser. If you
-        have a backup file, you can still restore an exchange and go straight to
-        running it.
+        Your recurring exchanges could not be read from this browser. One or
+        more stored records is unreadable -- likely from an old app version.
+        Remove the record below to recover the rest, or import a backup file.
       </p>
+      <RecoveryListing reload={reload} />
       <RestoreFromBackup />
     </>
+  );
+}
+
+/** The recovery listing on the read-failed surface: the diagnostic read's per-entry
+ * result, each row with the one-step delete-by-key. It loads on mount from the
+ * diagnostic read (which never rejects wholesale), so an unreadable record is
+ * identifiable and discardable even when the normal list cannot load. A delete calls
+ * `reload`, which re-runs the whole load -- once the offending record is gone the
+ * normal list read can succeed and the surface recovers to the run list. If the
+ * diagnostic read itself fails (the store's own failure, not a single bad record),
+ * the listing is simply omitted and the restore affordance below still stands. */
+function RecoveryListing({ reload }: { reload: () => void }) {
+  const [rows, setRows] = useState<Array<RecoveryRow>>();
+  useEffect(() => {
+    let live = true;
+    void listManagedExchangesDiagnostic()
+      .then((entries) => {
+        if (live) setRows(recoveryRows(entries));
+      })
+      .catch(() => {
+        if (live) setRows([]);
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  if (rows === undefined) return <Loader />;
+  if (rows.length === 0) return null;
+
+  return (
+    <ul className={styles.savedList}>
+      {rows.map((row) => (
+        <li key={row.id} className={styles.savedRow}>
+          <div className={styles.savedRowMain}>
+            <span className={styles.savedRowLabel}>{row.label}</span>
+            {!row.unreadable && (
+              <span className={`${styles.small} ${styles.sub}`}>
+                {row.sideLabel}
+                {row.lastRunAt !== undefined
+                  ? ` - last run ${row.lastRunAt}`
+                  : ""}
+              </span>
+            )}
+          </div>
+          <DeleteExchangeButton
+            id={row.id}
+            label={row.unreadable ? "" : row.label}
+            backedUp={false}
+            onDeleted={reload}
+          />
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/apps/web/src/bench/bench.module.css
+++ b/apps/web/src/bench/bench.module.css
@@ -1031,6 +1031,13 @@
   font-weight: 600;
 }
 
+.savedRowActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
 /* ---------- responsive ---------- */
 
 @media (max-width: 1080px) {

--- a/apps/web/src/bench/savedExchangesModel.ts
+++ b/apps/web/src/bench/savedExchangesModel.ts
@@ -26,8 +26,9 @@ import type { ManagedFailureTier } from "@psi/managedFailureTiers";
 import type { ManagedLocalState } from "@psi/managedLocalState";
 
 /** This party's side, as the run list names it: the operator recognizes "you
- * invite" / "you accept" more readily than the wire roles. */
-const SIDE_LABEL: Record<ManagedExchangeSide, string> = {
+ * invite" / "you accept" more readily than the wire roles. Shared with the
+ * read-failed recovery listing so both surfaces name the side identically. */
+export const SIDE_LABEL: Record<ManagedExchangeSide, string> = {
   inviter: "You invite",
   acceptor: "You accept",
 };

--- a/apps/web/src/bench/savedExchangesRecovery.ts
+++ b/apps/web/src/bench/savedExchangesRecovery.ts
@@ -13,57 +13,70 @@
  * entries carry display essentials only.
  */
 
+import { SIDE_LABEL } from "./savedExchangesModel";
 import { dateLabel } from "./inviterModel";
 
 import type { ManagedExchangeDiagnosticEntry } from "@psi/managedExchangeStore";
-import type { ManagedExchangeSide } from "@psi/managedExchangeRecord";
 
 /** The label a row shows for an unreadable entry: nothing about it could be
  * parsed, so it reads as an unreadable record rather than an empty or guessed
  * name. */
 export const UNREADABLE_RECORD_LABEL = "Unreadable record";
 
-/** This party's side phrased for the recovery listing, matching the run list's
- * wording. Absent on an unreadable row (the side could not be parsed). */
-const SIDE_LABEL: Record<ManagedExchangeSide, string> = {
-  inviter: "You invite",
-  acceptor: "You accept",
-};
-
 /** One row in the read-failed recovery listing: the stored key the delete acts on,
  * a display label (the operator's label, "(unnamed exchange)" when empty, or
- * {@link UNREADABLE_RECORD_LABEL} when the entry could not be parsed), the side and
- * last-run date when parseable, and whether the entry was unreadable. */
+ * {@link UNREADABLE_RECORD_LABEL} when the entry could not be parsed), the raw label
+ * the delete confirm names (empty when unlabeled, so the button's own empty-label
+ * branch fires rather than reading a doubly-transformed "(unnamed exchange)"), the
+ * side and last-run date when parseable, whether the entry was unreadable, and
+ * whether an exported backup remains under the operator's custody. */
 export interface RecoveryRow {
   /** The stored key the one-step delete-by-key dispatches on. */
   id: string;
-  /** The display label (see the interface doc). */
+  /** The display label for the row text (see the interface doc). */
   label: string;
+  /** The raw operator label the delete confirm names -- empty when unlabeled, so the
+   * confirm reads "Delete this exchange?" exactly as the normal list's does, not the
+   * transformed row text. Always empty on an unreadable row. */
+  deleteLabel: string;
   /** This party's side, as the listing names it; absent on an unreadable row. */
   sideLabel?: string;
   /** The last run's calendar-day phrase, when the entry parsed and had a run. */
   lastRunAt?: string;
   /** Whether the entry could not be parsed. */
   unreadable: boolean;
+  /** Whether an exported backup remains under the operator's custody, so the delete
+   * confirm carries the custody note. Survives record unreadability. */
+  backedUp: boolean;
 }
 
 /** Derive one recovery row from a diagnostic entry. A readable entry surfaces its
- * essentials (an empty label reads as "(unnamed exchange)", matching the run list);
- * an unreadable entry surfaces only its key and the fixed unreadable label. */
+ * essentials (an empty label reads as "(unnamed exchange)" for the row text, matching
+ * the run list, while the delete confirm names the raw label); an unreadable entry
+ * surfaces only its key and the fixed unreadable label. Both carry the entry's backup
+ * custody state through to the delete confirm. */
 export function recoveryRow(
   entry: ManagedExchangeDiagnosticEntry,
 ): RecoveryRow {
   if (entry.kind === "unreadable")
-    return { id: entry.id, label: UNREADABLE_RECORD_LABEL, unreadable: true };
+    return {
+      id: entry.id,
+      label: UNREADABLE_RECORD_LABEL,
+      deleteLabel: "",
+      unreadable: true,
+      backedUp: entry.backedUp,
+    };
   const { essentials } = entry;
   return {
     id: essentials.id,
     label: essentials.label === "" ? "(unnamed exchange)" : essentials.label,
+    deleteLabel: essentials.label,
     sideLabel: SIDE_LABEL[essentials.side],
     ...(essentials.lastRunAt !== undefined
       ? { lastRunAt: dateLabel(new Date(essentials.lastRunAt)) }
       : {}),
     unreadable: false,
+    backedUp: entry.backedUp,
   };
 }
 

--- a/apps/web/src/bench/savedExchangesRecovery.ts
+++ b/apps/web/src/bench/savedExchangesRecovery.ts
@@ -1,0 +1,75 @@
+/**
+ * The pure model behind the read-failed surface's recovery listing: turning the
+ * store's diagnostic entries into the small display rows that surface lists, each
+ * with the delete-by-key the surface dispatches. No React, no IndexedDB: the store
+ * reads and the delete action live in the component, so the display derivation is
+ * unit-testable in Node.
+ *
+ * A readable entry surfaces its label, side, and last-run date; an unreadable entry
+ * surfaces a fixed "Unreadable record" label and no other detail, since nothing
+ * about it could be parsed. Every row carries the stored key the one-step
+ * delete-by-key acts on, so an unreadable record is discardable without a
+ * successful parse. Secret material never reaches this model: the diagnostic
+ * entries carry display essentials only.
+ */
+
+import { dateLabel } from "./inviterModel";
+
+import type { ManagedExchangeDiagnosticEntry } from "@psi/managedExchangeStore";
+import type { ManagedExchangeSide } from "@psi/managedExchangeRecord";
+
+/** The label a row shows for an unreadable entry: nothing about it could be
+ * parsed, so it reads as an unreadable record rather than an empty or guessed
+ * name. */
+export const UNREADABLE_RECORD_LABEL = "Unreadable record";
+
+/** This party's side phrased for the recovery listing, matching the run list's
+ * wording. Absent on an unreadable row (the side could not be parsed). */
+const SIDE_LABEL: Record<ManagedExchangeSide, string> = {
+  inviter: "You invite",
+  acceptor: "You accept",
+};
+
+/** One row in the read-failed recovery listing: the stored key the delete acts on,
+ * a display label (the operator's label, "(unnamed exchange)" when empty, or
+ * {@link UNREADABLE_RECORD_LABEL} when the entry could not be parsed), the side and
+ * last-run date when parseable, and whether the entry was unreadable. */
+export interface RecoveryRow {
+  /** The stored key the one-step delete-by-key dispatches on. */
+  id: string;
+  /** The display label (see the interface doc). */
+  label: string;
+  /** This party's side, as the listing names it; absent on an unreadable row. */
+  sideLabel?: string;
+  /** The last run's calendar-day phrase, when the entry parsed and had a run. */
+  lastRunAt?: string;
+  /** Whether the entry could not be parsed. */
+  unreadable: boolean;
+}
+
+/** Derive one recovery row from a diagnostic entry. A readable entry surfaces its
+ * essentials (an empty label reads as "(unnamed exchange)", matching the run list);
+ * an unreadable entry surfaces only its key and the fixed unreadable label. */
+export function recoveryRow(
+  entry: ManagedExchangeDiagnosticEntry,
+): RecoveryRow {
+  if (entry.kind === "unreadable")
+    return { id: entry.id, label: UNREADABLE_RECORD_LABEL, unreadable: true };
+  const { essentials } = entry;
+  return {
+    id: essentials.id,
+    label: essentials.label === "" ? "(unnamed exchange)" : essentials.label,
+    sideLabel: SIDE_LABEL[essentials.side],
+    ...(essentials.lastRunAt !== undefined
+      ? { lastRunAt: dateLabel(new Date(essentials.lastRunAt)) }
+      : {}),
+    unreadable: false,
+  };
+}
+
+/** Derive the recovery rows from the store's diagnostic entries, in store order. */
+export function recoveryRows(
+  entries: ReadonlyArray<ManagedExchangeDiagnosticEntry>,
+): Array<RecoveryRow> {
+  return entries.map((entry) => recoveryRow(entry));
+}

--- a/apps/web/src/psi/managedExchangeRecord.ts
+++ b/apps/web/src/psi/managedExchangeRecord.ts
@@ -266,6 +266,53 @@ export function safeParseManagedExchangeRecord(raw: unknown) {
   return ManagedExchangeRecordSchema.safeParse(raw);
 }
 
+/**
+ * The display essentials a diagnostic read surfaces for one stored entry, when the
+ * entry parses: only the fields a recovery listing renders -- the label, this
+ * party's side, and the last run's instant when recorded. Deliberately NOT the
+ * whole record: the diagnostic path must never return the `sharedSecret` or any
+ * document field to a component, so this type structurally cannot carry secret
+ * material (see docs/MANAGED_EXCHANGE.md, "Deleting a managed exchange", and the
+ * read-failed recovery listing). The `id` is the stored key a delete-by-key acts
+ * on.
+ */
+export interface ManagedExchangeDiagnosticEssentials {
+  /** The stored key, the delete acts on it (matches the record's `id`). */
+  id: string;
+  /** The operator's display label; may be empty. */
+  label: string;
+  /** This party's side of the partnership. */
+  side: ManagedExchangeSide;
+  /** ISO 8601 UTC instant of the last recorded run, when one exists. */
+  lastRunAt?: string;
+}
+
+/**
+ * Extract only the display essentials from a stored value for the read-failed
+ * recovery listing: the `id`, `label`, `side`, and last-run instant, and nothing
+ * else. Structurally incapable of returning secret material -- it reads named
+ * scalar fields off the validated record and copies them into a
+ * {@link ManagedExchangeDiagnosticEssentials}, so the `sharedSecret`, the document,
+ * and the input handle never leave this function. Full record validation still
+ * runs first, so a value that would fail {@link parseManagedExchangeRecord}
+ * (unknown `schemaVersion`, malformed secret, a document carrying an
+ * `authentication` block) throws here exactly as it would on the strict read; the
+ * caller catches that to mark the entry unreadable.
+ *
+ * @throws {ZodError} if the value is not a valid v1 record.
+ */
+export function diagnoseManagedExchangeRecord(
+  raw: unknown,
+): ManagedExchangeDiagnosticEssentials {
+  const record = parseManagedExchangeRecord(raw);
+  return {
+    id: record.id,
+    label: record.label,
+    side: record.side,
+    ...(record.lastRun !== undefined ? { lastRunAt: record.lastRun.at } : {}),
+  };
+}
+
 /** Everything a caller supplies to compose the persisted exchange-file document
  * from a credential-free webrtc locator. The linkage terms and connection locator
  * are the document's substance; the optional blocks mirror

--- a/apps/web/src/psi/managedExchangeStore.ts
+++ b/apps/web/src/psi/managedExchangeStore.ts
@@ -28,11 +28,13 @@ import {
   applyManagedExchangeReinviteRotation,
   applyManagedExchangeRotation,
   buildManagedExchangeRecord,
+  diagnoseManagedExchangeRecord,
   parseManagedExchangeRecord,
 } from "./managedExchangeRecord";
 import { parseManagedLocalState } from "./managedLocalStateShape";
 
 import type {
+  ManagedExchangeDiagnosticEssentials,
   ManagedExchangeLastRun,
   ManagedExchangeLocalEdits,
   ManagedExchangeRecord,
@@ -234,6 +236,73 @@ export async function listManagedExchanges(): Promise<
 > {
   const raws = await withStore("readonly", (store) => store.getAll());
   return raws.map((raw) => parseManagedExchangeRecord(raw));
+}
+
+/**
+ * One entry in the diagnostic read: for a stored key, either the display essentials
+ * the entry parsed to (`readable`) or an unreadable marker (`unreadable`) carrying
+ * only the key. Both carry the stored `id` so a delete-by-key acts on either --
+ * deleting an unreadable entry must not require a successful parse.
+ */
+export type ManagedExchangeDiagnosticEntry =
+  | { kind: "readable"; essentials: ManagedExchangeDiagnosticEssentials }
+  | { kind: "unreadable"; id: string };
+
+/**
+ * Read every stored entry for the read-failed recovery listing, per-record and
+ * NEVER rejecting wholesale -- unlike {@link listManagedExchanges}, whose strict
+ * contract is deliberately untouched so a single bad record still fails the normal
+ * list read. This diagnostic read exists ONLY for the recovery surface: it walks
+ * the raw keys and values, attempts {@link diagnoseManagedExchangeRecord} on each,
+ * and returns for each stored key either its display essentials or an unreadable
+ * marker, so an operator can identify and discard the offending record even when
+ * the normal list cannot load.
+ *
+ * SECURITY: the entries carry display essentials only (the label, side, dates, and
+ * key); the `sharedSecret`, the document, and the input handle never leave the
+ * diagnostic extraction, so no secret material reaches the recovery surface. Keyed
+ * off the store's own keys rather than the parsed records, so an unreadable entry
+ * still yields a key to delete by.
+ */
+export async function listManagedExchangesDiagnostic(): Promise<
+  Array<ManagedExchangeDiagnosticEntry>
+> {
+  const db = await openManagedExchangeDatabase();
+  try {
+    return await new Promise<Array<ManagedExchangeDiagnosticEntry>>(
+      (resolve, reject) => {
+        const transaction = db.transaction(
+          MANAGED_EXCHANGE_STORE_NAME,
+          "readonly",
+        );
+        const store = transaction.objectStore(MANAGED_EXCHANGE_STORE_NAME);
+        const keysRequest = store.getAllKeys();
+        const valuesRequest = store.getAll();
+        transaction.oncomplete = () => {
+          const keys = keysRequest.result;
+          const values = valuesRequest.result;
+          const entries: Array<ManagedExchangeDiagnosticEntry> = [];
+          for (let index = 0; index < keys.length; index += 1) {
+            try {
+              entries.push({
+                kind: "readable",
+                essentials: diagnoseManagedExchangeRecord(values[index]),
+              });
+            } catch {
+              // The parse failed, so the record's own `id` is untrusted; the store
+              // key is the delete target instead, and the only field surfaced.
+              entries.push({ kind: "unreadable", id: String(keys[index]) });
+            }
+          }
+          resolve(entries);
+        };
+        transaction.onerror = () => reject(transaction.error);
+        transaction.onabort = () => reject(transaction.error);
+      },
+    );
+  } finally {
+    db.close();
+  }
 }
 
 /**

--- a/apps/web/src/psi/managedExchangeStore.ts
+++ b/apps/web/src/psi/managedExchangeStore.ts
@@ -242,11 +242,19 @@ export async function listManagedExchanges(): Promise<
  * One entry in the diagnostic read: for a stored key, either the display essentials
  * the entry parsed to (`readable`) or an unreadable marker (`unreadable`) carrying
  * only the key. Both carry the stored `id` so a delete-by-key acts on either --
- * deleting an unreadable entry must not require a successful parse.
+ * deleting an unreadable entry must not require a successful parse. Both also carry
+ * `backedUp`, derived from the sibling local-state store (the backup marker survives
+ * independently of record validity), so the delete confirm's custody note shows on
+ * the recovery path exactly as on the normal list. A boolean suffices: the marker's
+ * timestamp is never surfaced here.
  */
 export type ManagedExchangeDiagnosticEntry =
-  | { kind: "readable"; essentials: ManagedExchangeDiagnosticEssentials }
-  | { kind: "unreadable"; id: string };
+  | {
+      kind: "readable";
+      essentials: ManagedExchangeDiagnosticEssentials;
+      backedUp: boolean;
+    }
+  | { kind: "unreadable"; id: string; backedUp: boolean };
 
 /**
  * Read every stored entry for the read-failed recovery listing, per-record and
@@ -259,10 +267,18 @@ export type ManagedExchangeDiagnosticEntry =
  * the normal list cannot load.
  *
  * SECURITY: the entries carry display essentials only (the label, side, dates, and
- * key); the `sharedSecret`, the document, and the input handle never leave the
- * diagnostic extraction, so no secret material reaches the recovery surface. Keyed
- * off the store's own keys rather than the parsed records, so an unreadable entry
- * still yields a key to delete by.
+ * key) plus the `backedUp` boolean; the `sharedSecret`, the document, the input
+ * handle, and the marker's timestamp never leave the diagnostic extraction, so no
+ * secret material reaches the recovery surface. Keyed off the store's own keys
+ * rather than the parsed records, so an unreadable entry still yields a key to
+ * delete by.
+ *
+ * The transaction spans the record store AND the sibling local-state store so each
+ * entry's `backedUp` is read in the same read. The backup marker survives
+ * independently of record validity, so an entry whose record is unreadable can still
+ * hold a live exported backup. `backedUp` is CONSERVATIVE on doubt: if the sibling
+ * entry exists but cannot be parsed it reads as backed up (a wrongly-shown custody
+ * warning is harmless; a wrongly-suppressed one is not).
  */
 export async function listManagedExchangesDiagnostic(): Promise<
   Array<ManagedExchangeDiagnosticEntry>
@@ -272,26 +288,38 @@ export async function listManagedExchangesDiagnostic(): Promise<
     return await new Promise<Array<ManagedExchangeDiagnosticEntry>>(
       (resolve, reject) => {
         const transaction = db.transaction(
-          MANAGED_EXCHANGE_STORE_NAME,
+          [MANAGED_EXCHANGE_STORE_NAME, MANAGED_EXCHANGE_LOCAL_STORE_NAME],
           "readonly",
         );
-        const store = transaction.objectStore(MANAGED_EXCHANGE_STORE_NAME);
-        const keysRequest = store.getAllKeys();
-        const valuesRequest = store.getAll();
+        const records = transaction.objectStore(MANAGED_EXCHANGE_STORE_NAME);
+        const local = transaction.objectStore(
+          MANAGED_EXCHANGE_LOCAL_STORE_NAME,
+        );
+        const keysRequest = records.getAllKeys();
+        const valuesRequest = records.getAll();
+        const localKeysRequest = local.getAllKeys();
+        const localValuesRequest = local.getAll();
         transaction.oncomplete = () => {
           const keys = keysRequest.result;
           const values = valuesRequest.result;
+          const backedUpByKey = backedUpMarkersByKey(
+            localKeysRequest.result,
+            localValuesRequest.result,
+          );
           const entries: Array<ManagedExchangeDiagnosticEntry> = [];
           for (let index = 0; index < keys.length; index += 1) {
+            const key = String(keys[index]);
+            const backedUp = backedUpByKey.get(key) ?? false;
             try {
               entries.push({
                 kind: "readable",
                 essentials: diagnoseManagedExchangeRecord(values[index]),
+                backedUp,
               });
             } catch {
               // The parse failed, so the record's own `id` is untrusted; the store
               // key is the delete target instead, and the only field surfaced.
-              entries.push({ kind: "unreadable", id: String(keys[index]) });
+              entries.push({ kind: "unreadable", id: key, backedUp });
             }
           }
           resolve(entries);
@@ -303,6 +331,30 @@ export async function listManagedExchangesDiagnostic(): Promise<
   } finally {
     db.close();
   }
+}
+
+/** Derive, per sibling-store key, whether an exported backup marker is present --
+ * the `backedUp` boolean the diagnostic entries carry. CONSERVATIVE on doubt: a
+ * sibling entry that cannot be parsed reads as backed up (a wrongly-shown custody
+ * warning is harmless; a wrongly-suppressed one is not). The marker's timestamp is
+ * never surfaced -- only its presence. */
+function backedUpMarkersByKey(
+  keys: ReadonlyArray<IDBValidKey>,
+  values: ReadonlyArray<unknown>,
+): Map<string, boolean> {
+  const backedUpByKey = new Map<string, boolean>();
+  for (let index = 0; index < keys.length; index += 1) {
+    const key = String(keys[index]);
+    try {
+      backedUpByKey.set(
+        key,
+        parseManagedLocalState(values[index]).backup !== undefined,
+      );
+    } catch {
+      backedUpByKey.set(key, true);
+    }
+  }
+  return backedUpByKey;
 }
 
 /**

--- a/apps/web/src/psi/managedLocalState.ts
+++ b/apps/web/src/psi/managedLocalState.ts
@@ -115,15 +115,23 @@ export async function listManagedLocalState(): Promise<
         const keysRequest = store.getAllKeys();
         const valuesRequest = store.getAll();
         transaction.oncomplete = () => {
-          const map = new Map<string, ManagedLocalState>();
-          const keys = keysRequest.result;
-          const values = valuesRequest.result;
-          for (let index = 0; index < keys.length; index += 1)
-            map.set(
-              String(keys[index]),
-              managedLocalStateSchema.parse(values[index]),
-            );
-          resolve(map);
+          try {
+            const map = new Map<string, ManagedLocalState>();
+            const keys = keysRequest.result;
+            const values = valuesRequest.result;
+            for (let index = 0; index < keys.length; index += 1)
+              map.set(
+                String(keys[index]),
+                managedLocalStateSchema.parse(values[index]),
+              );
+            resolve(map);
+          } catch (error) {
+            // A parse throws inside `oncomplete`, outside the executor's own scope:
+            // reject with it so a corrupted sibling entry rejects the read (the
+            // documented contract) rather than throwing unhandled and leaving the
+            // promise unsettled.
+            reject(error);
+          }
         };
         transaction.onerror = () => reject(transaction.error);
         transaction.onabort = () => reject(transaction.error);

--- a/apps/web/test/browser/managedExchangeStore.test.ts
+++ b/apps/web/test/browser/managedExchangeStore.test.ts
@@ -135,6 +135,26 @@ async function rawPut(value: unknown): Promise<void> {
   }
 }
 
+/** Overwrite the sibling local-state value under a key with an arbitrary object,
+ * bypassing the validating write path, so a test can seed a corrupted sibling entry
+ * the diagnostic read must treat conservatively (backed up on a parse failure). */
+async function rawLocalPut(id: string, value: unknown): Promise<void> {
+  const db = await openManagedExchangeDatabase();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(
+        MANAGED_EXCHANGE_LOCAL_STORE_NAME,
+        "readwrite",
+      );
+      transaction.objectStore(MANAGED_EXCHANGE_LOCAL_STORE_NAME).put(value, id);
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
 beforeEach(async () => {
   await clearManagedExchanges();
 });
@@ -545,8 +565,41 @@ describe("diagnostic read never rejects wholesale", () => {
       label: "Riverbend quarterly",
       side: "acceptor",
     });
+    // A fresh record has no exported backup, and no marker's timestamp reaches the
+    // entry -- only the boolean.
+    expect(entry.backedUp).toBe(false);
     // The secret must never reach the diagnostic surface.
     expect(JSON.stringify(entries)).not.toContain(created.sharedSecret);
+  });
+
+  test("a backup marker present reads as backedUp; the timestamp never surfaces", async () => {
+    const created = await createManagedExchange(
+      newExchange({ label: "Backed up" }),
+    );
+    await markManagedExchangeBackedUp(created.id, "2026-07-10T09:00:00.000Z");
+
+    const [entry] = await listManagedExchangesDiagnostic();
+    expect(entry.backedUp).toBe(true);
+    // The marker's own instant is never surfaced -- a boolean suffices.
+    expect(JSON.stringify(entry)).not.toContain("2026-07-10T09:00:00.000Z");
+  });
+
+  test("an absent sibling entry reads as not backed up", async () => {
+    await createManagedExchange(newExchange({ label: "Fresh" }));
+    const [entry] = await listManagedExchangesDiagnostic();
+    expect(entry.backedUp).toBe(false);
+  });
+
+  test("an unparseable sibling entry reads as backed up (conservative on doubt)", async () => {
+    const created = await createManagedExchange(
+      newExchange({ label: "Doubtful" }),
+    );
+    // Corrupt the sibling entry so its parse fails: a wrongly-shown custody warning
+    // is harmless; a wrongly-suppressed one is not, so doubt reads as backed up.
+    await rawLocalPut(created.id, { backup: { backedUpAt: "not-an-instant" } });
+
+    const [entry] = await listManagedExchangesDiagnostic();
+    expect(entry.backedUp).toBe(true);
   });
 
   test("one unreadable record does not fail the read; it yields an unreadable marker keyed for delete", async () => {
@@ -567,7 +620,31 @@ describe("diagnostic read never rejects wholesale", () => {
     const readable = entries.find((entry) => entry.kind === "readable");
     const unreadable = entries.find((entry) => entry.kind === "unreadable");
     expect(readable).toBeDefined();
-    expect(unreadable).toEqual({ kind: "unreadable", id: "bad-record" });
+    expect(unreadable).toEqual({
+      kind: "unreadable",
+      id: "bad-record",
+      backedUp: false,
+    });
+  });
+
+  test("an unreadable record with a live sibling backup marker still reads as backed up", async () => {
+    const good = await createManagedExchange(newExchange({ label: "Good" }));
+    await rawPut({
+      ...good,
+      id: "bad-record",
+      schemaVersion: "psilink-managed-exchange/v2",
+    });
+    // The sibling backup marker survives the record's unreadability: a delete of the
+    // bad record must still warn about the exported backup's custody.
+    await markManagedExchangeBackedUp("bad-record", "2026-07-10T09:00:00.000Z");
+
+    const entries = await listManagedExchangesDiagnostic();
+    const unreadable = entries.find((entry) => entry.kind === "unreadable");
+    expect(unreadable).toEqual({
+      kind: "unreadable",
+      id: "bad-record",
+      backedUp: true,
+    });
   });
 
   test("an unreadable record is deletable by key without a successful parse", async () => {

--- a/apps/web/test/browser/managedExchangeStore.test.ts
+++ b/apps/web/test/browser/managedExchangeStore.test.ts
@@ -6,12 +6,14 @@ import { generateSharedSecret, getDefaultLinkageTerms } from "@psilink/core";
 
 import {
   MANAGED_EXCHANGE_DB_NAME,
+  MANAGED_EXCHANGE_LOCAL_STORE_NAME,
   MANAGED_EXCHANGE_STORE_NAME,
   clearManagedExchanges,
   createManagedExchange,
   deleteManagedExchange,
   getManagedExchange,
   listManagedExchanges,
+  listManagedExchangesDiagnostic,
   openManagedExchangeDatabase,
   persistManagedExchangeRotation,
   putManagedExchange,
@@ -23,6 +25,12 @@ import {
   MAX_LABEL_LENGTH,
   composeManagedExchangeFile,
 } from "@psi/managedExchangeRecord";
+import {
+  getManagedLocalState,
+  markManagedExchangeBackedUp,
+  markManagedExchangeSpent,
+} from "@psi/managedLocalState";
+import { buildManagedDeposit } from "@bench/manageOfferModel";
 
 import type {
   ManagedExchangeSchedule,
@@ -79,6 +87,25 @@ async function rawStored(id: string): Promise<unknown> {
       const request = db
         .transaction(MANAGED_EXCHANGE_STORE_NAME, "readonly")
         .objectStore(MANAGED_EXCHANGE_STORE_NAME)
+        .get(id);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/** The raw sibling local-state value under a key, read straight from the local-state
+ * store (bypassing the validating read path) so the delete test can assert the
+ * sibling entry is gone too, not merely absent through a validating read. */
+async function rawLocalStored(id: string): Promise<unknown> {
+  const db = await openManagedExchangeDatabase();
+  try {
+    return await new Promise<unknown>((resolve, reject) => {
+      const request = db
+        .transaction(MANAGED_EXCHANGE_LOCAL_STORE_NAME, "readonly")
+        .objectStore(MANAGED_EXCHANGE_LOCAL_STORE_NAME)
         .get(id);
       request.onsuccess = () => resolve(request.result);
       request.onerror = () => reject(request.error);
@@ -358,6 +385,94 @@ describe("input-file handle persistence", () => {
   });
 });
 
+describe("deposit persists a managed record of the party's side", () => {
+  const NOW = Date.parse("2026-02-01T14:00:00.000Z");
+
+  test("the inviter's save-as-recurring deposit adds an inviter record", async () => {
+    const secret = generateSharedSecret();
+    const deposit = buildManagedDeposit(
+      {
+        side: "inviter",
+        exchangeFile: composeManagedExchangeFile({
+          connection: webrtcLocator,
+          linkageTerms,
+        }),
+        sharedSecret: secret,
+        choices: { label: "Riverbend quarterly" },
+      },
+      NOW,
+    );
+
+    const created = await createManagedExchange(deposit);
+
+    const stored = await listManagedExchanges();
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe(created.id);
+    expect(stored[0].side).toBe("inviter");
+    expect(stored[0].sharedSecret).toBe(secret);
+  });
+
+  test("the acceptor's save-as-recurring deposit adds an acceptor record to the same store", async () => {
+    const secret = generateSharedSecret();
+    const deposit = buildManagedDeposit(
+      {
+        side: "acceptor",
+        exchangeFile: composeManagedExchangeFile({
+          connection: webrtcLocator,
+          linkageTerms,
+        }),
+        sharedSecret: secret,
+        choices: { label: "Riverbend quarterly" },
+      },
+      NOW,
+    );
+
+    const created = await createManagedExchange(deposit);
+
+    const stored = await listManagedExchanges();
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe(created.id);
+    expect(stored[0].side).toBe("acceptor");
+  });
+
+  test("both sides deposit into one list carrying both", async () => {
+    await createManagedExchange(
+      buildManagedDeposit(
+        {
+          side: "inviter",
+          exchangeFile: composeManagedExchangeFile({
+            connection: webrtcLocator,
+            linkageTerms,
+          }),
+          sharedSecret: generateSharedSecret(),
+          choices: { label: "Invited partnership" },
+        },
+        NOW,
+      ),
+    );
+    await createManagedExchange(
+      buildManagedDeposit(
+        {
+          side: "acceptor",
+          exchangeFile: composeManagedExchangeFile({
+            connection: webrtcLocator,
+            linkageTerms,
+          }),
+          sharedSecret: generateSharedSecret(),
+          choices: { label: "Accepted partnership" },
+        },
+        NOW,
+      ),
+    );
+
+    const stored = await listManagedExchanges();
+    expect(stored.map((record) => record.side).sort()).toEqual([
+      "acceptor",
+      "inviter",
+    ]);
+  });
+});
+
 describe("reader rejects unknown on a store read", () => {
   test("a future schemaVersion in the store rejects rather than loading", async () => {
     const created = await createManagedExchange(newExchange());
@@ -368,7 +483,7 @@ describe("reader rejects unknown on a store read", () => {
 });
 
 describe("one-step delete leaves nothing behind", () => {
-  test("delete removes the record, secret, handle, schedule, and bookkeeping", async () => {
+  test("delete removes the record, secret, handle, schedule, bookkeeping, and every local sibling marker", async () => {
     const root = await navigator.storage.getDirectory();
     const handle = await root.getFileHandle("managed-input.csv", {
       create: true,
@@ -381,19 +496,94 @@ describe("one-step delete leaves nothing behind", () => {
         schedule,
       }),
     );
-    // Everything the browser holds for the exchange is one object under one key.
+    await recordManagedExchangeLastRun(created.id, {
+      at: "2026-02-01T14:00:00.000Z",
+      outcome: "succeeded",
+    });
+    // Also stamp both sibling markers, so the delete must clear the local-state
+    // entry as well as the record -- the two stores the browser holds an exchange
+    // in.
+    await markManagedExchangeBackedUp(created.id, "2026-02-01T14:05:00.000Z");
+    await markManagedExchangeSpent(created.id, "2026-02-02T09:00:00.000Z");
+    // Everything the browser holds for the exchange -- the record under its key,
+    // and the sibling local-state entry -- exists before the delete.
     expect(await rawStored(created.id)).toBeDefined();
+    expect(await rawLocalStored(created.id)).toBeDefined();
 
     await deleteManagedExchange(created.id);
 
+    // Enumerate every location and assert emptiness, not merely that the row is
+    // gone: the record store (raw and through both validating reads) AND the
+    // sibling local-state store (raw and through its validating read).
     expect(await rawStored(created.id)).toBeUndefined();
     expect(await getManagedExchange(created.id)).toBeUndefined();
     expect(await listManagedExchanges()).toEqual([]);
+    expect(await rawLocalStored(created.id)).toBeUndefined();
+    expect(await getManagedLocalState(created.id)).toBeUndefined();
     await root.removeEntry("managed-input.csv");
   });
 
   test("delete of a missing id is idempotent", async () => {
     await expect(deleteManagedExchange("no-such-id")).resolves.toBeUndefined();
+  });
+});
+
+describe("diagnostic read never rejects wholesale", () => {
+  test("readable entries carry display essentials only, never the secret", async () => {
+    const created = await createManagedExchange(
+      newExchange({ label: "Riverbend quarterly", side: "acceptor" }),
+    );
+
+    const entries = await listManagedExchangesDiagnostic();
+
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    expect(entry.kind).toBe("readable");
+    if (entry.kind !== "readable") throw new Error("expected a readable entry");
+    expect(entry.essentials).toEqual({
+      id: created.id,
+      label: "Riverbend quarterly",
+      side: "acceptor",
+    });
+    // The secret must never reach the diagnostic surface.
+    expect(JSON.stringify(entries)).not.toContain(created.sharedSecret);
+  });
+
+  test("one unreadable record does not fail the read; it yields an unreadable marker keyed for delete", async () => {
+    const good = await createManagedExchange(newExchange({ label: "Good" }));
+    // Seed a future-version record under its own key: the strict list read rejects
+    // wholesale on it, but the diagnostic read must still enumerate both.
+    await rawPut({
+      ...good,
+      id: "bad-record",
+      schemaVersion: "psilink-managed-exchange/v2",
+    });
+
+    // The strict read still rejects wholesale -- the untouched contract.
+    await expect(listManagedExchanges()).rejects.toThrow();
+
+    const entries = await listManagedExchangesDiagnostic();
+    expect(entries).toHaveLength(2);
+    const readable = entries.find((entry) => entry.kind === "readable");
+    const unreadable = entries.find((entry) => entry.kind === "unreadable");
+    expect(readable).toBeDefined();
+    expect(unreadable).toEqual({ kind: "unreadable", id: "bad-record" });
+  });
+
+  test("an unreadable record is deletable by key without a successful parse", async () => {
+    const good = await createManagedExchange(newExchange({ label: "Good" }));
+    await rawPut({
+      ...good,
+      id: "bad-record",
+      schemaVersion: "psilink-managed-exchange/v2",
+    });
+
+    await deleteManagedExchange("bad-record");
+
+    // The offending record is gone, so the strict list read recovers.
+    expect(await rawStored("bad-record")).toBeUndefined();
+    const recovered = await listManagedExchanges();
+    expect(recovered.map((record) => record.id)).toEqual([good.id]);
   });
 });
 

--- a/apps/web/test/browser/savedExchanges.test.ts
+++ b/apps/web/test/browser/savedExchanges.test.ts
@@ -27,6 +27,22 @@ import type { NewManagedExchange } from "@psi/managedExchangeRecord";
 import type { ReactNode } from "react";
 import type { Root } from "react-dom/client";
 
+// The component's delete goes through this module. It is mocked so the delete-failure
+// test can make a single delete reject while every other case uses the real
+// transaction; `deleteOverride`, when set, replaces the real delete for one test.
+let deleteOverride: ((id: string) => Promise<void>) | undefined;
+vi.mock("@psi/managedExchangeStore", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const realDelete = actual.deleteManagedExchange as (
+    id: string,
+  ) => Promise<void>;
+  return {
+    ...actual,
+    deleteManagedExchange: (id: string) =>
+      deleteOverride ? deleteOverride(id) : realDelete(id),
+  };
+});
+
 // The managed-exchange list and its conditional home route, exercised against real
 // Chromium (real IndexedDB and the sibling object store). The home route at `/`
 // (SavedExchangesHome) is the management interface only once an exchange exists: a
@@ -94,6 +110,7 @@ afterEach(async () => {
   container?.remove();
   root = undefined;
   container = undefined;
+  deleteOverride = undefined;
   await clearManagedExchanges();
 });
 
@@ -347,5 +364,38 @@ describe("saved list route: delete is a first-class, always-available action", (
       .toBeInTheDocument();
     // A spent row does not offer Run.
     expect(page.getByRole("button", { name: "Run" }).query()).toBeNull();
+  });
+
+  test("a rejected delete surfaces an error and leaves the row standing", async () => {
+    await createManagedExchange(newExchange({ label: "Riverbend quarterly" }));
+    // The delete rejects (a transaction abort, quota, or blocked open): the confirm
+    // must not close silently over a row that is still there.
+    deleteOverride = () => Promise.reject(new Error("delete failed"));
+
+    mount(createElement(SavedExchanges));
+
+    await expect
+      .element(page.getByText("Riverbend quarterly"))
+      .toBeInTheDocument();
+
+    await page.getByRole("button", { name: "Delete" }).click();
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Delete" })
+      .click();
+
+    // The failure is visible, the modal stays open, and the row is still listed.
+    await expect
+      .element(
+        page.getByText("Removing it from this browser failed", {
+          exact: false,
+        }),
+      )
+      .toBeInTheDocument();
+    // The row's own label span still stands (exact, so the modal's "Delete
+    // "Riverbend quarterly"?" copy is not what this matches).
+    await expect
+      .element(page.getByText("Riverbend quarterly", { exact: true }))
+      .toBeInTheDocument();
   });
 });

--- a/apps/web/test/browser/savedExchanges.test.ts
+++ b/apps/web/test/browser/savedExchanges.test.ts
@@ -17,8 +17,11 @@ import {
   clearManagedExchanges,
   createManagedExchange,
 } from "@psi/managedExchangeStore";
+import {
+  markManagedExchangeBackedUp,
+  markManagedExchangeSpent,
+} from "@psi/managedLocalState";
 import { composeManagedExchangeFile } from "@psi/managedExchangeRecord";
-import { markManagedExchangeBackedUp } from "@psi/managedLocalState";
 
 import type { NewManagedExchange } from "@psi/managedExchangeRecord";
 import type { ReactNode } from "react";
@@ -211,5 +214,138 @@ describe("saved list route: the always-list surface", () => {
     });
     await expect.element(quick).toBeInTheDocument();
     expect((await quick.element()).getAttribute("href")).toBe("/quick");
+  });
+
+  test("a populated list offers a first-class create entry into the invite/configure flow", async () => {
+    await createManagedExchange(newExchange());
+
+    mount(createElement(SavedExchanges));
+
+    const create = page.getByRole("link", {
+      name: "Set up a recurring exchange",
+    });
+    await expect.element(create).toBeInTheDocument();
+    expect((await create.element()).getAttribute("href")).toBe("/exchange");
+  });
+
+  test("the side facet is readable at a glance: an inviter and an acceptor row", async () => {
+    await createManagedExchange(
+      newExchange({ label: "Invited partnership", side: "inviter" }),
+    );
+    await createManagedExchange(
+      newExchange({ label: "Accepted partnership", side: "acceptor" }),
+    );
+
+    mount(createElement(SavedExchanges));
+
+    await expect
+      .element(page.getByText("You invite", { exact: false }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("You accept", { exact: false }))
+      .toBeInTheDocument();
+  });
+});
+
+describe("saved list route: delete is a first-class, always-available action", () => {
+  test("delete confirms, then removes the exchange from the list", async () => {
+    await createManagedExchange(newExchange({ label: "Riverbend quarterly" }));
+
+    mount(createElement(SavedExchanges));
+
+    await expect
+      .element(page.getByText("Riverbend quarterly"))
+      .toBeInTheDocument();
+
+    await page.getByRole("button", { name: "Delete" }).click();
+
+    // The confirm names the exchange and says the partner is not notified.
+    await expect
+      .element(
+        page.getByText('Delete "Riverbend quarterly"?', { exact: false }),
+      )
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("your partner is not notified", { exact: false }))
+      .toBeInTheDocument();
+
+    // Confirm the delete: the modal's own Delete, scoped to the dialog so the row's
+    // Delete (behind the overlay) is never the target.
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Delete" })
+      .click();
+
+    // The row is gone and the empty state stands in its place.
+    await expect
+      .element(page.getByText("You have none saved yet.", { exact: false }))
+      .toBeInTheDocument();
+    expect(page.getByText("Riverbend quarterly").query()).toBeNull();
+  });
+
+  test("a backed-up exchange's confirm carries the exported-backup custody note", async () => {
+    const created = await createManagedExchange(
+      newExchange({ label: "Backed up partnership" }),
+    );
+    await markManagedExchangeBackedUp(created.id, "2026-07-10T09:00:00.000Z");
+
+    mount(createElement(SavedExchanges));
+
+    await expect
+      .element(page.getByText("Backed up as of", { exact: false }))
+      .toBeInTheDocument();
+    await page.getByRole("button", { name: "Delete" }).click();
+
+    await expect
+      .element(
+        page.getByText("A backup file you exported stays in your custody", {
+          exact: false,
+        }),
+      )
+      .toBeInTheDocument();
+    await expect
+      .element(
+        page.getByText("remains a credential until the partnership rotates", {
+          exact: false,
+        }),
+      )
+      .toBeInTheDocument();
+  });
+
+  test("a never-backed-up exchange's confirm carries no custody note", async () => {
+    await createManagedExchange(newExchange({ label: "Fresh partnership" }));
+
+    mount(createElement(SavedExchanges));
+
+    await page.getByRole("button", { name: "Delete" }).click();
+
+    await expect
+      .element(page.getByText("your partner is not notified", { exact: false }))
+      .toBeInTheDocument();
+    expect(
+      page
+        .getByText("A backup file you exported stays in your custody", {
+          exact: false,
+        })
+        .query(),
+    ).toBeNull();
+  });
+
+  test("a spent (handed-off) row offers Open and Delete", async () => {
+    const created = await createManagedExchange(
+      newExchange({ label: "Handed off partnership" }),
+    );
+    await markManagedExchangeSpent(created.id, "2026-07-12T09:00:00.000Z");
+
+    mount(createElement(SavedExchanges));
+
+    await expect
+      .element(page.getByRole("button", { name: "Open" }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByRole("button", { name: "Delete" }))
+      .toBeInTheDocument();
+    // A spent row does not offer Run.
+    expect(page.getByRole("button", { name: "Run" }).query()).toBeNull();
   });
 });

--- a/apps/web/test/browser/savedExchanges.test.ts
+++ b/apps/web/test/browser/savedExchanges.test.ts
@@ -398,4 +398,52 @@ describe("saved list route: delete is a first-class, always-available action", (
       .element(page.getByText("Riverbend quarterly", { exact: true }))
       .toBeInTheDocument();
   });
+
+  test("reopening the confirm after a failed delete starts clean, and a retry succeeds", async () => {
+    await createManagedExchange(newExchange({ label: "Riverbend quarterly" }));
+    deleteOverride = () => Promise.reject(new Error("delete failed"));
+
+    mount(createElement(SavedExchanges));
+
+    await page.getByRole("button", { name: "Delete" }).click();
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Delete" })
+      .click();
+    await expect
+      .element(
+        page.getByText("Removing it from this browser failed", {
+          exact: false,
+        }),
+      )
+      .toBeInTheDocument();
+
+    // Cancel the modal, then reopen it via the row's Delete button: the failure
+    // from the last attempt must not carry over into the fresh confirm.
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await page.getByRole("button", { name: "Delete" }).click();
+
+    expect(
+      page
+        .getByText("Removing it from this browser failed", { exact: false })
+        .query(),
+    ).toBeNull();
+    await expect
+      .element(
+        page.getByText('Delete "Riverbend quarterly"?', { exact: false }),
+      )
+      .toBeInTheDocument();
+
+    // Let a successful delete proceed to prove the retry path actually works.
+    deleteOverride = undefined;
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Delete" })
+      .click();
+
+    await expect
+      .element(page.getByText("You have none saved yet.", { exact: false }))
+      .toBeInTheDocument();
+    expect(page.getByText("Riverbend quarterly").query()).toBeNull();
+  });
 });

--- a/apps/web/test/browser/savedExchangesRecoveryListing.test.ts
+++ b/apps/web/test/browser/savedExchangesRecoveryListing.test.ts
@@ -13,12 +13,17 @@ import "@mantine/core/styles.css";
 import { MantineProvider } from "@mantine/core";
 
 import {
+  MANAGED_EXCHANGE_LOCAL_STORE_NAME,
   MANAGED_EXCHANGE_STORE_NAME,
   clearManagedExchanges,
   createManagedExchange,
   listManagedExchanges,
   openManagedExchangeDatabase,
 } from "@psi/managedExchangeStore";
+import {
+  listManagedLocalState,
+  markManagedExchangeBackedUp,
+} from "@psi/managedLocalState";
 import { SavedExchanges } from "@bench/SavedExchanges";
 import { composeManagedExchangeFile } from "@psi/managedExchangeRecord";
 
@@ -81,6 +86,26 @@ async function rawPut(value: unknown): Promise<void> {
         "readwrite",
       );
       transaction.objectStore(MANAGED_EXCHANGE_STORE_NAME).put(value);
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/** Seed a corrupted sibling local-state value under a key, bypassing the validating
+ * write, so a test can prove the diagnostic read treats an unparseable sibling
+ * conservatively (backed up on doubt). */
+async function rawLocalPut(id: string, value: unknown): Promise<void> {
+  const db = await openManagedExchangeDatabase();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(
+        MANAGED_EXCHANGE_LOCAL_STORE_NAME,
+        "readwrite",
+      );
+      transaction.objectStore(MANAGED_EXCHANGE_LOCAL_STORE_NAME).put(value, id);
       transaction.oncomplete = () => resolve();
       transaction.onerror = () => reject(transaction.error);
     });
@@ -179,5 +204,103 @@ describe("read-failed recovery listing", () => {
       .toBeInTheDocument();
     // The secret must not appear anywhere on the recovery surface.
     expect(document.body.textContent).not.toContain(good.sharedSecret);
+  });
+});
+
+describe("recovery listing: the delete confirm's backup custody note", () => {
+  /** Seed a good record (so a readable recovery row exists to delete) beside a bad
+   * one (so the surface is the read-failed one), run `seedState` to stamp any sibling
+   * state on the good record BEFORE the single mount, then render the always-list
+   * route. Returns the good record. Its row is first in store-key order (a hex-first
+   * randomUUID sorts before "zzz-bad-record"), so the `.first()` Delete opens it. */
+  async function mountReadFailedWith(
+    label: string,
+    seedState?: (id: string) => Promise<void>,
+  ): Promise<Awaited<ReturnType<typeof createManagedExchange>>> {
+    const good = await createManagedExchange(newExchange({ label }));
+    await rawPut({
+      ...good,
+      id: "zzz-bad-record",
+      schemaVersion: "psilink-managed-exchange/v2",
+    });
+    if (seedState) await seedState(good.id);
+    await expect(listManagedExchanges()).rejects.toThrow();
+    mount(createElement(SavedExchanges));
+    await expect
+      .element(page.getByText(label === "" ? "(unnamed exchange)" : label))
+      .toBeInTheDocument();
+    return good;
+  }
+
+  test("marker present -> the custody note shows on the recovery confirm", async () => {
+    await mountReadFailedWith("Backed up partnership", (id) =>
+      markManagedExchangeBackedUp(id, "2026-07-10T09:00:00.000Z"),
+    );
+
+    await page.getByRole("button", { name: "Delete" }).first().click();
+    await expect
+      .element(
+        page.getByText("A backup file you exported stays in your custody", {
+          exact: false,
+        }),
+      )
+      .toBeInTheDocument();
+  });
+
+  test("marker absent -> the custody note is not shown on the recovery confirm", async () => {
+    await mountReadFailedWith("Fresh partnership");
+
+    await page.getByRole("button", { name: "Delete" }).first().click();
+    await expect
+      .element(page.getByText("your partner is not notified", { exact: false }))
+      .toBeInTheDocument();
+    expect(
+      page
+        .getByText("A backup file you exported stays in your custody", {
+          exact: false,
+        })
+        .query(),
+    ).toBeNull();
+  });
+
+  test("an unparseable sibling entry -> the custody note shows (conservative on doubt)", async () => {
+    // No bad record here: a corrupted sibling entry alone fails the strict local-state
+    // read, which routes the surface to read-failed on its own. The diagnostic read
+    // then treats that unparseable sibling conservatively -- backed up on doubt -- so
+    // the good record's delete confirm carries the custody note.
+    const good = await createManagedExchange(
+      newExchange({ label: "Doubtful partnership" }),
+    );
+    await rawLocalPut(good.id, { backup: { backedUpAt: "not-an-instant" } });
+    await expect(listManagedLocalState()).rejects.toThrow();
+
+    mount(createElement(SavedExchanges));
+    await expect
+      .element(page.getByText("Doubtful partnership"))
+      .toBeInTheDocument();
+
+    await page.getByRole("button", { name: "Delete" }).first().click();
+    await expect
+      .element(
+        page.getByText("A backup file you exported stays in your custody", {
+          exact: false,
+        }),
+      )
+      .toBeInTheDocument();
+  });
+
+  test("an unlabeled readable entry's confirm reads 'Delete this exchange?', not the row's display text", async () => {
+    // The row text is the display transform "(unnamed exchange)", but the confirm
+    // must name the raw (empty) label, so the button's own empty-label branch fires.
+    await mountReadFailedWith("");
+
+    // The good (unlabeled) record's row is first; open its confirm.
+    await page.getByRole("button", { name: "Delete" }).first().click();
+    await expect
+      .element(page.getByText("Delete this exchange?", { exact: false }))
+      .toBeInTheDocument();
+    expect(
+      page.getByText('Delete "(unnamed exchange)"?', { exact: false }).query(),
+    ).toBeNull();
   });
 });

--- a/apps/web/test/browser/savedExchangesRecoveryListing.test.ts
+++ b/apps/web/test/browser/savedExchangesRecoveryListing.test.ts
@@ -1,0 +1,183 @@
+/// <reference types="@vitest/browser-playwright/context" />
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { generateSharedSecret, getDefaultLinkageTerms } from "@psilink/core";
+
+import { page } from "vitest/browser";
+
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+
+import "@mantine/core/styles.css";
+
+import { MantineProvider } from "@mantine/core";
+
+import {
+  MANAGED_EXCHANGE_STORE_NAME,
+  clearManagedExchanges,
+  createManagedExchange,
+  listManagedExchanges,
+  openManagedExchangeDatabase,
+} from "@psi/managedExchangeStore";
+import { SavedExchanges } from "@bench/SavedExchanges";
+import { composeManagedExchangeFile } from "@psi/managedExchangeRecord";
+
+import type { NewManagedExchange } from "@psi/managedExchangeRecord";
+import type { ReactNode } from "react";
+import type { Root } from "react-dom/client";
+
+// The read-failed recovery listing, against real Chromium (real IndexedDB). Unlike
+// savedExchangesFailed.test.ts, which mocks the strict read to always reject, this
+// file seeds a genuinely unreadable record beside a good one: the strict list read
+// rejects wholesale on the bad record (the untouched contract), which routes both
+// routes to the read-failed surface, and the surface's diagnostic read -- which never
+// rejects wholesale -- lists both stored entries, each with the one-step
+// delete-by-key. Deleting the offending record and reloading recovers the now-readable
+// list to the normal run surface.
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    children,
+    ...rest
+  }: {
+    to?: string;
+    children?: ReactNode;
+    [prop: string]: unknown;
+  }) =>
+    createElement(
+      "a",
+      { ...rest, href: typeof to === "string" ? to : "#" },
+      children,
+    ),
+  useNavigate: () => () => undefined,
+}));
+
+const linkageTerms = getDefaultLinkageTerms("County Health Dept");
+
+function newExchange(
+  overrides: Partial<NewManagedExchange> = {},
+): NewManagedExchange {
+  return {
+    label: "Riverbend quarterly",
+    exchangeFile: composeManagedExchangeFile({
+      connection: { channel: "webrtc", host: "signaling.example.org" },
+      linkageTerms,
+    }),
+    side: "inviter",
+    sharedSecret: generateSharedSecret(),
+    ...overrides,
+  };
+}
+
+/** Seed an arbitrary raw value under a key, so a test can plant a future-version
+ * record the strict read rejects but the diagnostic read still enumerates. */
+async function rawPut(value: unknown): Promise<void> {
+  const db = await openManagedExchangeDatabase();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(
+        MANAGED_EXCHANGE_STORE_NAME,
+        "readwrite",
+      );
+      transaction.objectStore(MANAGED_EXCHANGE_STORE_NAME).put(value);
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+let container: HTMLElement | undefined;
+let root: Root | undefined;
+
+function mount(content: ReactNode) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  root.render(createElement(MantineProvider, null, content));
+}
+
+beforeEach(async () => {
+  await clearManagedExchanges();
+});
+
+afterEach(async () => {
+  root?.unmount();
+  container?.remove();
+  root = undefined;
+  container = undefined;
+  await clearManagedExchanges();
+});
+
+describe("read-failed recovery listing", () => {
+  test("lists the readable record and the unreadable one, then delete-and-reload recovers", async () => {
+    const good = await createManagedExchange(
+      newExchange({ label: "Riverbend quarterly" }),
+    );
+    // A key that sorts after any hex-first randomUUID, so the unreadable row is
+    // deterministically last in the store-key-ordered listing (the delete below
+    // targets the last row).
+    await rawPut({
+      ...good,
+      id: "zzz-bad-record",
+      schemaVersion: "psilink-managed-exchange/v2",
+    });
+    // Precondition: the strict list read rejects wholesale on the bad record.
+    await expect(listManagedExchanges()).rejects.toThrow();
+
+    mount(createElement(SavedExchanges));
+
+    // The read-failed surface stands, and the recovery listing shows both entries.
+    await expect
+      .element(
+        page.getByText(
+          "Your recurring exchanges could not be read from this browser",
+          { exact: false },
+        ),
+      )
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("Riverbend quarterly"))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("Unreadable record"))
+      .toBeInTheDocument();
+
+    // Delete the unreadable record. Two Delete buttons in the listing (one per
+    // entry); the unreadable row is the second, seeded after the good one.
+    const deletes = page.getByRole("button", { name: "Delete" }).all();
+    await deletes[deletes.length - 1].click();
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Delete" })
+      .click();
+
+    // With the offending record gone, the reload recovers to the normal run
+    // surface: the good record renders as a runnable row.
+    await expect
+      .element(page.getByRole("button", { name: "Run" }))
+      .toBeInTheDocument();
+    expect(page.getByText("Unreadable record").query()).toBeNull();
+  });
+
+  test("the recovery listing never renders the stored secret", async () => {
+    const good = await createManagedExchange(
+      newExchange({ label: "Riverbend quarterly" }),
+    );
+    await rawPut({
+      ...good,
+      id: "zzz-bad-record",
+      schemaVersion: "psilink-managed-exchange/v2",
+    });
+
+    mount(createElement(SavedExchanges));
+
+    await expect
+      .element(page.getByText("Riverbend quarterly"))
+      .toBeInTheDocument();
+    // The secret must not appear anywhere on the recovery surface.
+    expect(document.body.textContent).not.toContain(good.sharedSecret);
+  });
+});

--- a/apps/web/test/unit/managedExchangeRecord.test.ts
+++ b/apps/web/test/unit/managedExchangeRecord.test.ts
@@ -15,6 +15,7 @@ import {
   applyManagedExchangeRotation,
   buildManagedExchangeRecord,
   composeManagedExchangeFile,
+  diagnoseManagedExchangeRecord,
   parseManagedExchangeRecord,
   safeParseManagedExchangeRecord,
 } from "@psi/managedExchangeRecord";
@@ -480,5 +481,47 @@ describe("applyManagedExchangeLastRun", () => {
     expect(
       applyManagedExchangeLastRun(record, wholeSecondOlder).lastRun,
     ).toEqual(fractionalNewer);
+  });
+});
+
+describe("diagnoseManagedExchangeRecord", () => {
+  test("returns only the display essentials -- id, label, side, and last-run date", () => {
+    const record = buildManagedExchangeRecord(
+      newExchange({ label: "Riverbend quarterly", side: "acceptor" }),
+    );
+    const withRun = applyManagedExchangeLastRun(record, {
+      at: "2026-07-10T09:00:00.000Z",
+      outcome: "succeeded",
+    });
+    expect(diagnoseManagedExchangeRecord(withRun)).toEqual({
+      id: withRun.id,
+      label: "Riverbend quarterly",
+      side: "acceptor",
+      lastRunAt: "2026-07-10T09:00:00.000Z",
+    });
+  });
+
+  test("omits the last-run date for a never-run record", () => {
+    const record = buildManagedExchangeRecord(newExchange());
+    expect(diagnoseManagedExchangeRecord(record).lastRunAt).toBeUndefined();
+  });
+
+  test("never surfaces the secret or the document", () => {
+    const record = buildManagedExchangeRecord(newExchange());
+    const essentials = diagnoseManagedExchangeRecord(record);
+    // The essentials object is display-only: the secret, the document, and the
+    // handle must not be reachable through it.
+    expect(Object.keys(essentials).sort()).toEqual(["id", "label", "side"]);
+    expect(JSON.stringify(essentials)).not.toContain(record.sharedSecret);
+  });
+
+  test("throws on a value the strict read would reject", () => {
+    const record = buildManagedExchangeRecord(newExchange());
+    expect(() =>
+      diagnoseManagedExchangeRecord({
+        ...record,
+        schemaVersion: "psilink-managed-exchange/v2",
+      }),
+    ).toThrow();
   });
 });

--- a/apps/web/test/unit/savedExchangesRecovery.test.ts
+++ b/apps/web/test/unit/savedExchangesRecovery.test.ts
@@ -19,10 +19,12 @@ function readable(
     label: string;
     side: "inviter" | "acceptor";
     lastRunAt: string;
+    backedUp: boolean;
   }> = {},
 ): ManagedExchangeDiagnosticEntry {
   return {
     kind: "readable",
+    backedUp: overrides.backedUp ?? false,
     essentials: {
       id: overrides.id ?? "abc",
       label: overrides.label ?? "Riverbend quarterly",
@@ -46,28 +48,53 @@ describe("recoveryRow", () => {
     );
     expect(row.id).toBe("one");
     expect(row.label).toBe("Riverbend quarterly");
+    expect(row.deleteLabel).toBe("Riverbend quarterly");
     expect(row.sideLabel).toBe("You accept");
     expect(row.lastRunAt).toBeDefined();
     expect(row.unreadable).toBe(false);
   });
 
-  test("an empty label reads as (unnamed exchange), matching the run list", () => {
+  test("an empty label reads as (unnamed exchange) in the row text", () => {
     expect(recoveryRow(readable({ label: "" })).label).toBe(
       "(unnamed exchange)",
     );
+  });
+
+  test("an empty label leaves the delete confirm's label raw, so the button says 'Delete this exchange?'", () => {
+    // The row text is the display transform, but the delete confirm names the raw
+    // label: an empty deleteLabel fires the button's own empty-label branch rather
+    // than a doubly-transformed "(unnamed exchange)".
+    expect(recoveryRow(readable({ label: "" })).deleteLabel).toBe("");
   });
 
   test("a readable entry with no run carries no last-run date", () => {
     expect(recoveryRow(readable()).lastRunAt).toBeUndefined();
   });
 
-  test("an unreadable entry surfaces the fixed label, its key, and nothing else", () => {
-    const row = recoveryRow({ kind: "unreadable", id: "bad-key" });
+  test("a readable entry threads its backup custody state through to the confirm", () => {
+    expect(recoveryRow(readable({ backedUp: true })).backedUp).toBe(true);
+    expect(recoveryRow(readable({ backedUp: false })).backedUp).toBe(false);
+  });
+
+  test("an unreadable entry surfaces the fixed label, an empty delete label, and its key", () => {
+    const row = recoveryRow({
+      kind: "unreadable",
+      id: "bad-key",
+      backedUp: false,
+    });
     expect(row.id).toBe("bad-key");
     expect(row.label).toBe(UNREADABLE_RECORD_LABEL);
+    expect(row.deleteLabel).toBe("");
     expect(row.sideLabel).toBeUndefined();
     expect(row.lastRunAt).toBeUndefined();
     expect(row.unreadable).toBe(true);
+  });
+
+  test("an unreadable entry with a live backup marker threads its custody state through", () => {
+    expect(
+      recoveryRow({ kind: "unreadable", id: "bad-key", backedUp: true })
+        .backedUp,
+    ).toBe(true);
   });
 });
 
@@ -75,7 +102,7 @@ describe("recoveryRows", () => {
   test("derives a row per entry in order, mixing readable and unreadable", () => {
     const rows = recoveryRows([
       readable({ id: "one" }),
-      { kind: "unreadable", id: "two" },
+      { kind: "unreadable", id: "two", backedUp: false },
     ]);
     expect(rows.map((row) => row.id)).toEqual(["one", "two"]);
     expect(rows[0].unreadable).toBe(false);

--- a/apps/web/test/unit/savedExchangesRecovery.test.ts
+++ b/apps/web/test/unit/savedExchangesRecovery.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  UNREADABLE_RECORD_LABEL,
+  recoveryRow,
+  recoveryRows,
+} from "@bench/savedExchangesRecovery";
+
+import type { ManagedExchangeDiagnosticEntry } from "@psi/managedExchangeStore";
+
+// The read-failed recovery listing's display derivation, tested in Node: a readable
+// entry surfaces its label, side, and last-run date; an unreadable entry surfaces a
+// fixed label and its stored key, and nothing more. Every row carries the key the
+// one-step delete-by-key acts on.
+
+function readable(
+  overrides: Partial<{
+    id: string;
+    label: string;
+    side: "inviter" | "acceptor";
+    lastRunAt: string;
+  }> = {},
+): ManagedExchangeDiagnosticEntry {
+  return {
+    kind: "readable",
+    essentials: {
+      id: overrides.id ?? "abc",
+      label: overrides.label ?? "Riverbend quarterly",
+      side: overrides.side ?? "inviter",
+      ...(overrides.lastRunAt !== undefined
+        ? { lastRunAt: overrides.lastRunAt }
+        : {}),
+    },
+  };
+}
+
+describe("recoveryRow", () => {
+  test("a readable entry surfaces its label, side, and last-run date", () => {
+    const row = recoveryRow(
+      readable({
+        id: "one",
+        label: "Riverbend quarterly",
+        side: "acceptor",
+        lastRunAt: "2026-07-10T09:00:00.000Z",
+      }),
+    );
+    expect(row.id).toBe("one");
+    expect(row.label).toBe("Riverbend quarterly");
+    expect(row.sideLabel).toBe("You accept");
+    expect(row.lastRunAt).toBeDefined();
+    expect(row.unreadable).toBe(false);
+  });
+
+  test("an empty label reads as (unnamed exchange), matching the run list", () => {
+    expect(recoveryRow(readable({ label: "" })).label).toBe(
+      "(unnamed exchange)",
+    );
+  });
+
+  test("a readable entry with no run carries no last-run date", () => {
+    expect(recoveryRow(readable()).lastRunAt).toBeUndefined();
+  });
+
+  test("an unreadable entry surfaces the fixed label, its key, and nothing else", () => {
+    const row = recoveryRow({ kind: "unreadable", id: "bad-key" });
+    expect(row.id).toBe("bad-key");
+    expect(row.label).toBe(UNREADABLE_RECORD_LABEL);
+    expect(row.sideLabel).toBeUndefined();
+    expect(row.lastRunAt).toBeUndefined();
+    expect(row.unreadable).toBe(true);
+  });
+});
+
+describe("recoveryRows", () => {
+  test("derives a row per entry in order, mixing readable and unreadable", () => {
+    const rows = recoveryRows([
+      readable({ id: "one" }),
+      { kind: "unreadable", id: "two" },
+    ]);
+    expect(rows.map((row) => row.id)).toEqual(["one", "two"]);
+    expect(rows[0].unreadable).toBe(false);
+    expect(rows[1].unreadable).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The recurring-exchange list gains its grow-and-prune affordances: a first-class entry into the invite/configure flow, and a per-row one-step delete that removes everything the browser holds for an exchange -- the record with its secret, schedule, input-file handle, and run bookkeeping, plus every local marker -- in a single cross-store transaction behind one confirm. The confirm names the exchange, states that deletion is local and unilateral, and, when a backup was exported, carries the operator-custody note. The read-failed surface gains a recovery listing built on a diagnostic per-record read that never rejects wholesale and returns display essentials only, so one unreadable record no longer strands the list: each stored entry can be deleted by key without a successful parse, and removing the offending record recovers the normal list. Both save paths (invite-side and accept-side deposits) already existed and are now pinned by store-level tests; the side facet was already visible on rows.

Implements [212131258](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=212131258).

## Changes

- apps/web/src/psi/managedExchangeStore.ts: listManagedExchangesDiagnostic -- per-record parse over raw keys/rows in one readonly transaction spanning both stores, returning per key either display essentials plus a backedUp boolean (marker presence; conservatively true when the sibling entry cannot be read) or an unreadable marker; parse failures are discarded, never quoted.
- apps/web/src/psi/managedExchangeRecord.ts: diagnoseManagedExchangeRecord -- validates the full record, then copies out only id/label/side/lastRun.at; secret, document, and handle fields are never referenced.
- apps/web/src/psi/managedLocalState.ts: a corrupted sibling entry now rejects the list read per its contract instead of leaving the promise unsettled (the load hung rather than classifying failed).
- apps/web/src/bench/savedExchangesRecovery.ts (new): pure recovery-row model (display label transform, raw delete label, side/date, backup flag), reusing the exported SIDE_LABEL from savedExchangesModel.ts.
- apps/web/src/bench/SavedExchanges.tsx: populated list gains the create entry (to /exchange) and per-row Delete (Modal confirm; failure keeps the confirm open with an error, retry and reopen paths reset cleanly); spent rows show Open + Delete; the read-failed surface renders the recovery listing with delete-by-key and reloads after delete.
- apps/web/src/bench/bench.module.css: row-actions layout.
- apps/web/test/: store tests for delete-leaves-nothing (both stores, raw and validated reads), deposit-persists-side coverage, diagnostic-read behavior (never rejects wholesale, marker join, timestamp never surfaced); browser tests for the create entry, delete confirm/custody/unilateral copy, rejected-delete error, cancel-reopen-retry, recovery listing (delete-and-recover, secret never rendered); unit tests for the recovery model.

## Test plan

Ran: root `npm run test` (core, cli, and web unit suites); `npx vitest run --project browser` in apps/web (36 files / 450 tests); `npm run typecheck && npm run lint && npm run format`.
New tests cover: delete removes the record and the sibling markers with nothing remaining in either store (raw and validating reads), deposit-on-create persists an inviter record and accept-deposit an acceptor record into one list, the diagnostic read never rejects wholesale and joins the backup marker by key without surfacing timestamps or secrets, delete-by-key of an unreadable record recovers the strict read, the confirm's custody note shows exactly when a backup marker exists (conservatively when the sibling is unreadable), a rejected delete surfaces an error with the row standing and a clean reopen, and the rendered recovery surface never contains the stored secret.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- no page updated: docs/MANAGED_EXCHANGE.md "Deleting a managed exchange" already specifies the shipped semantics (one step, everything, local and unilateral, custody note) and no docs/ or docs/spec/ page describes the list surface's row actions or the store's read paths at this level; the record shape and documented store contract are unchanged
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: UI completion of the already-listed recurring-exchange capability (add/delete affordances), not a new headline capability or a breaking change to a listed entry
- [x] Security review -- focused review of the diff: secret non-exposure on the new diagnostic read path (structural named-field copy, parse errors discarded unquoted, rendered fields and keys sink-checked), deletion completeness and transaction atomicity across both stores, truth of the confirm's security claims, and the custody-note gating; two findings (custody note suppressed on the recovery path, silent delete failure) fixed and adversarially re-verified