### PR TITLE
Surface the partner character constraint at consent

### DIFF
--- a/apps/web/src/components/InvitationTerms.tsx
+++ b/apps/web/src/components/InvitationTerms.tsx
@@ -578,6 +578,16 @@ export function InvitationTerms({
   const discloseGroupLabelId = useId();
   const receiveGroupLabelId = useId();
   const matchingGroupLabelId = useId();
+  const constraintGroupLabelId = useId();
+  // The fields carrying a partner-authored allowedCharacters class, surfaced
+  // always-visible: a partner-defined character-class constraint applies to a
+  // linkage field, so the acceptor must be on notice before consenting rather than
+  // finding it dimmed inside the collapsed "Other details" disclosure. The class is
+  // already sanitized once in summarizeInvitation, so this filter carries no fresh
+  // derivation of partner text -- only a presence selection.
+  const constrainedFields = summary.linkageFields.filter(
+    (field) => field.allowedCharacters !== undefined,
+  );
   // The "Other details" toggle is self-describing: a one-line summary of the
   // disclosure's contents renders beneath it and is associated as the toggle's
   // aria-describedby (detailsSummaryId), so a reader -- sighted or not -- knows what
@@ -1042,6 +1052,71 @@ export function InvitationTerms({
           </Stack>
         </Stack>
 
+        {/* Partner-authored allowed-character constraints, promoted to the
+          always-visible core as their own labelled group so a partner-defined
+          character-class rule on a linkage field is on notice at the consent point,
+          not dimmed inside the collapsed "Other details" disclosure. Rendered only
+          when at least one field declares such a class. Each entry names the field,
+          then a FIXED system label marking the class as partner-supplied and
+          unverified, then the raw (already-sanitized) class in its OWN bounded Text.
+          The class is never joined into one sentence: it is partner-controlled and
+          may contain any separator, so concatenating it with the label would let a
+          crafted value impersonate system chrome (the same reason the coercion notes
+          bind their partner value apart). The class is advisory (core's
+          `withinAllowedCharacters` warns, does not enforce), so the copy states an
+          expectation, not a guarantee; the group's accessible name is fixed via
+          aria-labelledby, so no raw partner text enters the name. */}
+        {constrainedFields.length > 0 && (
+          <Stack role="group" aria-labelledby={constraintGroupLabelId} gap="xs">
+            <Title
+              order={tierHeadingOrder}
+              fz="sm"
+              fw={600}
+              id={constraintGroupLabelId}
+            >
+              Partner-defined character constraints
+            </Title>
+            <Text size="sm">
+              Your partner declares an allowed-character pattern for these
+              fields. Each is a partner-supplied regular expression that psilink
+              has not verified, and it is a data expectation rather than an
+              enforced filter.
+            </Text>
+            <Stack gap="xs">
+              {/* Keyed by index: the fields are already deduped and their order is
+                  fixed for a given terms document, and the sanitized label is not
+                  unique across fields of one type. */}
+              {constrainedFields.map((field, index) => (
+                <Stack key={index} gap={2}>
+                  <Text size="sm" fw={500}>
+                    {field.label}
+                  </Text>
+                  {/* The fixed system label as static JSX, then the raw class in
+                      its own bounded Text between core-derived chrome -- mirroring
+                      the coercion-note pattern -- so partner text cannot be read as
+                      the label. field.allowedCharacters is present here (the filter
+                      above selects on it), sanitized once in summarizeInvitation. */}
+                  <Text size="sm">
+                    Allowed characters (partner-supplied, unverified):
+                  </Text>
+                  <Text
+                    size="sm"
+                    ff="monospace"
+                    style={{
+                      border: "1px solid var(--mantine-color-default-border)",
+                      borderRadius: "var(--mantine-radius-sm)",
+                      padding: "2px 6px",
+                      wordBreak: "break-all",
+                    }}
+                  >
+                    {field.allowedCharacters}
+                  </Text>
+                </Stack>
+              ))}
+            </Stack>
+          </Stack>
+        )}
+
         {/* The legal agreement -- a cross-cutting GOVERNANCE frame, not a disclosure
           direction, so it carries its own labelled group. Placed last in the
           always-visible core, below the disclosure/result/mechanics tiers, as a
@@ -1132,11 +1207,12 @@ export function InvitationTerms({
                     field.constraints.length > 0 ? (
                       <Stack key={index} gap={2}>
                         <Text size="sm">{field.label}</Text>
-                        {/* Each constraint as its own item rather than a joined
-                        string: a partner-controlled allowedCharacters class may
-                        contain the separator, which joined text would render as
-                        spurious extra clauses. Keyed by index -- order is fixed
-                        for a field. */}
+                        {/* Each constraint as its own item. These are fixed
+                        plain-language phrases (validity, affix removal, a count
+                        of excluded values) carrying no partner free text; the
+                        partner-authored allowedCharacters class is surfaced apart,
+                        in the always-visible constraints group above. Keyed by
+                        index -- order is fixed for a field. */}
                         <List size="xs" withPadding listStyleType="circle">
                           {field.constraints.map((constraint, ci) => (
                             <List.Item key={ci}>

--- a/apps/web/src/psi/invitationSummary.ts
+++ b/apps/web/src/psi/invitationSummary.ts
@@ -344,9 +344,29 @@ export interface InvitationFieldSummary {
   /**
    * Plain-language descriptions of the declared constraints, if any. The
    * `exclude` denylist is summarized as a count rather than listing its values:
-   * it is advisory and can hold hundreds of entries.
+   * it is advisory and can hold hundreds of entries. The partner-authored
+   * `allowedCharacters` class is NOT among these -- it is a raw partner-controlled
+   * regular expression, so it is carried apart in {@link allowedCharacters} for
+   * the renderer to bind in its own bounded element rather than fold into a joined
+   * phrase (see the field doc there).
    */
   constraints: Array<string>;
+  /**
+   * The partner-authored `allowedCharacters` class the field declares, sanitized
+   * for display, present only when the field declares one. Carried apart from
+   * {@link constraints} -- not folded into a joined "allowed-character pattern: X"
+   * phrase -- so the renderer can bind this partner-controlled value in its OWN
+   * bounded element between the fixed, core-derived system label, the way the
+   * transform-coercion notes bind their partner value (see
+   * {@link InvitationTransformSummary.coercions}). A partner cannot then place
+   * separator text inside the class to impersonate the surrounding system label.
+   * The value arrives in an invitation accepted on a transcription checksum and is
+   * never vetted (the evaluating check is warn-not-enforce, core's
+   * `withinAllowedCharacters`); the renderer's fixed label marks it as
+   * partner-supplied and unverified. Sanitized once here, at the single display
+   * boundary, so no caller re-derives the escaping.
+   */
+  allowedCharacters?: string;
 }
 
 /**
@@ -428,25 +448,11 @@ export interface InvitationSummary {
  * order. The `exclude` denylist is reported as a count, not its values: it is
  * advisory and may hold hundreds of entries.
  *
- * `allowedCharacters` is deliberately NOT rendered as "characters limited to X".
- * The value is a partner-authored regular-expression character class: it arrives
- * in the invitation token, accepted on a transcription checksum -- not an
- * authenticity guarantee -- and is never vetted, so a crafted class reads very
- * differently to a human than the set it admits. A leading `^` negates it (`^A-Z`
- * admits every character EXCEPT A-Z), and a shorthand or bracket breakout (`\p{L}`,
- * `[:alpha:]`, `]|\w|[`) is opaque to a non-regex-literate operator -- so a
- * "limited to <class>" phrasing would present raw partner regex as a vetted,
- * plain-language promise it is not. It is instead labelled as the partner-supplied,
- * unverified regular expression it is, so its surface reading is no longer
- * presented as a guarantee -- a non-regex-literate operator can still misread a
- * crafted class, but the copy no longer asserts a promise the value cannot back,
- * and the "not verified by psilink" clause names the trust boundary (partner-
- * authored, warn-not-enforce) rather than only the regex syntax family. The raw
- * class is still shown (sanitized) so a regex-literate reviewer can inspect the
- * actual pattern. The check that evaluates the class is warn-not-enforce (core's
- * `withinAllowedCharacters`); this is that check's operator-facing display
- * complement. `allowedCharacters` is a short, length-bounded, partner-controlled
- * string, so it is sanitized before display.
+ * The partner-authored `allowedCharacters` class is deliberately NOT among these
+ * phrases -- it is surfaced apart in {@link allowedCharactersClass}, so the
+ * renderer binds the raw partner value in its own bounded element rather than
+ * folding it into a joined sentence a partner could impersonate. See that
+ * function for the trust-boundary rationale.
  */
 function describeConstraints(field: LinkageField): Array<string> {
   const constraints = field.constraints;
@@ -457,19 +463,46 @@ function describeConstraints(field: LinkageField): Array<string> {
     descriptions.push("values must be valid");
   if ("affixesAllowed" in constraints && constraints.affixesAllowed === false)
     descriptions.push("honorifics and suffixes removed");
-  if (
-    "allowedCharacters" in constraints &&
-    constraints.allowedCharacters !== undefined
-  )
-    descriptions.push(
-      `allowed-character pattern (partner-supplied regular expression, not verified by psilink): ${sanitizeForDisplay(constraints.allowedCharacters)}`,
-    );
   const exclude = constraints.exclude ?? [];
   if (exclude.length > 0)
     descriptions.push(
       `${exclude.length} excluded value${exclude.length === 1 ? "" : "s"}`,
     );
   return descriptions;
+}
+
+/**
+ * The field's partner-authored `allowedCharacters` class, sanitized for display,
+ * or undefined when the field declares none. Surfaced as the raw class alone
+ * (with no joined system label) so the renderer can bind it in its own bounded
+ * element between the fixed, core-derived label -- the way the transform-coercion
+ * notes bind their partner value -- rather than concatenating label and value into
+ * one string a partner could impersonate with separator text.
+ *
+ * The value is a partner-authored regular-expression character class: it arrives
+ * in the invitation token, accepted on a transcription checksum -- not an
+ * authenticity guarantee -- and is never vetted, so a crafted class reads very
+ * differently to a human than the set it admits. A leading `^` negates it (`^A-Z`
+ * admits every character EXCEPT A-Z), and a shorthand or bracket breakout (`\p{L}`,
+ * `[:alpha:]`, `]|\w|[`) is opaque to a non-regex-literate operator -- so a
+ * "limited to <class>" phrasing would present raw partner regex as a vetted,
+ * plain-language promise it is not. The renderer instead labels it as the
+ * partner-supplied, unverified regular expression it is, and shows the raw class
+ * (sanitized) so a regex-literate reviewer can inspect the actual pattern. The
+ * check that evaluates the class is warn-not-enforce (core's
+ * `withinAllowedCharacters`); the display is that check's operator-facing
+ * complement. `allowedCharacters` is a short, length-bounded, partner-controlled
+ * string, so it is sanitized before display, once here at the single boundary.
+ */
+function allowedCharactersClass(field: LinkageField): string | undefined {
+  const constraints = field.constraints;
+  if (
+    constraints === undefined ||
+    !("allowedCharacters" in constraints) ||
+    constraints.allowedCharacters === undefined
+  )
+    return undefined;
+  return sanitizeForDisplay(constraints.allowedCharacters);
 }
 
 /**
@@ -939,29 +972,34 @@ export function summarizeInvitation(
     terms.linkageFields.map((field) => [field.name, field.type]),
   );
 
-  // Collapse fields that are identical for display -- same semantic-type label
-  // and same constraint phrases -- so several fields of one type (the schema
-  // permits, e.g., a maiden and a current name both typed `first_name`) do not
-  // list the same line twice with nothing to tell them apart (the field `name`
-  // that would distinguish them is partner-controlled and deliberately not
-  // shown). Fields whose constraints differ stay distinct, since the constraint
-  // text then distinguishes them. The dedupe key is the JSON encoding of the
-  // (label, constraints) pair, which is injective over that displayed content:
-  // a plain join would not be, since a constraint phrase can itself contain the
-  // separator (the allowed-character pattern phrase embeds the partner-controlled
-  // regex class, which carries spaces). The key is built from the already-sanitized
-  // display strings, so two
-  // fields whose `allowedCharacters` differ only in characters sanitizeForDisplay
-  // folds together collapse -- correctly, since they render identically and
-  // nothing the acceptor could distinguish is lost.
+  // Collapse fields that are identical for display -- same semantic-type label,
+  // same constraint phrases, and same allowed-character class -- so several fields
+  // of one type (the schema permits, e.g., a maiden and a current name both typed
+  // `first_name`) do not list the same line twice with nothing to tell them apart
+  // (the field `name` that would distinguish them is partner-controlled and
+  // deliberately not shown). Fields whose constraints or allowed-character class
+  // differ stay distinct, since that content then distinguishes them. The dedupe
+  // key is the JSON encoding of the (label, constraints, allowedCharacters) triple,
+  // which is injective over that displayed content: a plain join would not be,
+  // since a constraint phrase or the regex class can itself contain the separator.
+  // The key is built from the already-sanitized display strings, so two fields
+  // whose `allowedCharacters` differ only in characters sanitizeForDisplay folds
+  // together collapse -- correctly, since they render identically and nothing the
+  // acceptor could distinguish is lost.
   const seenFields = new Set<string>();
   const linkageFields: Array<InvitationFieldSummary> = [];
   for (const field of terms.linkageFields) {
-    const summary = {
+    const allowed = allowedCharactersClass(field);
+    const summary: InvitationFieldSummary = {
       label: FIELD_TYPE_LABELS[field.type],
       constraints: describeConstraints(field),
+      ...(allowed !== undefined ? { allowedCharacters: allowed } : {}),
     };
-    const dedupeKey = JSON.stringify([summary.label, summary.constraints]);
+    const dedupeKey = JSON.stringify([
+      summary.label,
+      summary.constraints,
+      summary.allowedCharacters ?? null,
+    ]);
     if (seenFields.has(dedupeKey)) continue;
     seenFields.add(dedupeKey);
     linkageFields.push(summary);

--- a/apps/web/test/browser/invitationTerms.test.ts
+++ b/apps/web/test/browser/invitationTerms.test.ts
@@ -409,16 +409,18 @@ describe("InvitationTerms: per-key matching disclosures", () => {
     expect(masterCollapse.getAttribute("aria-hidden")).toBe("true");
     expect(masterCollapse.hasAttribute("inert")).toBe(true);
 
-    // The non-key blocks (field constraints, payload, dedup) are in the master
+    // The non-key blocks (personal-data labels, payload, dedup) are in the master
     // disclosure ...
     const panel = await readyPanel("Other details");
-    expect(panel.textContent).toContain(
-      "allowed-character pattern (partner-supplied regular expression, not verified by psilink): A-Z",
-    );
+    expect(panel.textContent).toContain("Personal data used");
     expect(panel.textContent).toContain("risk_score");
     expect(panel.textContent).toContain("may match more than one");
-    // ... the legal agreement is NOT among them: it is promoted whole into the
-    // always-visible core, so its reference no longer sits in the disclosure ...
+    // ... the partner-authored allowed-character class is NOT among them: it is
+    // promoted whole into the always-visible core (its own constraints group), so
+    // the raw class no longer sits dimmed in the disclosure ...
+    expect(panel.textContent).not.toContain("A-Z");
+    // ... the legal agreement is NOT among them either: it is promoted whole into
+    // the always-visible core, so its reference no longer sits in the disclosure ...
     expect(panel.textContent).not.toContain("MOU-2025-0042");
     // ... and the per-key matching detail moved out, into the key's own
     // disclosure.
@@ -951,6 +953,133 @@ describe("InvitationTerms: always-visible egress and legal-agreement facts, tier
     expect(container!.textContent).not.toContain("attaches a legal agreement");
     expect(container!.textContent).not.toContain("MOU-2025-0042");
     expect(container!.textContent).not.toContain("Audit and evaluation");
+  });
+});
+
+describe("InvitationTerms: a partner-authored allowed-character constraint is on notice at consent", () => {
+  // A partner-defined allowedCharacters class is a rule on a linkage field the
+  // acceptor consents to. It must be legible at the consent point -- not dimmed
+  // inside the collapsed "Other details" disclosure -- so a partner-defined
+  // character-class constraint is on notice before consenting. Promoted into its
+  // own always-visible labelled group, with the raw partner-controlled class bound
+  // in its OWN bounded element (never joined into a sentence a partner could
+  // impersonate) under a fixed "unverified" system label.
+  const GROUP = "Partner-defined character constraints";
+  function render(
+    linkageTerms: LinkageTerms,
+    perspective?: "review" | "accepted" | "proposing",
+  ) {
+    renderTerms(linkageTerms, perspective ? { perspective } : undefined);
+  }
+
+  test("the constraint is surfaced always-visible, outside the 'Other details' disclosure", async () => {
+    // The module terms carry a first_name field with allowedCharacters "A-Z ".
+    render(terms);
+    await expect.element(toggle("Other details")).toBeInTheDocument();
+
+    // Its own always-visible labelled group: an acceptor sees a partner-defined
+    // constraint applies without expanding any disclosure.
+    const constraints = group(GROUP);
+    await expect.element(constraints).toBeInTheDocument();
+    expect(constraints.element().textContent).toContain("First name");
+    expect(constraints.element().textContent).toContain("A-Z ");
+
+    // ... and OUTSIDE the "Other details" panel, which carries its collapsed content
+    // even while hidden: the class is not also dimmed there.
+    const panel = await readyPanel("Other details");
+    expect(panel.textContent).not.toContain("A-Z");
+  });
+
+  test("the constraint is not de-emphasized relative to the always-visible terms core", async () => {
+    // The regression the raise fixes: the class formerly rendered dimmed
+    // (size="xs" c="dimmed") inside the collapsed disclosure. It is now in the core
+    // at the same non-dimmed prominence as the terms around it. Assert the raw class
+    // node resolves to the SAME color as a core body-weight line elsewhere on the
+    // screen (the always-visible matching summary, a plain size="sm" Text), rather
+    // than the muted --mantine-color-dimmed the old disclosure used -- so it is not
+    // rendered less prominently than the always-visible terms core.
+    render(terms);
+    const constraints = group(GROUP);
+    await expect.element(constraints).toBeInTheDocument();
+    const classNode = Array.from(
+      constraints.element().querySelectorAll("*"),
+    ).find((el) => el.children.length === 0 && el.textContent.trim() === "A-Z");
+    expect(classNode).toBeTruthy();
+    // A known non-dimmed core line: the always-visible "Matching on ..." summary is
+    // a plain size="sm" Text in the core, so its resolved color is the body text
+    // color the class must share (not the muted dimmed token).
+    const coreLine = page.getByText(
+      "Matching on SSN, last name, date of birth, first name.",
+    );
+    await expect.element(coreLine).toBeInTheDocument();
+    expect(getComputedStyle(classNode!).color).toBe(
+      getComputedStyle(coreLine.element()).color,
+    );
+  });
+
+  test("the raw partner class occupies its OWN element, not folded into a joined sentence", async () => {
+    // The security-load-bearing property: the raw partner-controlled class is bound
+    // in its own bounded element between the fixed system label and the field
+    // label, NOT concatenated into one string a crafted value could impersonate as
+    // system chrome. Assert a leaf element holds the class verbatim and alone (its
+    // trimmed text is exactly the class), so the fixed label does not share the
+    // element with the partner value.
+    render({
+      ...terms,
+      linkageFields: [
+        {
+          name: "first_name",
+          type: "first_name",
+          constraints: { allowedCharacters: "^A-Z" },
+        },
+        { name: "last_name", type: "last_name" },
+      ],
+      linkageKeys: [{ name: "FN", elements: [{ field: "first_name" }] }],
+    });
+    const constraints = group(GROUP);
+    await expect.element(constraints).toBeInTheDocument();
+    // The raw class stands alone in its own leaf node -- the fixed "unverified"
+    // label is a separate sibling, never joined into the same string.
+    const classNode = Array.from(
+      constraints.element().querySelectorAll("*"),
+    ).find(
+      (el) => el.children.length === 0 && el.textContent.trim() === "^A-Z",
+    );
+    expect(classNode).toBeTruthy();
+    // The fixed system label marking the class partner-supplied and unverified is
+    // present as its own text, not folded into the class node.
+    expect(constraints.element().textContent).toContain(
+      "partner-supplied, unverified",
+    );
+    expect(classNode!.textContent).not.toContain("unverified");
+    // The corrected framing from the prior rework is preserved: the class is not
+    // dressed up as a plain-language "limited to" guarantee.
+    expect(constraints.element().textContent).not.toContain("limited to");
+  });
+
+  test("no constraints group when no field declares an allowed-character class", async () => {
+    // Strip the only constrained field's class: the whole group is gated on at
+    // least one field carrying one, so it does not render (and no stray heading is
+    // left behind).
+    render({
+      ...terms,
+      linkageFields: [
+        { name: "ssn", type: "ssn" },
+        { name: "first_name", type: "first_name" },
+        { name: "last_name", type: "last_name" },
+        { name: "dob", type: "date_of_birth" },
+      ],
+    });
+    await expect.element(toggle("Other details")).toBeInTheDocument();
+    expect(group(GROUP).query()).toBeNull();
+    expect(container!.textContent).not.toContain(GROUP);
+  });
+
+  test("the group caption is a heading, so a screen-reader user can jump to it", async () => {
+    render(terms);
+    await expect
+      .element(page.getByRole("heading", { name: GROUP }))
+      .toBeInTheDocument();
   });
 });
 

--- a/apps/web/test/unit/acceptConsent.test.ts
+++ b/apps/web/test/unit/acceptConsent.test.ts
@@ -231,15 +231,17 @@ describe("summarizeInvitation", () => {
     );
     // A transform function name, its parameters, and a constraint's
     // allowedCharacters are all partner-controlled, so each is neutralized
-    // before it reaches the summary.
+    // before it reaches the summary. The allowedCharacters class is carried apart
+    // from the plain-language constraint phrases (surfaced as its own bounded
+    // element), so it is asserted on that field rather than in `constraints`.
     const transform = summary.linkageKeys[0].elements[0].transforms[0];
     expect(transform.function).not.toContain(BEL);
     expect(transform.function).toContain("\\x07");
     expect(transform.params[0]).not.toContain(BEL);
     expect(transform.params[0]).toContain("\\x07");
-    const constraint = summary.linkageFields[0].constraints[0];
-    expect(constraint).not.toContain(BEL);
-    expect(constraint).toContain("\\x07");
+    const allowed = summary.linkageFields[0].allowedCharacters;
+    expect(allowed).not.toContain(BEL);
+    expect(allowed).toContain("\\x07");
   });
 
   test("caps the number of transform parameters shown", () => {
@@ -409,14 +411,15 @@ describe("summarizeInvitation", () => {
     );
 
     // The two unconstrained "First name" entries collapse to one; the
-    // constraint-bearing one and the date field stay distinct.
+    // constraint-bearing one and the date field stay distinct. The allowedCharacters
+    // class is carried apart (its own field), not folded into a constraint phrase,
+    // and it participates in the dedupe key so the constrained field stays distinct.
     expect(summary.linkageFields).toEqual([
       { label: "First name", constraints: [] },
       {
         label: "First name",
-        constraints: [
-          "allowed-character pattern (partner-supplied regular expression, not verified by psilink): A-Z ",
-        ],
+        constraints: [],
+        allowedCharacters: "A-Z ",
       },
       { label: "Date of birth", constraints: [] },
     ]);
@@ -451,20 +454,23 @@ describe("summarizeInvitation", () => {
       "values must be valid",
       "2 excluded values",
     ]);
-    expect(firstName.constraints).toEqual([
-      "honorifics and suffixes removed",
-      "allowed-character pattern (partner-supplied regular expression, not verified by psilink): A-Z ",
-    ]);
+    // The plain-language constraint phrases; the partner-authored allowedCharacters
+    // class is carried apart (its own field), not folded into a phrase here.
+    expect(firstName.constraints).toEqual(["honorifics and suffixes removed"]);
+    expect(firstName.allowedCharacters).toBe("A-Z ");
     // A field with no constraints contributes nothing.
     expect(dob.constraints).toEqual([]);
+    expect(dob.allowedCharacters).toBeUndefined();
   });
 
-  test("frames a partner-authored allowedCharacters class as regex, not a plain-language guarantee", () => {
+  test("surfaces a partner-authored allowedCharacters class as its raw value apart from the constraint phrases", () => {
     // A leading `^` reads to a non-regex-literate operator as "allow caret and
-    // A-Z" but is class negation (admits everything EXCEPT A-Z). The display must
-    // not present this partner-authored, un-vetted regex as a "limited to"
-    // promise; it is labelled as the regular expression it is, with the raw class
-    // still shown so a regex-literate reviewer can inspect it.
+    // A-Z" but is class negation (admits everything EXCEPT A-Z). The summary
+    // surfaces the raw class ALONE -- not folded into a "limited to <class>"
+    // phrase, and not among the plain-language constraint phrases -- so the
+    // renderer can bind it in its own bounded element under a fixed, unverified
+    // system label. The raw class is preserved verbatim (sanitized) so a
+    // regex-literate reviewer can inspect the actual pattern.
     const summary = summarizeInvitation(
       makeToken({
         linkageFields: [
@@ -477,14 +483,12 @@ describe("summarizeInvitation", () => {
         linkageKeys: [{ name: "FN", elements: [{ field: "first_name" }] }],
       }),
     );
-    const [constraint] = summary.linkageFields[0].constraints;
-    expect(constraint).toBe(
-      "allowed-character pattern (partner-supplied regular expression, not verified by psilink): ^A-Z",
-    );
-    expect(constraint).not.toContain("limited to");
-    // The trust boundary is named, not just the regex syntax family, so the
-    // partner's un-vetted value is not read as one the app validated.
-    expect(constraint).toContain("not verified by psilink");
+    const field = summary.linkageFields[0];
+    expect(field.allowedCharacters).toBe("^A-Z");
+    // The raw class is not dressed up as a plain-language guarantee, nor folded
+    // into the plain-language constraint phrases.
+    expect(field.allowedCharacters).not.toContain("limited to");
+    expect(field.constraints).toEqual([]);
   });
 
   test("labels every fuzzy-comparison expansion in plain language", () => {


### PR DESCRIPTION
## Summary

An operator could consent to an invitation without seeing that a partner-authored `allowedCharacters` constraint applied to a linkage field: it rendered dimmed inside a default-collapsed disclosure. This raises it into an always-visible "partner-supplied, unverified" group, with the raw (sanitized) partner class in its own bounded element so it cannot impersonate system chrome. It is a display change only; the constraint stays warn-not-enforce.

Implements [208049118](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=208049118).

## Changes

- apps/web/src/psi/invitationSummary.ts: surface the sanitized partner class as its own structured field through a single `sanitizeForDisplay` boundary (`allowedCharactersClass`), rather than concatenating it into a sentence.
- apps/web/src/components/InvitationTerms.tsx: render an always-visible "Partner-defined character constraints" group in the terms core, with the raw class in its own bounded, monospace box behind a fixed "partner-supplied, unverified" label (separate sibling nodes, so partner text cannot read as system chrome).
- apps/web/test/browser/invitationTerms.test.ts, apps/web/test/unit/acceptConsent.test.ts: updated to the structured shape and the new always-visible placement.

## Test plan

Ran: `npm run typecheck && npm run lint && npm run format`; `npm test -w apps/web` (unit, 1343) and `npm run test:browser -w apps/web` (474, incl. 65 InvitationTerms) green.
New tests cover: the always-visible signal appears when a field carries a constraint; the raw partner class occupies its own leaf element (not folded into a joined sentence); no group renders when no field declares a class.

## Background

The `allowedCharacters` class is partner-authored and untrusted. It reaches the DOM only through the single `sanitizeForDisplay` boundary and renders as its own bounded element with the fixed labels as separate siblings, so a hostile value cannot present as psilink chrome. No `packages/core` change; the constraint remains warn-not-enforce.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: display-prominence change on the consent surface; no documented behavior or contract changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: consent-surface disclosure-prominence change, not a major feature or breaking change.
- [x] Security review -- independent security review of the untrusted partner-text rendering on the consent surface (single sanitize boundary, own bounded element, no chrome-impersonation vector, display-only); no findings.
