### PR TITLE
Remove landing-page verify-receipt entry point

### DIFF
--- a/apps/web/src/bench/BenchLobby.tsx
+++ b/apps/web/src/bench/BenchLobby.tsx
@@ -13,11 +13,10 @@ import styles from "./bench.module.css";
 /**
  * The quick path's screen: two primary actions side by side -- invite someone to a
  * one-off exchange, or accept an invitation you were sent -- above the standing how-it-works
- * explanation. Verifying a receipt is a secondary action, given as an inline text
- * link below the two cards rather than equal billing. It has its own route at
- * `/quick` and is also the home route's first-run landing (an empty or
- * unavailable managed store at `/` renders it directly, with no redirect); the
- * recurring-exchange list lives at `/saved`, which this screen links to.
+ * explanation. It has its own route at `/quick` and is also the home route's
+ * first-run landing (an empty or unavailable managed store at `/` renders it
+ * directly, with no redirect); the recurring-exchange list lives at `/saved`,
+ * which this screen links to.
  */
 export function BenchLobby() {
   const navigate = useNavigate();
@@ -143,13 +142,6 @@ export function BenchLobby() {
           lists the ones stored in this browser so you can run one without a new
           invitation, and is where you restore one from a backup file if this
           browser was cleared.
-        </p>
-        <p className={`${styles.sub} ${styles.small}`}>
-          Already have an exchange record?{" "}
-          <Anchor inherit component={Link} to="/verify">
-            Verify a receipt
-          </Anchor>{" "}
-          checks it&apos;s internally consistent, entirely in your browser.
         </p>
         <div className={styles.howItWorks}>
           <p>

--- a/apps/web/test/browser/bench.test.ts
+++ b/apps/web/test/browser/bench.test.ts
@@ -346,12 +346,6 @@ describe("bench quick path", () => {
     await expect
       .element(page.getByLabelText("Invitation link or code"))
       .toBeInTheDocument();
-
-    // Verifying a receipt is a secondary action below the two cards, not a
-    // third card of equal billing.
-    await expect
-      .element(page.getByRole("link", { name: "Verify a receipt" }))
-      .toBeInTheDocument();
   });
 
   test("applies the bench surface tokens", async () => {
@@ -370,20 +364,17 @@ describe("bench quick path", () => {
     );
   });
 
-  test("the sample-data line and the verify link both sit at the small-print size", async () => {
+  test("the sample-data line sits at the small-print size", async () => {
     mount(createElement(BenchLobby));
 
     const demoLink = page.getByRole("button", {
       name: "Start with sample data",
     });
     await expect.element(demoLink).toBeInTheDocument();
-    const verifyLink = page.getByRole("link", { name: "Verify a receipt" });
-    await expect.element(verifyLink).toBeInTheDocument();
 
-    // Each link's enclosing small-print paragraph, and the link itself, share
-    // one font size: the `inherit` fix keeps the Anchor from rendering larger.
+    // The link's enclosing small-print paragraph and the link itself share one
+    // font size: the `inherit` fix keeps the Anchor from rendering larger.
     const demoElement = demoLink.element() as HTMLElement;
-    const verifyElement = verifyLink.element() as HTMLElement;
     const paragraphSize = (element: HTMLElement) =>
       getComputedStyle(element.closest("p") as Element).fontSize;
     const linkSize = (element: HTMLElement) =>
@@ -391,8 +382,6 @@ describe("bench quick path", () => {
 
     expect(paragraphSize(demoElement)).toBe("14px");
     expect(linkSize(demoElement)).toBe(paragraphSize(demoElement));
-    expect(paragraphSize(verifyElement)).toBe("14px");
-    expect(linkSize(verifyElement)).toBe(paragraphSize(verifyElement));
   });
 });
 

--- a/apps/web/test/browser/benchVerify.test.ts
+++ b/apps/web/test/browser/benchVerify.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="@vitest/browser-playwright/context" />
 
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 
 import { page, userEvent } from "vitest/browser";
 
@@ -13,7 +13,6 @@ import {
   serializeVerificationKeys,
 } from "@psilink/core";
 
-import { BenchLobby } from "@bench/BenchLobby";
 import { VerifyReceiptBench } from "@bench/VerifyReceiptBench";
 
 import { renderApp } from "./renderApp";
@@ -27,26 +26,6 @@ import type {
 } from "@psilink/core";
 import type { ReactNode } from "react";
 import type { Root } from "react-dom/client";
-
-// Router seam: the lobby's action cards are Links; render them as plain anchors
-// so the navigation-target assertion reads the href. (vitest hoists vi.mock.)
-vi.mock("@tanstack/react-router", () => ({
-  Link: ({
-    to,
-    className,
-    children,
-  }: {
-    to?: string;
-    className?: string;
-    children?: ReactNode;
-  }) =>
-    createElement(
-      "a",
-      { href: typeof to === "string" ? to : "#", className },
-      children,
-    ),
-  useNavigate: () => () => undefined,
-}));
 
 const LOCAL_TERMS: LinkageTerms = {
   version: "1.0.0",
@@ -131,15 +110,6 @@ afterEach(() => {
   container?.remove();
   root = undefined;
   container = undefined;
-});
-
-describe("bench lobby: verify a receipt link", () => {
-  test("the inline verify link below the two action cards navigates to the verify bench", async () => {
-    mount(createElement(BenchLobby));
-    const verifyLink = page.getByRole("link", { name: "Verify a receipt" });
-    await expect.element(verifyLink).toBeInTheDocument();
-    await expect.element(verifyLink).toHaveAttribute("href", "/verify");
-  });
 });
 
 describe("verify receipt bench", () => {


### PR DESCRIPTION
## Summary

Removes the "Verify a receipt" link from the quick-path landing screen. Receipt verification is unchanged and stays fully reachable: the `/verify` route and its bench are untouched, and the managed-exchange record view already links to it. This only drops the landing-page entry point, which belongs in the managed exchange section.

## Changes

- `apps/web/src/bench/BenchLobby.tsx`: remove the "Already have an exchange record? Verify a receipt" paragraph and trim the stale "secondary action" sentence from the component doc comment.
- `apps/web/test/browser/bench.test.ts`: drop the verify-link assertion from the quick-path structure test; trim the small-print-size test to the sample-data line.
- `apps/web/test/browser/benchVerify.test.ts`: remove the lobby verify-link describe block and its now-unused imports and router mock; the direct `VerifyReceiptBench` tests are untouched.

## Test plan

Ran: `npx vitest run apps/web/test/browser/bench.test.ts apps/web/test/browser/benchVerify.test.ts` (48 passed) and `npm run test -w apps/web` (1375 passed); `npm run typecheck && npm run lint && npm run format` clean.
New tests cover: n/a -- removal only. Existing suites are updated to match; the direct verify-receipt bench tests and the managed-exchange `/verify` link test remain as coverage of the retained feature.

## Background

`BenchLobby` renders on both `/` (first-run home) and `/quick`, so this removes the link from both quick-path surfaces; the managed-exchange section (`ManagedExchangeDetail` record view) is where receipt verification now lives.

## Checklist

- [x] Docs: enumerated `docs/` and `docs/spec/` and updated affected pages or added new ones at the appropriate level of detail for the document tier -- n/a: no documented behavior changed; the `verify-receipt` references in `docs/CLI.md`, `docs/DESIGN.md`, and `docs/spec/EXCHANGE_RECORD.md` cover the CLI command and the exchange-record artifact, neither touched here, and the web landing-page link is not documented.
- [x] `CHANGELOG.md` `[Unreleased]` updated -- n/a: UI polish (a landing-page entry-point removal), not a major feature or breaking change.
- [x] Security review -- n/a: none of the listed surfaces touched; a presentational landing-page link removal plus test updates, with no change to crypto, auth, disclosure, credential handling, or dependencies.
