### PR TITLE
Make the deploy drift-guard failure actionable

### DIFF
--- a/.claude/scripts/lib/ciPathFilters.test.mjs
+++ b/.claude/scripts/lib/ciPathFilters.test.mjs
@@ -175,7 +175,14 @@ describe("ci path-filter drift guard (live workflows)", () => {
       const dirs = trackedTopLevelDirs(root);
       // Sanity: the root has tracked subdirs, so the assertion is actually live.
       expect(dirs.length).toBeGreaterThan(0);
-      expect(uncoveredDirs(dirs, deployEntries, DEPLOY_EXCLUDED)).toEqual([]);
+      const uncovered = uncoveredDirs(dirs, deployEntries, DEPLOY_EXCLUDED);
+      expect(
+        uncovered,
+        `new tracked dir(s) under ${root} are neither deploy-covered nor ` +
+          `allowlisted: ${uncovered.join(", ")}. Add each to DEPLOY_EXCLUDED if it ` +
+          `does not ship (dev/lint tooling, like apps/web/test), or a path to ` +
+          `${DEPLOY_WORKFLOW} if it does. Re-check with \`npm run test:scripts\`.`,
+      ).toEqual([]);
     }
   });
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Beyond the conventions in `CONTRIBUTING.md`:
 - Commit messages use no markdown and no top-level lists (other format rules in `CONTRIBUTING.md`, Commit Messages).
 - After a chain of edits, run `npm run typecheck && npm run lint && npm run format`; the LSP server often has a stale cache.
 - Typecheck, lint, and format are CI checks.
+- A change that adds a top-level directory under a guarded root (`apps/web`, `packages/core`) or edits CI/deploy config must also run `npm run test:scripts`; the workspace suites skip the CI/deploy drift guards (e.g. the deploy path-filter check), so a new unclassified dir passes locally and reddens only in CI.
 - Project state belongs in the GitHub project and docs/, not agent memory.
 - Encode a "does not happen at runtime" claim (a line that never fires, an unreachable branch) as a check, never a comment or doc note -- prose asserting a runtime fact rots silently; a check cannot lie. Full rule and the Global-listener cautionary example: `CONTRIBUTING.md`, Code Conventions.
 - Before committing, sweep your own diff: delete every comment that restates the code, narrates change history ("now", "previously", "moved here"), or cites a board item id. Thoroughness is demonstrated in tests and checks, not prose.


### PR DESCRIPTION
## Summary

The deploy path-filter drift guard (`.claude/scripts/lib/ciPathFilters.test.mjs`) fails when a new top-level directory under a guarded root (`apps/web`, `packages/core`) is neither deploy-covered nor allowlisted, but it asserted a bare `toEqual([])`, so the failure surfaced only the offending directory name with no hint of the fix. This gives that assertion an actionable message and records the local re-check in CLAUDE.md, so the next contributor who trips it (a real recent case: a new `apps/web/eslint-rules/` dir) sees what to do instead of reverse-engineering it from the test.

## Changes

- .claude/scripts/lib/ciPathFilters.test.mjs: the "every tracked top-level dir ... deploy-covered or allowlisted" assertion now carries a message that names each unclassified directory and the fix -- allowlist it in `DEPLOY_EXCLUDED` if it does not ship (dev/lint tooling), or add a path to `eb_deploy.yaml` if it does, and re-check with `npm run test:scripts`.
- CLAUDE.md: add an agent convention that a change adding a top-level dir under a guarded root, or editing CI/deploy config, must run `npm run test:scripts`, since the workspace suites skip these drift guards and a new unclassified dir reddens only in CI.

## Test plan

Ran (in an isolated worktree): `npm run test:scripts` (7 files / 64 tests green -- the guard still passes with the message), `npm run lint` and `npm run format` clean. Verified the message renders by adding a throwaway tracked dir and confirming the failure output names the dir and the fix, then reverted.
New tests cover: n/a -- this improves an existing guard's failure message and adds a doc convention; no behavior changed.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` -- n/a: no `docs/` or `docs/spec/` page is affected; the CLAUDE.md edit is an agent-convention line, not a documentation-tier change.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: internal test-infra message plus an agent convention, not operator-facing and not a major feature or breaking change.
- [x] Security review -- n/a: a CI test failure message and a CLAUDE.md convention line; none of the security triggers are touched.
