### PR TITLE
Focus the cleaning error-boundary fallback on catch

### DIFF
--- a/apps/web/src/components/CleaningErrorBoundary.tsx
+++ b/apps/web/src/components/CleaningErrorBoundary.tsx
@@ -1,15 +1,17 @@
-import { Component } from "react";
+import { Component, createRef } from "react";
 
 import { Alert, Button, Stack, Text } from "@mantine/core";
 import { IconAlertTriangle } from "@tabler/icons-react";
 
 import { whenDiagnostic } from "@utils/diagnostics";
 
-import type { ErrorInfo, ReactNode } from "react";
+import type { ErrorInfo, ReactNode, RefObject } from "react";
+
+type FallbackRef = RefObject<HTMLDivElement | null>;
 
 type BoundaryProps = {
   children: ReactNode;
-  fallback: (reset: () => void) => ReactNode;
+  fallback: (reset: () => void, ref: FallbackRef) => ReactNode;
   onCatch: (error: unknown) => void;
   resetKey: string;
 };
@@ -21,9 +23,21 @@ type BoundaryProps = {
  * renders the fallback on a caught render error and re-renders the children once the
  * {@link resetKey} changes (an edit / remap / reset to the prepared data) or the
  * fallback's reset fires.
+ *
+ * A caught error unmounts the subtree that held keyboard focus, so the boundary
+ * steers focus across each swap: to the fallback region when it appears, and to the
+ * recovered children when it clears, so focus is never left on a removed node.
  */
 class Boundary extends Component<BoundaryProps, { errored: boolean }> {
   state = { errored: false };
+  private readonly fallbackRef: FallbackRef = createRef();
+  private readonly childrenRef = createRef<HTMLDivElement>();
+  // Whether the current fallback appearance has already claimed focus. A caught
+  // error derives `errored` within the failing render itself, so there is no
+  // separate errored=false -> true commit to detect; this instead marks a fresh
+  // fallback so its focus fires once, and clears on recovery for the next catch.
+  private fallbackFocused = false;
+  private focusTimer: ReturnType<typeof setTimeout> | undefined;
 
   static getDerivedStateFromError(): { errored: boolean } {
     return { errored: true };
@@ -33,10 +47,30 @@ class Boundary extends Component<BoundaryProps, { errored: boolean }> {
     this.props.onCatch(error);
   }
 
+  componentDidMount(): void {
+    this.steerFocus();
+  }
+
   componentDidUpdate(prev: BoundaryProps): void {
     // The prepared data changed (a remap / edit / reset), so retry the children.
     if (this.state.errored && prev.resetKey !== this.props.resetKey)
       this.reset();
+    this.steerFocus();
+  }
+
+  componentWillUnmount(): void {
+    clearTimeout(this.focusTimer);
+  }
+
+  // Focus is deferred a task past the commit rather than set here directly:
+  // unmounting the focused child blurs focus to <body> as the DOM mutates, and that
+  // blur lands after this lifecycle, so a synchronous focus is immediately undone.
+  private steerFocus(): void {
+    if (this.state.errored === this.fallbackFocused) return;
+    this.fallbackFocused = this.state.errored;
+    const target = this.state.errored ? this.fallbackRef : this.childrenRef;
+    clearTimeout(this.focusTimer);
+    this.focusTimer = setTimeout(() => target.current?.focus());
   }
 
   reset = (): void => {
@@ -44,9 +78,13 @@ class Boundary extends Component<BoundaryProps, { errored: boolean }> {
   };
 
   render(): ReactNode {
-    return this.state.errored
-      ? this.props.fallback(this.reset)
-      : this.props.children;
+    return this.state.errored ? (
+      this.props.fallback(this.reset, this.fallbackRef)
+    ) : (
+      <div ref={this.childrenRef} tabIndex={-1}>
+        {this.props.children}
+      </div>
+    );
   }
 }
 
@@ -90,8 +128,10 @@ export function CleaningErrorBoundary({
           console.error("Cleaning section boundary caught:", error),
         )
       }
-      fallback={(reset) => (
+      fallback={(reset, ref) => (
         <Alert
+          ref={ref}
+          tabIndex={-1}
           color="red"
           variant="light"
           icon={<IconAlertTriangle aria-hidden />}

--- a/apps/web/test/browser/cleaningErrorBoundary.test.ts
+++ b/apps/web/test/browser/cleaningErrorBoundary.test.ts
@@ -37,9 +37,18 @@ function Boom({ broken }: { broken: boolean }) {
 }
 
 /** Drives the boundary the way a host does: `onReset` clears the offending state and
- * the resetKey signature changes with it, so the boundary auto-recovers. */
-function Harness() {
-  const [broken, setBroken] = useState(true);
+ * the resetKey signature changes with it, so the boundary auto-recovers. `initialBroken`
+ * chooses the entry path -- catch on first render (true) or catch on a later update
+ * (false, then broken via the exposed setter), the path the real hosts take. */
+function Harness({
+  initialBroken = true,
+  onReady,
+}: {
+  initialBroken?: boolean;
+  onReady?: (setBroken: (value: boolean) => void) => void;
+}) {
+  const [broken, setBroken] = useState(initialBroken);
+  onReady?.(setBroken);
   return createElement(CleaningErrorBoundary, {
     onReset: () => setBroken(false),
     // A real host keys this off the rendered standardization; here `broken` stands
@@ -75,6 +84,51 @@ describe("CleaningErrorBoundary contains a cleaning-section crash and recovers",
           .getByText("The cleaning editor hit an unexpected state")
           .elements(),
       ).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("focus moves to the announced fallback on catch and returns to the recovered cards on reset", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // Mount with valid children, then trip the boundary on an update -- the path a
+      // real host takes when prepared data goes bad mid-edit.
+      let breakCleaning: ((value: boolean) => void) | undefined;
+      render(
+        createElement(Harness, {
+          initialBroken: false,
+          onReady: (setBroken) => {
+            breakCleaning = setBroken;
+          },
+        }),
+      );
+      await expect.element(page.getByTestId("cards")).toBeInTheDocument();
+      breakCleaning?.(true);
+
+      // The fallback is a role="alert" live region (so the swap is announced) that
+      // carries an accessible name from its title, and it takes focus off the
+      // unmounted crashing subtree.
+      const fallback = page.getByRole("alert", {
+        name: "The cleaning editor hit an unexpected state",
+      });
+      await expect.element(fallback).toBeInTheDocument();
+      const fallbackNode = fallback.element();
+      await vi.waitFor(() => {
+        expect(document.activeElement).toBe(fallbackNode);
+      });
+
+      // Reset re-renders the cards; focus returns to the recovered children region,
+      // never stranded on the removed fallback.
+      await page.getByRole("button", { name: "Reset to defaults" }).click();
+      const cards = page.getByTestId("cards");
+      await expect.element(cards).toBeInTheDocument();
+      await vi.waitFor(() => {
+        const active = document.activeElement;
+        expect(active).not.toBe(null);
+        expect(active?.isConnected).toBe(true);
+        expect(active?.contains(cards.element())).toBe(true);
+      });
     } finally {
       spy.mockRestore();
     }


### PR DESCRIPTION
## Summary

When the cleaning editor's error boundary catches a render error, keyboard focus was stranded on the now-unmounted subtree and the swap was not announced. This moves focus to the fallback (a `role="alert"` region with an accessible name) so assistive tech announces it and a keyboard user lands on the recovery context, and returns focus to the recovered cards after "Reset to defaults".

Implements [204062479](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=204062479).

## Changes

- apps/web/src/components/CleaningErrorBoundary.tsx: on catch, move focus to the fallback `Alert` via a ref and a lifecycle-deferred focus (the timer is cleared on unmount, and normal non-error mounts do not steal focus); on reset, return focus to the recovered-children region.
- apps/web/test/browser/cleaningErrorBoundary.test.ts: drive the production update-catch path and assert the focus move on catch and the focus return on reset.

## Test plan

Ran: `npm run typecheck && npm run lint && npm run format`; `npm test -w apps/web` (unit, 1343) and `npm run test:browser -w apps/web` (470) green.
New tests cover: focus moves to the announced fallback on catch and returns to a connected recovered-cards region on reset (driven through the real update-catch path, not a first-render throw).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: accessibility focus behavior on an existing error boundary; no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: accessibility fix, not a major feature or breaking change.
- [x] Security review -- n/a: no security trigger (static fallback copy, no partner-controlled input, no crypto/credential/disclosure surface). An independent UX/accessibility review was completed with no findings.
