### PR TITLE
Tie the single-identifier error to its Type controls

### DIFF
--- a/apps/web/src/components/MetadataGrid.tsx
+++ b/apps/web/src/components/MetadataGrid.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 import { Select, Stack, Table, Text, VisuallyHidden } from "@mantine/core";
 
@@ -16,6 +16,8 @@ import {
 } from "@psi/metadataEditing";
 
 import { useDeferredAnnouncement } from "@components/useDeferredAnnouncement";
+
+import type { SelectProps } from "@mantine/core";
 
 import type { Metadata, SemanticType } from "@psilink/core";
 
@@ -37,6 +39,31 @@ const ANNOUNCE_DEBOUNCE_MS = 600;
  * announcement so the two cannot drift. */
 const SINGLE_IDENTIFIER_MESSAGE =
   "Only one column can be the row identifier. Choose a single identifier.";
+
+/**
+ * The error-association props for a Type control that is one of the offenders in a
+ * single-identifier conflict: `aria-invalid` as the control-level error signal and
+ * `aria-describedby` anchored to the visible error (`errorId`), so a reader landing
+ * on the control hears the error as its own context.
+ *
+ * `withAria: false` because Mantine's Select otherwise runs its own accessibility
+ * pass over the input, which drives `aria-invalid` off the `error` prop and
+ * `aria-describedby` off the Input.Wrapper context -- overriding the two attributes
+ * set here. Its own docs sanction disabling it for custom accessibility handling.
+ * The `error` prop is not the alternative: it would also paint a red border, an
+ * appearance change this control must not make. `withAria` is a real Input prop
+ * that Select forwards at runtime but omits from its narrower public prop type,
+ * hence the assertion.
+ */
+function conflictTypeControlAria(
+  errorId: string,
+): SelectProps<SemanticType> & { withAria: boolean } {
+  return {
+    "aria-invalid": true,
+    "aria-describedby": errorId,
+    withAria: false,
+  };
+}
 
 /**
  * The shared metadata grid: a real table mapping each input column to a semantic
@@ -120,6 +147,9 @@ export function MetadataGrid({
     applyEdit(setColumnDisclosure(metadata, columnName, choice));
 
   const multipleIdentifiers = hasMultipleIdentifiers(metadata);
+  // The visible error's id, so each conflicting Type control can point its
+  // aria-describedby at it -- useId keeps it unique if two grids mount.
+  const conflictErrorId = useId();
 
   // The conflict announcement is deferred one commit (see useDeferredAnnouncement),
   // so a seed that mounts ALREADY in the two-identifier state is announced as an
@@ -145,6 +175,11 @@ export function MetadataGrid({
         <Table.Tbody>
           {metadata.map((column) => {
             const choices = disclosureChoicesForType(column.type);
+            // Only the identifier-roled columns are the offenders in a
+            // single-identifier conflict, so the control-level error signal
+            // rides exactly those Type controls and clears on every other.
+            const inConflict =
+              multipleIdentifiers && column.role === "identifier";
             return (
               <Table.Tr key={column.name}>
                 <Table.Th scope="row" style={{ fontWeight: 500 }}>
@@ -156,6 +191,9 @@ export function MetadataGrid({
                     value={column.type}
                     allowDeselect={false}
                     aria-label={`Type for column ${column.name}`}
+                    {...(inConflict
+                      ? conflictTypeControlAria(conflictErrorId)
+                      : {})}
                     onChange={(value) =>
                       value !== null && onType(column.name, value)
                     }
@@ -190,9 +228,16 @@ export function MetadataGrid({
           what reaches assistive tech: see the conflictAnnouncement note above for
           why it is deferred. Both read the same message constant so they cannot
           drift; tests query the visible error by its data-testid (the announcement
-          carries the same text, so a getByText would be ambiguous). */}
+          carries the same text, so a getByText would be ambiguous). Its id also
+          anchors the offending Type controls' aria-describedby (see
+          conflictTypeControlAria). */}
       {multipleIdentifiers && (
-        <Text size="sm" c="red" data-testid="identifier-conflict">
+        <Text
+          size="sm"
+          c="red"
+          id={conflictErrorId}
+          data-testid="identifier-conflict"
+        >
           {SINGLE_IDENTIFIER_MESSAGE}
         </Text>
       )}

--- a/apps/web/test/browser/benchAccept.test.ts
+++ b/apps/web/test/browser/benchAccept.test.ts
@@ -838,6 +838,55 @@ describe("acceptor bench: confirm your columns (verdict, mapper, launch)", () =>
       .toBeInTheDocument();
   });
 
+  test("a two-identifier file ties the conflict error to the offending Type controls", async () => {
+    // `id` and `identifier` both infer to role: identifier, so the file seeds a
+    // single-identifier conflict the grid surfaces (inferMetadata seeds it; the
+    // mutators never create it).
+    await reachColumns("id,identifier,first_name,last_name\n1,2,Alice,Smith\n");
+    const conflict = page.getByTestId("identifier-conflict");
+    await expect.element(conflict).toBeInTheDocument();
+    const errorId = conflict.element().getAttribute("id");
+    expect(errorId).toBeTruthy();
+
+    // Both offending Type controls carry the control-level error signal and
+    // point their description at the visible error element. (exact: true --
+    // "Type for column id" is a substring of "Type for column identifier".)
+    for (const columnName of ["id", "identifier"]) {
+      const control = page.getByRole("combobox", {
+        name: `Type for column ${columnName}`,
+        exact: true,
+      });
+      expect(control.element().getAttribute("aria-invalid")).toBe("true");
+      expect(control.element().getAttribute("aria-describedby")).toBe(errorId);
+    }
+
+    // A non-identifier Type control carries no stale error association.
+    const bystander = page.getByRole("combobox", {
+      name: "Type for column first_name",
+      exact: true,
+    });
+    expect(bystander.element().getAttribute("aria-invalid")).toBeNull();
+    expect(bystander.element().getAttribute("aria-describedby")).toBeNull();
+
+    // Retype one identifier to Other: the conflict clears and no control keeps a
+    // stale aria-invalid/association.
+    const idControl = page.getByRole("combobox", {
+      name: "Type for column identifier",
+      exact: true,
+    });
+    await userEvent.click(idControl);
+    await userEvent.click(
+      page.getByRole("option", { name: "Other (not used for matching)" }),
+    );
+    expect(page.getByTestId("identifier-conflict").query()).toBeNull();
+    const survivor = page.getByRole("combobox", {
+      name: "Type for column id",
+      exact: true,
+    });
+    expect(survivor.element().getAttribute("aria-invalid")).toBeNull();
+    expect(survivor.element().getAttribute("aria-describedby")).toBeNull();
+  });
+
   test("the ledger's You will send names the extra disclosed column, not the invitation's request", async () => {
     // The invitation requests no payload from the acceptor (acceptorTerms has no
     // payload.receive), so its terms name nothing to send. But the file carries an


### PR DESCRIPTION
## Summary

On the acceptor's column-confirmation grid, the single-identifier conflict error was displayed but not programmatically associated with the controls it concerns, so a screen-reader user landing on an offending Type control got no error signal (WCAG 3.3.1). This ties the error to exactly the offending identifier Type controls via `aria-invalid` and `aria-describedby`, with no visual change.

Implements [206891346](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=206891346).

## Changes

- apps/web/src/components/MetadataGrid.tsx: when multiple identifier columns conflict, each offending Type `Select` gets `aria-invalid` and `aria-describedby` pointing at the existing visible error's `id`, cleared when the conflict resolves. Uses Mantine's `withAria: false` (via a small typed helper) so the raw attributes reach the input without the `error` prop's red-border repaint.
- apps/web/test/browser/benchAccept.test.ts: assert both offending controls carry the association, a bystander control carries neither, and resolving the conflict clears the attributes.

## Test plan

Ran: `npm test -w apps/web` (unit) and `npm run test:browser -w apps/web` (browser), all green; `npm run typecheck && npm run lint && npm run format` clean.
New tests cover: the control-level error association appears for exactly the offending identifier controls and clears on resolution.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: presentational ARIA wiring; no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: accessibility wiring, not a major feature or breaking change.
- [x] Security review -- n/a: none of the security triggers are touched (presentational ARIA on the acceptor's own column grid; nothing newly disclosed). An independent UX/accessibility review was completed with no findings.
