### PR TITLE
Warn the inviter on a dead linkage key

### DIFF
--- a/apps/web/src/bench/KeysTab.tsx
+++ b/apps/web/src/bench/KeysTab.tsx
@@ -25,9 +25,28 @@ import { TermsImportExport } from "@components/TermsImportExport";
 import { declaredFieldsFor, keySatisfiabilityFor } from "./inviterModel";
 import styles from "./bench.module.css";
 
-import type { AcquiredCsv, InviterEditor } from "./inviterModel";
+import type { AcquiredCsv, InviterEditor, KeyVerdict } from "./inviterModel";
 import type { Algorithm, LinkageStrategy, LinkageTerms } from "@psilink/core";
 import type { AdvancedInviteDraft } from "@psi/advancedInvite";
+
+/** The guided-list badge copy and CSS class for each per-key verdict
+ * ({@link KeyVerdict}). A dead key warns ("review", amber) rather than blocking:
+ * its columns resolve but a self-defeating transform would run it to a silent
+ * empty result, so the author is nudged to fix the terms. */
+const KEY_VERDICT_BADGES: Record<
+  KeyVerdict,
+  {
+    label: string;
+    className: "keyBadgeSatisfiable" | "keyBadgeUnsatisfiable" | "keyBadgeDead";
+  }
+> = {
+  satisfiable: { label: "satisfiable", className: "keyBadgeSatisfiable" },
+  unsatisfiable: {
+    label: "not satisfiable",
+    className: "keyBadgeUnsatisfiable",
+  },
+  dead: { label: "review", className: "keyBadgeDead" },
+};
 
 /**
  * The Matching keys tab: the guided ordered key list (enable + reorder, with
@@ -69,10 +88,7 @@ export function KeysTab({
   announce: (message: string) => void;
   onBack: () => void;
 }) {
-  const keyIsSatisfiable = useMemo(
-    () => keySatisfiabilityFor(editor),
-    [editor],
-  );
+  const keyVerdict = useMemo(() => keySatisfiabilityFor(editor), [editor]);
   const declaredFields = useMemo(
     () => declaredFieldsFor(editor.draft),
     [editor.draft],
@@ -96,7 +112,7 @@ export function KeysTab({
       <ol className={styles.guidedKeys} aria-describedby="bench-key-order-help">
         {editor.draft.keys.map((entry, index) => {
           const displayName = sanitizeForDisplay(entry.key.name);
-          const satisfiable = keyIsSatisfiable(index);
+          const badge = KEY_VERDICT_BADGES[keyVerdict(index)];
           return (
             <li key={entry.key.name}>
               <Checkbox
@@ -109,13 +125,9 @@ export function KeysTab({
                     Key {index + 1} -{" "}
                     <span className={styles.mono}>{displayName}</span>
                     <span
-                      className={
-                        satisfiable
-                          ? `${styles.keyBadge} ${styles.keyBadgeSatisfiable}`
-                          : `${styles.keyBadge} ${styles.keyBadgeUnsatisfiable}`
-                      }
+                      className={`${styles.keyBadge} ${styles[badge.className]}`}
                     >
-                      {satisfiable ? "satisfiable" : "not satisfiable"}
+                      {badge.label}
                     </span>
                   </>
                 }
@@ -161,7 +173,7 @@ export function KeysTab({
         <ExpertKeyEditor
           draft={editor.draft}
           declaredFields={declaredFields}
-          keyIsSatisfiable={keyIsSatisfiable}
+          keyVerdict={keyVerdict}
           fuzzyApplied={APPLIED_SETTINGS.fuzzyComparisons}
           onChange={onAuthoredDraft}
           announce={announce}

--- a/apps/web/src/bench/KeysTab.tsx
+++ b/apps/web/src/bench/KeysTab.tsx
@@ -30,14 +30,15 @@ import type { Algorithm, LinkageStrategy, LinkageTerms } from "@psilink/core";
 import type { AdvancedInviteDraft } from "@psi/advancedInvite";
 
 /** The guided-list badge copy and CSS class for each per-key verdict
- * ({@link KeyVerdict}). A dead key warns ("review", amber) rather than blocking:
- * its columns resolve but a self-defeating transform would run it to a silent
- * empty result, so the author is nudged to fix the terms. */
+ * ({@link KeyVerdict}). A dead key warns ("won't match", amber) rather than
+ * blocking: its columns resolve but a self-defeating transform would run it to
+ * a silent empty result, so the author is nudged to fix the terms. */
 const KEY_VERDICT_BADGES: Record<
   KeyVerdict,
   {
     label: string;
     className: "keyBadgeSatisfiable" | "keyBadgeUnsatisfiable" | "keyBadgeDead";
+    ariaLabel?: string;
   }
 > = {
   satisfiable: { label: "satisfiable", className: "keyBadgeSatisfiable" },
@@ -45,7 +46,12 @@ const KEY_VERDICT_BADGES: Record<
     label: "not satisfiable",
     className: "keyBadgeUnsatisfiable",
   },
-  dead: { label: "review", className: "keyBadgeDead" },
+  dead: {
+    label: "won't match",
+    className: "keyBadgeDead",
+    ariaLabel:
+      "This key's cleaning can never produce a value; review the transform",
+  },
 };
 
 /**
@@ -126,6 +132,9 @@ export function KeysTab({
                     <span className={styles.mono}>{displayName}</span>
                     <span
                       className={`${styles.keyBadge} ${styles[badge.className]}`}
+                      {...(badge.ariaLabel
+                        ? { role: "img", "aria-label": badge.ariaLabel }
+                        : {})}
                     >
                       {badge.label}
                     </span>

--- a/apps/web/src/bench/bench.module.css
+++ b/apps/web/src/bench/bench.module.css
@@ -567,6 +567,11 @@
   border: 1px solid var(--bench-danger);
 }
 
+.keyBadgeDead {
+  color: var(--bench-warn);
+  border: 1px solid var(--bench-warn);
+}
+
 .movers {
   display: inline-flex;
   gap: 6px;

--- a/apps/web/src/bench/inviterModel.ts
+++ b/apps/web/src/bench/inviterModel.ts
@@ -3,6 +3,7 @@ import {
   authoredLinkageFields,
   disclosedColumnNames,
   getDefaultLinkageTerms,
+  pipelineAlwaysDrops,
 } from "@psilink/core";
 
 import {
@@ -472,20 +473,42 @@ export function declaredFieldsFor(
   return authoredLinkageFields(draft.metadata, draft.standardization);
 }
 
-/** Per-key satisfiability for the guided list's and expert editor's badges:
- * whether the columns can produce every field the key references. */
+/**
+ * A per-key verdict for the guided list's and expert editor's badges. Three
+ * outcomes, because a shape-satisfiable key can still be self-defeating:
+ * - `satisfiable`: every element field is producible and no element's transform
+ *   is value-killing.
+ * - `dead`: the columns can produce every element field (shape passes), but an
+ *   element's authored standardization can never yield a value -- a
+ *   self-defeating `parse_date` whose input format omits a component the data
+ *   carries. The key would run to a silent empty result, so it warns even though
+ *   the shape check passes.
+ * - `unsatisfiable`: an element references a field the columns cannot produce.
+ *
+ * `dead` is derived from the authored terms alone (value-independent, via
+ * {@link pipelineAlwaysDrops}), consistent with how the shape verdict is
+ * computed without data. It matches the acceptor surface, whose `deadKeyCount`
+ * counts the same self-defeating keys.
+ */
+export type KeyVerdict = "satisfiable" | "dead" | "unsatisfiable";
+
+/** The per-key verdict function behind the Keys tab badges ({@link KeyVerdict}). */
 export function keySatisfiabilityFor(
   editor: InviterEditor,
-): (index: number) => boolean {
+): (index: number) => KeyVerdict {
   const producible = producibleFieldNames(
     editor.draft.metadata,
     editor.draft.standardization,
     editor.seed.columns,
   );
-  return (index) =>
-    editor.draft.keys[index].key.elements.every((element) =>
-      producible.has(element.field),
-    );
+  return (index) => {
+    const key = editor.draft.keys[index].key;
+    if (!key.elements.every((element) => producible.has(element.field)))
+      return "unsatisfiable";
+    if (key.elements.some((element) => pipelineAlwaysDrops(element.transform)))
+      return "dead";
+    return "satisfiable";
+  };
 }
 
 /** Discard every edit and re-derive the recommended draft from the file,

--- a/apps/web/src/components/ExpertKeyEditor.tsx
+++ b/apps/web/src/components/ExpertKeyEditor.tsx
@@ -47,6 +47,33 @@ import type {
 } from "@psilink/core";
 
 import type { AdvancedInviteDraft, FuzzyComparison } from "@psi/advancedInvite";
+import type { KeyVerdict } from "@bench/inviterModel";
+
+/** The expert-editor badge copy and Mantine color for each per-key verdict
+ * ({@link KeyVerdict}), reading consistently with the guided list. A dead key is
+ * warn-only (amber "review"): its columns resolve, but a self-defeating transform
+ * would run the key to a silent empty result. */
+const KEY_VERDICT_BADGES: Record<
+  KeyVerdict,
+  { label: string; color: string; ariaLabel: string }
+> = {
+  satisfiable: {
+    label: "satisfiable",
+    color: "green",
+    ariaLabel: "Your columns can satisfy this key",
+  },
+  unsatisfiable: {
+    label: "not satisfiable",
+    color: "red",
+    ariaLabel: "Your columns cannot satisfy this key",
+  },
+  dead: {
+    label: "review",
+    color: "yellow",
+    ariaLabel:
+      "This key's cleaning can never produce a value; review the transform",
+  },
+};
 
 /** The fuzzy-comparison expansions an element can declare, with plain-language
  * labels. The control is rendered only when the run applies fuzzy comparisons (see
@@ -83,7 +110,7 @@ function elementIdentifier(element: LinkageKeyElement): string {
 export function ExpertKeyEditor({
   draft,
   declaredFields,
-  keyIsSatisfiable,
+  keyVerdict,
   fuzzyApplied,
   onChange,
   announce,
@@ -91,8 +118,9 @@ export function ExpertKeyEditor({
   draft: AdvancedInviteDraft;
   /** The fields a key element may reference, in offer order (metadata-derived). */
   declaredFields: Array<LinkageField>;
-  /** Whether the inviter's columns can satisfy the key at this index. */
-  keyIsSatisfiable: (keyIndex: number) => boolean;
+  /** The per-key badge verdict at this index ({@link KeyVerdict}): satisfiable,
+   * unsatisfiable (a missing field), or dead (a self-defeating transform). */
+  keyVerdict: (keyIndex: number) => KeyVerdict;
   /** Whether the run applies fuzzy comparisons; when false the per-element fuzzy
    * control is hidden rather than shown disabled. */
   fuzzyApplied: boolean;
@@ -248,7 +276,7 @@ export function ExpertKeyEditor({
           // placeholder when it is blank so the toggle is never an empty target.
           const keyDisplayName =
             keyLabel.trim() === "" ? "Unnamed key" : keyLabel;
-          const satisfiable = keyIsSatisfiable(keyIndex);
+          const badge = KEY_VERDICT_BADGES[keyVerdict(keyIndex)];
           const keyId = idFor(keyIds.current, key);
           const keyOpen = expandedKeys.has(keyId);
           const keyBodyId = `key-body-${keyId}`;
@@ -301,15 +329,11 @@ export function ExpertKeyEditor({
                     <Badge
                       size="xs"
                       variant="light"
-                      color={satisfiable ? "green" : "red"}
+                      color={badge.color}
                       role="img"
-                      aria-label={
-                        satisfiable
-                          ? "Your columns can satisfy this key"
-                          : "Your columns cannot satisfy this key"
-                      }
+                      aria-label={badge.ariaLabel}
                     >
-                      {satisfiable ? "satisfiable" : "not satisfiable"}
+                      {badge.label}
                     </Badge>
                     <ActionIcon
                       variant="subtle"

--- a/apps/web/src/components/ExpertKeyEditor.tsx
+++ b/apps/web/src/components/ExpertKeyEditor.tsx
@@ -51,8 +51,8 @@ import type { KeyVerdict } from "@bench/inviterModel";
 
 /** The expert-editor badge copy and Mantine color for each per-key verdict
  * ({@link KeyVerdict}), reading consistently with the guided list. A dead key is
- * warn-only (amber "review"): its columns resolve, but a self-defeating transform
- * would run the key to a silent empty result. */
+ * warn-only (amber "won't match"): its columns resolve, but a self-defeating
+ * transform would run the key to a silent empty result. */
 const KEY_VERDICT_BADGES: Record<
   KeyVerdict,
   { label: string; color: string; ariaLabel: string }
@@ -68,7 +68,7 @@ const KEY_VERDICT_BADGES: Record<
     ariaLabel: "Your columns cannot satisfy this key",
   },
   dead: {
-    label: "review",
+    label: "won't match",
     color: "yellow",
     ariaLabel:
       "This key's cleaning can never produce a value; review the transform",

--- a/apps/web/test/browser/expertKeyEditor.test.ts
+++ b/apps/web/test/browser/expertKeyEditor.test.ts
@@ -15,6 +15,7 @@ import { seedAdvancedInvite } from "@psi/advancedInvite";
 
 import { ExpertKeyEditor } from "@components/ExpertKeyEditor";
 
+import type { KeyVerdict } from "@bench/inviterModel";
 import type { Root } from "react-dom/client";
 
 // A file carrying every default linkage column, so the seed keeps the full key set
@@ -58,7 +59,7 @@ function render() {
       createElement(ExpertKeyEditor, {
         draft,
         declaredFields,
-        keyIsSatisfiable: () => true,
+        keyVerdict: (): KeyVerdict => "satisfiable",
         fuzzyApplied: false,
         onChange: () => undefined,
         announce: () => undefined,

--- a/apps/web/test/browser/keysTab.test.ts
+++ b/apps/web/test/browser/keysTab.test.ts
@@ -1,0 +1,114 @@
+/// <reference types="@vitest/browser-playwright/context" />
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { page } from "vitest/browser";
+
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+
+import { MantineProvider } from "@mantine/core";
+
+import { editorFromCsv, editorWithAuthoredDraft } from "@bench/inviterModel";
+
+import { KeysTab } from "@bench/KeysTab";
+
+import type { AcquiredCsv } from "@bench/inviterModel";
+import type { Root } from "react-dom/client";
+
+// A minimal file carrying a date_of_birth column, so the seeded default keys
+// include one built from it (the element the dead-key transform below targets).
+const csv: AcquiredCsv = {
+  fileName: "clients.csv",
+  sizeBytes: 1024,
+  rawRows: [
+    {
+      client_id: "1",
+      first_name: "Ann",
+      last_name: "Lee",
+      dob: "01/02/1990",
+      ssn4: "1234",
+    },
+  ],
+  columns: ["client_id", "first_name", "last_name", "dob", "ssn4"],
+};
+
+// Author a self-defeating parse_date onto the date_of_birth element of the
+// first key: input_format "MM/DD" has no year, so every record's element
+// resolves empty and the whole key runs to a silent empty result -- the same
+// dead-key construction the model-level tests in benchInviterModel.test.ts use.
+function withDeadDobKey(editor: ReturnType<typeof editorFromCsv>) {
+  const keys = editor.draft.keys.map((entry, index) => {
+    if (index !== 0) return entry;
+    const elements = entry.key.elements.map((element) =>
+      element.field === "date_of_birth"
+        ? {
+            ...element,
+            transform: [
+              { function: "parse_date", params: { inputFormat: "MM/DD" } },
+            ],
+          }
+        : element,
+    );
+    return { ...entry, key: { ...entry.key, elements } };
+  });
+  return editorWithAuthoredDraft(editor, { ...editor.draft, keys });
+}
+
+let container: HTMLElement | undefined;
+let root: Root | undefined;
+
+function render() {
+  const editor = withDeadDobKey(editorFromCsv("Dana Okafor", csv));
+  root!.render(
+    createElement(
+      MantineProvider,
+      null,
+      createElement(KeysTab, {
+        editor,
+        csv,
+        expertMode: false,
+        onExpertMode: () => undefined,
+        onKeyEnabled: () => undefined,
+        onKeyMoved: () => undefined,
+        onAuthoredDraft: () => undefined,
+        onStrategy: () => undefined,
+        onAlgorithm: () => undefined,
+        onDeduplicate: () => undefined,
+        onImport: () => undefined,
+        keysError: undefined,
+        announce: () => undefined,
+        onBack: () => undefined,
+      }),
+    ),
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  root?.unmount();
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+describe("KeysTab: the guided-list dead-key badge", () => {
+  test('reads "won\'t match" and carries an explanatory aria-label', async () => {
+    render();
+
+    await expect
+      .element(page.getByRole("heading", { name: "Matching keys" }))
+      .toBeInTheDocument();
+
+    const badge = page.getByRole("img", {
+      name: "This key's cleaning can never produce a value; review the transform",
+    });
+    await expect.element(badge).toBeInTheDocument();
+    await expect.element(badge).toHaveTextContent("won't match");
+  });
+});

--- a/apps/web/test/unit/benchInviterModel.test.ts
+++ b/apps/web/test/unit/benchInviterModel.test.ts
@@ -730,9 +730,11 @@ describe("customize tabs", () => {
     expect(imported.keysAuthored).toBe(true);
     const disabled = imported.draft.keys.filter((entry) => !entry.enabled);
     expect(disabled.length).toBeGreaterThan(0);
-    const satisfiable = keySatisfiabilityFor(imported);
+    const verdict = keySatisfiabilityFor(imported);
     expect(
-      imported.draft.keys.some((_entry, index) => !satisfiable(index)),
+      imported.draft.keys.some(
+        (_entry, index) => verdict(index) === "unsatisfiable",
+      ),
     ).toBe(true);
     expect(reviewValidation(imported).canGenerate).toBe(true);
   });
@@ -911,5 +913,66 @@ describe("a column retype reconciles standardization even with authored keys", (
     // are demonstrably distinct.
     const guided = retypeFirstNameToLastName(seeded);
     expect(keyNames(guided)).not.toEqual(keyNames(seeded));
+  });
+});
+
+describe("per-key dead-key verdict on the authoring surface", () => {
+  // Author a self-defeating parse_date on a key element: input_format "MM/DD"
+  // has no year, so parseDate drops every record for that element and the whole
+  // key runs to a silent empty result. The columns still produce the field
+  // (shape passes), so the shape check alone would pass it -- the dead check is
+  // what catches it. The transform is authored onto the key ELEMENT (what the
+  // expert editor edits), not the field standardization.
+  function withDeadDobKey(
+    editor: ReturnType<typeof editorFromCsv>,
+    keyIndex: number,
+  ): ReturnType<typeof editorFromCsv> {
+    const keys = editor.draft.keys.map((entry, at) => {
+      if (at !== keyIndex) return entry;
+      const elements = entry.key.elements.map((element) =>
+        element.field === "date_of_birth"
+          ? {
+              ...element,
+              transform: [
+                { function: "parse_date", params: { inputFormat: "MM/DD" } },
+              ],
+            }
+          : element,
+      );
+      return { ...entry, key: { ...entry.key, elements } };
+    });
+    return editorWithAuthoredDraft(editor, { ...editor.draft, keys });
+  }
+
+  test("a value-killing parse_date flags the key dead, not unsatisfiable", () => {
+    const editor = editorFromCsv("Dana", csv);
+    // Key 0 (SSN4 + LN + DOB) carries a date_of_birth element the columns supply.
+    const dead = withDeadDobKey(editor, 0);
+    const verdict = keySatisfiabilityFor(dead);
+    expect(verdict(0)).toBe("dead");
+  });
+
+  test("a routine key is satisfiable, never flagged dead", () => {
+    const editor = editorFromCsv("Dana", csv);
+    const verdict = keySatisfiabilityFor(editor);
+    // Every recommended key passes cleanly on the default setup: no new warning.
+    for (const [index] of editor.draft.keys.entries())
+      expect(verdict(index)).toBe("satisfiable");
+  });
+
+  test("the dead verdict is scoped to the self-defeating key alone", () => {
+    const editor = editorFromCsv("Dana", csv);
+    const dead = withDeadDobKey(editor, 0);
+    const verdict = keySatisfiabilityFor(dead);
+    // Only the authored key is dead; its siblings keep their satisfiable badge.
+    for (const [index] of dead.draft.keys.entries())
+      expect(verdict(index)).toBe(index === 0 ? "dead" : "satisfiable");
+  });
+
+  test("a dead key does not block the mint gate (warn-only)", () => {
+    const editor = editorFromCsv("Dana", csv);
+    const dead = withDeadDobKey(editor, 0);
+    // The block gate is unchanged: a dead key warns but never hard-blocks Create.
+    expect(reviewValidation(dead).canGenerate).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

An inviter authoring a linkage key whose `parse_date` element can never produce a value got no warning; the dead-key signal core already computes was surfaced only to the acceptor. Surface it on the inviter's Keys-tab authoring surface as a per-key verdict, warn-only, so the author catches the dead key where it is written rather than via the acceptor or an empty result.

Implements [205071551](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=205071551).

## Changes

- `apps/web/src/bench/inviterModel.ts`: `keySatisfiabilityFor` returns a three-way verdict (satisfiable / dead / unsatisfiable), adding a per-key dead check via core's `pipelineAlwaysDrops`.
- `apps/web/src/bench/KeysTab.tsx`, `apps/web/src/components/ExpertKeyEditor.tsx`, `apps/web/src/bench/bench.module.css`: render a dead key as an amber "won't match" badge with an explanatory aria-label on both surfaces, distinct from the red "not satisfiable" verdict; the mint gate is unchanged.
- Unit and component tests for the verdict and the badge.

## Test plan

Ran: `npm run test:unit -w apps/web` (1336) and the affected browser tests (local Chromium) -- all green.
New tests cover: an authored value-killing `parse_date` flags the key dead (not unsatisfiable) while a routine key does not; a dead key does not newly block the mint gate; the guided-list badge carries the role and aria-label and reads "won't match".

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no documented behavior changed; an additive inviter-side warning surface.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: UI refinement mirroring the existing acceptor warning, not a headline feature or breaking change.
- [x] Security review -- n/a: web UI only; a dead key narrows matching with no disclosure, and the block gate is unchanged.
