### PR TITLE
Prepare the client draft model for console inputs

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -3,6 +3,45 @@ import pluginRouter from "@tanstack/eslint-plugin-router";
 import { tanstackConfig } from "@tanstack/eslint-config";
 import filledPrimaryContrastScope from "./eslint-rules/filled-primary-contrast-scope.mjs";
 
+// The sensitive-file YAML-parse ban (shared by the broad block and the rawRows
+// allowlist block, since flat config replaces -- does not merge -- a rule's options,
+// so the allowlist block must re-carry it).
+const sensitiveYamlParseBan = {
+  selector:
+    "CallExpression[callee.object.name='YAML'][callee.property.name=/^(parse|parseDocument|parseAllDocuments)$/]",
+  message:
+    "Parse config/credential or imported documents through @psilink/core's sensitive-file chokepoint (parseSensitiveYaml / parseSensitiveJson), not a raw YAML parser (it leaks source into errors).",
+};
+
+// Confine reads of an acquired CSV's `rawRows` to the enumerated file-intake, draft,
+// and coverage/preview consumers. The console acquires only a server-side profile
+// (row count, date format, column samples) and never the rows, so its acquired shape
+// exposes `rawRows` as a getter that throws in dev/test; this restriction is the
+// static half of that backstop, catching a new `.rawRows` reader at lint time rather
+// than at a stray runtime throw. A legitimate new consumer is added to
+// `rawRowsConsumers` below (and reviewed), never silenced inline.
+const rawRowsAccessBan = {
+  selector: "MemberExpression[property.name='rawRows']",
+  message:
+    "Read `.rawRows` only in the enumerated consumers (see rawRowsConsumers in apps/web/eslint.config.js). The console acquired CSV has no rows (a throwing getter); author from the profiled rowCount / dateInputFormat / column samples instead. If this is a legitimate new rawRows consumer, add its file to rawRowsConsumers.",
+};
+
+// The files that legitimately read `.rawRows`: the hosted file-intake and draft
+// consumers plus the exchange-run and coverage-worker internals that read rawRows off
+// non-acquired shapes (a prepared/minted invitation, a worker request, the
+// controller's own field).
+const rawRowsConsumers = [
+  "src/bench/inviterModel.ts",
+  "src/bench/AcceptorBench.tsx",
+  "src/bench/InviterBench.tsx",
+  "src/bench/KeysTab.tsx",
+  "src/bench/CleaningTab.tsx",
+  "src/bench/runOutputs.ts",
+  "src/bench/useInviterExchange.ts",
+  "src/psi/nonEmptyAggregate.worker.ts",
+  "src/psi/nonEmptyAggregateController.ts",
+];
+
 export default [
   {
     ignores: [
@@ -46,12 +85,8 @@ export default [
       "filled-primary-contrast/filled-primary-contrast-scope": "error",
       "no-restricted-syntax": [
         "error",
-        {
-          selector:
-            "CallExpression[callee.object.name='YAML'][callee.property.name=/^(parse|parseDocument|parseAllDocuments)$/]",
-          message:
-            "Parse config/credential or imported documents through @psilink/core's sensitive-file chokepoint (parseSensitiveYaml / parseSensitiveJson), not a raw YAML parser (it leaks source into errors).",
-        },
+        sensitiveYamlParseBan,
+        rawRowsAccessBan,
       ],
       "no-restricted-imports": [
         "error",
@@ -66,6 +101,17 @@ export default [
           ],
         },
       ],
+    },
+  },
+  {
+    // The enumerated rawRows consumers keep the sensitive-parse ban but are exempt
+    // from the rawRows-access ban. A separate block (not an `ignores`) because flat
+    // config replaces a rule's whole options across blocks: re-setting
+    // no-restricted-syntax to the YAML ban alone drops the rawRows selector for these
+    // files while the broad block above still applies it everywhere else.
+    files: rawRowsConsumers,
+    rules: {
+      "no-restricted-syntax": ["error", sensitiveYamlParseBan],
     },
   },
   // Any other config...

--- a/apps/web/src/bench/AcceptorBench.tsx
+++ b/apps/web/src/bench/AcceptorBench.tsx
@@ -14,7 +14,6 @@ import {
 import { emptyColumnPositions, unnameableColumnsAlert } from "@psi/columnNames";
 import { capturedInputHandle } from "@psi/managedInputHandle";
 import { createManagedExchange } from "@psi/managedExchangeStore";
-import { dateInputFormatForColumns } from "@psi/advancedInvite";
 import { loadCSVFileOffMainThread } from "@psi/csvParseController";
 import { prepareAcceptedInvitation } from "@psi/acceptInvitation";
 
@@ -410,7 +409,6 @@ export function AcceptorBench() {
         columns,
         rawRows: result.data,
         rowCount: result.data.length,
-        dateInputFormat: dateInputFormatForColumns(columns, result.data),
       });
       setColumnsState(acceptorInitialColumnsState(columns));
       goToStep("columns");

--- a/apps/web/src/bench/AcceptorBench.tsx
+++ b/apps/web/src/bench/AcceptorBench.tsx
@@ -14,16 +14,20 @@ import {
 import { emptyColumnPositions, unnameableColumnsAlert } from "@psi/columnNames";
 import { capturedInputHandle } from "@psi/managedInputHandle";
 import { createManagedExchange } from "@psi/managedExchangeStore";
+import { dateInputFormatForColumns } from "@psi/advancedInvite";
 import { loadCSVFileOffMainThread } from "@psi/csvParseController";
 import { prepareAcceptedInvitation } from "@psi/acceptInvitation";
 
 import { deploymentProfile } from "@utils/clientConfig";
 import { whenDiagnostic } from "@utils/diagnostics";
 
+import {
+  rowsCoverageProvider,
+  useNonEmptyRates,
+} from "@components/useNonEmptyRates";
 import { InvitationTerms } from "@components/InvitationTerms";
 import { MAX_CSV_FILE_BYTES } from "@components/csvIntake";
 import { setColumnTypeForMatching } from "@psi/metadataEditing";
-import { useNonEmptyRates } from "@components/useNonEmptyRates";
 
 import {
   ACCEPTOR_COLUMNS_LEDGER_FOOTER,
@@ -405,6 +409,8 @@ export function AcceptorBench() {
         sizeBytes: file.size,
         columns,
         rawRows: result.data,
+        rowCount: result.data.length,
+        dateInputFormat: dateInputFormatForColumns(columns, result.data),
       });
       setColumnsState(acceptorInitialColumnsState(columns));
       goToStep("columns");
@@ -437,7 +443,12 @@ export function AcceptorBench() {
     columnsState !== undefined &&
     acquired !== undefined &&
     linkageTerms !== undefined
-      ? acceptorColumnsEditorState(columnsState, linkageTerms, acquired.rawRows)
+      ? acceptorColumnsEditorState(
+          columnsState,
+          linkageTerms,
+          acquired.rawRows,
+          acquired.dateInputFormat,
+        )
       : undefined;
   const verdict =
     editorState !== undefined &&
@@ -481,6 +492,7 @@ export function AcceptorBench() {
   const { rates, pending: ratesPending } = useNonEmptyRates(
     acquired?.rawRows ?? EMPTY_ROWS,
     editorState?.standardization ?? EMPTY_STANDARDIZATION,
+    rowsCoverageProvider,
   );
   const cleaningAttention =
     editorState !== undefined && verdict !== undefined

--- a/apps/web/src/bench/AcceptorCleaningStep.tsx
+++ b/apps/web/src/bench/AcceptorCleaningStep.tsx
@@ -9,6 +9,7 @@ import { isSilentEmpty } from "@psi/nonEmptyAggregate";
 import { CleaningErrorBoundary } from "@components/CleaningErrorBoundary";
 import { FieldCoverage } from "@components/FieldCoverage";
 import { StandardizationCards } from "@components/StandardizationCards";
+import { columnSamplesFromRows } from "@components/columnSamples";
 
 import styles from "./bench.module.css";
 
@@ -74,6 +75,16 @@ export function AcceptorCleaningStep({
   const fieldByName = useMemo(
     () => new Map(declaredFields.map((field) => [field.name, field])),
     [declaredFields],
+  );
+  // The per-column preview samples, drawn from the rows once for the whole tab so a
+  // field rebound to another column finds its sample by lookup.
+  const columnSamples = useMemo(
+    () =>
+      columnSamplesFromRows(
+        rawRows,
+        metadata.map((column) => column.name),
+      ),
+    [rawRows, metadata],
   );
 
   // The safe labels of the fields whose transform drops every row, for the one
@@ -141,7 +152,7 @@ export function AcceptorCleaningStep({
           standardization={standardization}
           declaredFields={declaredFields}
           metadata={metadata}
-          rawRows={rawRows}
+          columnSamples={columnSamples}
           onStepsChange={(output, _input, steps) => onFieldSteps(output, steps)}
           onInputColumnChange={onFieldInput}
           renderCoverage={(output) => (

--- a/apps/web/src/bench/CleaningTab.tsx
+++ b/apps/web/src/bench/CleaningTab.tsx
@@ -8,6 +8,7 @@ import { isSilentEmpty } from "@psi/nonEmptyAggregate";
 import { CleaningErrorBoundary } from "@components/CleaningErrorBoundary";
 import { FieldCoverage } from "@components/FieldCoverage";
 import { StandardizationCards } from "@components/StandardizationCards";
+import { columnSamplesFromRows } from "@components/columnSamples";
 
 import { declaredFieldsFor } from "./inviterModel";
 import styles from "./bench.module.css";
@@ -60,6 +61,12 @@ export function CleaningTab({
   const declaredFields = useMemo(
     () => declaredFieldsFor(editor.draft),
     [editor.draft],
+  );
+  // The per-column preview samples, drawn from the rows once for the whole tab so a
+  // field rebound to another column finds its sample by lookup.
+  const columnSamples = useMemo(
+    () => columnSamplesFromRows(csv.rawRows, csv.columns),
+    [csv.rawRows, csv.columns],
   );
   const resetKey = editor.draft.standardization
     .map((transformation) => `${transformation.output}=${transformation.input}`)
@@ -121,7 +128,7 @@ export function CleaningTab({
           standardization={editor.draft.standardization}
           declaredFields={declaredFields}
           metadata={editor.draft.metadata}
-          rawRows={csv.rawRows}
+          columnSamples={columnSamples}
           onStepsChange={(output, _input, steps) => onFieldSteps(output, steps)}
           onInputColumnChange={onFieldInput}
           onAddField={expertMode ? onFieldAdded : undefined}

--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -17,7 +17,6 @@ import {
 import { emptyColumnPositions, unnameableColumnsAlert } from "@psi/columnNames";
 import { capturedInputHandle } from "@psi/managedInputHandle";
 import { createManagedExchange } from "@psi/managedExchangeStore";
-import { dateInputFormatForColumns } from "@psi/advancedInvite";
 import { fetchSftpRemotes } from "@psi/serverJobExchangeDriver";
 import { invitationLocation } from "@psi/invitationLocation";
 import { loadCSVFileOffMainThread } from "@psi/csvParseController";
@@ -482,7 +481,6 @@ export function InviterBench() {
         rawRows: result.data,
         columns,
         rowCount: result.data.length,
-        dateInputFormat: dateInputFormatForColumns(columns, result.data),
       };
       const seeded = editorFromCsv(identity, csv);
       setAcquired(csv);

--- a/apps/web/src/bench/InviterBench.tsx
+++ b/apps/web/src/bench/InviterBench.tsx
@@ -17,6 +17,7 @@ import {
 import { emptyColumnPositions, unnameableColumnsAlert } from "@psi/columnNames";
 import { capturedInputHandle } from "@psi/managedInputHandle";
 import { createManagedExchange } from "@psi/managedExchangeStore";
+import { dateInputFormatForColumns } from "@psi/advancedInvite";
 import { fetchSftpRemotes } from "@psi/serverJobExchangeDriver";
 import { invitationLocation } from "@psi/invitationLocation";
 import { loadCSVFileOffMainThread } from "@psi/csvParseController";
@@ -24,9 +25,12 @@ import { loadCSVFileOffMainThread } from "@psi/csvParseController";
 import { deploymentProfile, isConsoleBuild } from "@utils/clientConfig";
 import { whenDiagnostic } from "@utils/diagnostics";
 
+import {
+  rowsCoverageProvider,
+  useNonEmptyRates,
+} from "@components/useNonEmptyRates";
 import { triggerBlobDownload } from "@components/blobDownload";
 import { unlinkableFileAlert } from "@components/UnlinkableFileAlert";
-import { useNonEmptyRates } from "@components/useNonEmptyRates";
 
 import {
   EMPTY_SAVE_FIELDS,
@@ -261,6 +265,7 @@ export function InviterBench() {
   const { rates, pending: ratesPending } = useNonEmptyRates(
     acquired?.rawRows ?? EMPTY_ROWS,
     editor?.draft.standardization ?? EMPTY_STANDARDIZATION,
+    rowsCoverageProvider,
   );
   const cleaningAttention = inviterCleaningAttention(editor, rates);
   const coverageProblems = cleaningCoverageProblems(editor, rates);
@@ -476,6 +481,8 @@ export function InviterBench() {
         sizeBytes: file.size,
         rawRows: result.data,
         columns,
+        rowCount: result.data.length,
+        dateInputFormat: dateInputFormatForColumns(columns, result.data),
       };
       const seeded = editorFromCsv(identity, csv);
       setAcquired(csv);

--- a/apps/web/src/bench/KeysTab.tsx
+++ b/apps/web/src/bench/KeysTab.tsx
@@ -271,6 +271,7 @@ export function KeysTab({
             currentTerms={currentTerms}
             seed={editor.seed}
             rawRows={csv.rawRows}
+            dateInputFormat={csv.dateInputFormat}
             onImport={onImport}
           />
         </>

--- a/apps/web/src/bench/YourFileSection.tsx
+++ b/apps/web/src/bench/YourFileSection.tsx
@@ -160,7 +160,7 @@ export function YourFileSection({
               {acquired.fileName}
             </div>
             <div className={`${styles.fileMeta} ${styles.mono}`}>
-              {fileCardMeta(acquired.rawRows.length, acquired.sizeBytes)}
+              {fileCardMeta(acquired.rowCount, acquired.sizeBytes)}
             </div>
           </div>
         </div>

--- a/apps/web/src/bench/acceptorColumnsModel.ts
+++ b/apps/web/src/bench/acceptorColumnsModel.ts
@@ -64,9 +64,10 @@ export interface AcceptorAcquiredCsv {
   /** The file's row total, held explicitly so display surfaces never read
    * `rawRows.length` (the console profiles the count server-side). */
   rowCount: number;
-  /** The pre-inferred date-of-birth input layout
-   * ({@link dateInputFormatForColumns}), threaded into the derived standardization
-   * so a remap never re-derives it from the rows. */
+  /** A pre-inferred date-of-birth input layout
+   * ({@link dateInputFormatForColumns}), set only by sources that profile it
+   * without rows (the console); when absent, derivations infer it from the
+   * rows as before. */
   dateInputFormat?: string;
 }
 

--- a/apps/web/src/bench/acceptorColumnsModel.ts
+++ b/apps/web/src/bench/acceptorColumnsModel.ts
@@ -61,6 +61,13 @@ export interface AcceptorAcquiredCsv {
   sizeBytes: number;
   columns: Array<string>;
   rawRows: Array<CSVRow>;
+  /** The file's row total, held explicitly so display surfaces never read
+   * `rawRows.length` (the console profiles the count server-side). */
+  rowCount: number;
+  /** The pre-inferred date-of-birth input layout
+   * ({@link dateInputFormatForColumns}), threaded into the derived standardization
+   * so a remap never re-derives it from the rows. */
+  dateInputFormat?: string;
 }
 
 /**
@@ -122,6 +129,7 @@ export function acceptorColumnsEditorState(
   state: AcceptorColumnsState,
   linkageTerms: LinkageTerms,
   rawRows: ReadonlyArray<CSVRow>,
+  dateInputFormat?: string,
 ): { metadata: Metadata; standardization: Standardization } {
   const { metadata } = state;
   const fieldByName = new Map(
@@ -143,6 +151,7 @@ export function acceptorColumnsEditorState(
     metadata,
     linkageTerms,
     rawRows,
+    dateInputFormat,
   );
   const standardization = applyStepOverrides(
     applyInputOverrides(baseStandardization, effectiveInputOverrides),

--- a/apps/web/src/bench/consoleAcquiredCsv.ts
+++ b/apps/web/src/bench/consoleAcquiredCsv.ts
@@ -1,0 +1,51 @@
+import type { AcceptorAcquiredCsv } from "./acceptorColumnsModel";
+import type { AcquiredCsv } from "./inviterModel";
+import type { CSVRow } from "@psilink/core";
+
+/**
+ * The file facts the console acquires from the server-side profile instead of the
+ * rows: the browser never reads the file on the console (it is read on the
+ * appliance), so the intake has the name, size, column list, row count, and the
+ * pre-inferred date-of-birth format -- everything the pure draft model needs -- but
+ * no rows. The per-column preview samples ride a separate seam (the coverage/preview
+ * providers), not this shape.
+ */
+export interface ConsoleAcquiredProfile {
+  fileName: string;
+  sizeBytes: number;
+  columns: Array<string>;
+  rowCount: number;
+  dateInputFormat?: string;
+}
+
+/**
+ * Build the console's acquired CSV from a server-side profile -- structurally the
+ * hosted {@link AcquiredCsv} and {@link AcceptorAcquiredCsv}, but with no rows: the
+ * console reads the file on the appliance, never in the browser.
+ *
+ * `rawRows` is a getter that throws in dev and test and yields the empty array in a
+ * production build. Any `rawRows` read is a consumer that does not source from the
+ * profile (rowCount, dateInputFormat, and the preview/coverage seams); failing loud
+ * in every dev run and test catches it at once, while degrading to empty in
+ * production keeps an overlooked reader rendering an empty preview rather than
+ * crashing the operator's session. The ESLint `rawRows` restriction is the static
+ * half of the same backstop.
+ */
+export function consoleAcquiredCsv(
+  profile: ConsoleAcquiredProfile,
+): AcquiredCsv & AcceptorAcquiredCsv {
+  return {
+    fileName: profile.fileName,
+    sizeBytes: profile.sizeBytes,
+    columns: profile.columns,
+    rowCount: profile.rowCount,
+    dateInputFormat: profile.dateInputFormat,
+    get rawRows(): Array<CSVRow> {
+      if (import.meta.env.DEV)
+        throw new Error(
+          "console acquired CSV has no rawRows; read rowCount / dateInputFormat / the profile's column samples instead",
+        );
+      return [];
+    },
+  };
+}

--- a/apps/web/src/bench/inviterModel.ts
+++ b/apps/web/src/bench/inviterModel.ts
@@ -182,12 +182,19 @@ export function transportChooserCopy(
  */
 
 /** The read file the spine works over: identity for the file card plus the
- * parsed rows and columns every derivation binds to. */
+ * parsed rows and columns every derivation binds to. `rowCount` is the file's
+ * row total, held explicitly so the display surfaces do not read `rawRows.length`
+ * (the console acquires only a server-side profile, not the rows). `dateInputFormat`
+ * is the pre-inferred date-of-birth layout ({@link dateInputFormatForColumns}),
+ * threaded through the draft model so a reconciliation never re-derives it from the
+ * rows. */
 export interface AcquiredCsv {
   fileName: string;
   sizeBytes: number;
   rawRows: Array<CSVRow>;
   columns: Array<string>;
+  rowCount: number;
+  dateInputFormat?: string;
 }
 
 /** An editing session over the read file: the live draft and the fixed seed it
@@ -230,7 +237,12 @@ export function editorFromCsv(
   inviterName: string,
   csv: AcquiredCsv,
 ): InviterEditor {
-  return seedAdvancedInvite(inviterName, csv.columns, csv.rawRows);
+  return seedAdvancedInvite(
+    inviterName,
+    csv.columns,
+    csv.rawRows,
+    csv.dateInputFormat,
+  );
 }
 
 /** Carry a later name edit into the draft without disturbing the derived
@@ -353,6 +365,7 @@ export function editorWithImportedTerms(
       editor.seed,
       editor.draft.lifetimeSeconds,
       csv.rawRows,
+      csv.dateInputFormat,
     ),
     keysAuthored: true,
   };
@@ -460,6 +473,7 @@ export function editorWithRecommendedCleaning(
         editor.draft.metadata,
         getDefaultLinkageTerms(editor.draft.identity, editor.draft.metadata),
         csv.rawRows,
+        csv.dateInputFormat,
       ),
     },
   };
@@ -545,8 +559,18 @@ function withMetadata(
       // reconciliation (setDraftMetadata), never the standardization.
       draft:
         editor.keysAuthored === true
-          ? setDraftMetadataKeepingKeys(editor.draft, metadata, csv.rawRows)
-          : setDraftMetadata(editor.draft, metadata, csv.rawRows),
+          ? setDraftMetadataKeepingKeys(
+              editor.draft,
+              metadata,
+              csv.rawRows,
+              csv.dateInputFormat,
+            )
+          : setDraftMetadata(
+              editor.draft,
+              metadata,
+              csv.rawRows,
+              csv.dateInputFormat,
+            ),
     },
     demotedIdentifiers,
   };
@@ -1054,7 +1078,7 @@ export function answersRows(
     },
     {
       label: "Your file",
-      value: `${csv.fileName} - ${new Intl.NumberFormat("en-US").format(csv.rawRows.length)} rows`,
+      value: `${csv.fileName} - ${new Intl.NumberFormat("en-US").format(csv.rowCount)} rows`,
       mono: true,
       changeTarget: "file",
     },

--- a/apps/web/src/bench/inviterModel.ts
+++ b/apps/web/src/bench/inviterModel.ts
@@ -185,9 +185,9 @@ export function transportChooserCopy(
  * parsed rows and columns every derivation binds to. `rowCount` is the file's
  * row total, held explicitly so the display surfaces do not read `rawRows.length`
  * (the console acquires only a server-side profile, not the rows). `dateInputFormat`
- * is the pre-inferred date-of-birth layout ({@link dateInputFormatForColumns}),
- * threaded through the draft model so a reconciliation never re-derives it from the
- * rows. */
+ * is a pre-inferred date-of-birth layout ({@link dateInputFormatForColumns}), set
+ * only by sources that profile it without rows (the console); when absent, each
+ * derivation infers it from the rows as before. */
 export interface AcquiredCsv {
   fileName: string;
   sizeBytes: number;

--- a/apps/web/src/components/StandardizationCards.tsx
+++ b/apps/web/src/components/StandardizationCards.tsx
@@ -9,8 +9,9 @@ import { DisclosureSection } from "@components/DisclosureSection";
 import { StandardizationPreview } from "@components/StandardizationPreview";
 import { StandardizationStepEditor } from "@components/StandardizationStepEditor";
 
+import type { ColumnSamples } from "@components/columnSamples";
+
 import type {
-  CSVRow,
   LinkageField,
   Metadata,
   Standardization,
@@ -48,7 +49,7 @@ export function StandardizationCards({
   standardization,
   declaredFields,
   metadata,
-  rawRows,
+  columnSamples,
   onStepsChange,
   onInputColumnChange,
   onAddField,
@@ -66,8 +67,9 @@ export function StandardizationCards({
   declaredFields: Array<LinkageField>;
   /** The operator's column metadata, for the per-type input-column options. */
   metadata: Metadata;
-  /** The parsed rows the preview samples. */
-  rawRows: Array<CSVRow>;
+  /** The per-column preview samples the before/after preview reads (computed from
+   * the rows on hosted, read from the profile on the console). */
+  columnSamples: ColumnSamples;
   /** Emit a step edit: `output` names the field, `input` is the transformation's
    * input column AS RENDERED (echoed for the acceptor's stale-override check), and
    * `steps` is the next pipeline. */
@@ -179,7 +181,7 @@ export function StandardizationCards({
             field={field}
             inputColumn={transformation.input}
             steps={steps}
-            rawRows={rawRows}
+            columnSamples={columnSamples}
             inputColumnOptions={columnsForType(field.type)}
             onInputColumnChange={(column) =>
               onInputColumnChange(transformation.output, column)
@@ -231,7 +233,7 @@ function StandardizationCard({
   field,
   inputColumn,
   steps,
-  rawRows,
+  columnSamples,
   inputColumnOptions,
   onInputColumnChange,
   onStepsChange,
@@ -242,7 +244,7 @@ function StandardizationCard({
   field: LinkageField;
   inputColumn: string;
   steps: Array<StandardizationStep>;
-  rawRows: Array<CSVRow>;
+  columnSamples: ColumnSamples;
   inputColumnOptions: Array<string>;
   onInputColumnChange: (column: string) => void;
   onStepsChange: (steps: Array<StandardizationStep>) => void;
@@ -309,7 +311,7 @@ function StandardizationCard({
               field={field}
               inputColumn={inputColumn}
               steps={steps}
-              rawRows={rawRows}
+              columnSamples={columnSamples}
             />
           </DisclosureSection>
           {onRemove !== undefined && (

--- a/apps/web/src/components/StandardizationPreview.tsx
+++ b/apps/web/src/components/StandardizationPreview.tsx
@@ -18,7 +18,7 @@ import {
 
 import { isStepValid } from "@psi/standardizationAuthoring";
 
-import type { ColumnSamples } from "./columnSamples";
+import type { ColumnSamples } from "@components/columnSamples";
 
 import type {
   FieldValue,

--- a/apps/web/src/components/StandardizationPreview.tsx
+++ b/apps/web/src/components/StandardizationPreview.tsx
@@ -12,52 +12,19 @@ import {
 
 import {
   checkValueConstraints,
-  readRowColumn,
   runPipeline,
   sanitizeForDisplay,
 } from "@psilink/core";
 
 import { isStepValid } from "@psi/standardizationAuthoring";
 
+import type { ColumnSamples } from "./columnSamples";
+
 import type {
-  CSVRow,
   FieldValue,
   LinkageField,
   StandardizationStep,
 } from "@psilink/core";
-
-/**
- * Row-sample size for the before->after preview: the first few rows with a non-empty
- * value for the field's input column. The preview is for inspecting the transform on
- * representative values, so a small fixed window keeps it cheap and legible; the
- * whole-file coverage question (does the transform collapse the field?) is answered
- * separately and exhaustively by the off-main-thread non-empty-rate aggregate
- * ({@link ../psi/nonEmptyAggregate}), not by widening this sample. Settled at 5,
- * coordinated with that aggregate and its row threshold.
- */
-export const PREVIEW_SAMPLE_SIZE = 5;
-
-/** Pick up to `limit` non-empty raw values for `inputColumn`, in row order. A row
- * whose value is missing or blank after trimming carries no signal for the
- * preview, so it is skipped rather than shown as an empty before->after pair. */
-function sampleInputValues(
-  rawRows: ReadonlyArray<CSVRow>,
-  inputColumn: string,
-  limit: number,
-): Array<string> {
-  const values: Array<string> = [];
-  for (const row of rawRows) {
-    // Read by own-property so a short row lacking the column reads as absent even
-    // when the column is named an Object.prototype member (readRowColumn); a bare
-    // row[inputColumn] would surface the inherited function past the check below.
-    const raw = readRowColumn(row, inputColumn);
-    if (raw !== undefined && raw.trim() !== "") {
-      values.push(raw);
-      if (values.length >= limit) break;
-    }
-  }
-  return values;
-}
 
 /** Render one cleaned value as a chip with any warn-not-enforce constraint badges
  * beside it. The value is the operator's own data (local CSV), shown sanitized for
@@ -160,24 +127,25 @@ function Outcome({
 
 /**
  * The before->after value preview for one field's standardization pipeline, docked
- * beside its step list. Runs the operator's CURRENT steps over a small sample of
- * the field's input column ({@link sampleInputValues}) and renders each row's
- * outcome distinctly by its three pipeline shapes -- a cleaned value, a "dropped"
- * (null) chip, or a fan-out into several candidates (a Set) -- so the operator sees
- * exactly what each step does to real rows, in pipeline order. A value that does
- * not meet the field's declared constraints is flagged with a warn-not-enforce
- * badge ({@link checkValueConstraints}); the badge surfaces the violation without
- * blocking.
+ * beside its step list. Runs the operator's CURRENT steps over the field's input
+ * column's preview sample (looked up from {@link ColumnSamples}) and renders each
+ * row's outcome distinctly by its three pipeline shapes -- a cleaned value, a
+ * "dropped" (null) chip, or a fan-out into several candidates (a Set) -- so the
+ * operator sees exactly what each step does to real rows, in pipeline order. A value
+ * that does not meet the field's declared constraints is flagged with a
+ * warn-not-enforce badge ({@link checkValueConstraints}); the badge surfaces the
+ * violation without blocking.
  *
- * Pure over its inputs: it derives the sample and runs core's `runPipeline`, so
- * reordering or editing a step re-runs the pipeline and the preview tracks it.
+ * The sample is passed in, not derived from rows, so the console (which never holds
+ * the rows) can feed the same map from its server-side profile. Pure over its inputs:
+ * it runs core's `runPipeline`, so reordering or editing a step re-runs the pipeline
+ * and the preview tracks it.
  */
 export function StandardizationPreview({
   field,
   inputColumn,
   steps,
-  rawRows,
-  sampleSize = PREVIEW_SAMPLE_SIZE,
+  columnSamples,
 }: {
   /** The linkage field this pipeline produces, for the constraint check. */
   field: LinkageField;
@@ -185,14 +153,12 @@ export function StandardizationPreview({
   inputColumn: string;
   /** The current pipeline steps, in order. */
   steps: Array<StandardizationStep>;
-  /** The parsed CSV rows the sample is drawn from. */
-  rawRows: ReadonlyArray<CSVRow>;
-  /** Override the provisional sample size (testing/aesthetics). */
-  sampleSize?: number;
+  /** The per-column preview samples; the field's `inputColumn` entry is sampled. */
+  columnSamples: ColumnSamples;
 }) {
   const sample = useMemo(
-    () => sampleInputValues(rawRows, inputColumn, sampleSize),
-    [rawRows, inputColumn, sampleSize],
+    () => columnSamples.get(inputColumn) ?? [],
+    [columnSamples, inputColumn],
   );
   // Recompute the outcomes whenever the steps or sample change; `steps` is a new
   // array on every edit/reorder, so the pipeline re-runs and the preview tracks

--- a/apps/web/src/components/TermsImportExport.tsx
+++ b/apps/web/src/components/TermsImportExport.tsx
@@ -40,6 +40,7 @@ export function TermsImportExport({
   currentTerms,
   seed,
   rawRows,
+  dateInputFormat,
   onImport,
 }: {
   /** The terms the current draft represents, for export. */
@@ -47,10 +48,13 @@ export function TermsImportExport({
   /** The editor seed (inviter columns/metadata), needed to reconstruct what an
    * imported document would generate for the constraint-divergence refusal. */
   seed: AdvancedInviteSeed;
-  /** The inviter's parsed rows, threaded into the same reconstruction (the date
-   * format it infers does not affect the constraint comparison, but the rebuild
-   * takes them). */
+  /** The inviter's parsed rows, the reconstruction's fallback source for the
+   * date-format inference when no pre-inferred format is threaded (the format does
+   * not affect the constraint comparison, but the rebuild takes it). */
   rawRows: ReadonlyArray<CSVRow>;
+  /** The pre-inferred date-of-birth input format, threaded so the reconstruction
+   * never re-derives it from the rows (the console has none). */
+  dateInputFormat?: string;
   /** Called with validated, non-gated terms to load into the editor. */
   onImport: (terms: LinkageTerms) => void;
 }) {
@@ -77,6 +81,7 @@ export function TermsImportExport({
       result.terms,
       seed,
       rawRows,
+      dateInputFormat,
     );
     if (constraintDivergence !== undefined) {
       setError(constraintDivergence);

--- a/apps/web/src/components/columnSamples.ts
+++ b/apps/web/src/components/columnSamples.ts
@@ -1,0 +1,64 @@
+import { readRowColumn } from "@psilink/core";
+
+import type { CSVRow } from "@psilink/core";
+
+/**
+ * The before->after value preview and its inputs. The preview samples a few non-empty
+ * values of a field's input column so the operator can inspect a transform on real
+ * data; the whole-file coverage question (does the transform collapse the field?) is
+ * answered separately and exhaustively by the non-empty-rate aggregate
+ * ({@link ../psi/nonEmptyAggregate}), not by widening this sample.
+ *
+ * The sample is computed from the rows on the hosted build and read from the
+ * server-side profile on the console -- so it is passed to the preview as a resolved
+ * per-column map, not derived inside the component from the rows the console lacks.
+ */
+
+/**
+ * Row-sample size for the before->after preview: the first few rows with a non-empty
+ * value for the field's input column. Settled at 5, coordinated with the non-empty
+ * aggregate and its row threshold.
+ */
+export const PREVIEW_SAMPLE_SIZE = 5;
+
+/** The per-column preview samples, keyed by input-column name: the first
+ * {@link PREVIEW_SAMPLE_SIZE} non-empty values of each column, in row order. */
+export type ColumnSamples = ReadonlyMap<string, ReadonlyArray<string>>;
+
+/** Pick up to `limit` non-empty raw values for `inputColumn`, in row order. A row
+ * whose value is missing or blank after trimming carries no signal for the preview,
+ * so it is skipped rather than shown as an empty before->after pair. */
+export function sampleInputValues(
+  rawRows: ReadonlyArray<CSVRow>,
+  inputColumn: string,
+  limit: number,
+): Array<string> {
+  const values: Array<string> = [];
+  for (const row of rawRows) {
+    // Read by own-property so a short row lacking the column reads as absent even
+    // when the column is named an Object.prototype member (readRowColumn); a bare
+    // row[inputColumn] would surface the inherited function past the check below.
+    const raw = readRowColumn(row, inputColumn);
+    if (raw !== undefined && raw.trim() !== "") {
+      values.push(raw);
+      if (values.length >= limit) break;
+    }
+  }
+  return values;
+}
+
+/** The per-column {@link sampleInputValues} for every named column -- the hosted
+ * build's computation of the {@link ColumnSamples} the console reads from its profile.
+ * Keyed by column so a field rebound to another column finds its sample by lookup. */
+export function columnSamplesFromRows(
+  rawRows: ReadonlyArray<CSVRow>,
+  columns: ReadonlyArray<string>,
+  limit: number = PREVIEW_SAMPLE_SIZE,
+): ColumnSamples {
+  return new Map(
+    columns.map((column) => [
+      column,
+      sampleInputValues(rawRows, column, limit),
+    ]),
+  );
+}

--- a/apps/web/src/components/useNonEmptyRates.ts
+++ b/apps/web/src/components/useNonEmptyRates.ts
@@ -4,7 +4,6 @@ import { NonEmptyRateController } from "@psi/nonEmptyAggregateController";
 import { defaultSpawnAggregateWorker } from "@psi/nonEmptyAggregateWorkerClient";
 
 import type { FieldValueCoverage } from "@psi/nonEmptyAggregate";
-import type { SpawnAggregateWorker } from "@psi/nonEmptyAggregateController";
 
 import type { CSVRow, Standardization } from "@psilink/core";
 
@@ -24,18 +23,50 @@ export interface NonEmptyRatesState {
 }
 
 /**
- * Run the full-CSV per-field value coverage for the current standardization, off the
- * main thread above the row threshold. One {@link NonEmptyRateController} is created
- * per row set (the worker, if any, is seeded once); each debounced standardization
- * edit posts only the standardization for a recompute. The result is keyed by field
- * name for the host to read per card.
- *
- * `spawnWorker` is injectable for tests; production uses the real worker.
+ * A source of full-file per-field coverage: seeded once for a coverage input,
+ * recomputed for each standardization edit, and torn down on dispose. The hosted
+ * default ({@link rowsCoverageProvider}) wraps {@link NonEmptyRateController} over the
+ * browser's parsed rows; the console provider (a fetch to the server-side coverage
+ * sweep) is a later work package that plugs in through this same seam.
  */
-export function useNonEmptyRates(
-  rawRows: ReadonlyArray<CSVRow>,
+export interface CoverageProvider {
+  /** Resolve the per-field rates for `standardization`. A compute the hook
+   * supersedes may never settle -- the hook guards with its own cancellation flag. */
+  compute: (
+    standardization: Standardization,
+  ) => Promise<Array<FieldValueCoverage>>;
+  /** Release the underlying resource (the worker, a request, a connection). */
+  dispose: () => void;
+}
+
+/** Build a {@link CoverageProvider} for a coverage input -- injected so the hook is
+ * agnostic to whether the input is the browser's rows or a server-side file
+ * reference. */
+export type CoverageProviderFactory<TInput> = (
+  input: TInput,
+) => CoverageProvider;
+
+/** The hosted coverage provider: {@link NonEmptyRateController} over the parsed rows,
+ * preserving its inline-below-threshold / worker-above-threshold behavior exactly. */
+export const rowsCoverageProvider: CoverageProviderFactory<
+  ReadonlyArray<CSVRow>
+> = (rawRows) =>
+  new NonEmptyRateController(rawRows, defaultSpawnAggregateWorker);
+
+/**
+ * Run the full-CSV per-field value coverage for the current standardization behind
+ * a {@link CoverageProvider}. One provider is created per coverage `input` (the
+ * worker, if any, is seeded once); each debounced standardization edit posts only the
+ * standardization for a recompute. The result is keyed by field name for the host to
+ * read per card.
+ *
+ * `makeProvider` is the injectable seam: the hosted host passes
+ * {@link rowsCoverageProvider}, and the console host passes a fetch-backed provider.
+ */
+export function useNonEmptyRates<TInput>(
+  input: TInput,
   standardization: Standardization,
-  spawnWorker: SpawnAggregateWorker = defaultSpawnAggregateWorker,
+  makeProvider: CoverageProviderFactory<TInput>,
 ): NonEmptyRatesState {
   const [rates, setRates] = useState<ReadonlyMap<
     string,
@@ -43,33 +74,33 @@ export function useNonEmptyRates(
   > | null>(null);
   const [pending, setPending] = useState(true);
 
-  // One controller per row set: a new file rebuilds it (and re-seeds the worker);
-  // a standardization edit reuses it. Declared before the compute effect so it runs
-  // first and the ref is set when the compute effect reads it.
-  const controllerRef = useRef<NonEmptyRateController | null>(null);
+  // One provider per coverage input: a new file rebuilds it (and re-seeds the
+  // worker); a standardization edit reuses it. Declared before the compute effect so
+  // it runs first and the ref is set when the compute effect reads it.
+  const providerRef = useRef<CoverageProvider | null>(null);
   useEffect(() => {
-    const controller = new NonEmptyRateController(rawRows, spawnWorker);
-    controllerRef.current = controller;
+    const provider = makeProvider(input);
+    providerRef.current = provider;
     // Drop any prior file's coverage immediately and re-enter the pending state: until
     // the new sweep settles the host shows "Checking...", never nothing and never the
     // previous file's rate (or alarm) for a same-named field. Resetting pending here
     // (not only in the compute effect, which runs second) keeps the two in lockstep
-    // for the new row set rather than relying on effect-ordering and update batching.
+    // for the new input rather than relying on effect-ordering and update batching.
     setRates(null);
     setPending(true);
     return () => {
-      controller.dispose();
-      controllerRef.current = null;
+      provider.dispose();
+      providerRef.current = null;
     };
-  }, [rawRows, spawnWorker]);
+  }, [input, makeProvider]);
 
   useEffect(() => {
-    const controller = controllerRef.current;
-    if (controller === null) return;
+    const provider = providerRef.current;
+    if (provider === null) return;
     let cancelled = false;
     setPending(true);
     const handle = setTimeout(() => {
-      controller
+      provider
         .compute(standardization)
         .then((next) => {
           if (cancelled) return;
@@ -77,7 +108,7 @@ export function useNonEmptyRates(
           setPending(false);
         })
         .catch(() => {
-          // A worker error (dispose never settles -- see the controller) leaves the
+          // A provider error (dispose never settles -- see the controller) leaves the
           // coverage unknown: clear the prior rates rather than leave a stale rate or
           // alarm on screen, and clear pending so the UI never hangs mid-check.
           if (!cancelled) {
@@ -90,12 +121,12 @@ export function useNonEmptyRates(
       cancelled = true;
       clearTimeout(handle);
     };
-    // `spawnWorker` is a dep even though it is not read here: when it changes the
-    // controller effect rebuilds the controller, and this effect must re-run to
-    // dispatch a compute against the new one -- otherwise the readout wedges in the
-    // pending state with no compute in flight. Production passes the stable default,
-    // so this only matters for a caller that varies spawnWorker (e.g. a test).
-  }, [rawRows, standardization, spawnWorker]);
+    // `makeProvider` is a dep even though it is not read here: when it changes the
+    // provider effect rebuilds the provider, and this effect must re-run to dispatch a
+    // compute against the new one -- otherwise the readout wedges in the pending state
+    // with no compute in flight. Production passes a stable module-level factory, so
+    // this only matters for a caller that varies makeProvider (e.g. a test).
+  }, [input, standardization, makeProvider]);
 
   return { rates, pending };
 }

--- a/apps/web/src/psi/advancedInvite.ts
+++ b/apps/web/src/psi/advancedInvite.ts
@@ -29,9 +29,11 @@ export { outputForDirection } from "./advancedInviteTypes";
 export {
   addElement,
   addKey,
+  dateInputFormatForColumns,
   defaultStandardizationForRows,
   draftFromTerms,
   draftWithFieldAdded,
+  inferDateInputFormat,
   moveElement,
   removeElement,
   removeKey,

--- a/apps/web/src/psi/advancedInviteDraft.ts
+++ b/apps/web/src/psi/advancedInviteDraft.ts
@@ -57,15 +57,48 @@ export function defaultStandardizationForRows(
   metadata: Metadata,
   terms: LinkageTerms,
   rawRows: ReadonlyArray<CSVRow>,
+  dateInputFormat?: string,
 ): Standardization {
+  return getDefaultStandardization(metadata, terms, {
+    dateInputFormat: dateInputFormat ?? inferDateInputFormat(metadata, rawRows),
+  });
+}
+
+/**
+ * The date-of-birth input format the recommended cleaning parses with: inferred
+ * from the first present `role: linkage` date_of_birth column's values, or
+ * `undefined` (the `MM/DD/YYYY` default) when there is no such column or the layout
+ * cannot be inferred. The single derivation {@link defaultStandardizationForRows}
+ * falls back to when no pre-inferred format is threaded, and the value the console
+ * profiles server-side so the browser can author without the rows.
+ */
+export function inferDateInputFormat(
+  metadata: Metadata,
+  rawRows: ReadonlyArray<CSVRow>,
+): string | undefined {
   const dobColumn = metadata.find(
     (column) => column.type === "date_of_birth" && column.role === "linkage",
   );
-  const dateInputFormat =
-    dobColumn !== undefined
-      ? inferDateFormat(columnValues(rawRows, dobColumn.name))
-      : undefined;
-  return getDefaultStandardization(metadata, terms, { dateInputFormat });
+  return dobColumn !== undefined
+    ? inferDateFormat(columnValues(rawRows, dobColumn.name))
+    : undefined;
+}
+
+/**
+ * The date-of-birth input format {@link seedAdvancedInvite} derives for a set of
+ * columns and their rows -- {@link inferDateInputFormat} over the same seed metadata
+ * ({@link normalizeForEditor} of {@link inferMetadata}) the seed builds. The hosted
+ * intake derives it once here so the value can thread every reconciliation in place
+ * of the full rows, and a seed from (columns, format) reproduces one from full rows.
+ */
+export function dateInputFormatForColumns(
+  columns: Array<string>,
+  rawRows: ReadonlyArray<CSVRow>,
+): string | undefined {
+  return inferDateInputFormat(
+    normalizeForEditor(inferMetadata(columns)),
+    rawRows,
+  );
 }
 
 /**
@@ -75,12 +108,15 @@ export function defaultStandardizationForRows(
  * the editor never opens on a blank form; the seeded standardization infers the
  * date-of-birth format from `rawRows` (see {@link defaultStandardizationForRows}).
  * Calling this again is exactly the "Reset to defaults" action. `rawRows`
- * defaults to empty, which yields the `MM/DD/YYYY` date default.
+ * defaults to empty, which yields the `MM/DD/YYYY` date default; a pre-inferred
+ * `dateInputFormat` ({@link dateInputFormatForColumns}) overrides that derivation,
+ * so a seed from (columns, format) matches one from full rows without them.
  */
 export function seedAdvancedInvite(
   identity: string,
   columns: Array<string>,
   rawRows: ReadonlyArray<CSVRow> = [],
+  dateInputFormat?: string,
 ): { draft: AdvancedInviteDraft; seed: AdvancedInviteSeed } {
   // Normalized so the collapsed disclosure control opens on a faithful diagonal
   // (an inferred identifier column is not silently disclosed). Normalization only
@@ -111,7 +147,12 @@ export function seedAdvancedInvite(
       // equal getDefaultLinkageTerms' -- the editor opens on a known-good valid
       // state, byte-identical to the quick path's (the inferred format lives only in
       // the local steps, which the terms do not carry).
-      standardization: defaultStandardizationForRows(metadata, terms, rawRows),
+      standardization: defaultStandardizationForRows(
+        metadata,
+        terms,
+        rawRows,
+        dateInputFormat,
+      ),
       keys: terms.linkageKeys.map((key) => ({ key, enabled: true })),
     },
     seed: { terms, metadata, columns },
@@ -133,6 +174,7 @@ export function setDraftMetadataKeepingKeys(
   draft: AdvancedInviteDraft,
   metadata: Metadata,
   rawRows: ReadonlyArray<CSVRow> = [],
+  dateInputFormat?: string,
 ): AdvancedInviteDraft {
   return {
     ...draft,
@@ -143,6 +185,7 @@ export function setDraftMetadataKeepingKeys(
       metadata,
       draft.identity,
       rawRows,
+      dateInputFormat,
     ),
   };
 }
@@ -164,13 +207,14 @@ export function setDraftMetadata(
   draft: AdvancedInviteDraft,
   metadata: Metadata,
   rawRows: ReadonlyArray<CSVRow> = [],
+  dateInputFormat?: string,
 ): AdvancedInviteDraft {
   const offerable = getDefaultLinkageTerms(
     draft.identity,
     metadata,
   ).linkageKeys;
   return {
-    ...setDraftMetadataKeepingKeys(draft, metadata, rawRows),
+    ...setDraftMetadataKeepingKeys(draft, metadata, rawRows, dateInputFormat),
     keys: reconcileKeys(draft.keys, offerable),
   };
 }
@@ -203,6 +247,7 @@ function reconcileStandardization(
   metadata: Metadata,
   identity: string,
   rawRows: ReadonlyArray<CSVRow>,
+  dateInputFormat?: string,
 ): Standardization {
   const columnByName = new Map(metadata.map((column) => [column.name, column]));
   const prevTypeByName = new Map(
@@ -228,6 +273,7 @@ function reconcileStandardization(
     metadata,
     getDefaultLinkageTerms(identity, metadata),
     rawRows,
+    dateInputFormat,
   );
   const additions = fullDefault.filter((transformation) => {
     const column = columnByName.get(transformation.input);
@@ -545,8 +591,14 @@ function standardizationForImportedTerms(
   defaultTerms: LinkageTerms,
   terms: LinkageTerms,
   rawRows: ReadonlyArray<CSVRow>,
+  dateInputFormat?: string,
 ): Standardization {
-  const base = defaultStandardizationForRows(metadata, defaultTerms, rawRows);
+  const base = defaultStandardizationForRows(
+    metadata,
+    defaultTerms,
+    rawRows,
+    dateInputFormat,
+  );
   // The recommended steps each imported field's type cleans with, keyed by field
   // name. Derived from the default standardization over the IMPORTED terms (not the
   // seed's), so it covers every imported field's type -- including one the inviter
@@ -555,9 +607,12 @@ function standardizationForImportedTerms(
   // columns it picks collide on the first per type; only the steps are read here,
   // and the distinct columns are assigned below.
   const stepsByField = new Map(
-    defaultStandardizationForRows(metadata, terms, rawRows).map(
-      (transformation) => [transformation.output, transformation.steps],
-    ),
+    defaultStandardizationForRows(
+      metadata,
+      terms,
+      rawRows,
+      dateInputFormat,
+    ).map((transformation) => [transformation.output, transformation.steps]),
   );
   // The default-named field each type already binds; only the EXTRA same-typed
   // fields (first_name_2, ...) need a reconstructed binding.
@@ -633,12 +688,14 @@ export function draftFromTerms(
   seed: AdvancedInviteSeed,
   lifetimeSeconds: number = INVITATION_LIFETIME_SECONDS,
   rawRows: ReadonlyArray<CSVRow> = [],
+  dateInputFormat?: string,
 ): AdvancedInviteDraft {
   const standardization = standardizationForImportedTerms(
     seed.metadata,
     seed.terms,
     terms,
     rawRows,
+    dateInputFormat,
   );
   // Disable -- but keep -- any imported key the reconstructed binding cannot
   // supply: one referencing a field no column declares (more same-typed fields than

--- a/apps/web/src/psi/advancedInviteValidation.ts
+++ b/apps/web/src/psi/advancedInviteValidation.ts
@@ -396,9 +396,16 @@ export function importedConstraintDivergenceMessage(
   terms: LinkageTerms,
   seed: AdvancedInviteSeed,
   rawRows: ReadonlyArray<CSVRow> = [],
+  dateInputFormat?: string,
 ): string | undefined {
   const rebuilt = buildAdvancedTerms(
-    draftFromTerms(terms, seed, INVITATION_LIFETIME_SECONDS, rawRows),
+    draftFromTerms(
+      terms,
+      seed,
+      INVITATION_LIFETIME_SECONDS,
+      rawRows,
+      dateInputFormat,
+    ),
   );
   const importedByName = new Map(
     terms.linkageFields.map((field) => [field.name, field]),

--- a/apps/web/test/browser/keysTab.test.ts
+++ b/apps/web/test/browser/keysTab.test.ts
@@ -31,6 +31,7 @@ const csv: AcquiredCsv = {
     },
   ],
   columns: ["client_id", "first_name", "last_name", "dob", "ssn4"],
+  rowCount: 1,
 };
 
 // Author a self-defeating parse_date onto the date_of_birth element of the

--- a/apps/web/test/browser/standardizationCards.test.ts
+++ b/apps/web/test/browser/standardizationCards.test.ts
@@ -10,6 +10,7 @@ import { createRoot } from "react-dom/client";
 import { authoredLinkageFields } from "@psilink/core";
 
 import { StandardizationCards } from "@components/StandardizationCards";
+import { columnSamplesFromRows } from "@components/columnSamples";
 
 import { expandFieldCards } from "./fieldCards";
 import { renderApp } from "./renderApp";
@@ -42,6 +43,10 @@ const metadata: Metadata = [
   { name: "dob_col", type: "date_of_birth", role: "linkage", isPayload: false },
 ];
 const rawRows = [{ maiden_col: "Smith", current_col: "Jones", dob_col: "X" }];
+const columnSamples = columnSamplesFromRows(
+  rawRows,
+  metadata.map((column) => column.name),
+);
 
 type CardsProps = Parameters<typeof StandardizationCards>[0];
 
@@ -58,7 +63,7 @@ function render(
         standardization,
         declaredFields: authoredLinkageFields(metadata, standardization),
         metadata,
-        rawRows,
+        columnSamples,
         onStepsChange: () => {},
         onInputColumnChange: () => {},
         onMissingField: "skip",

--- a/apps/web/test/browser/standardizationStepEditor.test.ts
+++ b/apps/web/test/browser/standardizationStepEditor.test.ts
@@ -9,6 +9,7 @@ import { createRoot } from "react-dom/client";
 
 import { StandardizationPreview } from "@components/StandardizationPreview";
 import { StandardizationStepEditor } from "@components/StandardizationStepEditor";
+import { columnSamplesFromRows } from "@components/columnSamples";
 
 import { renderApp } from "./renderApp";
 
@@ -34,6 +35,23 @@ function render(node: ReturnType<typeof createElement>) {
 }
 
 const FIRST_NAME: LinkageField = { name: "fn", type: "first_name" };
+
+// The preview takes the per-column sample map the console profiles server-side; each
+// case builds that map from its rows with columnSamplesFromRows, so it exercises the
+// component with a fixed, resolved sample.
+function previewElement(props: {
+  field: LinkageField;
+  inputColumn: string;
+  steps: Array<StandardizationStep>;
+  rawRows: Array<Record<string, string>>;
+}) {
+  const { rawRows, inputColumn, ...rest } = props;
+  return createElement(StandardizationPreview, {
+    ...rest,
+    inputColumn,
+    columnSamples: columnSamplesFromRows(rawRows, [inputColumn]),
+  });
+}
 
 // A stateful harness that wires the editor to the preview through one steps state,
 // mirroring how the "Prepare your data" screen docks them: an edit in the editor
@@ -61,7 +79,7 @@ function EditorWithPreview({
       steps,
       onStepsChange: setSteps,
     }),
-    createElement(StandardizationPreview, {
+    previewElement({
       field,
       inputColumn,
       steps,
@@ -73,7 +91,7 @@ function EditorWithPreview({
 describe("StandardizationPreview renders each pipeline outcome distinctly", () => {
   test("a cleaned value", async () => {
     render(
-      createElement(StandardizationPreview, {
+      previewElement({
         field: FIRST_NAME,
         inputColumn: "n",
         steps: [{ function: "to_upper_case" }],
@@ -87,7 +105,7 @@ describe("StandardizationPreview renders each pipeline outcome distinctly", () =
 
   test("a dropped (null) value", async () => {
     render(
-      createElement(StandardizationPreview, {
+      previewElement({
         field: FIRST_NAME,
         inputColumn: "n",
         steps: [{ function: "null_if", params: { values: ["mary"] } }],
@@ -101,7 +119,7 @@ describe("StandardizationPreview renders each pipeline outcome distinctly", () =
 
   test("a fan-out (Set) into several candidates", async () => {
     render(
-      createElement(StandardizationPreview, {
+      previewElement({
         field: FIRST_NAME,
         inputColumn: "n",
         steps: [{ function: "split_on", params: { delimiter: " " } }],
@@ -119,7 +137,7 @@ describe("StandardizationPreview renders each pipeline outcome distinctly", () =
   test("an empty cleaned value is shown distinctly from a dropped value", async () => {
     // remove_dashes turns "---" into "" -- a value (an empty PSI key), not a drop.
     render(
-      createElement(StandardizationPreview, {
+      previewElement({
         field: FIRST_NAME,
         inputColumn: "n",
         steps: [{ function: "remove_dashes" }],
@@ -137,7 +155,7 @@ describe("StandardizationPreview renders each pipeline outcome distinctly", () =
   test("an incomplete step shows guidance instead of crashing the preview", async () => {
     // pad_left with no length yet throws when compiled; the preview must catch it.
     render(
-      createElement(StandardizationPreview, {
+      previewElement({
         field: FIRST_NAME,
         inputColumn: "n",
         steps: [{ function: "pad_left" }],
@@ -161,7 +179,7 @@ describe("StandardizationPreview renders each pipeline outcome distinctly", () =
     // the oversized source never reaches compile and the operator sees the same
     // guidance the inline length error already explains.
     render(
-      createElement(StandardizationPreview, {
+      previewElement({
         field: FIRST_NAME,
         inputColumn: "n",
         steps: [
@@ -183,7 +201,7 @@ describe("StandardizationPreview renders each pipeline outcome distinctly", () =
 
   test("a value that violates a field constraint is badged (warn, not blocked)", async () => {
     render(
-      createElement(StandardizationPreview, {
+      previewElement({
         // allowedCharacters "A-Z " -> a lowercase residue is flagged.
         field: {
           name: "fn",
@@ -620,7 +638,7 @@ describe("preview outcomes reach assistive tech by text/label, not color alone",
     // remove_dashes turns "---" into "" -- an empty key. The chip is icon-style, so
     // its meaning must reach a screen reader as a label.
     render(
-      createElement(StandardizationPreview, {
+      previewElement({
         field: FIRST_NAME,
         inputColumn: "n",
         steps: [{ function: "remove_dashes" }],
@@ -634,7 +652,7 @@ describe("preview outcomes reach assistive tech by text/label, not color alone",
 
   test("a constraint violation is a labelled badge, distinct from the value color", async () => {
     render(
-      createElement(StandardizationPreview, {
+      previewElement({
         field: {
           name: "fn",
           type: "first_name",
@@ -652,7 +670,7 @@ describe("preview outcomes reach assistive tech by text/label, not color alone",
 
   test("a dropped value carries the word 'dropped', not a color cue alone", async () => {
     render(
-      createElement(StandardizationPreview, {
+      previewElement({
         field: FIRST_NAME,
         inputColumn: "n",
         steps: [{ function: "null_if", params: { values: ["mary"] } }],

--- a/apps/web/test/unit/advancedInvite.test.ts
+++ b/apps/web/test/unit/advancedInvite.test.ts
@@ -19,6 +19,7 @@ import {
 import {
   addKey,
   buildAdvancedTerms,
+  dateInputFormatForColumns,
   defaultStandardizationForRows,
   draftFromTerms,
   draftWithFieldAdded,
@@ -1189,6 +1190,33 @@ describe("inviter standardization: per-field column binding and multi-field", ()
     });
   });
 
+  test("a seed from (columns + pre-inferred format) deep-equals one from full rows", () => {
+    // The console has no rows: it seeds from the columns plus the date format its
+    // server-side profile inferred. That must reproduce the hosted seed byte for byte,
+    // since the rows feed the model only through that one inferred value.
+    const isoRows = [
+      {
+        ssn: "123456789",
+        ssn4: "6789",
+        first_name: "A",
+        last_name: "B",
+        dob: "1990-01-31",
+      },
+      {
+        ssn: "987654321",
+        ssn4: "4321",
+        first_name: "C",
+        last_name: "D",
+        dob: "1985-12-25",
+      },
+    ];
+    const format = dateInputFormatForColumns(ALL_COLUMNS, isoRows);
+    expect(format).toBe("YYYY-MM-DD");
+    expect(seedAdvancedInvite("Org", ALL_COLUMNS, [], format)).toEqual(
+      seedAdvancedInvite("Org", ALL_COLUMNS, isoRows),
+    );
+  });
+
   test("the seeded default standardization yields the same terms as no standardization (guided path unchanged)", () => {
     // authoredLinkageFields over getDefaultStandardization reproduces the default
     // per-type field set, so seeding the draft with the recommended cleaning does
@@ -1686,6 +1714,32 @@ describe("importedConstraintDivergenceMessage refuses a non-representable-constr
         buildAdvancedTerms(draftFromTerms(exported, mfSeed, 3600, mfRows)),
       ),
     ).toEqual(canonicalString(exported));
+  });
+
+  test("the verdict is insensitive to the rows and the threaded date format", () => {
+    // The console runs this check with no rows -- it threads the profiled date format
+    // over an empty row set. The verdict must match the hosted (full-rows) result: the
+    // comparison is over the field DECLARATIONS, which the date format (a cleaning
+    // step) never touches. Pinned here rather than trusting the doc comment.
+    const seed = seedFor();
+    const format = dateInputFormatForColumns(columns, rawRows);
+    const refused = withFieldConstraints(defaultExport(), "ssn", {
+      exclude: ["999999999"],
+      validOnly: false,
+    });
+    for (const terms of [refused, defaultExport()]) {
+      const fromRows = importedConstraintDivergenceMessage(
+        terms,
+        seed,
+        rawRows,
+      );
+      expect(
+        importedConstraintDivergenceMessage(terms, seed, [], format),
+      ).toEqual(fromRows);
+      expect(importedConstraintDivergenceMessage(terms, seed, [])).toEqual(
+        fromRows,
+      );
+    }
   });
 });
 

--- a/apps/web/test/unit/benchInviterModel.test.ts
+++ b/apps/web/test/unit/benchInviterModel.test.ts
@@ -69,6 +69,7 @@ const csv: AcquiredCsv = {
     "ssn4",
     "program_code",
   ],
+  rowCount: 1,
 };
 
 function ledgerValue(editor: ReturnType<typeof editorFromCsv>, label: string) {
@@ -826,6 +827,7 @@ describe("a column retype reconciles standardization even with authored keys", (
       },
     ],
     columns: ["first_name", "last_name", "dob", "extra"],
+    rowCount: 1,
   };
 
   function retypeFirstNameToLastName(editor: ReturnType<typeof editorFromCsv>) {

--- a/apps/web/test/unit/benchSampleData.test.ts
+++ b/apps/web/test/unit/benchSampleData.test.ts
@@ -39,6 +39,7 @@ async function acquire(
     sizeBytes: csvText.length,
     rawRows: result.data,
     columns: result.meta.fields ?? [],
+    rowCount: result.data.length,
   };
 }
 

--- a/apps/web/test/unit/consoleAcquiredCsv.test.ts
+++ b/apps/web/test/unit/consoleAcquiredCsv.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+
+import { consoleAcquiredCsv } from "../../src/bench/consoleAcquiredCsv.js";
+
+describe("consoleAcquiredCsv", () => {
+  const profile = {
+    fileName: "clients.csv",
+    sizeBytes: 4096,
+    columns: ["first_name", "last_name", "dob"],
+    rowCount: 12408,
+    dateInputFormat: "YYYY-MM-DD",
+  };
+
+  test("carries the profiled facts an authoring session needs, without the rows", () => {
+    const acquired = consoleAcquiredCsv(profile);
+    expect(acquired.fileName).toBe("clients.csv");
+    expect(acquired.sizeBytes).toBe(4096);
+    expect(acquired.columns).toEqual(["first_name", "last_name", "dob"]);
+    expect(acquired.rowCount).toBe(12408);
+    expect(acquired.dateInputFormat).toBe("YYYY-MM-DD");
+  });
+
+  test("a stray rawRows read throws in dev/test rather than reading empty", () => {
+    const acquired = consoleAcquiredCsv(profile);
+    // The throwing getter is the runtime half of the backstop: a consumer that has
+    // not been moved onto the profile fails loud here instead of silently rendering
+    // an empty preview or zero coverage.
+    expect(() => acquired.rawRows).toThrow(/rawRows/);
+  });
+});


### PR DESCRIPTION
## Summary

Ground the client draft model for console work inputs: every edit-time dependency on full CSV rows now rides an optional seam the console can feed from a server-side profile, while hosted behavior stays byte-for-byte identical.

Implements [214995296](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=214995296).

## Changes

- apps/web/src/bench/inviterModel.ts, acceptorColumnsModel.ts: acquired shapes gain rowCount (display surfaces stop reading rawRows.length) and an optional pre-inferred dateInputFormat.
- apps/web/src/psi/advancedInviteDraft.ts, advancedInviteValidation.ts, bench/inviterModel.ts: seedAdvancedInvite, defaultStandardizationForRows, draftFromTerms, setDraftMetadata (+KeepingKeys), reconcileStandardization, standardizationForImportedTerms, editorWithRecommendedCleaning, and importedConstraintDivergenceMessage accept the optional format and fall back to row inference when absent; hosted intake leaves it unset, so every hosted derivation is unchanged.
- apps/web/src/components/useNonEmptyRates.ts: the injectable seam generalizes from spawn-a-worker to a coverage provider factory; the default provider wraps the existing controller, preserving its inline-below-threshold and worker-above-threshold behavior.
- apps/web/src/components/StandardizationPreview.tsx, StandardizationCards.tsx, columnSamples.ts: the preview takes a per-column sample map; hosted computes it from rows with the extracted sampleInputValues helper.
- apps/web/src/bench/consoleAcquiredCsv.ts, apps/web/eslint.config.js: the console acquired-shape factory (rawRows throws in dev/test, yields the empty array in production) and an ESLint restriction confining .rawRows reads to the enumerated consumers.
- apps/web/test/unit: seed-from-profile equivalence, divergence-message insensitivity, and throwing-getter coverage.

## Test plan

Ran: web unit suite (1379), web browser suite (483, locally), typecheck/lint/format, npm run test:scripts.
New tests cover: seeding from (columns + pre-inferred format) deep-equals seeding from full rows; the terms-import divergence check returns identical results with rows, with empty rows plus the threaded format, and with neither; the console factory's rawRows getter throws in test on stray access.

## Checklist

- [x] Docs: enumerated docs/ and docs/spec/ and checked affected pages -- n/a: internal draft-model seams only; hosted behavior and every documented flow are unchanged, and the console surface these seams serve lands in later PRs with its own docs.
- [x] CHANGELOG.md [Unreleased] updated -- n/a: internal refactor, not a major feature or breaking change.
- [x] Security review -- n/a: behavior-preserving client refactor; no crypto, credential, auth, disclosure, or security-relevant dependency surface touched.