### PR TITLE
Read parsed CSV rows by own property

### DIFF
--- a/apps/web/src/components/StandardizationPreview.tsx
+++ b/apps/web/src/components/StandardizationPreview.tsx
@@ -12,6 +12,7 @@ import {
 
 import {
   checkValueConstraints,
+  readRowColumn,
   runPipeline,
   sanitizeForDisplay,
 } from "@psilink/core";
@@ -46,9 +47,10 @@ function sampleInputValues(
 ): Array<string> {
   const values: Array<string> = [];
   for (const row of rawRows) {
-    // A short row may lack the column, so the read is honestly `string | undefined`
-    // (CSVRow's value type); the absence check below handles it.
-    const raw = row[inputColumn];
+    // Read by own-property so a short row lacking the column reads as absent even
+    // when the column is named an Object.prototype member (readRowColumn); a bare
+    // row[inputColumn] would surface the inherited function past the check below.
+    const raw = readRowColumn(row, inputColumn);
     if (raw !== undefined && raw.trim() !== "") {
       values.push(raw);
       if (values.length >= limit) break;

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -220,6 +220,28 @@ function releaseSource(detachGuard: () => void, source: StreamSource): void {
 export type CSVRow = Record<string, string | undefined>;
 
 /**
+ * Read one column's value from a parsed {@link CSVRow} by name, returning
+ * `undefined` when the row omits that column.
+ *
+ * A parsed row is a plain object, so `row[column]` for a column the row lacks
+ * walks the prototype chain: a column named exactly an `Object.prototype` member
+ * (`toString`, `valueOf`, `constructor`, `hasOwnProperty`, ...) would read the
+ * INHERITED function rather than `undefined`, and that non-string value slips
+ * past a nullish/undefined guard into standardization, the transmitted payload,
+ * and the on-disk table. A short row omitting such a column is the realistic
+ * trigger (a malformed but operator-local CSV). An own-property check
+ * ({@link Object.hasOwn}) reads a missing column as absent regardless of the
+ * prototype chain, so every by-name row read must go through here rather than
+ * index `row[column]` directly.
+ *
+ * @internal used across the core row consumers (standardization, payload
+ * extraction, date inference); not a supported public entry point.
+ */
+export function readRowColumn(row: CSVRow, column: string): string | undefined {
+  return Object.hasOwn(row, column) ? row[column] : undefined;
+}
+
+/**
  * Normalize one raw PapaParse row to a {@link CSVRow}, dropping any non-string
  * cell -- in practice the `__parsed_extra` array PapaParse attaches to a row longer
  * than the header -- so every retained value is a genuine string. A row that is

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -75,6 +75,7 @@ export {
   loadCSVFile,
   loadCSVColumns,
   loadCSVColumnSample,
+  readRowColumn,
   CSV_LINE_BYTE_CEILING,
 } from "./file";
 export type { CSVRow } from "./file";

--- a/packages/core/src/payloadExchange.ts
+++ b/packages/core/src/payloadExchange.ts
@@ -8,6 +8,7 @@ import {
 } from "./config/metadata.js";
 import type { Payload } from "./config/linkageTerms.js";
 import { MAX_NAME_LENGTH } from "./config/linkageTerms.js";
+import { readRowColumn } from "./file.js";
 import type { CSVRow } from "./file.js";
 import type { CommittedPayload } from "./exchangeRecord.js";
 import type { MessageConnection } from "./connection/messageConnection.js";
@@ -149,9 +150,12 @@ export function preparePayload(
 
   const columns = payloadCols.map((col) => col.name);
   const rowIndices = [...associationTable[0]];
-  const rows = rowIndices.map((idx) =>
-    columns.map((col) => rawRows[idx]?.[col] ?? null),
-  );
+  const rows = rowIndices.map((idx) => {
+    const row = rawRows[idx];
+    return columns.map((col) =>
+      row ? (readRowColumn(row, col) ?? null) : null,
+    );
+  });
 
   return { hasData: true, columns, rowIndices, rows };
 }
@@ -621,11 +625,10 @@ export function buildOutputTable(
 
   const rows = associationTable[0].map((ourIdx, i) => {
     const theirIdx = associationTable[1][i];
-    const ourId = quoteCsvField(
-      ourIdCol
-        ? (rawRows[ourIdx]?.[ourIdCol.name] ?? String(ourIdx))
-        : String(ourIdx),
-    );
+    const ourRow = rawRows[ourIdx];
+    const ourIdValue =
+      ourIdCol && ourRow ? readRowColumn(ourRow, ourIdCol.name) : undefined;
+    const ourId = quoteCsvField(ourIdValue ?? String(ourIdx));
     const partnerIndexCell = quoteCsvField(String(theirIdx));
 
     if (!hasPartnerCols) {

--- a/packages/core/src/recordVerification.ts
+++ b/packages/core/src/recordVerification.ts
@@ -1,4 +1,5 @@
 import { computeTermsHash, verifyCommitmentOpening } from "./exchangeRecord.js";
+import { readRowColumn } from "./file.js";
 
 import type {
   CommitmentName,
@@ -301,7 +302,7 @@ export function reconstructCommittedData(
     idToRow = new Map();
     let anyDuplicate = false;
     inputRows.forEach((row, index) => {
-      const value = row[ourIdColumn];
+      const value = readRowColumn(row, ourIdColumn);
       if (value === undefined) return;
       if (idToRow!.has(value)) anyDuplicate = true;
       else idToRow!.set(value, index);
@@ -358,9 +359,12 @@ export function reconstructCommittedData(
       ? { columns: [], rows: [] }
       : {
           columns: sentColumns,
-          rows: ourIndices.map((index) =>
-            sentColumns.map((column) => inputRows[index]?.[column] ?? null),
-          ),
+          rows: ourIndices.map((index) => {
+            const row = inputRows[index];
+            return sentColumns.map((column) =>
+              row ? (readRowColumn(row, column) ?? null) : null,
+            );
+          }),
         };
   data.localPayloadSent = localPayloadSent as CanonicalValue;
 

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -27,6 +27,7 @@ import {
 } from "./config/linkageTerms.js";
 import { inferMetadata } from "./config/metadata.js";
 import type { ColumnMetadata } from "./config/metadata.js";
+import { readRowColumn } from "./file.js";
 import type { CSVRow } from "./file.js";
 
 const logger = getLogger("cleaning");
@@ -1071,7 +1072,7 @@ export class StandardizedField {
     if (cached !== undefined) return cached;
 
     const row = this.rawRows[index];
-    const raw = row?.[this.inputColumn];
+    const raw = row ? readRowColumn(row, this.inputColumn) : undefined;
     if (raw === undefined) {
       this.cache.set(index, []);
       return [];

--- a/packages/core/src/utils/date.ts
+++ b/packages/core/src/utils/date.ts
@@ -1,5 +1,6 @@
 import { DateTime } from "luxon";
 
+import { readRowColumn } from "../file.js";
 import type { CSVRow } from "../file.js";
 
 /**
@@ -129,5 +130,5 @@ export function* columnValues(
   rows: Iterable<CSVRow>,
   column: string,
 ): Generator<string> {
-  for (const row of rows) yield row[column] ?? "";
+  for (const row of rows) yield readRowColumn(row, column) ?? "";
 }

--- a/packages/core/test/file.test.ts
+++ b/packages/core/test/file.test.ts
@@ -10,6 +10,7 @@ import {
   loadCSVFile,
 } from "../src/file";
 import { inferDateFormat, columnValues } from "../src/utils/date";
+import type { CSVRow } from "../src/file";
 
 /** A readable emitting `content` then EOF, standing in for a CSV file/stream. */
 function streamOf(content: string): Readable {
@@ -154,6 +155,26 @@ test("loadCSVColumnSample: the bounded sample reproduces a full-scan date format
   const fromFull = inferDateFormat(columnValues(allRows, "dob"));
   expect(fromSample).toBe("YYYY-MM-DD");
   expect(fromSample).toBe(fromFull);
+});
+
+test("columnValues: a short row omitting a prototype-member column yields the empty-string absent marker, not the inherited function", () => {
+  // The column is named exactly an Object.prototype member and the row omits it:
+  // a bare row[column] would yield the INHERITED function, which inferDateFormat
+  // (expecting a string) would then trip over. The own-property read yields the
+  // "" absent marker instead. Test one present row and one short row so the
+  // present value still flows through.
+  const rows: CSVRow[] = [{ toString: "1990-01-01" }, { other: "x" }];
+  const values = [...columnValues(rows, "toString")];
+  expect(values).toEqual(["1990-01-01", ""]);
+  for (const value of values) expect(typeof value).toBe("string");
+});
+
+test("columnValues: a present prototype-member column yields its real value", () => {
+  const rows = [{ constructor: "1990-01-01" }, { constructor: "1990-01-02" }];
+  expect([...columnValues(rows, "constructor")]).toEqual([
+    "1990-01-01",
+    "1990-01-02",
+  ]);
 });
 
 test("loadCSVColumnSample: an empty input yields an empty header and sample", async () => {

--- a/packages/core/test/payloadExchange.test.ts
+++ b/packages/core/test/payloadExchange.test.ts
@@ -100,6 +100,38 @@ test("preparePayload: missing column value becomes null", () => {
   expect(result.rows[0]).toEqual(["P0", null]);
 });
 
+test("preparePayload: a short row omitting a prototype-member column sends null, not the inherited function", () => {
+  // A payload column named exactly an Object.prototype member, omitted by a short
+  // row: a bare row[col] would read the INHERITED function off the prototype chain
+  // and transmit it to the partner. The own-property read sends null instead.
+  const metaProto: Metadata = [
+    { name: "ssn", type: "ssn", role: "linkage", isPayload: false },
+    { name: "toString", type: "other", role: "payload", isPayload: true },
+    { name: "constructor", type: "other", role: "payload", isPayload: true },
+  ];
+  const sparse = [{ ssn: "001" }]; // omits both 'toString' and 'constructor'
+  const result = preparePayload(sparse, metaProto, [[0], [0]]);
+  if (!result.hasData) throw new Error("expected hasData:true");
+  expect(result.columns).toEqual(["toString", "constructor"]);
+  expect(result.rows[0]).toEqual([null, null]);
+  for (const cell of result.rows[0])
+    expect(typeof cell === "string" || cell === null).toBe(true);
+});
+
+test("preparePayload: a present prototype-member column sends its real value", () => {
+  // The shadowing guard must not swallow a real value: a row that DOES carry a
+  // 'toString' column transmits that value verbatim.
+  const metaProto: Metadata = [
+    { name: "ssn", type: "ssn", role: "linkage", isPayload: false },
+    { name: "toString", type: "other", role: "payload", isPayload: true },
+  ];
+  const rows = [{ ssn: "001", toString: "real-value" }];
+  const result = preparePayload(rows, metaProto, [[0], [0]]);
+  if (!result.hasData) throw new Error("expected hasData:true");
+  expect(result.columns).toEqual(["toString"]);
+  expect(result.rows[0]).toEqual(["real-value"]);
+});
+
 test("preparePayload: ignored column is never transmitted, even with isPayload:true", () => {
   // The role: ignored opt-out wins over isPayload (accept-but-ignore resolution
   // of the is_payload + ignored open question). diagnosis is a normal payload
@@ -149,6 +181,61 @@ test("buildOutputTable: an ignored column is not treated as the identifier", () 
     partnerPayload,
   );
   expect(headers[0]).toBe("row_id");
+});
+
+test("buildOutputTable: a short row omitting a prototype-member identifier column falls back to the row index, not the inherited function", () => {
+  // The identifier column is named exactly an Object.prototype member and the
+  // matched row omits it: a bare rawRows[ourIdx]?.[ourIdCol.name] would read the
+  // INHERITED function and write it into the on-disk identifier cell. The own-
+  // property read falls back to String(ourIdx) as it does for any absent column.
+  const metaProtoId: Metadata = [
+    { name: "ssn", type: "ssn", role: "linkage", isPayload: false },
+    {
+      name: "toString",
+      type: "identifier",
+      role: "identifier",
+      isPayload: false,
+    },
+  ];
+  const sparse = [{ ssn: "001" }]; // omits the 'toString' identifier column
+  const partnerPayload: PartnerPayload = {
+    columns: ["partner_id"],
+    rowIndices: [0],
+    rows: [["Q0"]],
+  };
+  const { headers, rows } = buildOutputTable(
+    [[0], [0]],
+    sparse,
+    metaProtoId,
+    partnerPayload,
+  );
+  expect(headers[0]).toBe("toString");
+  expect(rows[0][0]).toBe("0");
+});
+
+test("buildOutputTable: a present prototype-member identifier column emits its real value", () => {
+  const metaProtoId: Metadata = [
+    { name: "ssn", type: "ssn", role: "linkage", isPayload: false },
+    {
+      name: "toString",
+      type: "identifier",
+      role: "identifier",
+      isPayload: false,
+    },
+  ];
+  const rows = [{ ssn: "001", toString: "real-id" }];
+  const partnerPayload: PartnerPayload = {
+    columns: ["partner_id"],
+    rowIndices: [0],
+    rows: [["Q0"]],
+  };
+  const { rows: outRows } = buildOutputTable(
+    [[0], [0]],
+    rows,
+    metaProtoId,
+    partnerPayload,
+  );
+  expect(outRows[0][0]).toBe("real-id");
 });
 
 // --- assertPayloadSendDisclosed ----------------------------------------------

--- a/packages/core/test/recordReconstruction.test.ts
+++ b/packages/core/test/recordReconstruction.test.ts
@@ -185,6 +185,65 @@ describe("reconstructCommittedData round-trips through the real build path", () 
     expect(report.commitments.localPayloadSent).toBe("verified");
   });
 
+  test("a short row omitting a prototype-member payload column reconstructs null, not the inherited function", async () => {
+    // A payload column named exactly an Object.prototype member ('toString'),
+    // omitted by a short input row: the send side (preparePayload) commits null,
+    // so reconstruction must read the same absent value. A bare inputRows[i]?.[col]
+    // would read the INHERITED function off the prototype chain, reconstructing a
+    // different byte than was committed -- a spurious localPayloadSent mismatch on a
+    // legitimate exchange. The own-property read reproduces the committed null.
+    const protoMeta: Metadata = [
+      { name: "pid", type: "ssn", role: "identifier", isPayload: false },
+      { name: "toString", type: "other", role: "payload", isPayload: true },
+    ];
+    const sparseRows: CSVRow[] = [{ pid: "P0" }, { pid: "P1" }]; // omit 'toString'
+    const partnerPayload: PartnerPayload = {
+      columns: ["note"],
+      rowIndices: [0],
+      rows: [["s-0"]],
+    };
+    const { report } = await roundTrip({
+      rawRows: sparseRows,
+      metadata: protoMeta,
+      associationTable: [[0], [0]],
+      partnerPayload,
+      ourIdColumn: "pid",
+    });
+    expect(report.outcome).toBe("verified");
+    expect(report.commitments.localPayloadSent).toBe("verified");
+  });
+
+  test("short rows omitting a prototype-member identifier column raise no spurious duplicate warning", async () => {
+    // Two input rows omit the 'toString' identifier column. A bare row[ourIdColumn]
+    // reads the SAME inherited prototype function for each, so the id-to-row map
+    // sees a repeated "value" and warns of a duplicate identifier that does not
+    // exist. The own-property read treats each omitting row as having no identifier
+    // (undefined), so no spurious duplicate warning is raised.
+    const protoIdMeta: Metadata = [
+      { name: "toString", type: "ssn", role: "identifier", isPayload: false },
+      { name: "dose", type: "first_name", role: "payload", isPayload: true },
+    ];
+    const rows: CSVRow[] = [
+      { toString: "P0", dose: "10mg" },
+      { dose: "20mg" }, // omits the 'toString' identifier column
+      { dose: "30mg" }, // also omits it -- same inherited value under a bare read
+    ];
+    const partnerPayload: PartnerPayload = {
+      columns: ["note"],
+      rowIndices: [0],
+      rows: [["s-0"]],
+    };
+    const { report, warnings } = await roundTrip({
+      rawRows: rows,
+      metadata: protoIdMeta,
+      associationTable: [[0], [0]],
+      partnerPayload,
+      ourIdColumn: "toString",
+    });
+    expect(warnings.some((w) => w.includes("duplicate"))).toBe(false);
+    expect(report.outcome).toBe("verified");
+  });
+
   test("warns, and fails to open, when a re-supplied input misses an identifier", async () => {
     // Reconstruct against an input whose identifier values do not cover the
     // result: the reconstruction warns and the affected commitments do not open.

--- a/packages/core/test/standardization.test.ts
+++ b/packages/core/test/standardization.test.ts
@@ -1249,6 +1249,39 @@ describe("StandardizedField", () => {
     expect(field.get(0)).toEqual([]);
   });
 
+  test("short row omitting a prototype-member input column reads as absent, not the inherited function", () => {
+    // The input column is named exactly an Object.prototype member and the row
+    // omits it: a bare row[inputColumn] would read the INHERITED function off the
+    // prototype chain, which then flows into the pipeline where a string is
+    // expected. The own-property read excludes the record instead.
+    for (const proto of [
+      "toString",
+      "valueOf",
+      "constructor",
+      "hasOwnProperty",
+    ]) {
+      const field = new StandardizedField(
+        "last_name",
+        proto,
+        [],
+        [{ other: "x" }],
+      );
+      expect(field.get(0)).toEqual([]);
+    }
+  });
+
+  test("present prototype-member input column standardizes its real value", () => {
+    // The shadowing guard must not swallow a real value: a row carrying a
+    // 'toString' column standardizes that value as any other column would.
+    const field = new StandardizedField(
+      "last_name",
+      "toString",
+      [{ function: "to_upper_case" }],
+      [{ toString: "smith" }],
+    );
+    expect(field.get(0)).toEqual(["SMITH"]);
+  });
+
   test("out-of-bounds index returns empty array (excluded from linkage)", () => {
     const field = new StandardizedField(
       "last_name",


### PR DESCRIPTION
## Summary

Reading a parsed CSV row by a computed column name returned an inherited `Object.prototype` member (`toString`, `valueOf`, ...) when a short row omitted a column whose name matched that member, because the nullish and undefined guards do not catch an inherited function. That value could flow into standardization, the payload sent to the partner, the on-disk result table, and receipt reconstruction -- where a send-vs-reconstruct divergence produced a spurious verification mismatch. Read rows by own property so a missing column always reads absent.

Implements [207394749](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=207394749).

## Changes

- `packages/core/src/file.ts`, `main.ts`: add and export `readRowColumn(row, col)`, an own-property (`Object.hasOwn`) read.
- `packages/core/src/standardization.ts`, `payloadExchange.ts`, `utils/date.ts`, `recordVerification.ts`: route every by-name row read through the helper, preserving each site's absent marker; the reconstruction reads now reproduce the committed bytes.
- `apps/web/src/components/StandardizationPreview.tsx`: the one web by-name read audited.
- Tests across `packages/core/test/` pin the prototype-member-column plus short-row case at each read path.

## Test plan

Ran: `npm test -w packages/core` and the full root `npm run test` (core 2215, cli 1199, web 1332) -- all green. Each new negative test fails against the un-hardened reads (verified by reverting them).
New tests cover: a short row omitting a `toString`-named (and other prototype-member-named) column reads absent at `StandardizedField.get`, `preparePayload`, `buildOutputTable`, `columnValues`, and receipt reconstruction; a legitimately-named present column still reads its value.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; this is defense-in-depth on an operator-local input.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: bug fix / hardening, not a major feature or breaking change.
- [x] Security review -- done: an independent security review covered the payload-extraction and receipt-verification read paths and confirmed the own-property reads preserve each absent marker and restore send-vs-reconstruct byte consistency; the input is operator-local, so this is integrity/robustness, not a disclosure vector.
