### PR TITLE
Harden transform param types in standardization

### DIFF
--- a/docs/EXCHANGE_REFERENCE.md
+++ b/docs/EXCHANGE_REFERENCE.md
@@ -979,7 +979,7 @@ Parameter names below are written in snake_case in YAML (e.g. `input_format`, `i
 | `to_lower_case` | Convert to lowercase | — |
 | `remove_accents` | Remove accents and other diacritics, ASCII-ifying the text; re-normalizes to NFC after the diacritic strip | — |
 | `remove_affixes` | Remove name titles (Mr., Dr., ...) (and suffixes (Jr., III, ...) | — |
-| `substring` | Extract a substring | `start` (1-indexed, required; negative counts from end), `length` (required) |
+| `substring` | Extract a substring | `start` (integer, 1-indexed, required; negative counts from end), `length` (positive integer, required) |
 | `parse_date` | Reformat a date string | `input_format` (default `MM/DD/YYYY`), `output_format` (default `YYYYMMDD`), each at most 256 characters; tokens: `YYYY`, `YY`, `MM`, `DD` |
 | `pad_left` | Left-pad the value with a fill character up to a target length; pass-through if already at or above the length | `length` (positive integer, required, at most 256), `char` (single character, default `"0"`) |
 | `phonetic` | Apply a phonetic encoding | `algorithm`: `soundex` (default); result is a 4-character string |

--- a/packages/core/src/config/linkageTerms.ts
+++ b/packages/core/src/config/linkageTerms.ts
@@ -650,6 +650,26 @@ const TransformStepSchema: z.ZodType<TransformStep> = TransformStepBaseSchema
       message: `transform regex pattern must not exceed ${MAX_TRANSFORM_PATTERN_LENGTH} characters`,
       path: ["params"],
     },
+  )
+  // `substring` slices by numeric `start` / `length`. A non-integer bound never
+  // slices as intended -- substringFactory drops it to an all-null fn, so the
+  // step silently excludes every row rather than erroring. Reject a present
+  // non-integer bound at parse instead, mirroring the descriptor schema's own
+  // `int` requirement. An absent bound is left alone: the factory ignores it the
+  // same way, so it is a no-op step, not a malformed one.
+  .refine(
+    (step) => {
+      if (step.function !== "substring") return true;
+      const { start, length } = step.params ?? {};
+      return (
+        (start === undefined || Number.isInteger(start)) &&
+        (length === undefined || Number.isInteger(length))
+      );
+    },
+    {
+      message: "substring start and length must be integers",
+      path: ["params"],
+    },
   );
 
 /**

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -533,10 +533,10 @@ export function loadCSVColumnSample(
         }
         // `target` is non-undefined past this point, but it is an outer-scope
         // `let` read inside this callback, which TypeScript will not narrow on its
-        // own; this guard does the narrowing for the indexing below.
+        // own; this guard does the narrowing for the row read below.
         if (target === undefined) return;
         for (const row of results.data as Array<Record<string, unknown>>) {
-          const value = row[target];
+          const value = readRowColumn(row as CSVRow, target);
           if (typeof value === "string" && value.trim() !== "") {
             sample.push(value);
             // Enough to reproduce a full scan; stop reading the rest of the file.

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -341,8 +341,8 @@ function parseDateFactory(params: Params): StandardizingFn {
   // satisfiability pre-flight is pinned to that verdict), realized here as an
   // empty format that tokenizes to an all-dropping pattern -- a raw non-string
   // would instead throw in parseDateFormat (`.startsWith` on an array). Guard the
-  // output format by type too: a non-string there reaches `.replace` on a matched
-  // row and throws, so it falls back to the absent default.
+  // output format by type too: a non-string there reaches `.replaceAll` on a
+  // matched row and throws, so it falls back to the absent default.
   const rawInputFormat = params.inputFormat;
   const inputFormat =
     rawInputFormat == null
@@ -390,16 +390,30 @@ function parseDateFactory(params: Params): StandardizingFn {
     if (!isCalendarDateValid(year, month, day)) return null;
 
     return outputFormat
-      .replace("YYYY", year)
-      .replace("MM", month)
-      .replace("DD", day);
+      .replaceAll("YYYY", year)
+      .replaceAll("MM", month)
+      .replaceAll("DD", day);
   };
 }
 
 function substringFactory(params: Params): StandardizingFn {
-  const start = params.start as number | undefined;
-  const len = params.length as number | undefined;
-  if (start === undefined || len === undefined || start === 0)
+  // Guard both bounds by type, not just presence: the wire params are
+  // z.unknown() and only count-bounded, so a partner can declare either as a
+  // non-integer (a string, float, or other JSON value). An unguarded non-number
+  // `length` turns `startIdx + len` into string concatenation, silently
+  // producing the wrong slice rather than the intended one. A start or length
+  // that is not an integer -- like the always-null `start === 0` no-op -- yields
+  // a fn that drops every value, the ignore path this factory already takes for a
+  // degenerate bound (never crashing the partner-reachable key build).
+  const start = params.start;
+  const len = params.length;
+  if (
+    typeof start !== "number" ||
+    !Number.isInteger(start) ||
+    typeof len !== "number" ||
+    !Number.isInteger(len) ||
+    start === 0
+  )
     return (_s) => null;
   if (start > 0) {
     // SQL SUBSTR convention: 1-indexed positive start — startIdx is fixed.
@@ -836,13 +850,13 @@ export const STANDARDIZATION_FUNCTION_DESCRIPTORS: Record<
     label: "Substring",
     blurb: "Keep a fixed slice of the value by start position and length.",
     tier: "standard",
-    // The factory does no numeric validation -- it relies on String.slice, which
-    // tolerates fractional and negative bounds -- so the schema is deliberately
-    // stricter than the factory here, rejecting footgun shapes (a fractional
-    // position, a non-positive length, a 0 start) that slice would silently
-    // mangle. 0 is rejected because the factory treats it as a no-op returning an
-    // always-null fn; positions are 1-indexed, with a negative start counting
-    // from the end.
+    // The factory drops a non-integer or 0 bound to an always-null fn, but leaves
+    // a negative length (which slices to empty) alone -- so the schema is
+    // deliberately stricter here, rejecting footgun shapes (a fractional position,
+    // a non-positive length, a 0 start) at parse time with a message rather than
+    // silently dropping every row. 0 is rejected because the factory treats it as
+    // an always-null no-op; positions are 1-indexed, with a negative start
+    // counting from the end.
     params: z.object({
       start: z
         .number()

--- a/packages/core/test/linkageTerms.test.ts
+++ b/packages/core/test/linkageTerms.test.ts
@@ -764,6 +764,59 @@ test("a non-string parse_date format still validates, so the runtime factory han
   ).toBe(true);
 });
 
+// --- substring integer bounds (partner-controlled non-integer footgun) --------
+// substring slices by numeric `start` / `length`; a non-integer bound never
+// slices as intended (the factory drops it to an all-null fn, silently excluding
+// every row). The refine rejects a present non-integer bound at validation.
+
+const substringTerms = (params: Record<string, unknown>) => ({
+  ...base,
+  linkageKeys: [
+    {
+      name: "SSN",
+      elements: [
+        { field: "ssn", transform: [{ function: "substring", params }] },
+      ],
+    },
+  ],
+});
+
+test("a non-integer substring start or length is rejected at validation", () => {
+  for (const params of [
+    { start: 1, length: "5" },
+    { start: "1", length: 5 },
+    { start: 1, length: 5.5 },
+    { start: 1.5, length: 5 },
+    { start: 1, length: true },
+  ]) {
+    const result = safeParseLinkageTerms(substringTerms(params));
+    expect(result.success, JSON.stringify(params)).toBe(false);
+    if (result.success) continue;
+    expect(
+      result.error.issues.some((i) =>
+        /substring start and length must be integers/.test(i.message),
+      ),
+    ).toBe(true);
+  }
+});
+
+test("integer substring bounds parse and are preserved", () => {
+  const result = safeParseLinkageTerms(substringTerms({ start: 3, length: 5 }));
+  expect(result.success).toBe(true);
+  if (!result.success) return;
+  expect(result.data.linkageKeys[0].elements[0].transform?.[0].params).toEqual({
+    start: 3,
+    length: 5,
+  });
+});
+
+test("absent substring bounds validate; the factory ignores the no-op step", () => {
+  expect(safeParseLinkageTerms(substringTerms({})).success).toBe(true);
+  expect(safeParseLinkageTerms(substringTerms({ start: 3 })).success).toBe(
+    true,
+  );
+});
+
 // --- transform regex pattern-length bound (source sanity pre-filter) --
 // The four tier:"regex" functions compile their raw pattern / delimiter under the
 // linear-time engine (compiled once per transform array, memoized).

--- a/packages/core/test/standardization.test.ts
+++ b/packages/core/test/standardization.test.ts
@@ -195,6 +195,41 @@ describe("runPipeline — string functions", () => {
     expect(runPipeline("SMITH", [{ function: "substring" }])).toBeNull();
   });
 
+  test("substring with a valid integer slice still works", () => {
+    expect(
+      runPipeline("ABCDEFGHIJ", [
+        { function: "substring", params: { start: 3, length: 5 } },
+      ]),
+    ).toBe("CDEFG");
+  });
+
+  test("substring drops a non-integer length without string-concatenating", () => {
+    // The wire params are z.unknown(), so a partner can declare `length` as a
+    // non-number. An unguarded `startIdx + length` would then concatenate strings
+    // -- {start: 3, length: "5"} on "ABCDEFGHIJ" once sliced to "CDEFGHIJ" (from
+    // index 2 to "2" + "5" = "25") rather than the intended "CDEFG". The guard
+    // drops any non-integer bound to null instead.
+    for (const length of ["5", 5.5, true, ["5"]]) {
+      expect(
+        runPipeline("ABCDEFGHIJ", [
+          { function: "substring", params: { start: 3, length } },
+        ]),
+        JSON.stringify({ length }),
+      ).toBeNull();
+    }
+  });
+
+  test("substring drops a non-integer start without string-concatenating", () => {
+    for (const start of ["3", 3.5, true, ["3"]]) {
+      expect(
+        runPipeline("ABCDEFGHIJ", [
+          { function: "substring", params: { start, length: 5 } },
+        ]),
+        JSON.stringify({ start }),
+      ).toBeNull();
+    }
+  });
+
   test("pad_left pads a short string with zeros", () => {
     expect(
       runPipeline("123", [{ function: "pad_left", params: { length: 9 } }]),
@@ -524,6 +559,19 @@ describe("runPipeline — parse_date", () => {
       expect(parseWithOutput("06/15/1990", "YY")).toBe("YY");
       expect(parseWithOutput("01/02/2003", "YY")).toBe("YY");
     });
+  });
+
+  test("a repeated output token is substituted at every occurrence", () => {
+    const parseWithOutput = (value: string, outputFormat: string) =>
+      runPipeline(value, [
+        {
+          function: "parse_date",
+          params: { inputFormat: "MM/DD/YYYY", outputFormat },
+        },
+      ]);
+    expect(parseWithOutput("06/15/1990", "MM/DD/MM")).toBe("06/15/06");
+    expect(parseWithOutput("06/15/1990", "YYYY-YYYY")).toBe("1990-1990");
+    expect(parseWithOutput("06/15/1990", "DD.DD.DD")).toBe("15.15.15");
   });
 });
 


### PR DESCRIPTION
## Summary

Guard the `substring` standardization transform against non-integer parameters. A non-integer `length` or `start` previously fell through to `startIdx + len`, silently concatenating strings and producing a wrong slice on a partner-reachable linkage-key build path. The transform now rejects non-integer bounds at both the schema (parse time) and the factory (runtime), matching its sibling transforms. This PR also assembles `parse_date` output with `replaceAll` so a repeated token fills at every occurrence, and routes the CSV column sample through the `readRowColumn` own-property chokepoint.

## Changes

- packages/core/src/standardization.ts: integer-guard `substringFactory` start/length; assemble `parse_date` output with `replaceAll`.
- packages/core/src/config/linkageTerms.ts: reject a present non-integer `substring` start/length in the `TransformStepSchema` refine, mirroring the pad_left/parse_date refines.
- packages/core/src/file.ts: read the sampled column via `readRowColumn` with a string-type guard, restoring the own-property invariant without a non-string throw.
- packages/core/test: cover substring with non-integer start/length and parse_date with a repeated output token.
- docs/EXCHANGE_REFERENCE.md: note substring start/length are integers.

## Test plan

Ran: `npm run build -w packages/core` then the full `npm run test` (core 2255, cli 1202, web 1362, all passing); typecheck/lint/format clean.
New tests cover: substring rejecting string/array/boolean/float start and length (returns null, valid integer and negative-integer cases unchanged) and parse_date filling a repeated output token.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- updated `docs/EXCHANGE_REFERENCE.md` (substring start/length are integers); no `docs/spec` page documents transform-param typing, so nothing else needed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: bug fix, not a major feature or breaking change.
- [x] Security review -- done: independent review of the diff (partner-reachable transform-param validation on the linkage-key build path); verdict safe to land, with one LOW robustness note (the non-string CSV cell guard) applied.
