### PR TITLE
Refresh payload lock-in on accept reuse

### DIFF
--- a/apps/cli/src/commands/accept.ts
+++ b/apps/cli/src/commands/accept.ts
@@ -22,6 +22,7 @@ import type {
 import {
   diffLinkageTerms,
   formatReconcileDiffs,
+  persistExpectedPayloadColumns,
   type ReconcileDiff,
 } from "../config";
 import { detectFileConflicts } from "../fileUtils";
@@ -721,12 +722,28 @@ export async function handler(argv: Arguments): Promise<void> {
         { reuseExistingConfig: ready.reuseExistingConfig },
       );
 
-      if (ready.reuseExistingConfig)
+      if (ready.reuseExistingConfig) {
+        // Refresh the consented received-column lock-in in the reused config. The
+        // operator has just re-consented to THIS invitation's terms (the prompt
+        // above, or --consent-to-terms, gates every write here), so the lock-in is
+        // rewritten to the set they consented to on this acceptance -- the token's
+        // disclosed subset, in the inviter's namespace. Unlike the connection and
+        // linkage blocks (operator prose provisionConfigAndKey deliberately leaves
+        // untouched under reuse), this is a machine-managed consent record: leaving
+        // a prior acceptance's value stale would false-abort the next recurring
+        // exchange after a legitimate re-consent to a changed disclosure. A surgical
+        // one-field write; undefined (an older or metadata-unknown mint) removes the
+        // field so the exchange reconciles lazily, an empty set is a strict "receive
+        // nothing". The fresh-config paths persist the same set via their own write.
+        persistExpectedPayloadColumns(
+          configPath,
+          ready.token.disclosedPayloadColumns,
+        );
         log.info(
           `reused the existing configuration at ${configPath}; it already matches ` +
             "the invitation, so the connection and linkage settings are unchanged.",
         );
-      else if (ready.seeded)
+      } else if (ready.seeded)
         log.info(
           `wrote config to ${configPath}, seeding the connection block from the ` +
             "invitation's endpoint; review it and add your own credentials " +

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -925,6 +925,65 @@ export function persistDisclosedPayloadColumns(
   writeFileOwnerOnly(configPath, serialized);
 }
 
+/**
+ * Write, overwrite, or remove the top-level `expected_payload_columns` in an
+ * existing `psilink.yaml`. This is the RECEIVE-side consent lock-in (the
+ * PARTNER's column namespace): the disclosed subset the operator consented to on
+ * the acceptance it just made, which a later recurring `psilink exchange` holds
+ * the received payload to ({@link reconcileReceivedPayload} in core).
+ *
+ * Used by the offline accept-reuse path, which keeps the operator's existing
+ * config rather than rewriting it. Like {@link persistDisclosedPayloadColumns}
+ * -- its send-side twin -- and unlike {@link saveConfig}, which re-serializes the
+ * whole spec and would strip comments, this edits the file in place through the
+ * YAML document model so the operator's comments, key order, and formatting
+ * survive: the lock-in is one machine-managed field, not operator prose. Binding
+ * this write to the accept-reuse path is what keeps the consent record from going
+ * stale relative to what the operator consented to on the latest acceptance (a
+ * re-accept over a changed disclosed set refreshes it here; an exchange with no
+ * re-accept keeps the prior lock-in).
+ *
+ * `columns === undefined` REMOVES the field (deleteIn), never leaves a stale
+ * value: an acceptance whose invitation carried no disclosed subset (an older or
+ * metadata-unknown mint) records no consented set (the exchange reconciles
+ * lazily), so any lock-in previously recorded must be cleared rather than
+ * silently retained. An empty array is written verbatim -- a strict "receive
+ * nothing" consent, distinct from absent.
+ *
+ * The columns are the partner's (token-derived), non-secret, but the file is
+ * rewritten with the same owner-only permissions {@link saveConfig} uses (a
+ * config may carry an SFTP credential). The key is written snake_case to match
+ * the on-disk convention. Throws if the file cannot be read or parsed -- the
+ * caller has just reconciled the same file, so a failure here is unexpected and
+ * must not be silently swallowed (it would leave the operator believing the
+ * lock-in was refreshed).
+ */
+export function persistExpectedPayloadColumns(
+  configPath: string,
+  columns: string[] | undefined,
+): void {
+  // Parse, edit, and re-serialize through the sensitive-file chokepoint (see
+  // persistHostKeyFingerprint), preserving the operator's comments and key order
+  // on this surgical one-field write.
+  const serialized = editSensitiveYamlDocument(
+    fs.readFileSync(configPath, "utf8"),
+    `config file ${configPath}`,
+    (doc) => {
+      if (columns === undefined) {
+        // No consented subset on record for this acceptance: remove any stale
+        // field rather than leave a value the latest consent no longer backs.
+        doc.deleteIn(["expected_payload_columns"]);
+        return;
+      }
+      // createNode turns the JS array into a proper YAML sequence node (a bare
+      // value is not reliably wrapped by setIn across versions); setIn creates or
+      // overwrites the single top-level key, leaving everything else untouched.
+      doc.setIn(["expected_payload_columns"], doc.createNode(columns));
+    },
+  );
+  writeFileOwnerOnly(configPath, serialized);
+}
+
 // --- Config reader -----------------------------------------------------------
 
 /**

--- a/apps/cli/test/unit/accept.test.ts
+++ b/apps/cli/test/unit/accept.test.ts
@@ -6,10 +6,13 @@ import { Readable } from "node:stream";
 import { afterEach, expect, test, vi } from "vitest";
 import type { Arguments } from "yargs";
 import logLibrary from "loglevel";
+import YAML from "yaml";
 import {
   encodeInvitation,
   getDefaultLinkageTerms,
   getLogger,
+  parseExchangeSpec,
+  reconcileReceivedPayload,
   UsageError,
 } from "@psilink/core";
 import type {
@@ -1446,6 +1449,173 @@ test("handler: online accept forwards the token's disclosed set to runOnlineBoot
     exit.mockRestore();
     // Module-level mock: reset so no later test inherits this call/impl.
     runOnlineBootstrapMock.mockReset();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- handler: offline accept-reuse refreshes the received-payload lock-in -----
+
+/**
+ * Run the offline accept handler over a pre-existing config, with
+ * --consent-to-terms so the confirmation prompt is skipped (its own tests cover
+ * the prompt gate). The token carries `disclosed`, the disclosed subset the
+ * operator consents to on this acceptance. Returns the config file's raw text and
+ * the exit spy so the caller can assert the on-disk refresh.
+ */
+async function runOfflineAcceptReuse(params: {
+  configFile: string;
+  input: string;
+  disclosed: string[] | undefined;
+}): Promise<string> {
+  const exit = vi
+    .spyOn(process, "exit")
+    .mockImplementation((() => undefined) as never);
+  try {
+    const encoded = await encodeInvitation({
+      ...sampleToken(FUTURE()),
+      disclosedPayloadColumns: params.disclosed,
+    });
+    await acceptHandler({
+      _: [],
+      $0: "psilink",
+      args: [encoded, params.input],
+      "consent-to-terms": true,
+      "config-file": params.configFile,
+      "key-file": path.join(path.dirname(params.configFile), ".psilink.key"),
+      "log-level": "silent",
+      record: false,
+    } as unknown as Arguments);
+    expect(exit).not.toHaveBeenCalled();
+    return fs.readFileSync(params.configFile, "utf8");
+  } finally {
+    exit.mockRestore();
+  }
+}
+
+test("handler: offline accept-reuse refreshes a stale lock-in, preserving operator content", async () => {
+  // A reused config carrying an OLD consented set is re-accepted over an invitation
+  // whose disclosed subset changed. The surgical refresh overwrites the stale
+  // value, preserving the operator's connection block, linkage terms, and a
+  // hand-authored comment.
+  const { dir, input, configFile } = offlineAcceptFixture();
+  try {
+    // A config whose linkage terms agree with the invitation's defaults (so it
+    // reconciles for reuse), then a hand-authored comment and a stale lock-in
+    // appended so the surgical write has operator content to preserve.
+    writeExistingConfig(configFile);
+    fs.appendFileSync(
+      configFile,
+      "# operator-authored note\nexpected_payload_columns:\n  - old_col\n",
+    );
+    const raw = await runOfflineAcceptReuse({
+      configFile,
+      input,
+      disclosed: ["diagnosis", "notes"],
+    });
+    // The operator's comment and connection block survive the surgical write.
+    expect(raw).toContain("# operator-authored note");
+    expect(raw).toContain("/mnt/share");
+    expect(raw).not.toContain("old_col");
+    const parsed = parseExchangeSpec(YAML.parse(raw));
+    expect(parsed.expectedPayloadColumns).toEqual(["diagnosis", "notes"]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("handler: offline accept-reuse fixes the false-abort a stale lock-in would have caused", async () => {
+  // The end-to-end failure this task closes. Before the refresh the config holds
+  // the partner's OLD disclosed set; the partner now discloses a new set, so a
+  // recurring exchange's reconcileReceivedPayload would abort the honest exchange.
+  // After the re-accept the config holds the NEW set, so the same reconcile passes;
+  // asserting the stale set would have thrown proves the config actually changed
+  // the outcome.
+  const { dir, input, configFile } = offlineAcceptFixture();
+  try {
+    writeExistingConfig(configFile);
+    // Seed the stale lock-in the operator originally consented to.
+    fs.appendFileSync(configFile, "expected_payload_columns:\n  - old_col\n");
+    const staleSpec = parseExchangeSpec(
+      YAML.parse(fs.readFileSync(configFile, "utf8")),
+    );
+    expect(staleSpec.expectedPayloadColumns).toEqual(["old_col"]);
+
+    const raw = await runOfflineAcceptReuse({
+      configFile,
+      input,
+      disclosed: ["diagnosis", "notes"],
+    });
+    const refreshedSpec = parseExchangeSpec(YAML.parse(raw));
+    // What the partner actually transmits now: its new disclosed set.
+    const partnerPayload = {
+      columns: ["diagnosis", "notes"],
+      rowIndices: [],
+      rows: [],
+    };
+    // The refreshed lock-in matches the partner's transmission -> no abort.
+    expect(() =>
+      reconcileReceivedPayload(
+        partnerPayload,
+        refreshedSpec.expectedPayloadColumns,
+      ),
+    ).not.toThrow();
+    // The stale lock-in would have aborted the same honest exchange.
+    expect(() =>
+      reconcileReceivedPayload(
+        partnerPayload,
+        staleSpec.expectedPayloadColumns,
+      ),
+    ).toThrow(/payload disclosure mismatch/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("handler: offline accept-reuse removes the lock-in when the invitation carries no disclosed subset", async () => {
+  // A re-accept whose invitation carried no disclosed subset (an older or
+  // metadata-unknown mint) records no consented set: the prior lock-in is cleared
+  // so the recurring exchange reconciles lazily, not left stale.
+  const { dir, input, configFile } = offlineAcceptFixture();
+  try {
+    writeExistingConfig(configFile);
+    fs.appendFileSync(configFile, "expected_payload_columns:\n  - old_col\n");
+    const raw = await runOfflineAcceptReuse({
+      configFile,
+      input,
+      disclosed: undefined,
+    });
+    expect(raw).not.toContain("expected_payload_columns");
+    expect(raw).not.toContain("old_col");
+    const parsed = parseExchangeSpec(YAML.parse(raw));
+    expect(parsed.expectedPayloadColumns).toBeUndefined();
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("handler: offline accept-reuse writes an empty consented set verbatim (strict receive-nothing)", async () => {
+  // An empty disclosed subset is a real consent ("receive nothing"), distinct from
+  // absent: it must be written as an empty list so a later non-empty payload aborts.
+  const { dir, input, configFile } = offlineAcceptFixture();
+  try {
+    writeExistingConfig(configFile);
+    fs.appendFileSync(configFile, "expected_payload_columns:\n  - old_col\n");
+    const raw = await runOfflineAcceptReuse({
+      configFile,
+      input,
+      disclosed: [],
+    });
+    expect(raw).not.toContain("old_col");
+    const parsed = parseExchangeSpec(YAML.parse(raw));
+    expect(parsed.expectedPayloadColumns).toEqual([]);
+    // Strict "receive nothing": any transmitted column aborts.
+    expect(() =>
+      reconcileReceivedPayload(
+        { columns: ["diagnosis"], rowIndices: [], rows: [] },
+        parsed.expectedPayloadColumns,
+      ),
+    ).toThrow(/payload disclosure mismatch/);
+  } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/apps/cli/test/unit/config.test.ts
+++ b/apps/cli/test/unit/config.test.ts
@@ -18,6 +18,7 @@ import {
   formatReconcileDiffs,
   loadConfigLinkageSource,
   persistDisclosedPayloadColumns,
+  persistExpectedPayloadColumns,
   persistHostKeyFingerprint,
   saveConfig,
 } from "../../src/config";
@@ -1259,6 +1260,169 @@ test("persistDisclosedPayloadColumns does not echo an inline credential via an u
   let caught: unknown;
   try {
     persistDisclosedPayloadColumns(configPath, ["notes"]);
+  } catch (err) {
+    caught = err;
+  }
+  expect(caught).toBeInstanceOf(UsageError);
+  expect((caught as Error).message).toContain(
+    "could not be serialized as YAML",
+  );
+  expect((caught as Error).message).not.toContain(SECRET);
+  expect(fs.readFileSync(configPath, "utf8")).toContain(`*${SECRET}`);
+});
+
+// --- persistExpectedPayloadColumns -------------------------------------------
+
+test("persistExpectedPayloadColumns adds the field and preserves comments and other fields", () => {
+  const configPath = path.join(dir, "psilink.yaml");
+  fs.writeFileSync(
+    configPath,
+    [
+      "# hand-authored config",
+      "connection:",
+      "  channel: sftp",
+      "  server:",
+      "    host: sftp.example.org # the drop",
+      "",
+    ].join("\n"),
+  );
+  persistExpectedPayloadColumns(configPath, ["diagnosis", "notes"]);
+  const raw = fs.readFileSync(configPath, "utf8");
+  // Operator comments and other fields survive the surgical write.
+  expect(raw).toContain("# hand-authored config");
+  expect(raw).toContain("host: sftp.example.org # the drop");
+  const parsed = YAML.parse(raw) as {
+    expected_payload_columns: string[];
+  };
+  expect(parsed.expected_payload_columns).toEqual(["diagnosis", "notes"]);
+});
+
+test("persistExpectedPayloadColumns refreshes a stale value (the accept-reuse fix)", () => {
+  // A config carrying an OLD consented set, re-accepted over a changed disclosed
+  // subset: the field must be overwritten to the newly-consented set, never left
+  // stale (else the next recurring exchange false-aborts against a set the partner
+  // no longer discloses).
+  const configPath = path.join(dir, "psilink.yaml");
+  fs.writeFileSync(
+    configPath,
+    [
+      "connection:",
+      "  channel: sftp",
+      "  server:",
+      "    host: h",
+      "expected_payload_columns:",
+      "  - old_col",
+      "",
+    ].join("\n"),
+  );
+  persistExpectedPayloadColumns(configPath, ["new_col"]);
+  const raw = fs.readFileSync(configPath, "utf8");
+  expect(raw).not.toContain("old_col");
+  const parsed = YAML.parse(raw) as { expected_payload_columns: string[] };
+  expect(parsed.expected_payload_columns).toEqual(["new_col"]);
+});
+
+test("persistExpectedPayloadColumns removes the field when the consented set is undefined", () => {
+  // A re-accept whose invitation carried no disclosed subset records no consented
+  // set, so a previously-recorded lock-in must be cleared, not retained stale --
+  // the exchange then reconciles lazily.
+  const configPath = path.join(dir, "psilink.yaml");
+  fs.writeFileSync(
+    configPath,
+    [
+      "connection:",
+      "  channel: sftp",
+      "  server:",
+      "    host: h",
+      "expected_payload_columns:",
+      "  - old_col",
+      "",
+    ].join("\n"),
+  );
+  persistExpectedPayloadColumns(configPath, undefined);
+  const raw = fs.readFileSync(configPath, "utf8");
+  expect(raw).not.toContain("expected_payload_columns");
+  expect(raw).not.toContain("old_col");
+  // The rest of the config is intact.
+  const parsed = YAML.parse(raw) as {
+    connection: { channel: string };
+    expected_payload_columns?: string[];
+  };
+  expect(parsed.connection.channel).toBe("sftp");
+  expect(parsed.expected_payload_columns).toBeUndefined();
+});
+
+test("persistExpectedPayloadColumns writes an empty array verbatim (strict receive-nothing)", () => {
+  // Empty is a real consent ("receive nothing"), distinct from absent; it must be
+  // written, not dropped.
+  const configPath = path.join(dir, "psilink.yaml");
+  fs.writeFileSync(
+    configPath,
+    "connection:\n  channel: sftp\n  server:\n    host: h\n",
+  );
+  persistExpectedPayloadColumns(configPath, []);
+  const raw = fs.readFileSync(configPath, "utf8");
+  const parsed = YAML.parse(raw) as { expected_payload_columns: string[] };
+  expect(parsed.expected_payload_columns).toEqual([]);
+});
+
+test("persistExpectedPayloadColumns writes the config owner-read-only (0600)", () => {
+  if (process.platform === "win32") return;
+  const configPath = path.join(dir, "psilink.yaml");
+  fs.writeFileSync(
+    configPath,
+    "connection:\n  channel: sftp\n  server:\n    host: h\n",
+  );
+  persistExpectedPayloadColumns(configPath, ["diagnosis"]);
+  expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+});
+
+test("persistExpectedPayloadColumns throws (not silently) on a malformed config", () => {
+  const configPath = path.join(dir, "psilink.yaml");
+  fs.writeFileSync(configPath, "connection: [unbalanced\n");
+  // Classified as a local usage error (exit 64), like persistDisclosedPayloadColumns,
+  // not a bare Error that would fall through to the generic exit code.
+  expect(() =>
+    persistExpectedPayloadColumns(configPath, ["diagnosis"]),
+  ).toThrow(UsageError);
+});
+
+test("persistExpectedPayloadColumns does not echo an inline credential on a malformed config", () => {
+  // Parity with persistDisclosedPayloadColumns: a syntax error's message embeds a
+  // snippet of the offending source; the shared path-only guard must not echo it,
+  // or an inline credential near the malformed line leaks into the (logged) error.
+  const SECRET = "S3cr3tSFTPPassw0rd";
+  const configPath = path.join(dir, "psilink.yaml");
+  fs.writeFileSync(
+    configPath,
+    `connection:\n  server:\n\t  password: ${SECRET}\n`,
+  );
+  let caught: unknown;
+  try {
+    persistExpectedPayloadColumns(configPath, ["diagnosis"]);
+  } catch (err) {
+    caught = err;
+  }
+  expect(caught).toBeInstanceOf(UsageError);
+  expect((caught as Error).message).toContain("could not be parsed as YAML");
+  expect((caught as Error).message).not.toContain(SECRET);
+});
+
+test("persistExpectedPayloadColumns does not echo an inline credential via an unresolved alias", () => {
+  // Parity with persistDisclosedPayloadColumns: an unresolved alias clears
+  // doc.errors and setIn succeeds; the failure surfaces only at doc.toString(),
+  // whose message echoes the alias token. The path-only guard at serialization must
+  // not echo it, and the original file must be left untouched (the throw precedes
+  // the write).
+  const SECRET = "S3cr3tSFTPPassw0rd";
+  const configPath = path.join(dir, "psilink.yaml");
+  fs.writeFileSync(
+    configPath,
+    `connection:\n  channel: sftp\n  server:\n    password: *${SECRET}\n`,
+  );
+  let caught: unknown;
+  try {
+    persistExpectedPayloadColumns(configPath, ["diagnosis"]);
   } catch (err) {
     caught = err;
   }


### PR DESCRIPTION
## Summary

The CLI's offline accept-reuse path never rewrote the receive-side consent lock-in (expected_payload_columns) into the reused config, so a re-accept where the partner changed only its disclosed payload set left the stale lock-in and the next recurring exchange false-aborted. The reuse branch now refreshes the lock-in with exactly the disclosed subset the operator just re-consented to, via a surgical writer that mirrors the existing disclosed-columns writer.

Implements [207446006](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=207446006).

## Changes

- apps/cli/src/config.ts: persistExpectedPayloadColumns, the receive-side twin of persistDisclosedPayloadColumns -- same editSensitiveYamlDocument chokepoint, owner-only atomic write, fail-closed on unparseable YAML, undefined-removes / empty-array-verbatim semantics.
- apps/cli/src/commands/accept.ts: call the writer on the offline reuse branch, strictly after the consent gate, passing the token's disclosed set.
- apps/cli/test/unit/config.test.ts, accept.test.ts: the writer's surgical-preservation and fail-closed coverage mirrored from the twin, plus handler-level tests that a changed set refreshes the lock-in, an unchanged set is a no-op, and the false-abort scenario is fixed in both directions.

## Test plan

Ran: root `npm run test` (core 2173, cli 1185, web 1332); `npm run typecheck && npm run lint && npm run format`. The SFTP integration suite is CI-only in this container.
New tests cover: stale-lock-in refresh with operator-content preservation, the false-abort scenario proven both directions (stale set aborts, refreshed set passes), subset-removes and empty-verbatim semantics, owner-only permissions, and no credential echo on malformed YAML or unresolved alias.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: this fixes the offline accept-reuse path to honor the already-documented expected_payload_columns consent-lock-in semantics; no documented behavior changed
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: a bug fix to consent-lock-in persistence, not a major feature or breaking change
- [x] Security review -- focused review of the consent-fidelity envelope: the write is reachable only strictly after the operator consented to this invitation's terms and writes exactly the displayed disclosed subset, the writer matches its twin's fail-closed / owner-only / no-credential-echo guarantees, the reuse-branch config and key writes cannot tear or race, and no other check keys off the old value; NO FINDINGS