### PR TITLE
Settle a blocked store open; yield old tabs

### DIFF
--- a/apps/web/src/bench/savedExchangesLoad.ts
+++ b/apps/web/src/bench/savedExchangesLoad.ts
@@ -5,8 +5,9 @@
  * on. No React: the ordering and the failure classification are unit-testable in
  * Node with the store reads injected.
  *
- * The two failure outcomes are deliberately distinct. A store that cannot be opened
- * at all -- private mode with storage blocked, or an engine without IndexedDB -- is
+ * The two failure outcomes are deliberately distinct. A store whose open does not
+ * succeed -- private mode with storage blocked, an engine without IndexedDB, or a
+ * version-change open transiently blocked by another tab's older connection -- is
  * `"unavailable"`: the operator can still run a one-off exchange, so the home route
  * renders the quick path and the list route shows an explicit degrade. A store that
  * opens but whose read fails (a corrupted or app-upgrade-invalidated record) is

--- a/apps/web/src/psi/managedExchangeStore.ts
+++ b/apps/web/src/psi/managedExchangeStore.ts
@@ -61,8 +61,9 @@ export const MANAGED_EXCHANGE_LOCAL_STORE_NAME = "localState";
 /** The database schema version this build opens. Bump only for an IndexedDB
  * structural migration (a new object store or index), never for a change to the
  * record's own `schemaVersion`, which the record schema governs. Bumped to 2 to add
- * the local-sibling-state store. */
-const IDB_VERSION = 2;
+ * the local-sibling-state store.
+ * @internal */
+export const IDB_VERSION = 2;
 
 /**
  * Open (creating or upgrading) the managed-exchange database. The records store is
@@ -81,8 +82,26 @@ export function openManagedExchangeDatabase(): Promise<IDBDatabase> {
       if (!db.objectStoreNames.contains(MANAGED_EXCHANGE_LOCAL_STORE_NAME))
         db.createObjectStore(MANAGED_EXCHANGE_LOCAL_STORE_NAME);
     };
-    request.onsuccess = () => resolve(request.result);
+    request.onsuccess = () => {
+      const db = request.result;
+      // Close on a later open's version-change so this connection stops holding an
+      // older version open. Without it a long-lived page's connection blocks the next
+      // build's upgrade open indefinitely, which is the condition that fires `blocked`
+      // below; closing here is the root-cause half that keeps that condition rare.
+      db.onversionchange = () => db.close();
+      resolve(db);
+    };
     request.onerror = () => reject(request.error);
+    // A version-change open is blocked when another live connection still holds an
+    // older version. It settles neither way on its own, so without this handler the
+    // promise would hang forever; reject it so a blocked open classifies as
+    // store-unavailable (the degrade-to-quick-path branch) rather than hanging a
+    // caller. The blocked state is transient and self-healing -- the `onversionchange`
+    // close above lets the other connection yield -- so a reload recovers it.
+    request.onblocked = () =>
+      reject(
+        new Error("managed-exchange database open blocked by another tab"),
+      );
   });
 }
 

--- a/apps/web/src/psi/managedExchangeStore.ts
+++ b/apps/web/src/psi/managedExchangeStore.ts
@@ -74,6 +74,12 @@ export const IDB_VERSION = 2;
  */
 export function openManagedExchangeDatabase(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
+    // Per the IndexedDB spec, `blocked` does not abort the request: it stays pending,
+    // and once the blocking connection closes, this SAME request's onupgradeneeded/
+    // onsuccess still fire. This flag lets that late success tell it already lost the
+    // promise (settled by `onblocked` below) and must close the connection instead of
+    // leaking it or resolving a second time.
+    let blocked = false;
     const request = indexedDB.open(MANAGED_EXCHANGE_DB_NAME, IDB_VERSION);
     request.onupgradeneeded = () => {
       const db = request.result;
@@ -84,6 +90,10 @@ export function openManagedExchangeDatabase(): Promise<IDBDatabase> {
     };
     request.onsuccess = () => {
       const db = request.result;
+      if (blocked) {
+        db.close();
+        return;
+      }
       // Close on a later open's version-change so this connection stops holding an
       // older version open. Without it a long-lived page's connection blocks the next
       // build's upgrade open indefinitely, which is the condition that fires `blocked`
@@ -98,10 +108,12 @@ export function openManagedExchangeDatabase(): Promise<IDBDatabase> {
     // store-unavailable (the degrade-to-quick-path branch) rather than hanging a
     // caller. The blocked state is transient and self-healing -- the `onversionchange`
     // close above lets the other connection yield -- so a reload recovers it.
-    request.onblocked = () =>
+    request.onblocked = () => {
+      blocked = true;
       reject(
         new Error("managed-exchange database open blocked by another tab"),
       );
+    };
   });
 }
 

--- a/apps/web/test/browser/managedExchangeStore.test.ts
+++ b/apps/web/test/browser/managedExchangeStore.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="@vitest/browser-playwright/context" />
 /// <reference types="vite/client" />
 
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { generateSharedSecret, getDefaultLinkageTerms } from "@psilink/core";
 
 import {
@@ -755,6 +755,39 @@ describe("a blocked open settles instead of hanging", () => {
       expect(db.version).toBe(IDB_VERSION);
     } finally {
       db.close();
+    }
+  });
+
+  test("a late success after blocked-rejection closes the connection instead of leaking it", async () => {
+    // The blocked request never aborts: it stays pending, and once `held` closes, this
+    // SAME request's onupgradeneeded/onsuccess fire late -- after the promise already
+    // rejected. A leaked (never-closed) connection here would still self-close on the
+    // VERY NEXT version-change open via its own onversionchange handler, so probing with
+    // a higher-version open cannot distinguish "closed immediately" from "left open
+    // until the next version bump happens to come along" -- both would pass that probe.
+    // The real proof is that `close()` is called on the late connection itself (a THIRD
+    // instance, distinct from `held`); a spy on IDBDatabase.prototype.close, checked by
+    // instance identity, pins exactly that -- with the leak this never happens and the
+    // wait below times out.
+    const closeSpy = vi.spyOn(IDBDatabase.prototype, "close");
+    try {
+      await deleteDatabase();
+      const held = await openRawHeldConnection(IDB_VERSION - 1);
+      await expect(openManagedExchangeDatabase()).rejects.toThrow();
+      held.close();
+      // Give the same request's now-unblocked onupgradeneeded/onsuccess a beat to fire,
+      // by polling the spy itself (no new IDB opens per attempt, so no risk of stacking
+      // probe connections) rather than a fixed sleep.
+      await vi.waitFor(() => {
+        const closedInstances = new Set(
+          closeSpy.mock.instances as Array<IDBDatabase>,
+        );
+        expect(closedInstances.has(held)).toBe(true);
+        expect(closedInstances.size).toBeGreaterThanOrEqual(2);
+      });
+    } finally {
+      closeSpy.mockRestore();
+      await deleteDatabase();
     }
   });
 

--- a/apps/web/test/browser/managedExchangeStore.test.ts
+++ b/apps/web/test/browser/managedExchangeStore.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { generateSharedSecret, getDefaultLinkageTerms } from "@psilink/core";
 
 import {
+  IDB_VERSION,
   MANAGED_EXCHANGE_DB_NAME,
   MANAGED_EXCHANGE_LOCAL_STORE_NAME,
   MANAGED_EXCHANGE_STORE_NAME,
@@ -153,6 +154,31 @@ async function rawLocalPut(id: string, value: unknown): Promise<void> {
   } finally {
     db.close();
   }
+}
+
+/** Delete the whole managed-exchange database, so a test can re-create it at a chosen
+ * version. Resolves once the delete completes; a delete blocked by a live connection
+ * still fires `onsuccess` once that connection closes, so callers close held
+ * connections first. */
+async function deleteDatabase(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(MANAGED_EXCHANGE_DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/** Open a raw connection at `version`, deliberately WITHOUT the module's
+ * `onversionchange` self-close, so it models an old tab whose connection never yields
+ * to a later upgrade -- the condition that fires `blocked` on the next open. The caller
+ * closes it. */
+async function openRawHeldConnection(version: number): Promise<IDBDatabase> {
+  return await new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(MANAGED_EXCHANGE_DB_NAME, version);
+    request.onupgradeneeded = () => undefined;
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
 }
 
 beforeEach(async () => {
@@ -698,5 +724,58 @@ describe("persistent storage request", () => {
     } finally {
       StorageManager.prototype.persist = realPersist;
     }
+  });
+});
+
+describe("a blocked open settles instead of hanging", () => {
+  test("a version-change open held off by an older connection rejects, not hangs", async () => {
+    // Recreate the database one version below this build, then hold that older
+    // connection open WITHOUT the module's onversionchange self-close, modelling an old
+    // tab that never yields. The module's open (at IDB_VERSION) is a version-change open
+    // the older connection blocks: it must reject rather than hang forever.
+    await deleteDatabase();
+    const held = await openRawHeldConnection(IDB_VERSION - 1);
+    try {
+      await expect(openManagedExchangeDatabase()).rejects.toThrow();
+    } finally {
+      held.close();
+    }
+  });
+
+  test("closing the blocking connection lets a reopened open succeed", async () => {
+    // The blocked state is transient: once the older connection closes, the same open
+    // succeeds. This pins the self-healing property the degrade relies on -- a reload
+    // (or the other tab closing) recovers a store the first open found blocked.
+    await deleteDatabase();
+    const held = await openRawHeldConnection(IDB_VERSION - 1);
+    await expect(openManagedExchangeDatabase()).rejects.toThrow();
+    held.close();
+    const db = await openManagedExchangeDatabase();
+    try {
+      expect(db.version).toBe(IDB_VERSION);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("an opened connection closes itself on a later version-change open", async () => {
+    // The root-cause half: a connection this module opens registers onversionchange to
+    // close itself, so it does not block the next build's upgrade the way an old tab's
+    // unyielding connection does. With the module-opened connection left open, a raw
+    // open one version higher completes rather than staying blocked.
+    await deleteDatabase();
+    const moduleConnection = await openManagedExchangeDatabase();
+    const higher = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(MANAGED_EXCHANGE_DB_NAME, IDB_VERSION + 1);
+      request.onupgradeneeded = () => undefined;
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+      request.onblocked = () =>
+        reject(new Error("module connection did not yield on versionchange"));
+    });
+    higher.close();
+    // The module connection closed itself, so a subsequent module open is clean.
+    moduleConnection.close();
+    await deleteDatabase();
   });
 });


### PR DESCRIPTION
## Summary

A version-change open of the managed-exchange database blocked by another live connection left the open promise unsettled forever, hanging every surface that probes or reads the store -- including the home route, since the recurring-exchange list became home. The open now rejects on blocked (every caller already classifies that as store-unavailable and degrades to the quick path), each opened connection closes itself on versionchange so a new build's upgrade is not blocked by old tabs in the first place, and the late success a rejected-blocked request still delivers is closed on arrival rather than leaked.

Implements [213907058](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=213907058).

## Changes

- apps/web/src/psi/managedExchangeStore.ts: openManagedExchangeDatabase gains onblocked (rejects, with a settled flag so the request's late success closes the connection it hands back) and an onversionchange self-close on every resolved connection.
- apps/web/src/bench/savedExchangesLoad.ts: the unavailable classification's doc names the transiently-blocked open alongside the permanent gaps.
- apps/web/test/browser/managedExchangeStore.test.ts: a blocked open rejects rather than hangs; closing the blocker lets a fresh open succeed; a module-opened connection yields on a later version-change open; the late success after a blocked rejection closes its connection (close-spy discriminator, verified to fail on the pre-fix code).

## Test plan

Ran: full apps/web browser project (37 files / 462 tests) and unit project (1332 tests); `npm run typecheck && npm run lint && npm run format`.
New tests cover: reject-on-blocked, self-healing reopen after the blocker closes, versionchange self-close on held connections, and the no-leak close of a late-arriving connection.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed; the open-settle lifecycle is code-level and no docs page describes it
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: a robustness bug fix, not a major feature or breaking change
- [x] Security review -- n/a: none of the listed surfaces touched; the diff converts a hang into a settle and closes stale connections on an already-reviewed store, adding no read/write path and no secret, disclosure, or crypto handling