### PR TITLE
Lint the filled-primary contrast scope

### DIFF
--- a/.claude/scripts/lib/ciPathFilters.test.mjs
+++ b/.claude/scripts/lib/ciPathFilters.test.mjs
@@ -37,13 +37,18 @@ const DEPLOY_WORKFLOW = ".github/workflows/eb_deploy.yaml";
 // explicitly excluded below.
 const GUARDED_ROOTS = ["apps/web", "packages/core"];
 
-// Subtrees the deploy filter omits ON PURPOSE: a change to test sources runs the
-// PR suite but must not trigger a rebuild+redeploy. Allowlisting a directory
-// SUPPRESSES its deploy-coverage check, so an entry here must be a real "this
-// directory does not ship" decision, not a way to mute a failure. The live tests
-// below assert each entry still exists, so a removed/renamed tree cannot rot the
-// list.
-const DEPLOY_EXCLUDED = new Set(["apps/web/test", "packages/core/test"]);
+// Subtrees the deploy filter omits ON PURPOSE: a change to test or dev-tooling
+// sources runs the PR suite but must not trigger a rebuild+redeploy. Allowlisting
+// a directory SUPPRESSES its deploy-coverage check, so an entry here must be a real
+// "this directory does not ship" decision, not a way to mute a failure. The live
+// tests below assert each entry still exists, so a removed/renamed tree cannot rot
+// the list. apps/web/eslint-rules holds lint-time custom rules that never ship in
+// the artifact.
+const DEPLOY_EXCLUDED = new Set([
+  "apps/web/test",
+  "packages/core/test",
+  "apps/web/eslint-rules",
+]);
 
 // Inputs that feed the shipped artifact but live OUTSIDE the guarded roots, so
 // the top-level-dir scan cannot see them. Assert the deploy filter still lists

--- a/apps/web/eslint-rules/filled-primary-contrast-scope.d.mts
+++ b/apps/web/eslint-rules/filled-primary-contrast-scope.d.mts
@@ -1,0 +1,26 @@
+import type { Rule } from "eslint";
+
+/** The theme's filled-primary predicate, held equal to `isFilledPrimary` in
+ * apps/web/src/theme.ts by the rule's unit test. */
+export function isFilledPrimary(
+  variant: string | undefined,
+  color: string | undefined,
+): boolean;
+
+/** Audited secondary / status (variant, color) shapes the rule allows past the
+ * filled-primary core. */
+export const AUDITED_SECONDARY: ReadonlyArray<{
+  variant: string;
+  color: string | undefined;
+}>;
+
+/** True when a resolved (variant, color) pair is filled-primary or audited. */
+export function isAudited(
+  variant: string | undefined,
+  color: string | undefined,
+): boolean;
+
+export const rule: Rule.RuleModule;
+
+declare const plugin: { rules: Record<string, Rule.RuleModule> };
+export default plugin;

--- a/apps/web/eslint-rules/filled-primary-contrast-scope.mjs
+++ b/apps/web/eslint-rules/filled-primary-contrast-scope.mjs
@@ -1,0 +1,162 @@
+/**
+ * Local ESLint rule guarding the filled-primary WCAG-AA contrast scope that
+ * apps/web/src/theme.ts establishes.
+ *
+ * The theme routes a filled-primary Button / ActionIcon / Checkbox's text and
+ * icon color through `--mantine-primary-color-contrast` (FILLED_PRIMARY_CONTRAST)
+ * so it clears AA in both color schemes. That override is scoped by the theme's
+ * `isFilledPrimary(variant, color)` predicate: it reaches only the default
+ * (`filled`, no explicit `color`) surface. A surface authored with an explicit
+ * `color` or a non-`filled` `variant` leaves that scope and paints on its own
+ * color's shade with Mantine's color-scheme-blind text pick, which can fall below
+ * the contrast floor without failing either the arithmetic theme test or the
+ * render harness (neither samples call sites).
+ *
+ * This rule fails such a surface at authoring time. A surface passes when it is
+ * filled-primary, or when its (variant, color) pair is one of the audited
+ * secondary / status shapes below -- each a shape the app already uses whose text
+ * does not ride the primary fill (a `default` / `outline` / `subtle` control
+ * carries body text; a `light` / `subtle` status control carries its status
+ * color's own AA-tuned text). Any other pair -- a filled surface with an explicit
+ * color, or a variant/color combination not audited here -- is reported.
+ */
+
+const SURFACES = new Set(["Button", "ActionIcon", "Checkbox"]);
+const MANTINE_MODULE = "@mantine/core";
+
+/**
+ * The theme's filled-primary predicate, kept byte-identical to
+ * `isFilledPrimary` in apps/web/src/theme.ts (the ESLint runtime cannot import
+ * theme.ts, which pulls in @mantine/core, so the two are locked equal by the
+ * rule's unit test rather than by a shared import).
+ */
+export const isFilledPrimary = (variant, color) =>
+  (variant === undefined || variant === "filled") && color === undefined;
+
+/**
+ * Audited secondary / status (variant, color) shapes whose text does not ride
+ * the primary fill, so they need no filled-primary contrast route. A `color` of
+ * `undefined` means "no explicit color". Extend only with a shape whose text
+ * clears WCAG AA on its own; never add a filled surface with a color (its text
+ * would ride that color's fill, the exact scope this rule guards).
+ */
+export const AUDITED_SECONDARY = [
+  { variant: "default", color: undefined },
+  { variant: "outline", color: undefined },
+  { variant: "subtle", color: undefined },
+  { variant: "subtle", color: "red" },
+  { variant: "light", color: undefined },
+  { variant: "light", color: "red" },
+];
+
+/**
+ * Classify one resolved (variant, color) pair: `true` if it is filled-primary or
+ * an audited secondary shape (allowed), `false` if it leaves the guarded scope.
+ */
+export const isAudited = (variant, color) =>
+  isFilledPrimary(variant, color) ||
+  AUDITED_SECONDARY.some(
+    (shape) => shape.variant === variant && shape.color === color,
+  );
+
+/**
+ * The set of string values an attribute's JSX value can take, or `undefined`
+ * when it cannot be resolved to string literals (a non-literal expression the
+ * rule must not silently pass). An absent attribute is caller-supplied as the
+ * single value `undefined`.
+ */
+function resolvableValues(node) {
+  if (node === null) return undefined;
+  if (node.type === "Literal" && typeof node.value === "string") {
+    return [node.value];
+  }
+  if (node.type === "JSXExpressionContainer") {
+    return resolvableValues(node.expression);
+  }
+  if (node.type === "ConditionalExpression") {
+    const consequent = resolvableValues(node.consequent);
+    const alternate = resolvableValues(node.alternate);
+    if (consequent === undefined || alternate === undefined) return undefined;
+    return [...consequent, ...alternate];
+  }
+  return undefined;
+}
+
+const MESSAGE =
+  "This {{name}} leaves the filled-primary contrast scope (isFilledPrimary in " +
+  "apps/web/src/theme.ts): its text no longer routes through " +
+  "FILLED_PRIMARY_CONTRAST and can fall below WCAG AA. Keep it filled-primary " +
+  "(drop the explicit color / non-filled variant), or use one of the audited " +
+  "secondary shapes. A new secondary/status shape whose text clears AA on its " +
+  "own goes in AUDITED_SECONDARY in " +
+  "apps/web/eslint-rules/filled-primary-contrast-scope.mjs.";
+
+/** @type {import("eslint").Rule.RuleModule} */
+export const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Keep a primary-action Button / ActionIcon / Checkbox inside the theme's filled-primary WCAG-AA contrast scope.",
+    },
+    schema: [],
+    messages: { unscoped: MESSAGE },
+  },
+  create(context) {
+    const mantineSurfaces = new Set();
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== MANTINE_MODULE) return;
+        for (const spec of node.specifiers) {
+          if (
+            spec.type === "ImportSpecifier" &&
+            SURFACES.has(spec.imported.name)
+          ) {
+            mantineSurfaces.add(spec.local.name);
+          }
+        }
+      },
+      JSXOpeningElement(node) {
+        if (node.name.type !== "JSXIdentifier") return;
+        const name = node.name.name;
+        if (!mantineSurfaces.has(name)) return;
+
+        let variantAttr;
+        let colorAttr;
+        for (const attr of node.attributes) {
+          if (attr.type !== "JSXAttribute") continue;
+          if (attr.name.name === "variant") variantAttr = attr;
+          if (attr.name.name === "color") colorAttr = attr;
+        }
+        if (variantAttr === undefined && colorAttr === undefined) return;
+
+        const variants =
+          variantAttr === undefined
+            ? [undefined]
+            : resolvableValues(variantAttr.value);
+        const colors =
+          colorAttr === undefined
+            ? [undefined]
+            : resolvableValues(colorAttr.value);
+
+        const unresolved = variants === undefined || colors === undefined;
+        const escapes =
+          unresolved ||
+          variants.some((variant) =>
+            colors.some((color) => !isAudited(variant, color)),
+          );
+        if (escapes) {
+          context.report({
+            node,
+            messageId: "unscoped",
+            data: { name },
+          });
+        }
+      },
+    };
+  },
+};
+
+export default {
+  rules: { "filled-primary-contrast-scope": rule },
+};

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,6 +1,7 @@
 // eslint.config.js
 import pluginRouter from "@tanstack/eslint-plugin-router";
 import { tanstackConfig } from "@tanstack/eslint-config";
+import filledPrimaryContrastScope from "./eslint-rules/filled-primary-contrast-scope.mjs";
 
 export default [
   {
@@ -40,7 +41,9 @@ export default [
     // Fail CI on a stray or rule-silencing disable so the tripwire cannot be
     // quietly turned off on a sensitive parse (a bare `eslint .` only warns).
     linterOptions: { reportUnusedDisableDirectives: "error" },
+    plugins: { "filled-primary-contrast": filledPrimaryContrastScope },
     rules: {
+      "filled-primary-contrast/filled-primary-contrast-scope": "error",
       "no-restricted-syntax": [
         "error",
         {

--- a/apps/web/src/bench/SavedExchanges.tsx
+++ b/apps/web/src/bench/SavedExchanges.tsx
@@ -371,7 +371,12 @@ export function DeleteExchangeButton({
           <Button variant="default" onClick={() => setConfirming(false)}>
             Cancel
           </Button>
-          <Button color="red" loading={deleting} onClick={confirmDelete}>
+          <Button
+            color="red"
+            variant="light"
+            loading={deleting}
+            onClick={confirmDelete}
+          >
             Delete
           </Button>
         </div>

--- a/apps/web/test/unit/filledPrimaryContrastScope.test.ts
+++ b/apps/web/test/unit/filledPrimaryContrastScope.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, test } from "vitest";
+
+import { DEFAULT_THEME, mergeMantineTheme } from "@mantine/core";
+import { RuleTester } from "eslint";
+import tsParser from "@typescript-eslint/parser";
+
+import { mantineTheme } from "@theme";
+
+import {
+  AUDITED_SECONDARY,
+  isAudited,
+  isFilledPrimary,
+  rule,
+} from "../../eslint-rules/filled-primary-contrast-scope.mjs";
+
+// The rule guards the theme's filled-primary contrast scope at authoring time.
+// Its predicate must not drift from the theme's own `isFilledPrimary` scoping,
+// which the ESLint runtime cannot import (theme.ts pulls in @mantine/core). These
+// tests lock the two together against the theme's real vars resolvers -- the
+// authoritative runtime scoping -- and exercise the rule over the JSX shapes it
+// must accept and reject.
+
+// Report each RuleTester case as its own vitest test.
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const theme = mergeMantineTheme(DEFAULT_THEME, mantineTheme);
+
+// The CSS variable each surface's vars override emits for a filled-primary
+// instance (mirrors the wiring pinned in themeContrast.test.ts). A resolver
+// emits it iff the theme scopes that (variant, color) as filled-primary.
+const FILLED_PRIMARY_WIRING: Array<[string, string]> = [
+  ["Button", "--button-color"],
+  ["ActionIcon", "--ai-color"],
+  ["Checkbox", "--checkbox-icon-color"],
+];
+
+const VARIANTS = [undefined, "filled", "default", "subtle", "light", "outline"];
+const COLORS = [undefined, "red", "gray", "blue"];
+
+describe("filled-primary contrast lint rule", () => {
+  test("classifier matches the theme's own filled-primary scoping", () => {
+    // Drive each component's real vars resolver over the variant x color matrix
+    // and assert the rule's isFilledPrimary agrees with whether the resolver
+    // routes text through the per-scheme contrast variable. Ties the rule to the
+    // theme's runtime scoping instead of a duplicated literal, without importing
+    // (or modifying) theme.ts's module-local predicate.
+    for (const [name, cssVar] of FILLED_PRIMARY_WIRING) {
+      const resolve = theme.components[name].vars;
+      expect(resolve, `${name} vars override`).toBeDefined();
+      for (const variant of VARIANTS) {
+        for (const color of COLORS) {
+          const props: Record<string, unknown> = {};
+          if (variant !== undefined) props.variant = variant;
+          if (color !== undefined) props.color = color;
+          const routed = resolve!(theme, props, {}).root[cssVar] !== undefined;
+          expect(
+            isFilledPrimary(variant, color),
+            `${name} variant=${variant} color=${color}`,
+          ).toBe(routed);
+        }
+      }
+    }
+  });
+
+  test("audited secondary shapes are never filled-primary", () => {
+    // The allowlist only ever widens the guard past the filled-primary core; a
+    // filled-primary shape must reach the theme's contrast route, not the
+    // allowlist, so a shape landing in both would mean the allowlist had begun
+    // shadowing the guarded scope.
+    for (const shape of AUDITED_SECONDARY) {
+      expect(
+        isFilledPrimary(shape.variant, shape.color),
+        `${shape.variant} / ${shape.color}`,
+      ).toBe(false);
+      expect(isAudited(shape.variant, shape.color)).toBe(true);
+    }
+  });
+
+  const ruleTester = new RuleTester({
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+        sourceType: "module",
+      },
+    },
+  });
+
+  ruleTester.run("filled-primary-contrast-scope", rule, {
+    valid: [
+      // Filled-primary: default variant, no color (the guarded core).
+      { code: `import { Button } from "@mantine/core"; <Button>Go</Button>;` },
+      {
+        code: `import { Button } from "@mantine/core"; <Button variant="filled">Go</Button>;`,
+      },
+      {
+        code: `import { Checkbox } from "@mantine/core"; <Checkbox label="ok" />;`,
+      },
+      // Audited secondary / status shapes.
+      {
+        code: `import { Button } from "@mantine/core"; <Button variant="default">Reset</Button>;`,
+      },
+      {
+        code: `import { Button } from "@mantine/core"; <Button variant="subtle" color="red">Remove</Button>;`,
+      },
+      {
+        code: `import { Button } from "@mantine/core"; <Button variant="light" color="red">Try again</Button>;`,
+      },
+      {
+        code: `import { ActionIcon } from "@mantine/core"; <ActionIcon variant="subtle">x</ActionIcon>;`,
+      },
+      // A conditional variant whose every branch is audited.
+      {
+        code: `import { Button } from "@mantine/core"; <Button variant={spent ? "default" : "subtle"}>Open</Button>;`,
+      },
+      // A same-named surface not imported from @mantine/core is out of scope.
+      {
+        code: `import { Button } from "./local"; <Button color="red" variant="filled">x</Button>;`,
+      },
+    ],
+    invalid: [
+      // Explicit color on a filled surface leaves the scope.
+      {
+        code: `import { Button } from "@mantine/core"; <Button color="red">Delete</Button>;`,
+        errors: [{ messageId: "unscoped" }],
+      },
+      {
+        code: `import { Button } from "@mantine/core"; <Button variant="filled" color="red">Delete</Button>;`,
+        errors: [{ messageId: "unscoped" }],
+      },
+      // A variant/color pair outside the audited set.
+      {
+        code: `import { ActionIcon } from "@mantine/core"; <ActionIcon variant="filled" color="blue">i</ActionIcon>;`,
+        errors: [{ messageId: "unscoped" }],
+      },
+      {
+        code: `import { Checkbox } from "@mantine/core"; <Checkbox color="grape" />;`,
+        errors: [{ messageId: "unscoped" }],
+      },
+      // A conditional variant with an unaudited branch.
+      {
+        code: `import { Button } from "@mantine/core"; <Button variant={x ? "filled" : "subtle"} color="red">x</Button>;`,
+        errors: [{ messageId: "unscoped" }],
+      },
+      // A dynamic, unresolvable variant is not silently passed.
+      {
+        code: `import { Button } from "@mantine/core"; <Button variant={someVariant}>x</Button>;`,
+        errors: [{ messageId: "unscoped" }],
+      },
+    ],
+  });
+});


### PR DESCRIPTION
## Summary

The filled-primary contrast guarantee applies only to the default-variant, no-explicit-color scope the theme's `isFilledPrimary` helper encodes. A primary-action control authored with an explicit `color` or a non-filled `variant` silently leaves that scope and can paint an inaccessible color while the arithmetic unit test and the render harness stay green. This adds an ESLint rule that fails that drift at authoring time across every call site, and fixes the one latent AA failure the rule caught.

Implements [207020762](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=207020762).

## Changes

- apps/web/eslint-rules/filled-primary-contrast-scope.mjs (+ its type shim), apps/web/eslint.config.js: a custom rule that fails an explicit `color` or a non-filled `variant` on the primary-action Button/ActionIcon/Checkbox surfaces meant to be filled-primary, scoped by the theme's own predicate rather than a hand-maintained call-site list.
- apps/web/test/unit/filledPrimaryContrastScope.test.ts: drives the theme's real `vars` resolvers over the variant x color matrix and asserts the rule's `isFilledPrimary` agrees with them, so the rule and the theme cannot drift.
- apps/web/src/bench/SavedExchanges.tsx: fix the delete-confirm Button from filled `color="red"` (3.28:1 in the dark scheme, below AA) to `variant="light" color="red"` (~6.45:1), matching every other destructive control in the app.

## Test plan

Ran: `npm run typecheck && npm run lint && npm run format`; `npm test -w apps/web` (unit) green. Verified the rule fires (injected an explicit `color` on a filled-primary site, saw the actionable message, reverted) and passes on all current call sites; the theme-consistency test is mutation-checked.
New tests cover: the rule's `isFilledPrimary` predicate matches the theme's filled-primary routing across the full variant x color matrix, and every audited secondary/status shape is provably non-filled-primary (the allowlist cannot shadow the guarded core).

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: internal lint tooling plus a one-line contrast fix; no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test/CI/tooling change plus a UI contrast fix, not a major feature or breaking change.
- [x] Security review -- n/a: developer lint tooling and a contrast fix; no crypto, credential, disclosure, or dependency trigger touched. An independent UX/accessibility review was completed with no findings.
