### PR TITLE
Keep an emitted terminal authoritative on job exit

### DIFF
--- a/apps/web/src/jobs/jobManager.ts
+++ b/apps/web/src/jobs/jobManager.ts
@@ -537,15 +537,19 @@ export class JobManager {
     this.clearCancelTimers(record);
     this.releaseSftpRemoteForRecord(record);
 
-    if (state.outcome === "succeeded") record.status = "succeeded";
-    else if (state.outcome === "cancelled") record.status = "cancelled";
-    else record.status = "failed";
-
+    // An already-emitted terminal is authoritative: a job failed on buffer
+    // overflow signals SIGKILL, and if the child's own clean exit is observed
+    // before that kill lands, this exit outcome must not overwrite the failed
+    // status the overflow already committed.
     if (record.terminalEmitted) {
       record.terminalAt = record.terminalAt ?? Date.now();
       this.scheduleEviction(record);
       return;
     }
+
+    if (state.outcome === "succeeded") record.status = "succeeded";
+    else if (state.outcome === "cancelled") record.status = "cancelled";
+    else record.status = "failed";
 
     if (state.outcome === "cancelled") {
       this.synthesizeTerminal(record, {

--- a/apps/web/test/unit/jobManager.unit.test.ts
+++ b/apps/web/test/unit/jobManager.unit.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, test, vi } from "vitest";
 
+import * as cliDriver from "@jobs/cliDriver";
 import {
   JobManager,
   SftpRemoteBusyError,
@@ -24,6 +25,7 @@ import {
 } from "../utils/jobFixtures";
 
 import type { BufferedEvent, JobRecord } from "@jobs/jobManager";
+import type { CliDriverHandlers } from "@jobs/cliDriver";
 import type { JobSftpRemotesTable } from "@jobs/sftpRemotes";
 
 vi.mock("@jobs/workdir", { spy: true });
@@ -260,6 +262,48 @@ describe("event cap fails the job", () => {
     const terminal = record.events[record.events.length - 1].event;
     expect(terminal.type).toBe("error");
     expect(String(terminal.message)).toContain("buffer cap");
+  });
+
+  test("a clean child exit after overflow does not revert the failed status", async () => {
+    // The overflow fails the job and signals SIGKILL, but the exit reconciliation
+    // races that kill: if the child's own exit-0 close is observed first, the
+    // succeeded outcome must not overwrite the failed status the overflow set. The
+    // spawn is stubbed so both edges fire in the losing order with no timing luck.
+    let handlers!: CliDriverHandlers;
+    const spy = vi
+      .spyOn(cliDriver, "spawnExchangeJob")
+      .mockImplementation((args) => {
+        handlers = args.handlers;
+        return { signal: () => true, isRunning: () => true };
+      });
+
+    const root = tempDataRoot("overflow-exit-race");
+    roots.push(root);
+    const manager = new JobManager({
+      dataRoot: root,
+      binaryPath: STUB_CLI_PATH,
+      eventBufferCap: 3,
+    });
+    managers.push(manager);
+
+    const id = await manager.createJob(validIntent());
+    const record = manager.getJob(id)!;
+    for (let i = 0; i < 5; i++)
+      handlers.onEvent({
+        v: 1,
+        type: "stage",
+        id: `s${i}`,
+        label: `stage ${i}`,
+      });
+    expect(record.status).toBe("failed");
+
+    handlers.onTerminal({ outcome: "succeeded", exitCode: 0, signal: null });
+    expect(record.status).toBe("failed");
+    const terminal = record.events[record.events.length - 1].event;
+    expect(terminal.type).toBe("error");
+    expect(String(terminal.message)).toContain("buffer cap");
+
+    spy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

A job failed by the event-buffer overflow backstop could report `succeeded` on the status route: the child's own clean exit-0 raced the overflow's `SIGKILL`, and the exit-driven status derivation overwrote the already-committed `failed`. This makes an emitted terminal authoritative so a failed job's status can no longer be reverted by a later child exit, and pins the ordering with a timing-free regression test.

Implements [213034483](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=213034483).

## Changes

- apps/web/src/jobs/jobManager.ts: in `reconcileTerminal`, move the exit-outcome status derivation after the `terminalEmitted` early-return, so an emitted terminal (the overflow-synthesized failure, or the CLI's own terminal) stands and a racing clean exit cannot flip status back to succeeded.
- apps/web/test/unit/jobManager.unit.test.ts: add a deterministic pin -- a clean child exit after overflow does not revert the failed status.

## Test plan

Ran: `npx vitest run apps/web/test/unit/jobManager.unit.test.ts` -- the overflow test was 40/40 green under sustained CPU load (previously ~3/8 flaky), and the new pin fails against the unfixed ordering. Full web unit suite (1338 tests) passes.
New tests cover: an emitted overflow-failure terminal is not reverted to succeeded by a subsequent clean child-exit reconciliation.

## Background

The root cause is an ordering race that only loses under load. docs/spec/SERVER_JOB_API.md already specifies this contract: on buffer overflow the job is failed (SIGKILL, synthesized error terminal, status failed), and an emitted terminal stands over a synthesized one. Because the exit reconciliation ran before the emitted-terminal guard, a racing clean exit-0 violated "an emitted terminal stands". The fix reorders those two steps so the code conforms to the documented contract; no control is weakened.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- docs/spec/SERVER_JOB_API.md already documents this contract (overflow -> status failed; an emitted terminal stands, lines 205 and 220); the code now conforms, so no doc change is needed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: bug fix to job-status reconciliation, not a major feature or breaking change.
- [x] Security review -- independent security review of the status-disclosure invariant (a failed job never reports succeeded, traced through every status and download consumer); no findings.
