### PR TITLE
Share browser-test mount helper for app theme

### DIFF
--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -12,8 +12,6 @@ import { createRoot } from "react-dom/client";
 // bound and blankets the top bar, intercepting unrelated clicks.
 import "@mantine/core/styles.css";
 
-import { MantineProvider } from "@mantine/core";
-
 import { decodeInvitation } from "@psilink/core";
 
 import { BENCH_STEP_STATE_KEY } from "@bench/stepHistory";
@@ -22,6 +20,8 @@ import { InvitationFileError } from "@psi/invitation";
 import { InviterBench } from "@bench/InviterBench";
 import { stagesFor } from "@bench/exchangeRun";
 import styles from "@bench/bench.module.css";
+
+import { renderApp } from "./renderApp";
 
 import type { PreparedExchange } from "@psilink/core";
 import type { ReactNode } from "react";
@@ -164,7 +164,7 @@ function mount(content: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, content));
+  root.render(renderApp(content));
 }
 
 afterEach(async () => {

--- a/apps/web/test/browser/benchAccept.test.ts
+++ b/apps/web/test/browser/benchAccept.test.ts
@@ -12,8 +12,6 @@ import { createRoot } from "react-dom/client";
 // bound and blankets the top bar, intercepting unrelated clicks.
 import "@mantine/core/styles.css";
 
-import { MantineProvider } from "@mantine/core";
-
 import {
   encodeInvitation,
   generateSharedSecret,
@@ -31,6 +29,8 @@ import { BENCH_STEP_STATE_KEY } from "@bench/stepHistory";
 import { BenchLobby } from "@bench/BenchLobby";
 import { stagesFor } from "@bench/exchangeRun";
 import styles from "@bench/bench.module.css";
+
+import { renderApp } from "./renderApp";
 
 import type { ReactNode } from "react";
 import type { Root } from "react-dom/client";
@@ -269,7 +269,7 @@ function mount(content: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, content));
+  root.render(renderApp(content));
 }
 
 afterEach(() => {

--- a/apps/web/test/browser/benchConsoleSftp.test.ts
+++ b/apps/web/test/browser/benchConsoleSftp.test.ts
@@ -12,12 +12,12 @@ import { createRoot } from "react-dom/client";
 // bound and blankets the top bar, intercepting unrelated clicks.
 import "@mantine/core/styles.css";
 
-import { MantineProvider } from "@mantine/core";
-
 import { decodeInvitation } from "@psilink/core";
 
 import { InviterBench } from "@bench/InviterBench";
 import styles from "@bench/bench.module.css";
+
+import { renderApp } from "./renderApp";
 
 import type { ReactNode } from "react";
 import type { Root } from "react-dom/client";
@@ -137,7 +137,7 @@ function mount(content: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, content));
+  root.render(renderApp(content));
 }
 
 afterEach(() => {

--- a/apps/web/test/browser/benchDeepLink.test.ts
+++ b/apps/web/test/browser/benchDeepLink.test.ts
@@ -12,12 +12,12 @@ import { createRoot } from "react-dom/client";
 // bound and blankets the top bar, intercepting unrelated clicks.
 import "@mantine/core/styles.css";
 
-import { MantineProvider } from "@mantine/core";
-
 import { encodeInvitation, generateSharedSecret } from "@psilink/core";
 
 import { deepLinkFor, tokenFromInput } from "@psi/invitation";
 import { AcceptorBench } from "@bench/AcceptorBench";
+
+import { renderApp } from "./renderApp";
 
 import type { ReactNode } from "react";
 import type { Root } from "react-dom/client";
@@ -93,7 +93,7 @@ function mount(content: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, content));
+  root.render(renderApp(content));
 }
 
 afterEach(() => {

--- a/apps/web/test/browser/benchRouterHistory.test.ts
+++ b/apps/web/test/browser/benchRouterHistory.test.ts
@@ -11,8 +11,6 @@ import { createRoot } from "react-dom/client";
 // (the bench browser suites' shared discipline).
 import "@mantine/core/styles.css";
 
-import { MantineProvider } from "@mantine/core";
-
 // The REAL router history -- deliberately not mocked here. createBrowserHistory
 // is what the app router runs on (router.tsx -> createRouter): it patches
 // window.history.pushState/replaceState and classifies every popstate as
@@ -24,6 +22,8 @@ import { MantineProvider } from "@mantine/core";
 import { createBrowserHistory } from "@tanstack/react-router";
 
 import { InviterBench } from "@bench/InviterBench";
+
+import { renderApp } from "./renderApp";
 
 import type { ReactNode } from "react";
 import type { Root } from "react-dom/client";
@@ -47,7 +47,7 @@ function mount(content: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, content));
+  root.render(renderApp(content));
 }
 
 afterEach(() => {

--- a/apps/web/test/browser/benchVerify.test.ts
+++ b/apps/web/test/browser/benchVerify.test.ts
@@ -7,8 +7,6 @@ import { page, userEvent } from "vitest/browser";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MantineProvider } from "@mantine/core";
-
 import {
   buildExchangeRecord,
   serializeExchangeRecord,
@@ -17,6 +15,8 @@ import {
 
 import { BenchLobby } from "@bench/BenchLobby";
 import { VerifyReceiptBench } from "@bench/VerifyReceiptBench";
+
+import { renderApp } from "./renderApp";
 
 import type {
   AssociationTable,
@@ -106,7 +106,7 @@ function mount(content: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, content));
+  root.render(renderApp(content));
 }
 
 // The Mantine Dropzone renders a hidden file input; the page's dropzones appear

--- a/apps/web/test/browser/cleaningErrorBoundary.test.ts
+++ b/apps/web/test/browser/cleaningErrorBoundary.test.ts
@@ -7,9 +7,9 @@ import { page } from "vitest/browser";
 import { createElement, useState } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MantineProvider } from "@mantine/core";
-
 import { CleaningErrorBoundary } from "@components/CleaningErrorBoundary";
+
+import { renderApp } from "./renderApp";
 
 import type { Root } from "react-dom/client";
 
@@ -27,7 +27,7 @@ function render(node: ReturnType<typeof createElement>) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, node));
+  root.render(renderApp(node));
 }
 
 /** Throws on render while `broken`, like a tripped StandardizationCards invariant. */

--- a/apps/web/test/browser/defaultCatchBoundary.test.ts
+++ b/apps/web/test/browser/defaultCatchBoundary.test.ts
@@ -7,11 +7,10 @@ import { page, userEvent } from "vitest/browser";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MantineProvider } from "@mantine/core";
-
 import { DefaultCatchBoundary } from "@components/DefaultCatchBoundary";
-import { mantineTheme } from "@theme";
 import { whenDiagnostic } from "@utils/diagnostics";
+
+import { renderApp } from "./renderApp";
 
 import type { ReactNode } from "react";
 import type { Root } from "react-dom/client";
@@ -74,12 +73,12 @@ vi.mock("@utils/diagnostics", () => ({ whenDiagnostic: vi.fn() }));
 let container: HTMLElement | undefined;
 let root: Root | undefined;
 
-// Mount under the real app theme, the way the running app composes it.
+// Mount under the real app provider config, the way the running app composes it.
 function mount(node: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, { theme: mantineTheme }, node));
+  root.render(renderApp(node));
 }
 
 // DefaultCatchBoundary takes ErrorComponentProps; it reads only `error`, but the

--- a/apps/web/test/browser/disclosureSection.test.ts
+++ b/apps/web/test/browser/disclosureSection.test.ts
@@ -7,9 +7,9 @@ import { page } from "vitest/browser";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MantineProvider } from "@mantine/core";
-
 import { DisclosureSection } from "@components/DisclosureSection";
+
+import { renderApp } from "./renderApp";
 
 import type { Root } from "react-dom/client";
 
@@ -58,9 +58,7 @@ function setReducedMotion(prefersReduced: boolean) {
 
 function render(open: boolean) {
   root!.render(
-    createElement(
-      MantineProvider,
-      { theme: { respectReducedMotion: true } },
+    renderApp(
       createElement(DisclosureSection, {
         label: LABEL,
         open,

--- a/apps/web/test/browser/expertKeyEditor.test.ts
+++ b/apps/web/test/browser/expertKeyEditor.test.ts
@@ -7,13 +7,13 @@ import { page } from "vitest/browser";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MantineProvider } from "@mantine/core";
-
 import { authoredLinkageFields } from "@psilink/core";
 
 import { seedAdvancedInvite } from "@psi/advancedInvite";
 
 import { ExpertKeyEditor } from "@components/ExpertKeyEditor";
+
+import { renderApp } from "./renderApp";
 
 import type { KeyVerdict } from "@bench/inviterModel";
 import type { Root } from "react-dom/client";
@@ -53,9 +53,7 @@ function render() {
     draft.standardization,
   );
   root!.render(
-    createElement(
-      MantineProvider,
-      { theme: { respectReducedMotion: true } },
+    renderApp(
       createElement(ExpertKeyEditor, {
         draft,
         declaredFields,

--- a/apps/web/test/browser/inputDescriptionA11y.test.ts
+++ b/apps/web/test/browser/inputDescriptionA11y.test.ts
@@ -6,9 +6,9 @@ import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
 import "@mantine/core/styles.css";
-import { Checkbox, MantineProvider, Radio } from "@mantine/core";
+import { Checkbox, Radio } from "@mantine/core";
 
-import { cssVariablesResolver, mantineTheme } from "@theme";
+import { renderApp } from "./renderApp";
 
 import type { ComponentType, ReactNode } from "react";
 import type { Root } from "react-dom/client";
@@ -48,16 +48,7 @@ function mount(node: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(
-    createElement(
-      MantineProvider,
-      // The app root (routes/__root.tsx) configures the provider with both the theme
-      // and the cssVariablesResolver; render under the same config so a theme override
-      // that broke the description association would fail here, not only raw Mantine.
-      { theme: mantineTheme, cssVariablesResolver },
-      node,
-    ),
-  );
+  root.render(renderApp(node));
 }
 
 afterEach(() => {

--- a/apps/web/test/browser/invitationTerms.test.ts
+++ b/apps/web/test/browser/invitationTerms.test.ts
@@ -7,9 +7,9 @@ import { page, userEvent } from "vitest/browser";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MantineProvider } from "@mantine/core";
-
 import { InvitationTerms } from "@components/InvitationTerms";
+
+import { renderApp } from "./renderApp";
 
 import type { Root } from "react-dom/client";
 
@@ -84,9 +84,9 @@ afterEach(() => {
 });
 
 // The single render entry point for every describe block: render InvitationTerms
-// under a MantineProvider with the given terms and any optional props. Each block
-// wraps this thinly for the one or two params it varies. Only props explicitly set
-// are forwarded, so the component sees each optional prop absent (not undefined)
+// under the app provider config with the given terms and any optional props. Each
+// block wraps this thinly for the one or two params it varies. Only props explicitly
+// set are forwarded, so the component sees each optional prop absent (not undefined)
 // exactly as before -- the difference the perspective/outbound gates turn on.
 function renderTerms(
   linkageTerms: LinkageTerms = terms,
@@ -98,9 +98,7 @@ function renderTerms(
   },
 ) {
   root!.render(
-    createElement(
-      MantineProvider,
-      null,
+    renderApp(
       createElement(InvitationTerms, {
         linkageTerms,
         ...(options?.perspective ? { perspective: options.perspective } : {}),
@@ -546,11 +544,7 @@ describe("InvitationTerms: a key disclosure stays mounted but hidden under a red
 
   test("every disclosure's aria-controls resolves to a present, hidden panel while collapsed under reduced motion", async () => {
     root!.render(
-      createElement(
-        MantineProvider,
-        { theme: { respectReducedMotion: true } },
-        createElement(InvitationTerms, { linkageTerms: terms }),
-      ),
+      renderApp(createElement(InvitationTerms, { linkageTerms: terms })),
     );
 
     // The always-mounted-wrapper design for every disclosure. The top-level ones
@@ -601,9 +595,7 @@ describe("InvitationTerms: a key disclosure stays mounted but hidden under a red
     // the Collapse panel (instead of the outer wrapper) would dangle -- assert the
     // wrapper stays present here, the invariant the other disclosures are held to.
     root!.render(
-      createElement(
-        MantineProvider,
-        { theme: { respectReducedMotion: true } },
+      renderApp(
         createElement(InvitationTerms, {
           linkageTerms: terms,
           perspective: "proposing",

--- a/apps/web/test/browser/keysTab.test.ts
+++ b/apps/web/test/browser/keysTab.test.ts
@@ -7,11 +7,11 @@ import { page } from "vitest/browser";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MantineProvider } from "@mantine/core";
-
 import { editorFromCsv, editorWithAuthoredDraft } from "@bench/inviterModel";
 
 import { KeysTab } from "@bench/KeysTab";
+
+import { renderApp } from "./renderApp";
 
 import type { AcquiredCsv } from "@bench/inviterModel";
 import type { Root } from "react-dom/client";
@@ -61,9 +61,7 @@ let root: Root | undefined;
 function render() {
   const editor = withDeadDobKey(editorFromCsv("Dana Okafor", csv));
   root!.render(
-    createElement(
-      MantineProvider,
-      null,
+    renderApp(
       createElement(KeysTab, {
         editor,
         csv,

--- a/apps/web/test/browser/manageExchangeOffer.test.ts
+++ b/apps/web/test/browser/manageExchangeOffer.test.ts
@@ -9,9 +9,9 @@ import { createRoot } from "react-dom/client";
 
 import "@mantine/core/styles.css";
 
-import { MantineProvider } from "@mantine/core";
-
 import { ManageExchangeOffer } from "@bench/ManageExchangeOffer";
+
+import { renderApp } from "./renderApp";
 
 import type { ReactNode } from "react";
 import type { Root } from "react-dom/client";
@@ -54,7 +54,7 @@ function mount(content: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, content));
+  root.render(renderApp(content));
 }
 
 afterEach(() => {

--- a/apps/web/test/browser/managedExchangeDetail.test.ts
+++ b/apps/web/test/browser/managedExchangeDetail.test.ts
@@ -10,13 +10,13 @@ import { createRoot } from "react-dom/client";
 
 import "@mantine/core/styles.css";
 
-import { MantineProvider } from "@mantine/core";
-
 import {
   buildManagedExchangeRecord,
   composeManagedExchangeFile,
 } from "@psi/managedExchangeRecord";
 import { ManagedExchangeDetail } from "@bench/ManagedExchangeDetail";
+
+import { renderApp } from "./renderApp";
 
 import type {
   ManagedExchangeLastRun,
@@ -85,7 +85,7 @@ function mount(content: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, content));
+  root.render(renderApp(content));
 }
 
 afterEach(() => {
@@ -175,9 +175,7 @@ describe("managed exchange detail configuration", () => {
 
     function render() {
       root?.render(
-        createElement(
-          MantineProvider,
-          null,
+        renderApp(
           createElement(ManagedExchangeDetail, {
             record: record("inviter"),
             onSaveLocalFields: () => Promise.resolve(),

--- a/apps/web/test/browser/notFound.test.ts
+++ b/apps/web/test/browser/notFound.test.ts
@@ -7,10 +7,9 @@ import { page, userEvent } from "vitest/browser";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MantineProvider } from "@mantine/core";
-
 import { NotFound } from "@components/NotFound";
-import { mantineTheme } from "@theme";
+
+import { renderApp } from "./renderApp";
 
 import type { ReactNode } from "react";
 import type { Root } from "react-dom/client";
@@ -44,12 +43,12 @@ vi.mock("@tanstack/react-router", () => ({
 let container: HTMLElement | undefined;
 let root: Root | undefined;
 
-// Mount under the real app theme, the way the running app composes it.
+// Mount under the real app provider config, the way the running app composes it.
 function mount(node: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, { theme: mantineTheme }, node));
+  root.render(renderApp(node));
 }
 
 afterEach(() => {

--- a/apps/web/test/browser/renderApp.ts
+++ b/apps/web/test/browser/renderApp.ts
@@ -1,0 +1,52 @@
+import { createElement } from "react";
+
+import { MantineProvider } from "@mantine/core";
+
+import { cssVariablesResolver, mantineTheme } from "@theme";
+
+import type { ReactElement, ReactNode } from "react";
+import type { MantineProviderProps } from "@mantine/core";
+
+/**
+ * Overrides a browser test may layer onto the app provider config. Only the
+ * knobs a test genuinely varies are exposed; anything else stays fixed at the
+ * app root's configuration so a test cannot silently diverge from what ships.
+ */
+export interface RenderAppOptions {
+  /**
+   * Pin the rendered subtree to one color scheme, for a test asserting
+   * scheme-specific behavior (e.g. the light-only resolver token overrides).
+   * Left unset, the provider follows its default color-scheme resolution, as
+   * the app root does.
+   */
+  forceColorScheme?: MantineProviderProps["forceColorScheme"];
+}
+
+/**
+ * Wraps `node` in a `MantineProvider` configured exactly as the app root
+ * (`routes/__root.tsx`) does -- `theme={mantineTheme}` plus
+ * `cssVariablesResolver={cssVariablesResolver}`, both from `theme.ts`. A
+ * component reading a resolver-overridden token (`dimmed`, `placeholder`, the
+ * light-variant status text, `error`) then renders the app's real value, not
+ * the Mantine default the app never ships.
+ *
+ * Returns the provider element rather than mounting it: the browser suite owns
+ * its own `createRoot`/`render` lifecycle (and some tests re-render the same
+ * root), so this composes into that idiom.
+ */
+export function renderApp(
+  node: ReactNode,
+  options: RenderAppOptions = {},
+): ReactElement {
+  return createElement(
+    MantineProvider,
+    {
+      theme: mantineTheme,
+      cssVariablesResolver,
+      ...(options.forceColorScheme !== undefined
+        ? { forceColorScheme: options.forceColorScheme }
+        : {}),
+    },
+    node,
+  );
+}

--- a/apps/web/test/browser/savedExchanges.test.ts
+++ b/apps/web/test/browser/savedExchanges.test.ts
@@ -10,8 +10,6 @@ import { createRoot } from "react-dom/client";
 
 import "@mantine/core/styles.css";
 
-import { MantineProvider } from "@mantine/core";
-
 import { SavedExchanges, SavedExchangesHome } from "@bench/SavedExchanges";
 import {
   clearManagedExchanges,
@@ -22,6 +20,8 @@ import {
   markManagedExchangeSpent,
 } from "@psi/managedLocalState";
 import { composeManagedExchangeFile } from "@psi/managedExchangeRecord";
+
+import { renderApp } from "./renderApp";
 
 import type { NewManagedExchange } from "@psi/managedExchangeRecord";
 import type { ReactNode } from "react";
@@ -98,7 +98,7 @@ function mount(content: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, content));
+  root.render(renderApp(content));
 }
 
 beforeEach(async () => {

--- a/apps/web/test/browser/savedExchangesFailed.test.ts
+++ b/apps/web/test/browser/savedExchangesFailed.test.ts
@@ -9,9 +9,9 @@ import { createRoot } from "react-dom/client";
 
 import "@mantine/core/styles.css";
 
-import { MantineProvider } from "@mantine/core";
-
 import { SavedExchanges, SavedExchangesHome } from "@bench/SavedExchanges";
+
+import { renderApp } from "./renderApp";
 
 import type { ReactNode } from "react";
 import type { Root } from "react-dom/client";
@@ -59,7 +59,7 @@ function mount(content: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, content));
+  root.render(renderApp(content));
 }
 
 afterEach(() => {

--- a/apps/web/test/browser/savedExchangesRecoveryListing.test.ts
+++ b/apps/web/test/browser/savedExchangesRecoveryListing.test.ts
@@ -10,8 +10,6 @@ import { createRoot } from "react-dom/client";
 
 import "@mantine/core/styles.css";
 
-import { MantineProvider } from "@mantine/core";
-
 import {
   MANAGED_EXCHANGE_LOCAL_STORE_NAME,
   MANAGED_EXCHANGE_STORE_NAME,
@@ -26,6 +24,8 @@ import {
 } from "@psi/managedLocalState";
 import { SavedExchanges } from "@bench/SavedExchanges";
 import { composeManagedExchangeFile } from "@psi/managedExchangeRecord";
+
+import { renderApp } from "./renderApp";
 
 import type { NewManagedExchange } from "@psi/managedExchangeRecord";
 import type { ReactNode } from "react";
@@ -121,7 +121,7 @@ function mount(content: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, content));
+  root.render(renderApp(content));
 }
 
 beforeEach(async () => {

--- a/apps/web/test/browser/savedExchangesUnavailable.test.ts
+++ b/apps/web/test/browser/savedExchangesUnavailable.test.ts
@@ -9,9 +9,9 @@ import { createRoot } from "react-dom/client";
 
 import "@mantine/core/styles.css";
 
-import { MantineProvider } from "@mantine/core";
-
 import { SavedExchanges, SavedExchangesHome } from "@bench/SavedExchanges";
+
+import { renderApp } from "./renderApp";
 
 import type { ReactNode } from "react";
 import type { Root } from "react-dom/client";
@@ -61,7 +61,7 @@ function mount(content: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, content));
+  root.render(renderApp(content));
 }
 
 afterEach(() => {

--- a/apps/web/test/browser/standardizationCards.test.ts
+++ b/apps/web/test/browser/standardizationCards.test.ts
@@ -7,13 +7,12 @@ import { page, userEvent } from "vitest/browser";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MantineProvider } from "@mantine/core";
-
 import { authoredLinkageFields } from "@psilink/core";
 
 import { StandardizationCards } from "@components/StandardizationCards";
 
 import { expandFieldCards } from "./fieldCards";
+import { renderApp } from "./renderApp";
 
 import type { Root } from "react-dom/client";
 
@@ -54,9 +53,7 @@ function render(
   document.body.appendChild(container);
   root = createRoot(container);
   root.render(
-    createElement(
-      MantineProvider,
-      null,
+    renderApp(
       createElement(StandardizationCards, {
         standardization,
         declaredFields: authoredLinkageFields(metadata, standardization),

--- a/apps/web/test/browser/standardizationStepEditor.test.ts
+++ b/apps/web/test/browser/standardizationStepEditor.test.ts
@@ -7,10 +7,10 @@ import { page, userEvent } from "vitest/browser";
 import { createElement, useState } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MantineProvider } from "@mantine/core";
-
 import { StandardizationPreview } from "@components/StandardizationPreview";
 import { StandardizationStepEditor } from "@components/StandardizationStepEditor";
+
+import { renderApp } from "./renderApp";
 
 import type { Root } from "react-dom/client";
 
@@ -30,7 +30,7 @@ function render(node: ReturnType<typeof createElement>) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, node));
+  root.render(renderApp(node));
 }
 
 const FIRST_NAME: LinkageField = { name: "fn", type: "first_name" };

--- a/apps/web/test/browser/stepListEditor.test.ts
+++ b/apps/web/test/browser/stepListEditor.test.ts
@@ -7,9 +7,9 @@ import { page } from "vitest/browser";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MantineProvider } from "@mantine/core";
-
 import { StepListEditor } from "@components/StepListEditor";
+
+import { renderApp } from "./renderApp";
 
 import type { EditableStep } from "@components/StepListEditor";
 import type { Root } from "react-dom/client";
@@ -28,7 +28,7 @@ function render(node: ReturnType<typeof createElement>) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(createElement(MantineProvider, null, node));
+  root.render(renderApp(node));
 }
 
 // The cross-party trust boundary: the token-embedded key-element transform editor

--- a/apps/web/test/browser/termsImportExport.test.ts
+++ b/apps/web/test/browser/termsImportExport.test.ts
@@ -7,12 +7,12 @@ import { page, userEvent } from "vitest/browser";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
-import { MantineProvider } from "@mantine/core";
-
 import { buildAdvancedTerms, seedAdvancedInvite } from "@psi/advancedInvite";
 import { exportLinkageTerms } from "@psi/linkageTermsIO";
 
 import { TermsImportExport } from "@components/TermsImportExport";
+
+import { renderApp } from "./renderApp";
 
 import type { Root } from "react-dom/client";
 
@@ -28,9 +28,7 @@ function mount() {
   document.body.appendChild(container);
   root = createRoot(container);
   root.render(
-    createElement(
-      MantineProvider,
-      null,
+    renderApp(
       createElement(TermsImportExport, {
         currentTerms,
         seed,

--- a/apps/web/test/browser/themeContrast.test.ts
+++ b/apps/web/test/browser/themeContrast.test.ts
@@ -12,13 +12,10 @@ import {
   Alert,
   Button,
   Checkbox,
-  MantineProvider,
   Text,
   TextInput,
 } from "@mantine/core";
 import { IconCheck, IconCopy } from "@tabler/icons-react";
-
-import { cssVariablesResolver, mantineTheme } from "@theme";
 
 // tokens.css defines the --bench-* custom properties bench.module.css reads
 // (--bench-accent among them); BenchPage.tsx imports it as a side effect in
@@ -26,6 +23,8 @@ import { cssVariablesResolver, mantineTheme } from "@theme";
 // --bench-accent resolves to nothing and masks the rule this test targets.
 import "@bench/tokens.css";
 import benchStyles from "@bench/bench.module.css";
+
+import { renderApp } from "./renderApp";
 
 import type { ComponentType, ReactNode } from "react";
 import type { Root } from "react-dom/client";
@@ -125,17 +124,7 @@ function mount(scheme: "light" | "dark", node: ReactNode) {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  root.render(
-    createElement(
-      MantineProvider,
-      // The app root (routes/__root.tsx) configures the provider with BOTH the theme
-      // and the cssVariablesResolver; render under the same config so a resolver
-      // override on a covered surface is exercised here, not only in the idealized
-      // arithmetic of the unit test.
-      { theme: mantineTheme, cssVariablesResolver, forceColorScheme: scheme },
-      node,
-    ),
-  );
+  root.render(renderApp(node, { forceColorScheme: scheme }));
 }
 
 afterEach(() => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -162,8 +162,8 @@ export default defineConfig((_configEnv) => {
         {
           test: {
             include: [
-              "test/browser/**/*.{test,spec}.ts",
-              "test/**/*.browser.{test,spec}.ts",
+              "test/browser/**/*.{test,spec}.{ts,tsx}",
+              "test/**/*.browser.{test,spec}.{ts,tsx}",
             ],
             name: "browser",
             // Stand up the dev server (PeerJS coordination + /api) the same way


### PR DESCRIPTION
## Summary

The browser test suite mounted components under bare or partial MantineProviders that omitted the app root cssVariablesResolver, so any test asserting a resolver-overridden token (dimmed, placeholder, error, the light-variant status text) rendered Mantine defaults the app never ships. This adds a shared mount helper that renders under the real app-root provider config and migrates the suite onto it, so rendering under the app real provider is enforced rather than a per-file accident.

Implements [207020574](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=207020574).

## Changes

- apps/web/test/browser/renderApp.ts: new shared helper wrapping a node in a MantineProvider configured exactly as the app root (theme plus cssVariablesResolver), exposing only forceColorScheme as a per-test override; returns the element so the suite keeps its own createRoot lifecycle.
- apps/web/test/browser: 25 files migrated off hand-rolled MantineProvider usage onto the helper.
- apps/web/vite.config.ts: browser-project include glob widened from .ts to .{ts,tsx} (additive; unit and integration globs untouched).

## Test plan

Ran: npm run typecheck, npm run lint, npm run format; npm run test:browser -w apps/web (40 files, 475 tests, run twice, deterministic); npm run test -w apps/web (80 files, 1362 tests). An independent adversarial verification confirmed helper fidelity, no silently-dropped per-test override, reduced-motion preservation, and that the glob change is additive.
New tests cover: n/a -- behavior-preserving test-harness refactor; existing coverage runs unchanged under the real provider config.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier (`/docs` high level + design; `/docs/spec` low level + details) -- n/a: test-harness refactor, no documented behavior changed.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: test/CI/tooling change, not a major feature or breaking change.
- [x] Security review -- n/a: test-only mount helper and vitest config; no crypto, credential, channel-hardening, wire-format, or disclosure surface touched.