### PR TITLE
Document and test Windows owner-only ACLs

### DIFF
--- a/apps/cli/test/unit/fileUtils.test.ts
+++ b/apps/cli/test/unit/fileUtils.test.ts
@@ -1,6 +1,8 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { getLogger } from "@psilink/core";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
@@ -8,6 +10,7 @@ import {
   detectFileConflicts,
   expandTilde,
   FileExistsError,
+  warnIfFileOverPermissive,
   writeFileAtomic,
   writeFileOwnerOnly,
 } from "../../src/fileUtils";
@@ -380,6 +383,112 @@ describe("createOwnerOnlyWriteStream", () => {
     expect(openSpy).toHaveBeenCalledTimes(1);
     expect(openedFd).toBeDefined();
     expect(closeSpy).toHaveBeenCalledWith(openedFd);
+  });
+});
+
+// --- Windows owner-only ACL --------------------------------------------------
+
+// The current user's domain-qualified name (DOMAIN\user), the principal the
+// writers grant Modify and the only non-inherited ACE a narrowed file may carry.
+function currentWindowsUser(): string {
+  return execFileSync("whoami", [], { encoding: "utf8" }).trim();
+}
+
+// One parsed line of `icacls <file>` output: the principal and the raw flag/
+// rights token after the `:(` separator (e.g. "(I)(M)" or "(R)"). The first
+// line of icacls output echoes the path before the first ACE; the trailing
+// "Successfully processed" summary line has no `:(` and is skipped.
+type Ace = { principal: string; rights: string };
+
+function readAcl(filePath: string): Ace[] {
+  const output = execFileSync("icacls", [filePath], { encoding: "utf8" });
+  const echoed = filePath.replace(/\//g, "\\");
+  const aces: Ace[] = [];
+  for (const rawLine of output.split(/\r?\n/)) {
+    let line = rawLine;
+    if (line.startsWith(echoed)) line = line.slice(echoed.length).trimStart();
+    const trimmed = line.trim();
+    const sep = trimmed.indexOf(":(");
+    if (sep === -1) continue;
+    aces.push({
+      principal: trimmed.slice(0, sep).trim(),
+      rights: trimmed.slice(sep + 1),
+    });
+  }
+  return aces;
+}
+
+// True when the file's ACL grants only the current user, with no inherited (I)
+// ACE and no other explicit principal -- the owner-only state the writers must
+// produce. Deny ACEs are restrictive and ignored.
+function isOwnerOnly(filePath: string, owner: string): boolean {
+  const aces = readAcl(filePath);
+  if (aces.length === 0) return false;
+  return aces.every((ace) => {
+    if (ace.rights.includes("(DENY)")) return true;
+    if (ace.rights.includes("(I)")) return false;
+    return ace.principal.toLowerCase() === owner.toLowerCase();
+  });
+}
+
+describe("Windows owner-only ACL", () => {
+  test("each owner-only writer grants Modify to the current user only", async () => {
+    if (process.platform !== "win32") return;
+    const owner = currentWindowsUser();
+
+    const secret = path.join(dir, "secret");
+    writeFileOwnerOnly(secret, "x");
+    expect(isOwnerOnly(secret, owner)).toBe(true);
+    expect(readAcl(secret).some((a) => a.rights.includes("(M)"))).toBe(true);
+
+    const atomic = path.join(dir, "atomic");
+    writeFileAtomic(atomic, "x", 0o600);
+    expect(isOwnerOnly(atomic, owner)).toBe(true);
+
+    const streamed = path.join(dir, "streamed.csv");
+    await writeAndClose(createOwnerOnlyWriteStream(streamed), "a,b\n1,2\n");
+    expect(isOwnerOnly(streamed, owner)).toBe(true);
+    expect(readAcl(streamed).some((a) => a.rights.includes("(M)"))).toBe(true);
+  });
+
+  test("createOwnerOnlyWriteStream overwrite drops a foreign explicit ACE", async () => {
+    if (process.platform !== "win32") return;
+    const owner = currentWindowsUser();
+    const p = path.join(dir, "result.csv");
+
+    // Seed a pre-existing file carrying a foreign principal's explicit
+    // (non-inherited) grant, the ACE an in-place narrow would miss.
+    fs.writeFileSync(p, "stale\n");
+    execFileSync("icacls", [p, "/grant", "Guests:(R)"], { stdio: "ignore" });
+    expect(
+      readAcl(p).some((a) => a.principal.toLowerCase().includes("guests")),
+    ).toBe(true);
+
+    await writeAndClose(createOwnerOnlyWriteStream(p), "fresh\n");
+
+    // The fresh-inode recreation must have dropped the Guests ACE.
+    expect(
+      readAcl(p).some((a) => a.principal.toLowerCase().includes("guests")),
+    ).toBe(false);
+    expect(isOwnerOnly(p, owner)).toBe(true);
+  });
+
+  test("the load-time check warns on a loosened ACL and stays quiet on an owner-only file", () => {
+    if (process.platform !== "win32") return;
+    const p = path.join(dir, "secret");
+    writeFileOwnerOnly(p, "x");
+
+    const log = getLogger("file-utils");
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    // A correctly-narrowed file must not warn.
+    warnIfFileOverPermissive(p, "shared secret");
+    expect(warn).not.toHaveBeenCalled();
+
+    // Grant a foreign principal read, defeating owner-only; the next load warns.
+    execFileSync("icacls", [p, "/grant", "Guests:(R)"], { stdio: "ignore" });
+    warnIfFileOverPermissive(p, "shared secret");
+    expect(warn).toHaveBeenCalled();
   });
 });
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -216,6 +216,62 @@ stat -f "%Lp %N" .psilink.key  # macOS
 
 The output must show `600`. If it does not, the CLI will emit a warning on load; correct the permissions before proceeding.
 
+## Verifying Windows owner-only file protections
+
+On Windows the CLI protects its owner-only files with ACLs rather than POSIX mode bits, and no automated test leg runs on Windows. The checks below are a manual procedure to run on a Windows host to confirm the owner-only writers still narrow ACLs correctly after a change to their Windows branch. Run them in PowerShell from a scratch directory on an NTFS volume that carries the usual inheritable ACEs (a subdirectory of the user profile is fine); each check produces an artifact you then inspect. `$me` below is the domain-qualified account the CLI narrows the file to; derive it from `whoami`, the same call the CLI uses to name the grant principal, so the comparison matches the granted identity exactly (domain casing and NetBIOS form included).
+
+```powershell
+$me = (whoami)
+```
+
+Owner-only artifacts on Windows come from three writers: `writeFileOwnerOnly` (the key file, the config writer, exchange records, and the signing identity), `createOwnerOnlyWriteStream` (the result CSV), and `writeFileAtomic` for a file written with the owner-only mode. Produce one artifact from each by running the operations that use them: an exchange writes the result CSV and rotates the key file, `accept` writes the signing identity, and so on (see [CLI.md](CLI.md)). Each check assumes a file at `$f`.
+
+**A narrowed file grants Modify to the current user only, with no inherited or foreign non-owner ACE.** After a writer creates `$f`, its DACL must grant `Modify` to the current user and to no one else, and must not be inheriting from the parent directory:
+
+```powershell
+icacls $f
+# Expect one line granting the current user (M); no BUILTIN\Users, no (I)
+# inherited entries, no other principal.
+(Get-Acl $f).AreAccessRulesProtected   # must be True (inheritance stripped)
+(Get-Acl $f).Access | ForEach-Object {
+  "{0}  {1}  Inherited={2}" -f $_.IdentityReference, $_.FileSystemRights, $_.IsInherited
+}
+# Every rule must be IdentityReference = $me, FileSystemRights = Modify,
+# Inherited = False. Any other principal, or any Inherited = True rule, fails.
+```
+
+This is what `writeFileOwnerOnly`, `writeFileAtomic` (owner-only mode), and `createOwnerOnlyWriteStream` all produce: they run `icacls <file> /inheritance:r /grant:r "$me:(M)"`, which strips inheritance and replaces the DACL with the single owner Modify grant.
+
+**`createOwnerOnlyWriteStream`'s overwrite path drops a pre-existing foreign explicit ACE.** The stream writer unlinks and recreates the destination as a fresh inode before narrowing, so a foreign principal's explicit (non-inherited) grant left on a prior file at that path does not survive the overwrite. Seed such a grant on a stand-in file, overwrite it by writing a result CSV to the same path, and confirm the foreign grant is gone:
+
+```powershell
+# Seed a pre-existing file with an explicit grant for another principal
+# (Guests is present on a default install; substitute any non-owner account).
+"stale" | Out-File -Encoding utf8 $f
+icacls $f /grant "Guests:(R)"
+icacls $f    # confirm the Guests ACE is present before the overwrite
+
+# Now run an exchange whose result CSV output path is $f, then re-inspect:
+icacls $f
+# Expect only the current user (M); the Guests ACE must be absent. If it
+# survived, the fresh-inode overwrite regressed to an in-place narrow.
+```
+
+**The load-time over-permissive check flags a loosened ACL.** On load, before reading an owner-only secret (the key file or the signing identity), the CLI runs `warnIfFileOverPermissive`, which on Windows checks the ACL: first via PowerShell `Get-Acl` with SID translation (both inherited and explicit ACEs; SYSTEM and Administrators are exempt), falling back to `icacls` (explicit non-owner ACEs only) where PowerShell is unavailable. Loosen a correctly-narrowed key file and confirm the next CLI load warns:
+
+```powershell
+# Grant another principal read on the key file, defeating owner-only.
+icacls .psilink.key /grant "Guests:(R)"
+```
+
+Run a command that loads the key file (for example `psilink exchange`) and confirm it logs a warning that the file grants access to other users and should be restricted to owner-only. To confirm the `icacls` fallback tier (used where `Get-Acl` cannot run, such as a Nano Server container or a constrained-language environment), repeat with PowerShell unavailable on `PATH`; the warning must still fire. Restore owner-only afterward:
+
+```powershell
+icacls .psilink.key /inheritance:r /grant:r "$me:(M)"
+```
+
+A clean load emits no such warning, so absence of the warning after restoring the ACL confirms the check clears a correctly-narrowed file.
+
 ## See also
 
 - [COMMUNICATION.md](COMMUNICATION.md) - the communication channels and services described here


### PR DESCRIPTION
## Summary

The win32 branches of the CLI's owner-only file writers narrow ACLs via `icacls`, but no CI leg runs on Windows (the suite is macOS/Linux), so this forward-compatibility code can rot unnoticed. This adds a manual Windows verification procedure and win32-runnable unit assertions that exercise the three writers and the load-time over-permissive check, giving the ACL path a documented baseline and executable coverage a future Windows runner can run. It changes no production code.

Implements [200904211](https://github.com/orgs/georgetown-mdi/projects/10/views/1?pane=issue&itemId=200904211).

## Changes

- docs/DEPLOYMENT.md: add "Verifying Windows owner-only file protections" -- a PowerShell/`icacls`/`Get-Acl` procedure asserting owner-only Modify with inheritance stripped and no foreign ACE, the fresh-inode overwrite dropping a pre-existing foreign explicit ACE, and the load-time check flagging a loosened ACL. The principal is derived from `whoami` to match the identity the code actually grants.
- apps/cli/test/unit/fileUtils.test.ts: add win32-guarded tests mirroring those assertions (they skip cleanly off Windows), plus `icacls`-parsing helpers.

## Test plan

Ran: `npm test -w apps/cli` (unit project, 1202 tests) -- the three new win32-guarded tests skip cleanly on this Linux host.
New tests cover: on Windows, each owner-only writer produces an owner-only Modify DACL with inheritance stripped and no foreign ACE; `createOwnerOnlyWriteStream`'s overwrite drops a pre-existing foreign explicit ACE; `warnIfFileOverPermissive` warns on a loosened ACL. They are executable only on a Windows runner, so their correctness rests on fidelity to `apps/cli/src/fileUtils.ts`, which was independently reviewed.

## Background

Windows is a forward-compatibility ambition, not a current deployment target (the CLI ships as a Linux Docker image), so this is a bitrot guard, not an active security gap. The scope is deliberately the verification scaffolding only: no `windows-latest` CI leg and no change to the ACL logic itself.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- added "Verifying Windows owner-only file protections" to docs/DEPLOYMENT.md (an operational procedure, the correct tier); no docs/spec change, since this is not spec-level detail.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test and doc-only change, not a major feature or breaking change.
- [x] Security review -- independent security review confirming the documented and tested assertions faithfully match the win32 ACL writers and the load-time check in `fileUtils.ts` (which is unchanged); no findings.
