### PR TITLE
Tighten user-facing copy; relabel exchange as recurring

### DIFF
--- a/apps/cli/src/cliParser.ts
+++ b/apps/cli/src/cliParser.ts
@@ -71,7 +71,8 @@ export function buildCli(argv: string[]): Argv {
       .version(readCliVersion())
       .command(
         "$0",
-        "Quick exchange: psilink [--save] URL INPUT_FILE [OUTPUT_FILE]",
+        "Quick exchange (no shared secret; trusts the server): psilink " +
+          "[--save] URL INPUT_FILE [OUTPUT_FILE]",
         zeroSetupBuilder,
         zeroSetupHandler,
       )

--- a/apps/cli/src/commands/verifyReceipt.ts
+++ b/apps/cli/src/commands/verifyReceipt.ts
@@ -71,8 +71,8 @@ export function builder(cmd: Argv): Argv {
     .positional("result-file", {
       type: "string",
       describe:
-        "the result file this party retained; needed to open the received-" +
-        "payload and pairing commitments",
+        "the result file this party retained (a path, not - for stdin); " +
+        "needed to open the received-payload and pairing commitments",
     })
     .option("keys", {
       type: "string",
@@ -207,7 +207,9 @@ const COMMITMENT_WORD: Record<CommitmentStatus, string> = {
   verified: "opened and matches",
   mismatch: "DOES NOT MATCH",
   "not-supplied": "not opened (no data re-supplied)",
-  unopenable: "not opened (no salt in the keys file)",
+  unopenable:
+    "cannot be opened (no salt in the keys file; likely a wrong or drifted " +
+    "keys file, not a problem with the record)",
 };
 const TERMS_WORD: Record<TermsHashStatus, string> = {
   verified: "re-derives and matches",

--- a/apps/cli/src/optionDefinitions.ts
+++ b/apps/cli/src/optionDefinitions.ts
@@ -198,8 +198,9 @@ export function addCommonBootstrapOptions(
       type: "string",
       describe:
         "how often to poll the shared directory for the partner's files on " +
-        "the sftp/filedrop channels (default: 5s). A conservative default " +
-        "keeps within SFTP servers' anti-flood limits; a sub-second value is " +
+        "the sftp/filedrop channels (default: 5s); overrides " +
+        "connection.options.poll_interval_ms. A conservative default keeps " +
+        "within SFTP servers' anti-flood limits; a sub-second value is " +
         "accepted for a demo against a controlled server but warns. " +
         FINE_DURATION_VALUE_HELP,
     })

--- a/apps/web/src/bench/AcceptorBench.tsx
+++ b/apps/web/src/bench/AcceptorBench.tsx
@@ -788,7 +788,7 @@ export function AcceptorBench() {
               withAsterisk
               required
               label="Your name"
-              description="Recorded in your exchange record so your partner can identify you"
+              description="Shown to your partner so they can identify you in this exchange"
               value={acceptorName}
               maxLength={200}
               error={fieldErrors.name}
@@ -982,7 +982,7 @@ export function AcceptorBench() {
             />
             {/* The manage offer is webrtc-only (its record composes a webrtc
                 locator from the invitation's endpoint) and is skippable: leaving
-                it untouched keeps the exchange one-time. It stands from launch
+                it untouched keeps the exchange one-off. It stands from launch
                 through completion, so this party can manage the partnership. */}
             {decode.invitation.endpoint.channel === "webrtc" &&
               launched !== undefined &&

--- a/apps/web/src/bench/BenchLobby.tsx
+++ b/apps/web/src/bench/BenchLobby.tsx
@@ -69,7 +69,7 @@ export function BenchLobby() {
         </VisuallyHidden>
         <div className={styles.lobbyActions}>
           <div className={styles.actionCard}>
-            <h3>Set up an exchange</h3>
+            <h3>Set up a recurring exchange</h3>
             <p className={`${styles.small} ${styles.sub}`}>
               Choose a file, confirm what you disclose, and share an invitation.
               Default terms come from your file; most exchanges need nothing
@@ -77,7 +77,7 @@ export function BenchLobby() {
             </p>
             <p>
               <Button component={Link} to="/exchange">
-                Set up an exchange
+                Set up a recurring exchange
               </Button>
             </p>
           </div>

--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -1026,7 +1026,7 @@ export function InviterBench() {
             />
             {/* The manage offer is webrtc-only (its record composes a webrtc
                 locator) and is skippable: leaving it untouched keeps the exchange
-                one-time. It stands from the share screen through completion, so
+                one-off. It stands from the share screen through completion, so
                 either party can manage the partnership. The sample demo is
                 excluded: a standing record of synthetic terms armed with a real
                 secret is not a partnership to manage. */}

--- a/apps/web/src/bench/ManageExchangeOffer.tsx
+++ b/apps/web/src/bench/ManageExchangeOffer.tsx
@@ -124,15 +124,15 @@ export function ManageExchangeOffer({
 
   // The store cannot be opened at all in this browser, so no deposit can land: offer
   // the honest state instead of a form that only fails at the write. No alarm
-  // styling -- the one-time exchange the operator just completed is unaffected.
+  // styling -- the one-off exchange the operator just completed is unaffected.
   if (!storeAvailable)
     return (
       <div className={styles.callout}>
         <p className={styles.calloutLead}>Save as a recurring exchange</p>
         <p className={styles.small}>
           This browser cannot store recurring exchanges -- private browsing may
-          be blocking storage, or this browser does not support it. Your
-          one-time exchange is unaffected.
+          be blocking storage, or this browser does not support it. Your one-off
+          exchange is unaffected.
         </p>
       </div>
     );
@@ -157,7 +157,7 @@ export function ManageExchangeOffer({
       <p className={styles.small}>
         Store this exchange&apos;s terms and secret in this browser so you can
         run it again with the same partner, without re-inviting. Skip this to
-        keep the exchange one-time: nothing is stored.
+        keep the exchange one-off: nothing is stored.
       </p>
       <TextInput
         label="Label"
@@ -206,8 +206,8 @@ export function ManageExchangeOffer({
           title="Could not save this recurring exchange"
           mt="sm"
         >
-          The exchange was not stored. Your one-time exchange is unaffected -
-          try again.
+          The exchange was not stored. Your one-off exchange is unaffected - try
+          again.
         </Alert>
       )}
       <Button

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -324,7 +324,7 @@ describe("bench quick path", () => {
       (heading) => heading.textContent,
     );
     expect(cardHeadings).toEqual([
-      "Set up an exchange",
+      "Set up a recurring exchange",
       "Accept an invitation you were sent",
     ]);
 
@@ -339,7 +339,7 @@ describe("bench quick path", () => {
       .toBeInTheDocument();
 
     const setUpLink = Array.from(document.querySelectorAll("a")).find(
-      (anchor) => anchor.textContent === "Set up an exchange",
+      (anchor) => anchor.textContent === "Set up a recurring exchange",
     );
     expect(setUpLink?.getAttribute("href")).toBe("/exchange");
 

--- a/apps/web/test/browser/savedExchanges.test.ts
+++ b/apps/web/test/browser/savedExchanges.test.ts
@@ -134,7 +134,9 @@ describe("home route: conditional on a stored exchange existing", () => {
     // The first-run landing is the quick (invite/accept) path: its two primary
     // actions, not the list's designed empty state.
     await expect
-      .element(page.getByRole("heading", { name: "Set up an exchange" }))
+      .element(
+        page.getByRole("heading", { name: "Set up a recurring exchange" }),
+      )
       .toBeInTheDocument();
     await expect
       .element(

--- a/apps/web/test/browser/savedExchangesFailed.test.ts
+++ b/apps/web/test/browser/savedExchangesFailed.test.ts
@@ -84,7 +84,9 @@ describe("store opens but the read fails", () => {
 
     // The lobby's one-off cards must not stand in for the loss.
     expect(
-      page.getByRole("heading", { name: "Set up an exchange" }).query(),
+      page
+        .getByRole("heading", { name: "Set up a recurring exchange" })
+        .query(),
     ).toBeNull();
   });
 

--- a/apps/web/test/browser/savedExchangesUnavailable.test.ts
+++ b/apps/web/test/browser/savedExchangesUnavailable.test.ts
@@ -77,7 +77,9 @@ describe("store unavailable", () => {
 
     // The one-off flow itself, not the list's degrade message.
     await expect
-      .element(page.getByRole("heading", { name: "Set up an exchange" }))
+      .element(
+        page.getByRole("heading", { name: "Set up a recurring exchange" }),
+      )
       .toBeInTheDocument();
     await expect
       .element(

--- a/apps/web/test/browser/themeContrast.test.ts
+++ b/apps/web/test/browser/themeContrast.test.ts
@@ -339,7 +339,7 @@ describe("rendered filled-primary contrast (WCAG 2.1 AA)", () => {
         createElement(
           LinkRenderedButton,
           { component: "a", href: "/exchange" },
-          "Set up an exchange",
+          "Set up a recurring exchange",
         ),
       ),
     );


### PR DESCRIPTION
## Summary

Tighten and align user-facing copy across the CLI and web app, and reframe the full-setup exchange entry point as recurring. The `/exchange` route is the configurable, inspectable exchange setup; per a maintainer IA decision it is now labelled "Set up a recurring exchange" consistently across the lobby and the recurring-exchanges page, while `/quick` remains the one-off path. The remaining edits are copy-consistency fixes: verify-receipt help and verdict wording, the `--polling-frequency` override note, a zero-setup trust caveat, an acceptor field description, and unified "one-off" terminology.

## Changes

- apps/web/src/bench/BenchLobby.tsx: relabel the `/exchange` card heading and CTA "Set up an exchange" -> "Set up a recurring exchange" (matches SavedExchanges.tsx); browser-test assertions updated.
- apps/cli/src/commands/verifyReceipt.ts: clarify the result-file positional is a path (not stdin); align the "unopenable" verdict wording with the web copy and add the wrong/drifted-keys guidance.
- apps/cli/src/optionDefinitions.ts: note `--polling-frequency` overrides `connection.options.poll_interval_ms`.
- apps/cli/src/cliParser.ts: add a "no shared secret; trusts the server" caveat to the zero-setup command summary.
- apps/web/src/bench/AcceptorBench.tsx: reword the "Your name" description to drop the managed-store "exchange record" term.
- apps/web/src/bench/{InviterBench,ManageExchangeOffer}.tsx: standardize on "one-off" (the distinct "one-time secret" wording is left untouched).

## Test plan

Ran: typecheck/lint/format clean; apps/cli unit (1202) and apps/web unit (1360) suites; apps/web browser suite for the relabeled CTA (bench, savedExchanges, savedExchangesUnavailable, savedExchangesFailed, themeContrast -- 142 passing).
New tests cover: n/a -- user-facing copy only; existing browser-test assertions were updated to the new CTA string.

## Out of scope / follow-on

- Two coherence notes surfaced by the relabel, left for review-in-action (both predate this PR): BenchLobby's component JSDoc still calls the lobby "the quick path"; and the SavedExchanges empty-state "Set up a recurring exchange" link routes to `/quick`.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: user-facing CLI/web copy only; `docs/CLI.md` already documents the `--polling-frequency` override and the verify-receipt input/stdin behavior; enumerated `docs/` and `docs/spec/`, none affected.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: UI/copy polish, not a major feature or breaking change.
- [x] Security review -- n/a: user-facing copy only (the verify-receipt verdict/help strings change no logic, disclosure, or control).
