### PR TITLE
Restore one-off invite framing to the lobby CTA

### DIFF
--- a/apps/web/src/bench/BenchLobby.tsx
+++ b/apps/web/src/bench/BenchLobby.tsx
@@ -11,8 +11,8 @@ import { downloadSampleCsvs } from "./sampleData";
 import styles from "./bench.module.css";
 
 /**
- * The quick path's screen: two primary actions side by side -- set up a one-off
- * exchange, or accept an invitation you were sent -- above the standing how-it-works
+ * The quick path's screen: two primary actions side by side -- invite someone to a
+ * one-off exchange, or accept an invitation you were sent -- above the standing how-it-works
  * explanation. Verifying a receipt is a secondary action, given as an inline text
  * link below the two cards rather than equal billing. It has its own route at
  * `/quick` and is also the home route's first-run landing (an empty or
@@ -69,7 +69,7 @@ export function BenchLobby() {
         </VisuallyHidden>
         <div className={styles.lobbyActions}>
           <div className={styles.actionCard}>
-            <h3>Set up a recurring exchange</h3>
+            <h3>Invite someone to exchange data</h3>
             <p className={`${styles.small} ${styles.sub}`}>
               Choose a file, confirm what you disclose, and share an invitation.
               Default terms come from your file; most exchanges need nothing
@@ -77,7 +77,7 @@ export function BenchLobby() {
             </p>
             <p>
               <Button component={Link} to="/exchange">
-                Set up a recurring exchange
+                Create an invitation
               </Button>
             </p>
           </div>

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -324,7 +324,7 @@ describe("bench quick path", () => {
       (heading) => heading.textContent,
     );
     expect(cardHeadings).toEqual([
-      "Set up a recurring exchange",
+      "Invite someone to exchange data",
       "Accept an invitation you were sent",
     ]);
 
@@ -339,7 +339,7 @@ describe("bench quick path", () => {
       .toBeInTheDocument();
 
     const setUpLink = Array.from(document.querySelectorAll("a")).find(
-      (anchor) => anchor.textContent === "Set up a recurring exchange",
+      (anchor) => anchor.textContent === "Create an invitation",
     );
     expect(setUpLink?.getAttribute("href")).toBe("/exchange");
 

--- a/apps/web/test/browser/savedExchanges.test.ts
+++ b/apps/web/test/browser/savedExchanges.test.ts
@@ -135,7 +135,7 @@ describe("home route: conditional on a stored exchange existing", () => {
     // actions, not the list's designed empty state.
     await expect
       .element(
-        page.getByRole("heading", { name: "Set up a recurring exchange" }),
+        page.getByRole("heading", { name: "Invite someone to exchange data" }),
       )
       .toBeInTheDocument();
     await expect

--- a/apps/web/test/browser/savedExchangesFailed.test.ts
+++ b/apps/web/test/browser/savedExchangesFailed.test.ts
@@ -85,7 +85,7 @@ describe("store opens but the read fails", () => {
     // The lobby's one-off cards must not stand in for the loss.
     expect(
       page
-        .getByRole("heading", { name: "Set up a recurring exchange" })
+        .getByRole("heading", { name: "Invite someone to exchange data" })
         .query(),
     ).toBeNull();
   });

--- a/apps/web/test/browser/savedExchangesUnavailable.test.ts
+++ b/apps/web/test/browser/savedExchangesUnavailable.test.ts
@@ -78,7 +78,7 @@ describe("store unavailable", () => {
     // The one-off flow itself, not the list's degrade message.
     await expect
       .element(
-        page.getByRole("heading", { name: "Set up a recurring exchange" }),
+        page.getByRole("heading", { name: "Invite someone to exchange data" }),
       )
       .toBeInTheDocument();
     await expect

--- a/apps/web/test/browser/themeContrast.test.ts
+++ b/apps/web/test/browser/themeContrast.test.ts
@@ -339,7 +339,7 @@ describe("rendered filled-primary contrast (WCAG 2.1 AA)", () => {
         createElement(
           LinkRenderedButton,
           { component: "a", href: "/exchange" },
-          "Set up a recurring exchange",
+          "Create an invitation",
         ),
       ),
     );


### PR DESCRIPTION
## Summary

The web app's first-run lobby is the front door for new visitors: the home route renders it whenever this browser holds no managed exchanges. A recent copy change relabeled its primary card "Set up a recurring exchange", framing a one-off entry as a standing commitment before the visitor has run anything. This restores an invite-framed CTA that pairs with the accept card, keeping "make it recurring" an opt-in at the end of the flow.

## Changes

- apps/web/src/bench/BenchLobby.tsx: lobby card heading "Set up a recurring exchange" -> "Invite someone to exchange data" and button -> "Create an invitation"; the docstring is resynced to the one-off framing.
- apps/web/test/browser/bench.test.ts, savedExchanges.test.ts, savedExchangesFailed.test.ts, savedExchangesUnavailable.test.ts, themeContrast.test.ts: update the lobby heading/button assertions to the new strings. The `/saved`-surface recurring-CTA link assertions (SavedExchanges.tsx) are deliberately left unchanged.

## Test plan

Ran: `npm run typecheck`, `npm run lint`, `npm run format`, and `npm run test:browser -w apps/web` over bench.test.ts, savedExchanges.test.ts, savedExchangesFailed.test.ts, savedExchangesUnavailable.test.ts, and themeContrast.test.ts (80/80 passed).
New tests cover: n/a -- copy-only change; the existing lobby assertions are updated to guard the restored strings, and a grep over the tree confirms no other reference to the old copy.

## Background

Making an exchange recurring already happens at the end of the flow via ManageExchangeOffer ("Save as a recurring exchange"), offered on the inviter share surface (InviterBench) and the acceptor completion surface (AcceptorBench); skipping it keeps the exchange one-off. The lobby is the quick path; the `/saved` surface owns the recurring-framed CTAs. docs/DESIGN.md already describes the home quick path as "setting up or accepting a one-off exchange", so this restores the UI to the documented framing rather than changing it.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: no documented behavior changed; docs/DESIGN.md already describes the home quick path as one-off setup/accept, which this restores agreement with.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: UI polish (copy fix), not a major feature or breaking change.
- [x] Security review -- n/a: static lobby heading/button copy only; no crypto, disclosure, authentication, or dependency surface touched, and no partner-controlled input path changed. Independent UX review run on the diff.
