### PR TITLE
Carry disclosed columns into exchange file

### DIFF
--- a/apps/web/src/bench/saveExchangeModel.ts
+++ b/apps/web/src/bench/saveExchangeModel.ts
@@ -1,5 +1,3 @@
-import { disclosedColumnNames } from "@psilink/core";
-
 import type {
   ConnectionEndpointRequest,
   GeneratedInvitation,
@@ -250,13 +248,10 @@ export function exchangeFileInputFor(
     ...(invitation.standardization !== undefined
       ? { standardization: invitation.standardization }
       : {}),
-    // The token's disclosed set is disclosedColumnNames over the same metadata
-    // the invitation mint used (or the inferred metadata on the quick path);
-    // deriving it here from that metadata keeps the file's commitment identical
-    // to the token's.
-    ...(invitation.metadata !== undefined
-      ? { disclosedPayloadColumns: disclosedColumnNames(invitation.metadata) }
-      : {}),
+    // The token's own published set (including the strict empty set), so the
+    // persisted send-side commitment is the one the token carries -- never a
+    // re-derivation that could drift from it.
+    disclosedPayloadColumns: invitation.disclosedPayloadColumns,
   };
 }
 

--- a/apps/web/test/unit/benchSaveExchangeModel.test.ts
+++ b/apps/web/test/unit/benchSaveExchangeModel.test.ts
@@ -23,8 +23,12 @@ const terms = {
 } as unknown as LinkageTerms;
 
 // Two columns, one disclosed (`program_code`, isPayload) and one match-only
-// (`dob`): the disclosed set the exchange file's commitment must equal is
-// exactly the disclosed subset (see disclosedColumnNames / isDisclosedToPartner).
+// (`dob`): disclosedColumnNames(metadata) is exactly ["program_code"]. The
+// stub's own disclosedPayloadColumns is deliberately a DIFFERENT set
+// (["case_number"], not a payload column in this metadata at all) so a test
+// asserting against it can only pass on a verbatim pass-through of the
+// invitation's field -- a re-derivation via disclosedColumnNames(metadata)
+// would produce ["program_code"] instead and fail.
 const metadata = [
   { name: "program_code", role: "payload", isPayload: true },
   { name: "dob", role: "match", isPayload: false },
@@ -43,7 +47,7 @@ function invitationStub(
     columns: ["program_code", "dob"],
     metadata,
     standardization: undefined,
-    disclosedPayloadColumns: ["program_code"],
+    disclosedPayloadColumns: ["case_number"],
     ...overrides,
   };
 }
@@ -191,10 +195,22 @@ describe("endpoint and config derive from one locator", () => {
       path: "/exchanges/psilink",
     });
     // The config's terms, metadata, and disclosed set are read off the same
-    // minted invitation the code came from -- config and token agree.
+    // minted invitation the code came from -- config and token agree. The
+    // disclosed set equals the STUB's own field (["case_number"]), not
+    // disclosedColumnNames(metadata) (["program_code"]): this only holds
+    // under a verbatim pass-through of invitation.disclosedPayloadColumns.
     expect(input.linkageTerms).toBe(terms);
     expect(input.metadata).toBe(metadata);
-    expect(input.disclosedPayloadColumns).toEqual(["program_code"]);
+    expect(input.disclosedPayloadColumns).toEqual(["case_number"]);
+  });
+
+  test("an empty disclosed set is carried through, not omitted", () => {
+    const input = exchangeFileInputFor(
+      "sftp",
+      sftpFields,
+      invitationStub({ disclosedPayloadColumns: [] }),
+    );
+    expect(input.disclosedPayloadColumns).toEqual([]);
   });
 
   test("an empty remote directory is omitted, not sent as an empty path", () => {


### PR DESCRIPTION
## Summary

The CLI-transport save surface re-derived the disclosed payload set from metadata when minting the downloadable exchange file, instead of consuming the set the minted invitation already carries. This carries `GeneratedInvitation.disclosedPayloadColumns` through verbatim, so the persisted send-side commitment is the token's own set by identity of source rather than a second derivation that could drift from it. No divergence is possible today (the save surface is reached only from the AdvancedInvite editor, whose metadata is always present), so this is robustness against future change.

Implements [213389526](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=213389526).

## Changes

- `apps/web/src/bench/saveExchangeModel.ts`: `exchangeFileInputFor` carries `invitation.disclosedPayloadColumns` verbatim (including the strict empty set) and no longer calls `disclosedColumnNames`; dropped the now-unused import.
- `apps/web/test/unit/benchSaveExchangeModel.test.ts`: reshaped the fixture so the stub's `disclosedPayloadColumns` diverges from `disclosedColumnNames(metadata)`, so the test fails on a re-derivation and passes only on a pass-through; added empty-set coverage.

## Test plan

Ran: `npx vitest run apps/web/test/unit/benchSaveExchangeModel.test.ts` (14 passing). Verified fail-then-pass: with the fix stashed, the reshaped and empty-set assertions both fail against the re-derivation.
New tests cover: the persisted disclosed set equals the invitation's field by identity of source (a divergent stub proves pass-through, not re-derivation), and an empty disclosed set is carried, not omitted.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; `docs/spec/FILE_SYNC.md`'s "every mint path persists that same subset" invariant still holds, now sourced once instead of twice.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: internal robustness refactor, not a major feature or breaking change.
- [x] Security review -- reviewed: replaces a re-derivation with the invitation's own committed disclosedPayloadColumns, so the persisted set cannot diverge from or exceed the token's; it does not change what is disclosed.
