### PR TITLE
Guard SSE stream against a pre-aborted request

### DIFF
--- a/apps/web/src/jobs/jobManager.ts
+++ b/apps/web/src/jobs/jobManager.ts
@@ -484,9 +484,25 @@ export class JobManager {
     }
     const entry: BufferedEvent = { id: record.events.length + 1, event };
     record.events.push(entry);
-    for (const listener of record.listeners) listener(entry);
+    this.notifyListeners(record, entry);
     if (event.type === "result" || event.type === "error")
       this.markTerminalEmitted(record, event.type);
+  }
+
+  /**
+   * Notify every SSE listener of one buffered entry, isolating each: a listener
+   * whose enqueue throws (a controller in an unexpected state) is dropped rather
+   * than allowed to propagate out of the fd-3 relay and break every other
+   * subscriber's stream.
+   */
+  private notifyListeners(record: JobRecord, entry: BufferedEvent): void {
+    for (const listener of record.listeners) {
+      try {
+        listener(entry);
+      } catch {
+        record.listeners.delete(listener);
+      }
+    }
   }
 
   /** Fail a job whose event buffer overflowed, appending a synthesized error. */
@@ -503,7 +519,7 @@ export class JobManager {
       },
     };
     record.events.push(entry);
-    for (const listener of record.listeners) listener(entry);
+    this.notifyListeners(record, entry);
     this.markTerminalEmitted(record, "error");
     record.status = "failed";
     record.handle?.signal("SIGKILL");
@@ -591,7 +607,7 @@ export class JobManager {
       event,
     };
     record.events.push(entry);
-    for (const listener of record.listeners) listener(entry);
+    this.notifyListeners(record, entry);
     this.markTerminalEmitted(
       record,
       event.type === "result" ? "result" : "error",

--- a/apps/web/src/routes/api/jobs/$jobId/events.ts
+++ b/apps/web/src/routes/api/jobs/$jobId/events.ts
@@ -30,6 +30,14 @@ export const Route = createFileRoute("/api/jobs/$jobId/events")({
 
         const stream = new ReadableStream<Uint8Array>({
           start(controller) {
+            // Already aborted between the request and this callback: the later
+            // addEventListener would never fire post-abort, so the subscription
+            // would leak into the record. Close without subscribing.
+            if (request.signal.aborted) {
+              controller.close();
+              return;
+            }
+
             const encoder = new TextEncoder();
             const push = (id: number, event: unknown): void => {
               controller.enqueue(encoder.encode(renderSseFrame(id, event)));

--- a/apps/web/test/unit/jobManager.unit.test.ts
+++ b/apps/web/test/unit/jobManager.unit.test.ts
@@ -243,6 +243,44 @@ describe("SSE replay", () => {
     await waitForTerminal(record);
     expect(seen.some((entry) => entry.event.type === "result")).toBe(true);
   });
+
+  test("a throwing listener is dropped and never breaks the relay", async () => {
+    // Drive the append path directly so a listener whose enqueue throws (a
+    // controller in an unexpected state) is isolated: it is unsubscribed, the
+    // append does not throw, and every other subscriber still receives events.
+    let handlers!: CliDriverHandlers;
+    const spy = vi
+      .spyOn(cliDriver, "spawnExchangeJob")
+      .mockImplementation((args) => {
+        handlers = args.handlers;
+        return { signal: () => true, isRunning: () => true };
+      });
+
+    const root = tempDataRoot("throwing-listener");
+    roots.push(root);
+    const manager = new JobManager({
+      dataRoot: root,
+      binaryPath: STUB_CLI_PATH,
+    });
+    managers.push(manager);
+
+    const id = await manager.createJob(validIntent());
+    const record = manager.getJob(id)!;
+    const healthy: Array<BufferedEvent> = [];
+    manager.subscribe(record, 0, () => {
+      throw new Error("enqueue on a closed controller");
+    });
+    manager.subscribe(record, 0, (entry) => healthy.push(entry));
+
+    expect(() =>
+      handlers.onEvent({ v: 1, type: "stage", id: "s1", label: "one" }),
+    ).not.toThrow();
+    expect(record.listeners.size).toBe(1);
+    handlers.onEvent({ v: 1, type: "stage", id: "s2", label: "two" });
+    expect(healthy.map((entry) => entry.id)).toEqual([1, 2]);
+
+    spy.mockRestore();
+  });
 });
 
 describe("event cap fails the job", () => {

--- a/apps/web/test/unit/jobRoutes.unit.test.ts
+++ b/apps/web/test/unit/jobRoutes.unit.test.ts
@@ -224,6 +224,37 @@ describe("create validates and never CORS", () => {
   });
 });
 
+describe("GET /api/jobs/:id/events guards an already-aborted request", () => {
+  test("a pre-aborted signal closes the stream and leaks no listener", async () => {
+    const root = tempDataRoot("routes-abort");
+    roots.push(root);
+    vi.stubEnv("JOB_DATA_ROOT", root);
+    const manager = new JobManager({
+      dataRoot: root,
+      binaryPath: STUB_CLI_PATH,
+      // A delayed stub keeps the job non-terminal, so the route reaches the
+      // live-subscribe path rather than closing on an already-terminal replay.
+      childEnv: { STUB_FD3_EVENTS: JSON.stringify([]), STUB_DELAY_MS: "5000" },
+    });
+    (globalThis as { jobManagerInstance?: JobManager }).jobManagerInstance =
+      manager;
+    const id = await manager.createJob(validIntent());
+    const record = manager.getJob(id)!;
+
+    const response = (await handlersOf(EventsRoute).GET({
+      request: new Request(`http://localhost/api/jobs/${id}/events`, {
+        signal: AbortSignal.abort(),
+      }),
+      params: { jobId: id },
+    })) as Response;
+    // Draining the body runs the stream's start callback, where the guard fires.
+    await response.text();
+    expect(record.listeners.size).toBe(0);
+
+    manager.cancelJob(record);
+  });
+});
+
 describe("routes validate the job id before filesystem use", () => {
   test("a malformed id is 404 on status, events, cancel, result, delete", async () => {
     enableJobApi();


### PR DESCRIPTION
## Summary

Fix a subscription leak in the job-events SSE stream and harden the event relay. If a client's request was already aborted when the stream's `start` callback ran, the abort listener never fired, so the subscription leaked into the job's listener set and every later event pushed to a defunct controller. A synchronous aborted-check now short-circuits before subscribing, matching the guard pattern used elsewhere in the app. The per-listener relay in the job manager now isolates and drops a throwing listener so a defunct controller cannot break the fd-3 event pump for other subscribers.

## Changes

- apps/web/src/routes/api/jobs/$jobId/events.ts: return early (closing the stream) when `request.signal` is already aborted, before subscribing.
- apps/web/src/jobs/jobManager.ts: route the three listener-iteration sites through a `notifyListeners` helper that try/catches each listener and unsubscribes one that throws.
- apps/web/test: cover the pre-aborted guard (no leaked listener) and a throwing listener (dropped, others still delivered).

## Test plan

Ran: apps/web unit suite (1362 passing); typecheck/lint/format clean. Both new tests fail against the pre-fix source and pass with the fix.
New tests cover: subscribe-on-already-aborted leaves no listener; a throwing listener does not break `appendEvent` and healthy subscribers still receive events.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: internal SSE/relay robustness; the `docs/spec/SERVER_JOB_API.md` endpoint and event contract is unchanged; no `docs/` page affected.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: bug fix (robustness), not a major feature or breaking change.
- [x] Security review -- done: independent review of the diff (client-reachable SSE subscription leak and event-relay hardening); no findings.
