### PR TITLE
Serve mounted work inputs via job API routes

### DIFF
--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -1,6 +1,11 @@
 import type { Argv, Arguments } from "yargs";
 
-import { getDefaultLinkageTerms, getLogger, UsageError } from "@psilink/core";
+import {
+  getDefaultLinkageTerms,
+  getLogger,
+  inferDateInputFormatFromSource,
+  UsageError,
+} from "@psilink/core";
 
 import { DEFAULT_CONFIG_PATH } from "../config";
 import {
@@ -15,11 +20,12 @@ import {
   assertNoUnknownOptions,
   configureLogging,
   LOG_LEVELS,
+  openInputSource,
   promptConfirm,
   runOrExit,
   singleValue,
 } from "../util/cli";
-import { buildDataSpec, loadInputRowsForInference } from "../onlineBootstrap";
+import { buildDataSpec } from "../onlineBootstrap";
 
 // The identity written into a fresh template when --identity is not given. A
 // placeholder, like the connection's host/username -- init produces a scaffold to
@@ -192,8 +198,12 @@ export function resolveInitInput(
  * default linkage terms when it is not. Reuses `buildDataSpec` -- the same
  * inference `invite`/`accept`/zero-setup run -- so the template's terms match
  * what those commands would author from the same file. Reads the input through
- * `loadInputRowsForInference` (header plus a bounded DOB sample), not the full
- * row set the exchange commands load, since init's inference needs no more.
+ * `inferDateInputFormatFromSource` (header plus a bounded DOB sample), not the
+ * full row set the exchange commands load, since init's inference needs no more:
+ * it wants only the column header and the DOB date-input format, and the bounded
+ * sample yields the same format as a full read (see that helper). The metadata,
+ * linkage fields, and standardization then follow from the header alone in
+ * `buildDataSpec`, fed the pre-inferred format.
  *
  * @internal exported for testing
  */
@@ -205,9 +215,11 @@ export async function buildTemplateData(
   if (input === undefined)
     return { linkageTerms: getDefaultLinkageTerms(identity) };
 
-  let rows;
+  let inferred;
   try {
-    rows = await loadInputRowsForInference(input, { allowStdin: true });
+    inferred = await inferDateInputFormatFromSource(
+      openInputSource(input, { allowStdin: true }),
+    );
   } catch (err) {
     // openInputSource's stdin-specific rejections (`-` disallowed, `-` at a bare
     // TTY) are already UsageErrors with actionable wording -- keep them. A missing
@@ -221,7 +233,13 @@ export async function buildTemplateData(
     );
   }
 
-  const { dataSpec, warnings } = buildDataSpec({ identity, rows });
+  const { dataSpec, warnings } = buildDataSpec({
+    identity,
+    rows: { rawRows: [], columns: inferred.columns },
+    ...(inferred.dateInputFormat !== undefined
+      ? { dateInputFormat: inferred.dateInputFormat }
+      : {}),
+  });
   for (const w of warnings) log.warn(w);
   return dataSpec;
 }

--- a/apps/cli/src/onlineBootstrap.ts
+++ b/apps/cli/src/onlineBootstrap.ts
@@ -3,8 +3,6 @@ import type { Arguments } from "yargs";
 import {
   getLogger,
   loadCSVFile,
-  loadCSVColumnSample,
-  INFER_DATE_SCAN_CAP,
   prepareForExchange,
   inferMetadata,
   getDefaultLinkageTerms,
@@ -383,47 +381,6 @@ export async function loadInputRows(
   };
 }
 
-/**
- * Load only what `init`'s inference needs from a CSV -- the column header names
- * and a bounded sample of the date-of-birth column -- instead of the full row set
- * {@link loadInputRows} reads. `init` infers column metadata and linkage fields
- * from the header alone and the date-input format from the DOB column, and never
- * consumes any other row data, so this caps `init`'s peak memory at one parse
- * chunk rather than letting it scale with the input file.
- *
- * The result is shaped exactly as {@link loadInputRows}'s -- `{ rawRows, columns
- * }` -- so it drops straight into {@link buildDataSpec} unchanged, keeping `init`
- * on the same inference path as `invite`/`accept` (matching their inferred terms
- * is a design goal). The trick is that `buildDataSpec` reads `rawRows` for one
- * purpose only: the DOB column's values, fed to {@link inferDateFormat}. So
- * `rawRows` here holds just that column's bounded sample, projected to one-field
- * records keyed by the DOB column name. The bound is exact, not heuristic: the
- * sample caps at {@link INFER_DATE_SCAN_CAP} non-empty values, the same cap
- * `inferDateFormat` stops its own scan at, so the date format inferred from the
- * sample is identical to one inferred from a full read.
- *
- * The DOB column is resolved by running {@link inferMetadata} over the header --
- * the same resolution `buildDataSpec` repeats internally, so the column the sample
- * is keyed on always matches the one `buildDataSpec` reads. The loader reports the
- * column it sampled, so that resolution runs once. When no DOB column is inferred,
- * the sample is empty and `rawRows` is empty (only the header was read).
- */
-export async function loadInputRowsForInference(
-  input: string,
-  { allowStdin = false }: { allowStdin?: boolean } = {},
-): Promise<{ rawRows: Array<CSVRow>; columns: string[] }> {
-  const { columns, sampledColumn, sample } = await loadCSVColumnSample(
-    openInputSource(input, { allowStdin }),
-    (cols) => inferMetadata(cols).find((c) => c.type === "date_of_birth")?.name,
-    INFER_DATE_SCAN_CAP,
-  );
-  const rawRows =
-    sampledColumn !== undefined
-      ? sample.map((value) => ({ [sampledColumn]: value }))
-      : [];
-  return { rawRows, columns };
-}
-
 // --- Linkage strategy selection ----------------------------------------------
 
 /**
@@ -510,11 +467,19 @@ export function singlePassDisclosureNotice(): string {
  * agreed strategy), the selection is not applied -- the partner's choice stands.
  * Absent (or `cascade`) leaves the default strategy untouched, so omitting the
  * selection is byte-identical to before the flag existed.
+ *
+ * `dateInputFormat`, when given, is the DOB date-input format the caller already
+ * inferred (via `inferDateInputFormatFromSource`, from a bounded sample) and short
+ * -circuits this function's own inference from `rawRows`. `init` uses it because
+ * its bounded read carries no full row set to scan; the invite/accept paths omit
+ * it and this function infers the format from their full `rawRows` exactly as
+ * before -- so the parameter is additive and behavior-preserving for them.
  */
 export function buildDataSpec(args: {
   terms?: LinkageTerms;
   identity: string;
   rows?: { rawRows: Array<CSVRow>; columns: string[] };
+  dateInputFormat?: string;
   linkageStrategy?: LinkageStrategy;
 }): { dataSpec: ResolvedDataSpec; warnings: string[] } {
   const { terms, identity, rows, linkageStrategy } = args;
@@ -538,9 +503,10 @@ export function buildDataSpec(args: {
 
   const dobCol = metadata.find((c) => c.type === "date_of_birth");
   const dateInputFormat =
-    dobCol !== undefined
+    args.dateInputFormat ??
+    (dobCol !== undefined
       ? inferDateFormat(columnValues(rows.rawRows, dobCol.name))
-      : undefined;
+      : undefined);
 
   try {
     const standardization = getDefaultStandardization(metadata, linkageTerms, {

--- a/apps/cli/src/onlineBootstrap.ts
+++ b/apps/cli/src/onlineBootstrap.ts
@@ -469,10 +469,10 @@ export function singlePassDisclosureNotice(): string {
  * selection is byte-identical to before the flag existed.
  *
  * `dateInputFormat`, when given, is the DOB date-input format the caller already
- * inferred (via `inferDateInputFormatFromSource`, from a bounded sample) and short
- * -circuits this function's own inference from `rawRows`. `init` uses it because
- * its bounded read carries no full row set to scan; the invite/accept paths omit
- * it and this function infers the format from their full `rawRows` exactly as
+ * inferred (via `inferDateInputFormatFromSource`, from a bounded sample) and
+ * short-circuits this function's own inference from `rawRows`. `init` uses it
+ * because its bounded read carries no full row set to scan; the invite/accept paths
+ * omit it and this function infers the format from their full `rawRows` exactly as
  * before -- so the parameter is additive and behavior-preserving for them.
  */
 export function buildDataSpec(args: {

--- a/apps/cli/test/unit/onlineBootstrap.test.ts
+++ b/apps/cli/test/unit/onlineBootstrap.test.ts
@@ -9,6 +9,7 @@ import {
   CSV_LINE_BYTE_CEILING,
   getDefaultLinkageTerms,
   getLogger,
+  inferDateInputFormatFromSource,
   INFER_DATE_SCAN_CAP,
   MAX_PAYLOAD_ENTRIES,
   MAX_RECONNECT_ATTEMPTS,
@@ -47,7 +48,6 @@ import {
   endpointFromConnection,
   generateSharedSecret,
   loadInputRows,
-  loadInputRowsForInference,
   logOnlineBootstrapOutcome,
   looksLikeUrl,
   observedReceivedColumnsForSave,
@@ -56,7 +56,11 @@ import {
   singlePassDisclosureNotice,
 } from "../../src/onlineBootstrap";
 import { redactUrlCredentials } from "../../src/util/connectionUrl";
-import { MAX_TIMEOUT_SECONDS, runOrExit } from "../../src/util/cli";
+import {
+  MAX_TIMEOUT_SECONDS,
+  openInputSource,
+  runOrExit,
+} from "../../src/util/cli";
 import { runProtocol } from "../../src/protocol";
 import { streamOf, ttyStream, withStdin } from "../stdinStream";
 
@@ -2693,7 +2697,7 @@ test("loadInputRows: `-` at an interactive terminal is rejected (invite path inh
   });
 });
 
-// --- loadInputRowsForInference (init's bounded read) -------------------------
+// --- init's bounded inference read (inferDateInputFormatFromSource) -----------
 
 // A column set where date_of_birth joins a satisfiable default linkage key (a
 // name + DOB combination), so the inferred terms include a date_of_birth field
@@ -2721,7 +2725,27 @@ function dobInputFormat(
   return (step?.params as { inputFormat?: unknown } | undefined)?.inputFormat;
 }
 
-test("loadInputRowsForInference: infers the same metadata, fields, standardization, and dob format as a full read", async () => {
+/** Reproduce init's inference: read only the header + a bounded DOB sample via
+ * the shared core helper, then author the data spec from the header with the
+ * pre-inferred format -- exactly what `buildTemplateData` does. */
+async function inferInitDataSpec(
+  input: string,
+  opts: { allowStdin?: boolean } = {},
+) {
+  const inferred = await inferDateInputFormatFromSource(
+    openInputSource(input, opts),
+  );
+  const { dataSpec } = buildDataSpec({
+    identity: "Org",
+    rows: { rawRows: [], columns: inferred.columns },
+    ...(inferred.dateInputFormat !== undefined
+      ? { dateInputFormat: inferred.dateInputFormat }
+      : {}),
+  });
+  return { inferred, dataSpec };
+}
+
+test("inferDateInputFormatFromSource: the init path infers the same metadata, fields, standardization, and dob format as a full read", async () => {
   // The divergence guard the issue makes load-bearing: init's lighter read must
   // author terms byte-identical to what invite/accept derive from a full read of
   // the same file. Pin all four inferred outputs by comparing the two dataSpecs.
@@ -2733,26 +2757,22 @@ test("loadInputRowsForInference: infers the same metadata, fields, standardizati
       identity: "Org",
       rows: await loadInputRows(file),
     });
-    const light = buildDataSpec({
-      identity: "Org",
-      rows: await loadInputRowsForInference(file),
-    });
-    expect(light.dataSpec.metadata).toEqual(full.dataSpec.metadata);
-    expect(light.dataSpec.linkageTerms).toEqual(full.dataSpec.linkageTerms);
-    expect(light.dataSpec.standardization).toEqual(
-      full.dataSpec.standardization,
-    );
-    expect(dobInputFormat(light.dataSpec)).toBe("YYYY-MM-DD");
-    expect(dobInputFormat(light.dataSpec)).toBe(dobInputFormat(full.dataSpec));
+    const { dataSpec: light } = await inferInitDataSpec(file);
+    expect(light.metadata).toEqual(full.dataSpec.metadata);
+    expect(light.linkageTerms).toEqual(full.dataSpec.linkageTerms);
+    expect(light.standardization).toEqual(full.dataSpec.standardization);
+    expect(dobInputFormat(light)).toBe("YYYY-MM-DD");
+    expect(dobInputFormat(light)).toBe(dobInputFormat(full.dataSpec));
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("loadInputRowsForInference: does not read the full row set -- the dob sample is bounded to the scan cap", async () => {
+test("inferDateInputFormatFromSource: reads a bounded DOB sample, so a file far larger than the scan cap still yields the header and format", async () => {
   // A file with more dob rows than the inference cap: the full read returns every
-  // row, the inference read returns the header plus a sample capped at
-  // INFER_DATE_SCAN_CAP, so init's memory does not scale with the file.
+  // row, while the helper reads only the header plus a sample bounded at
+  // INFER_DATE_SCAN_CAP, so init's memory does not scale with the file yet the
+  // inferred format is unchanged.
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-bounded-"));
   try {
     const file = path.join(dir, "in.csv");
@@ -2761,45 +2781,39 @@ test("loadInputRowsForInference: does not read the full row set -- the dob sampl
     const full = await loadInputRows(file);
     expect(full.rawRows).toHaveLength(rowCount);
 
-    const light = await loadInputRowsForInference(file);
-    // The header is read whole...
-    expect(light.columns).toEqual(INFER_COLUMNS);
-    // ...but the rows handed to inference are capped at the scan limit, and hold
-    // only the projected dob column rather than the full record.
-    expect(light.rawRows).toHaveLength(INFER_DATE_SCAN_CAP);
-    expect(Object.keys(light.rawRows[0])).toEqual(["dob"]);
+    const { inferred } = await inferInitDataSpec(file);
+    expect(inferred.columns).toEqual(INFER_COLUMNS);
+    expect(inferred.dobColumn).toBe("dob");
+    expect(inferred.dateInputFormat).toBe("YYYY-MM-DD");
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("loadInputRowsForInference: a file with no dob column reads only the header", async () => {
+test("inferDateInputFormatFromSource: a file with no dob column yields no format and infers the same terms as a full read", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-nodob-"));
   try {
     const file = path.join(dir, "in.csv");
     fs.writeFileSync(file, "first_name,last_name,member_id\nAlice,Smith,1\n");
-    const { columns, rawRows } = await loadInputRowsForInference(file);
-    expect(columns).toEqual(["first_name", "last_name", "member_id"]);
-    // No DOB column to sample, so no row data is retained at all.
-    expect(rawRows).toEqual([]);
+    const { inferred, dataSpec: light } = await inferInitDataSpec(file);
+    expect(inferred.columns).toEqual(["first_name", "last_name", "member_id"]);
+    // No DOB column to sample, so no format is inferred.
+    expect(inferred.dobColumn).toBeUndefined();
+    expect(inferred.dateInputFormat).toBeUndefined();
     // Inference over it still matches a full read (no date format to infer).
     const full = buildDataSpec({
       identity: "Org",
       rows: await loadInputRows(file),
     });
-    const light = buildDataSpec({
-      identity: "Org",
-      rows: { columns, rawRows },
-    });
-    expect(light.dataSpec).toEqual(full.dataSpec);
+    expect(light).toEqual(full.dataSpec);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("loadInputRowsForInference: a header larger than the read buffer is read whole, matching the full read", async () => {
+test("inferDateInputFormatFromSource: a header larger than the read buffer is read whole, matching the full read", async () => {
   // A header longer than fs.createReadStream's 64 KiB read buffer spans multiple
-  // stream reads, so the bounded loader must not commit to the first (empty-field)
+  // stream reads, so the bounded read must not commit to the first (empty-field)
   // chunk -- otherwise init reads an empty header and silently infers nothing
   // while the full read infers correctly. Compare the header both paths recover.
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-bighdr-"));
@@ -2813,28 +2827,31 @@ test("loadInputRowsForInference: a header larger than the read buffer is read wh
     fs.writeFileSync(file, `${cols.join(",")}\n${row}\n`);
 
     const full = await loadInputRows(file);
-    const light = await loadInputRowsForInference(file);
-    expect(light.columns).toEqual(full.columns);
-    expect(light.columns).toHaveLength(8000);
+    const { inferred } = await inferInitDataSpec(file);
+    expect(inferred.columns).toEqual(full.columns);
+    expect(inferred.columns).toHaveLength(8000);
     // The DOB sample was still taken from the (now correctly read) header.
-    expect(light.rawRows).toEqual([{ dob: "1990-01-02" }]);
+    expect(inferred.dobColumn).toBe("dob");
+    expect(inferred.dateInputFormat).toBe("YYYY-MM-DD");
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("loadInputRowsForInference: a `-` CSV from stdin infers the same terms as the file", async () => {
+test("inferDateInputFormatFromSource: a `-` CSV from stdin infers the same as the file", async () => {
   // init reads its input with allowStdin enabled; the bounded read must work over
   // a non-rewindable stdin stream in a single pass, matching the file path.
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "psilink-infer-stdin-"));
   try {
     const file = path.join(dir, "in.csv");
     fs.writeFileSync(file, csvWithRows(10));
-    const fromFile = await loadInputRowsForInference(file, {
-      allowStdin: true,
-    });
+    const fromFile = await inferDateInputFormatFromSource(
+      openInputSource(file, { allowStdin: true }),
+    );
     const fromStdin = await withStdin(streamOf(csvWithRows(10)), () =>
-      loadInputRowsForInference("-", { allowStdin: true }),
+      inferDateInputFormatFromSource(
+        openInputSource("-", { allowStdin: true }),
+      ),
     );
     expect(fromStdin).toEqual(fromFile);
   } finally {
@@ -2842,7 +2859,7 @@ test("loadInputRowsForInference: a `-` CSV from stdin infers the same terms as t
   }
 });
 
-test("loadInputRowsForInference: a no-newline input fails fast rather than buffering the span", async () => {
+test("inferDateInputFormatFromSource: a no-newline input fails fast rather than buffering the span", async () => {
   // init's bounded read carries the byte ceiling end to end: a pathological local
   // CSV with no row terminator (one giant line) aborts with an operator-readable
   // error instead of consuming memory proportional to the span. Exercised over
@@ -2851,7 +2868,9 @@ test("loadInputRowsForInference: a no-newline input fails fast rather than buffe
   const giant = "x".repeat(CSV_LINE_BYTE_CEILING + 1024);
   await withStdin(streamOf(giant), async () => {
     await expect(
-      loadInputRowsForInference("-", { allowStdin: true }),
+      inferDateInputFormatFromSource(
+        openInputSource("-", { allowStdin: true }),
+      ),
     ).rejects.toThrow(/single-line limit/);
   });
 });

--- a/apps/web/nitro.config.ts
+++ b/apps/web/nitro.config.ts
@@ -1,12 +1,36 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { defineNitroConfig } from "nitropack/config";
+
+const srcDir = resolve(dirname(fileURLToPath(import.meta.url)), "src");
+
+// The `@`-prefixed source aliases (mirrored from vite.config.ts `srcAliases`).
+// Vite's `resolve.alias` governs only the client and SSR rollup passes; Nitro's
+// own server rollup pass reads its aliases from the Nitro config alone, so an
+// aliased import that Nitro externalizes into the server entry (rather than
+// inlining) would otherwise survive as an unresolved bare specifier and crash
+// the server at boot with ERR_MODULE_NOT_FOUND. Resolving the whole prefix set
+// here keeps any `@`-aliased server-graph import resolvable regardless of
+// Nitro's inline-vs-externalize decision.
+const serverAliases = {
+  "@bench": resolve(srcDir, "bench"),
+  "@components": resolve(srcDir, "components"),
+  "@jobs": resolve(srcDir, "jobs"),
+  "@utils": resolve(srcDir, "utils"),
+  "@util": resolve(srcDir, "util"),
+  "@peerjs-server": resolve(srcDir, "contrib/peerjs-server"),
+  "@psi": resolve(srcDir, "psi"),
+  "@theme": resolve(srcDir, "theme"),
+};
 
 export default defineNitroConfig({
   preset: "node_server",
   entry: "./server/custom-entry.ts",
+  alias: serverAliases,
   esbuild: {
     options: {
       target: "esnext",
     },
   },
-  // plugins: ['nitro/plugins/serverHook.ts']
 });

--- a/apps/web/server/custom-entry.ts
+++ b/apps/web/server/custom-entry.ts
@@ -20,6 +20,7 @@ import logLibrary from "loglevel";
 import { getLogger } from "@psilink/core";
 
 import { assertJobApiStartupSafe, readJobApiConfig } from "../src/jobs/gate";
+import { logJobInputDirBoot, useJobInputDir } from "../src/jobs/workInputs";
 import { shutdownJobManager, useSftpRemotesTable } from "../src/jobs/index";
 import { ConfigManager } from "../src/utils/serverConfig";
 import { registerServer } from "../src/httpServer";
@@ -70,6 +71,14 @@ assertJobApiStartupSafe(
 // file that does not load (or one configured without a data root) refuses to
 // start rather than deferring the error to the first sftp job request.
 useSftpRemotesTable();
+
+// And for the work-input directory: a configured JOB_INPUT_DIR that does not
+// resolve to a directory, is set without a data root, or overlaps the data root
+// refuses startup. When configured and valid, log the one boot-diagnostic line
+// (resolved realpath plus readdir/admissible counts) so a mis-mount is visible at
+// boot without touching the API.
+const jobInputDir = useJobInputDir();
+if (jobInputDir !== undefined) logJobInputDirBoot(jobInputDir, log);
 
 // @ts-ignore part of preset
 const listener = server.listen(path ? { path } : { port, host }, (err) => {

--- a/apps/web/src/components/StandardizationPreview.tsx
+++ b/apps/web/src/components/StandardizationPreview.tsx
@@ -12,11 +12,11 @@ import {
 
 import {
   checkValueConstraints,
-  readRowColumn,
   runPipeline,
   sanitizeForDisplay,
 } from "@psilink/core";
 
+import { PREVIEW_SAMPLE_SIZE, sampleInputValues } from "@psi/previewSamples";
 import { isStepValid } from "@psi/standardizationAuthoring";
 
 import type {
@@ -25,39 +25,6 @@ import type {
   LinkageField,
   StandardizationStep,
 } from "@psilink/core";
-
-/**
- * Row-sample size for the before->after preview: the first few rows with a non-empty
- * value for the field's input column. The preview is for inspecting the transform on
- * representative values, so a small fixed window keeps it cheap and legible; the
- * whole-file coverage question (does the transform collapse the field?) is answered
- * separately and exhaustively by the off-main-thread non-empty-rate aggregate
- * ({@link ../psi/nonEmptyAggregate}), not by widening this sample. Settled at 5,
- * coordinated with that aggregate and its row threshold.
- */
-export const PREVIEW_SAMPLE_SIZE = 5;
-
-/** Pick up to `limit` non-empty raw values for `inputColumn`, in row order. A row
- * whose value is missing or blank after trimming carries no signal for the
- * preview, so it is skipped rather than shown as an empty before->after pair. */
-function sampleInputValues(
-  rawRows: ReadonlyArray<CSVRow>,
-  inputColumn: string,
-  limit: number,
-): Array<string> {
-  const values: Array<string> = [];
-  for (const row of rawRows) {
-    // Read by own-property so a short row lacking the column reads as absent even
-    // when the column is named an Object.prototype member (readRowColumn); a bare
-    // row[inputColumn] would surface the inherited function past the check below.
-    const raw = readRowColumn(row, inputColumn);
-    if (raw !== undefined && raw.trim() !== "") {
-      values.push(raw);
-      if (values.length >= limit) break;
-    }
-  }
-  return values;
-}
 
 /** Render one cleaned value as a chip with any warn-not-enforce constraint badges
  * beside it. The value is the operator's own data (local CSV), shown sanitized for

--- a/apps/web/src/jobs/workInputs.ts
+++ b/apps/web/src/jobs/workInputs.ts
@@ -216,6 +216,13 @@ interface OpenedInput {
   modifiedAt: number;
 }
 
+/** Open-time errno codes that are indistinguishable from an unknown name to the
+ * client: a symlink swapped in after the admission lstat (`ELOOP`, the exact race
+ * `O_NOFOLLOW` exists to close), a file that vanished (`ENOENT`), or one made
+ * unreadable (`EACCES`). Each maps to {@link UnknownJobInputError} (empty-bodied
+ * 404, name never echoed), never a generic error. */
+const UNKNOWN_INPUT_OPEN_CODES = new Set(["ELOOP", "ENOENT", "EACCES"]);
+
 /**
  * Open an admitted input for reading, closing the symlink-swap and file-swap TOCTOU
  * windows. Re-runs the admission listing and requires `name` to match an admitted
@@ -223,7 +230,11 @@ interface OpenedInput {
  * enumerated), then `open(join(root, name), O_RDONLY | O_NOFOLLOW)` and `fstat`,
  * requiring `(dev, ino)` to equal the admission lstat. A name that is not admitted,
  * or an inode that no longer matches, is an {@link UnknownJobInputError}; the fd is
- * closed on any post-open failure so no descriptor leaks.
+ * closed on any post-open failure so no descriptor leaks. An open that fails on a
+ * post-admission race ({@link UNKNOWN_INPUT_OPEN_CODES}: the swapped-in symlink's
+ * `ELOOP`, a vanished file's `ENOENT`, an unreadable file's `EACCES`) is mapped to
+ * the same {@link UnknownJobInputError} rather than escaping as a generic error that
+ * the routes would surface as a 400.
  *
  * `O_NOFOLLOW` protects only the FINAL path component, and the root's realpath was
  * resolved once at boot; a post-boot remount or replacement of an intermediate
@@ -234,10 +245,18 @@ function openAdmittedInput(resolvedDir: string, name: string): OpenedInput {
   const entry = admitted.find((candidate) => candidate.name === name);
   if (entry === undefined) throw new UnknownJobInputError();
   const filePath = path.join(resolvedDir, name);
-  const fd = fs.openSync(
-    filePath,
-    fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW,
-  );
+  let fd: number;
+  try {
+    fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  } catch (error) {
+    const code =
+      error instanceof Error && "code" in error
+        ? (error as NodeJS.ErrnoException).code
+        : undefined;
+    if (code !== undefined && UNKNOWN_INPUT_OPEN_CODES.has(code))
+      throw new UnknownJobInputError();
+    throw error;
+  }
   try {
     const stat = fs.fstatSync(fd);
     if (stat.dev !== entry.dev || stat.ino !== entry.ino)
@@ -512,34 +531,45 @@ export function logJobInputDirBoot(
 }
 
 /**
- * Whether every standardization step's pattern/delimiter source stays within
+ * The standardization functions whose named param is compiled to a linear-time
+ * regex at pipeline construction (`compileLinearRegex` in core's
+ * standardization.ts), paired with that param's camelCase name. These are the only
+ * sources whose LENGTH drives the super-linear RE2 compile this route bounds. A
+ * plain-string param -- coalesce's `default`, null_if's `value`/`values` -- is never
+ * compiled and is unbounded on every other path (core's schema, the browser
+ * preview, the job-create intent), so capping it here would 400 a pipeline that runs
+ * fine everywhere else. `parse_date`'s format param also compiles, but the shared
+ * coverage accumulator already gates every field through `isStepValid`, which bounds
+ * that format at its own cap before any compile; only the regex-tier
+ * pattern/delimiter sources need this route's pre-parse rejection.
+ */
+const REGEX_SOURCE_PARAM_BY_FUNCTION: Record<string, string> = {
+  replace_regex: "pattern",
+  extract_regex: "pattern",
+  filter_regex: "pattern",
+  split_on: "delimiter",
+};
+
+/**
+ * Whether every standardization step's compiled regex source stays within
  * {@link MAX_TRANSFORM_PATTERN_LENGTH}. The intent-level schema bounds counts, not
- * pattern length, and while RE2JS execution is linear-time its COMPILE cost lands
- * on this process's event loop before any row streams, so this route caps the
- * source length of every string param (a regex pattern, a split delimiter). It is a
- * route-level cap only: the shared intent schema (and the job-create path) is
- * unchanged.
+ * pattern length, and while RE2JS execution is linear-time its COMPILE cost lands on
+ * this process's event loop before any row streams, so this route caps the source
+ * length of exactly the params that reach regex compilation
+ * ({@link REGEX_SOURCE_PARAM_BY_FUNCTION}). It is a route-level cap only: the shared
+ * intent schema (and the job-create path) is unchanged.
  */
 function stepPatternsWithinCap(
   transformation: Standardization[number],
 ): boolean {
   for (const step of transformation.steps ?? []) {
-    const params = step.params;
-    if (params === undefined) continue;
-    for (const value of Object.values(params)) {
-      if (
-        typeof value === "string" &&
-        value.length > MAX_TRANSFORM_PATTERN_LENGTH
-      )
-        return false;
-      if (Array.isArray(value))
-        for (const element of value)
-          if (
-            typeof element === "string" &&
-            element.length > MAX_TRANSFORM_PATTERN_LENGTH
-          )
-            return false;
-    }
+    if (!Object.hasOwn(REGEX_SOURCE_PARAM_BY_FUNCTION, step.function)) continue;
+    const value = step.params?.[REGEX_SOURCE_PARAM_BY_FUNCTION[step.function]];
+    if (
+      typeof value === "string" &&
+      value.length > MAX_TRANSFORM_PATTERN_LENGTH
+    )
+      return false;
   }
   return true;
 }

--- a/apps/web/src/jobs/workInputs.ts
+++ b/apps/web/src/jobs/workInputs.ts
@@ -1,0 +1,598 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { z } from "zod";
+
+import {
+  INFER_DATE_SCAN_CAP,
+  MAX_NAME_LENGTH,
+  MAX_TRANSFORM_PATTERN_LENGTH,
+  StandardizationSchema,
+  inferDateFormat,
+  inferDateOfBirthColumn,
+  readRowColumn,
+  streamCSVRows,
+} from "@psilink/core";
+
+import { PREVIEW_SAMPLE_SIZE } from "@psi/previewSamples";
+import { createFieldCoverageAccumulator } from "@psi/nonEmptyAggregate";
+
+import { JOB_DATA_ROOT_ENV, JobApiConfigError } from "./gate";
+import {
+  MAX_STANDARDIZATION_STEPS,
+  MAX_STANDARDIZATION_TRANSFORMATIONS,
+} from "./intent";
+
+import type { Standardization, getLogger } from "@psilink/core";
+import type { FieldValueCoverage } from "@psi/nonEmptyAggregate";
+
+/**
+ * The environment variable naming the one operator-mounted directory the server
+ * may list and read input CSVs from. Resolved and validated once at startup,
+ * fail-closed like the SFTP remotes table (see {@link loadJobInputDirFromEnv}).
+ * Unset/empty leaves the feature off: the listing reports `configured: false` and
+ * the profile/coverage routes answer an empty-bodied 404. It is set only
+ * server-side, never derived from a request, and is never baked into the image, so
+ * an upgraded console deployment that has not opted in gets the explicit
+ * unconfigured state, not a silently served filesystem directory.
+ */
+export const JOB_INPUT_DIR_ENV = "JOB_INPUT_DIR";
+
+/**
+ * The listing cap: at most this many admitted files are returned, with a
+ * `truncated` flag when more exist. Admitted names are sorted BEFORE the cap so
+ * truncation is deterministic across readdir orderings.
+ */
+export const MAX_INPUT_LISTING_ENTRIES = 512;
+
+/** The maximum length of an admissible input file name (a single path segment). */
+export const MAX_INPUT_NAME_LENGTH = 255;
+
+/**
+ * The byte cap on a coverage request body: a generous bound on the streamed read
+ * of the standardization JSON, which is a handful of transformations at most. The
+ * input CSV never rides the body -- it is read from the mounted directory -- so
+ * this stays small, unlike the job-create body.
+ */
+export const MAX_COVERAGE_BODY_BYTES = 1024 * 1024;
+
+/** A requested input name that does not resolve to an admitted entry, an inode
+ * that no longer matches, or an unreadable/vanished file. Mapped to an
+ * empty-bodied response that never echoes the requested name. */
+export class UnknownJobInputError extends Error {
+  constructor() {
+    super("unknown job input");
+    this.name = "UnknownJobInputError";
+  }
+}
+
+/** The named file's open-time size/mtime no longer match the client's profiled
+ * snapshot: the file changed under the client, so the coverage is refused rather
+ * than computed over content that drifted. */
+export class JobInputDriftError extends Error {
+  constructor() {
+    super("job input changed since it was profiled");
+    this.name = "JobInputDriftError";
+  }
+}
+
+/** A parse/sweep was requested while one is running and another is already
+ * queued: the depth-one gate is full (mapped to 429). */
+export class JobInputParseBusyError extends Error {
+  constructor() {
+    super("job input parse/sweep gate is busy");
+    this.name = "JobInputParseBusyError";
+  }
+}
+
+declare global {
+  var jobInputDirConfig: { resolvedDir?: string } | undefined;
+  var jobInputParseGate: JobInputParseGate | undefined;
+}
+
+/** Truncate a stat's float `mtimeMs` to integer epoch milliseconds, the single
+ * serialized representation used everywhere (listing, profile, and the coverage
+ * drift comparison), so a round-tripped value compares by exact equality. */
+function mtimeMsInt(mtimeMs: number): number {
+  return Math.trunc(mtimeMs);
+}
+
+// C0 controls (which include NUL) and DEL: an operator-controlled name is still
+// rendered through the UI, and a control character has no place in a file name.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001f\u007f]/;
+
+/**
+ * Whether `name` is an admissible input file name: a single path segment (no `/`,
+ * `\`, or NUL), not `.`/`..`, no leading dot (so a `.psilink.key`-shaped file is
+ * excluded by construction), no control characters, length 1..255. Symlink and
+ * directory exclusion is a separate lstat check ({@link listAdmitted}); this bounds
+ * only the name shape.
+ */
+export function isAdmissibleInputName(name: string): boolean {
+  if (name.length === 0 || name.length > MAX_INPUT_NAME_LENGTH) return false;
+  if (name === "." || name === "..") return false;
+  if (name.startsWith(".")) return false;
+  if (name.includes("/") || name.includes("\\")) return false;
+  if (CONTROL_CHAR_PATTERN.test(name)) return false;
+  return true;
+}
+
+/** One admitted entry, carrying the lstat identity ({@link mtimeMsInt}, `dev`,
+ * `ino`) the by-name open recipe rechecks against the fstat. */
+interface AdmittedEntry {
+  name: string;
+  sizeBytes: number;
+  modifiedAt: number;
+  dev: number;
+  ino: number;
+}
+
+/**
+ * The listing that is the ONLY source of truth for admissible names: readdir the
+ * resolved root non-recursively, admit an entry only when its name is admissible
+ * ({@link isAdmissibleInputName}) AND `lstat` says a regular file (a symlink's
+ * lstat is a symlink, so `isFile()` is false and it is never admitted), and sort
+ * the admitted entries by name. Every by-name operation re-runs this and requires
+ * exact string equality against an admitted entry, so a crafted name never reaches
+ * `path.join` with a non-enumerated value.
+ */
+function listAdmitted(resolvedDir: string): {
+  totalEntries: number;
+  admitted: Array<AdmittedEntry>;
+} {
+  const names = fs.readdirSync(resolvedDir);
+  const admitted: Array<AdmittedEntry> = [];
+  for (const name of names) {
+    if (!isAdmissibleInputName(name)) continue;
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(path.join(resolvedDir, name));
+    } catch {
+      // The entry vanished between readdir and lstat, or is otherwise
+      // unstattable: skip it rather than fail the whole listing.
+      continue;
+    }
+    if (!stat.isFile()) continue;
+    admitted.push({
+      name,
+      sizeBytes: stat.size,
+      modifiedAt: mtimeMsInt(stat.mtimeMs),
+      dev: stat.dev,
+      ino: stat.ino,
+    });
+  }
+  admitted.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  return { totalEntries: names.length, admitted };
+}
+
+/** One file in the listing response: an admissible name and its lstat size/mtime. */
+export interface JobInputFileEntry {
+  name: string;
+  sizeBytes: number;
+  modifiedAt: number;
+}
+
+/** The `GET /api/jobs/inputs` response shape. */
+export interface JobInputListing {
+  /** False when {@link JOB_INPUT_DIR_ENV} is unset -- the actionable "set the var
+   * and mount a directory" state -- with an empty list. */
+  configured: boolean;
+  /** The raw readdir entry count before admission, so the UI can tell an empty
+   * directory from one whose entries are all inadmissible. */
+  totalEntries: number;
+  /** True when more than {@link MAX_INPUT_LISTING_ENTRIES} files were admitted and
+   * the list was capped. */
+  truncated: boolean;
+  files: Array<JobInputFileEntry>;
+}
+
+/**
+ * List the admissible input files, or the unconfigured state when `resolvedDir` is
+ * undefined. Sorts before the {@link MAX_INPUT_LISTING_ENTRIES} cap and reports
+ * `totalEntries` (raw readdir count) alongside the capped `files`.
+ */
+export function listJobInputs(
+  resolvedDir: string | undefined,
+): JobInputListing {
+  if (resolvedDir === undefined)
+    return { configured: false, totalEntries: 0, truncated: false, files: [] };
+  const { totalEntries, admitted } = listAdmitted(resolvedDir);
+  const truncated = admitted.length > MAX_INPUT_LISTING_ENTRIES;
+  const files = admitted.slice(0, MAX_INPUT_LISTING_ENTRIES).map((entry) => ({
+    name: entry.name,
+    sizeBytes: entry.sizeBytes,
+    modifiedAt: entry.modifiedAt,
+  }));
+  return { configured: true, totalEntries, truncated, files };
+}
+
+/** An opened, identity-verified input file: the fd to stream from and the
+ * open-time fstat size/mtime the caller uses for the response and drift check. */
+interface OpenedInput {
+  fd: number;
+  filePath: string;
+  sizeBytes: number;
+  modifiedAt: number;
+}
+
+/**
+ * Open an admitted input for reading, closing the symlink-swap and file-swap TOCTOU
+ * windows. Re-runs the admission listing and requires `name` to match an admitted
+ * entry by exact string equality (the server opens only names it itself
+ * enumerated), then `open(join(root, name), O_RDONLY | O_NOFOLLOW)` and `fstat`,
+ * requiring `(dev, ino)` to equal the admission lstat. A name that is not admitted,
+ * or an inode that no longer matches, is an {@link UnknownJobInputError}; the fd is
+ * closed on any post-open failure so no descriptor leaks.
+ *
+ * `O_NOFOLLOW` protects only the FINAL path component, and the root's realpath was
+ * resolved once at boot; a post-boot remount or replacement of an intermediate
+ * component is out of model for the appliance (documented in the spec).
+ */
+function openAdmittedInput(resolvedDir: string, name: string): OpenedInput {
+  const { admitted } = listAdmitted(resolvedDir);
+  const entry = admitted.find((candidate) => candidate.name === name);
+  if (entry === undefined) throw new UnknownJobInputError();
+  const filePath = path.join(resolvedDir, name);
+  const fd = fs.openSync(
+    filePath,
+    fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW,
+  );
+  try {
+    const stat = fs.fstatSync(fd);
+    if (stat.dev !== entry.dev || stat.ino !== entry.ino)
+      throw new UnknownJobInputError();
+    return {
+      fd,
+      filePath,
+      sizeBytes: stat.size,
+      modifiedAt: mtimeMsInt(stat.mtimeMs),
+    };
+  } catch (error) {
+    fs.closeSync(fd);
+    throw error;
+  }
+}
+
+/** The `GET /api/jobs/inputs/profile` response shape. */
+export interface JobInputProfile {
+  name: string;
+  sizeBytes: number;
+  modifiedAt: number;
+  rowCount: number;
+  columns: Array<string>;
+  dateInputFormat?: string;
+  columnSamples: Record<string, Array<string>>;
+}
+
+/**
+ * Profile an admitted input in ONE streaming pass that retains no rows: columns
+ * from the header, `rowCount` by counting, `columnSamples` as the first
+ * {@link PREVIEW_SAMPLE_SIZE} non-empty values per column in row order (the
+ * `sampleInputValues` semantics the browser preview uses), and `dateInputFormat`
+ * via the shared date-of-birth-column composition -- the DOB column is picked with
+ * {@link inferDateOfBirthColumn} and its first {@link INFER_DATE_SCAN_CAP} non-empty
+ * values are fed to {@link inferDateFormat}, so the format equals a full-column
+ * read by the cap-exactness argument. Every accumulator is constant-size, so peak
+ * memory is one parse chunk regardless of file size. `sizeBytes`/`modifiedAt` are
+ * the open-time fstat values the client keeps for the drift signal.
+ */
+export async function profileJobInput(
+  resolvedDir: string,
+  name: string,
+): Promise<JobInputProfile> {
+  const opened = openAdmittedInput(resolvedDir, name);
+  const stream = fs.createReadStream(opened.filePath, { fd: opened.fd });
+  const samples = new Map<string, Array<string>>();
+  const dobSample: Array<string> = [];
+  let dobColumn: string | undefined;
+  let dobResolved = false;
+  let rowCount = 0;
+  const columns = await streamCSVRows(stream, (rows, cols) => {
+    if (!dobResolved && cols.length > 0) {
+      dobColumn = inferDateOfBirthColumn(cols);
+      dobResolved = true;
+    }
+    for (const row of rows) {
+      rowCount++;
+      for (const col of cols) {
+        let bucket = samples.get(col);
+        if (bucket === undefined) {
+          bucket = [];
+          samples.set(col, bucket);
+        }
+        if (bucket.length < PREVIEW_SAMPLE_SIZE) {
+          const value = readRowColumn(row, col);
+          if (value !== undefined && value.trim() !== "") bucket.push(value);
+        }
+      }
+      if (dobColumn !== undefined && dobSample.length < INFER_DATE_SCAN_CAP) {
+        const value = readRowColumn(row, dobColumn);
+        if (value !== undefined && value.trim() !== "") dobSample.push(value);
+      }
+    }
+  });
+  const dateInputFormat =
+    dobColumn !== undefined ? inferDateFormat(dobSample) : undefined;
+  const columnSamples: Record<string, Array<string>> = {};
+  for (const col of columns) columnSamples[col] = samples.get(col) ?? [];
+  return {
+    name,
+    sizeBytes: opened.sizeBytes,
+    modifiedAt: opened.modifiedAt,
+    rowCount,
+    columns,
+    ...(dateInputFormat !== undefined ? { dateInputFormat } : {}),
+    columnSamples,
+  };
+}
+
+/**
+ * Sweep an admitted input's per-field coverage in ONE streaming pass, feeding the
+ * shared per-row accumulator ({@link createFieldCoverageAccumulator}) so the result
+ * equals `computeFieldCoverage` over the same rows. Refuses on drift: the
+ * open-time fstat size/mtime must equal the client's submitted pair (its profiled
+ * snapshot), else a {@link JobInputDriftError} -- coverage is never computed over
+ * content that changed since profiling.
+ */
+export async function coverageJobInput(
+  resolvedDir: string,
+  name: string,
+  expectedSizeBytes: number,
+  expectedModifiedAt: number,
+  standardization: Standardization,
+): Promise<Array<FieldValueCoverage>> {
+  const opened = openAdmittedInput(resolvedDir, name);
+  if (
+    opened.sizeBytes !== expectedSizeBytes ||
+    opened.modifiedAt !== expectedModifiedAt
+  ) {
+    fs.closeSync(opened.fd);
+    throw new JobInputDriftError();
+  }
+  const stream = fs.createReadStream(opened.filePath, { fd: opened.fd });
+  const accumulator = createFieldCoverageAccumulator(standardization);
+  await streamCSVRows(stream, (rows) => {
+    for (const row of rows) accumulator.add(row);
+  });
+  return accumulator.result();
+}
+
+/**
+ * The single-flight gate over the parse/sweep routes: one profile or coverage pass
+ * runs at a time (the single-operator appliance bound, doing double duty as the
+ * memory bound), a second waits in a depth-one queue, and a third is refused with
+ * {@link JobInputParseBusyError} (mapped to 429). The client treats a 429 like a
+ * superseded response and its next debounced edit retries.
+ */
+export class JobInputParseGate {
+  private busy = false;
+  private waiter: (() => void) | null = null;
+
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    if (this.busy) {
+      if (this.waiter !== null) throw new JobInputParseBusyError();
+      // Take the single queue slot; release() hands the running flag to us.
+      await new Promise<void>((resolve) => {
+        this.waiter = resolve;
+      });
+    } else {
+      this.busy = true;
+    }
+    try {
+      return await task();
+    } finally {
+      this.release();
+    }
+  }
+
+  private release(): void {
+    const next = this.waiter;
+    if (next !== null) {
+      // Hand the running flag to the queued waiter without clearing `busy`.
+      this.waiter = null;
+      next();
+    } else {
+      this.busy = false;
+    }
+  }
+}
+
+/** The process-wide parse/sweep gate, memoized on globalThis (like the job
+ * manager) so dev-mode HMR does not duplicate it. */
+export function useJobInputParseGate(): JobInputParseGate {
+  return (globalThis.jobInputParseGate ??= new JobInputParseGate());
+}
+
+/** Resolve the data root to compare against for containment: its realpath when it
+ * exists (the manager creates it lazily, so it may not yet), else its lexical
+ * absolute path. */
+function resolveDataRootPath(dataRoot: string): string {
+  try {
+    return fs.realpathSync(dataRoot);
+  } catch {
+    return path.resolve(dataRoot);
+  }
+}
+
+/** Whether `child` is `parent` or nested under it (a lexical containment test over
+ * already-resolved absolute paths). */
+function containsOrEqual(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+/**
+ * Read {@link JOB_INPUT_DIR_ENV} and resolve the input directory, or undefined when
+ * it is unset. Fail-closed like the SFTP remotes table: every failure is a
+ * {@link JobApiConfigError} that refuses startup. Setting it without
+ * {@link JOB_DATA_ROOT_ENV} is a configuration error (the directory serves only the
+ * job API, which the data root enables), matching the `JOB_SFTP_REMOTES` rule
+ * exactly. The configured directory is resolved with `fs.realpathSync` once; one
+ * that does not exist or is not a directory refuses startup. Mutual containment
+ * with the resolved data root is refused: the input directory must not equal,
+ * contain, or be contained by it, so the listing can never expose job workdirs and
+ * a job can never be fed its own artifacts or another job's key material.
+ */
+export function loadJobInputDirFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const configured = (env[JOB_INPUT_DIR_ENV] ?? "").trim();
+  if (configured.length === 0) return undefined;
+
+  const dataRoot = (env[JOB_DATA_ROOT_ENV] ?? "").trim();
+  if (dataRoot.length === 0)
+    throw new JobApiConfigError(
+      `${JOB_INPUT_DIR_ENV} is set but ${JOB_DATA_ROOT_ENV} is not; the input ` +
+        "directory serves only the job API, which the data root enables. Set " +
+        "both or neither.",
+    );
+
+  let resolvedDir: string;
+  try {
+    resolvedDir = fs.realpathSync(configured);
+  } catch (error) {
+    const code =
+      error instanceof Error && "code" in error
+        ? String((error as NodeJS.ErrnoException).code)
+        : "unresolvable";
+    throw new JobApiConfigError(
+      `${JOB_INPUT_DIR_ENV} names a directory that could not be resolved ` +
+        `(${code}); it must exist and be a directory`,
+    );
+  }
+  if (!fs.statSync(resolvedDir).isDirectory())
+    throw new JobApiConfigError(`${JOB_INPUT_DIR_ENV} must name a directory`);
+
+  const resolvedDataRoot = resolveDataRootPath(dataRoot);
+  if (
+    containsOrEqual(resolvedDataRoot, resolvedDir) ||
+    containsOrEqual(resolvedDir, resolvedDataRoot)
+  )
+    throw new JobApiConfigError(
+      `${JOB_INPUT_DIR_ENV} must not equal, contain, or be contained by ` +
+        `${JOB_DATA_ROOT_ENV}; the two directories must be disjoint`,
+    );
+
+  return resolvedDir;
+}
+
+/**
+ * Resolve the input directory once and memoize it on globalThis (like the SFTP
+ * remotes table): loaded from the environment on first use, then shared. A
+ * {@link JobApiConfigError} propagates to the caller -- the server entry calls this
+ * at startup so a misconfiguration refuses to boot. The wrapper distinguishes
+ * "loaded, feature off" (an undefined `resolvedDir`) from "not yet loaded".
+ */
+export function useJobInputDir(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  globalThis.jobInputDirConfig ??= { resolvedDir: loadJobInputDirFromEnv(env) };
+  return globalThis.jobInputDirConfig.resolvedDir;
+}
+
+/**
+ * Log the one boot-diagnostic line for a configured input directory: the resolved
+ * realpath, the total readdir count, and the admissible file count. This is the
+ * primary mis-mount diagnostic -- an operator who mounted the wrong host path, or
+ * whose entries are all filtered out, sees it at boot without touching the API.
+ */
+export function logJobInputDirBoot(
+  resolvedDir: string,
+  log: ReturnType<typeof getLogger>,
+): void {
+  const { totalEntries, admitted } = listAdmitted(resolvedDir);
+  log.info(
+    `job input directory ${resolvedDir}: ${totalEntries} readdir entries, ` +
+      `${admitted.length} admissible`,
+  );
+}
+
+/**
+ * Whether every standardization step's pattern/delimiter source stays within
+ * {@link MAX_TRANSFORM_PATTERN_LENGTH}. The intent-level schema bounds counts, not
+ * pattern length, and while RE2JS execution is linear-time its COMPILE cost lands
+ * on this process's event loop before any row streams, so this route caps the
+ * source length of every string param (a regex pattern, a split delimiter). It is a
+ * route-level cap only: the shared intent schema (and the job-create path) is
+ * unchanged.
+ */
+function stepPatternsWithinCap(
+  transformation: Standardization[number],
+): boolean {
+  for (const step of transformation.steps ?? []) {
+    const params = step.params;
+    if (params === undefined) continue;
+    for (const value of Object.values(params)) {
+      if (
+        typeof value === "string" &&
+        value.length > MAX_TRANSFORM_PATTERN_LENGTH
+      )
+        return false;
+      if (Array.isArray(value))
+        for (const element of value)
+          if (
+            typeof element === "string" &&
+            element.length > MAX_TRANSFORM_PATTERN_LENGTH
+          )
+            return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * The coverage route's standardization validation: core's structural schema plus
+ * the same count bounds the intent schema applies (reusing its exported caps) plus
+ * the route-level per-step pattern-length cap ({@link stepPatternsWithinCap}). The
+ * shared intent schema is deliberately NOT modified -- only this in-process
+ * compute endpoint needs the pattern cap.
+ */
+const coverageStandardizationSchema = StandardizationSchema.refine(
+  (transformations) =>
+    transformations.length <= MAX_STANDARDIZATION_TRANSFORMATIONS,
+  { message: "standardization must not exceed the transformation cap" },
+)
+  .refine(
+    (transformations) =>
+      transformations.every(
+        (transformation) =>
+          (transformation.steps?.length ?? 0) <= MAX_STANDARDIZATION_STEPS,
+      ),
+    { message: "a standardization transformation exceeds the step cap" },
+  )
+  .refine(
+    (transformations) =>
+      transformations.every(
+        (transformation) =>
+          transformation.output.length <= MAX_NAME_LENGTH &&
+          transformation.input.length <= MAX_NAME_LENGTH,
+      ),
+    { message: "a standardization output or input exceeds the length cap" },
+  )
+  .refine((transformations) => transformations.every(stepPatternsWithinCap), {
+    message: "a standardization step pattern exceeds the length cap",
+  });
+
+/** The validated `POST /api/jobs/inputs/coverage` request body. */
+export interface CoverageRequestBody {
+  name: string;
+  sizeBytes: number;
+  modifiedAt: number;
+  standardization: Standardization;
+}
+
+/** Schema for the coverage request body. `name` is length-bounded here and
+ * exact-matched against the admission listing at open time; `sizeBytes`/`modifiedAt`
+ * are the client's profiled snapshot, compared for drift after open. */
+export const coverageRequestSchema: z.ZodType<CoverageRequestBody> = z
+  .object({
+    name: z.string().min(1).max(MAX_INPUT_NAME_LENGTH),
+    sizeBytes: z.number().int().nonnegative(),
+    modifiedAt: z.number().int().nonnegative(),
+    standardization: coverageStandardizationSchema,
+  })
+  .strict();

--- a/apps/web/src/psi/nonEmptyAggregate.ts
+++ b/apps/web/src/psi/nonEmptyAggregate.ts
@@ -117,6 +117,89 @@ export interface FieldValueCoverage {
 }
 
 /**
+ * A per-field coverage tally fed one row at a time, so the sweep can run over a
+ * STREAM that retains no rows: the whole-file batch entry point
+ * ({@link computeFieldCoverage}) and the server-side streaming pass over a mounted
+ * CLI-scale file share this one accumulator, so the two drivers count identically
+ * (equivalence pinned by test).
+ *
+ * Each field's {@link StandardizedField} pipeline is compiled ONCE in
+ * {@link createFieldCoverageAccumulator} (over an empty backing row set, since rows
+ * arrive through {@link FieldCoverageAccumulator.add}, not by index), so a
+ * regex/`parse_date` pipeline is not recompiled per row. A field whose steps are
+ * not all valid ({@link isStepValid}), or whose compile throws, is marked
+ * `unavailable` WITHOUT compiling on the sweep path -- so one mid-edit step does
+ * not blank the whole aggregate, and an in-dialect but over-length regex source
+ * never reaches the compiler (the super-linear-in-length compile the length cap
+ * exists to bound stays off the main thread / off the server event loop).
+ */
+export interface FieldCoverageAccumulator {
+  /**
+   * Fold one row into every field's tally: for each available field, count the row
+   * as produced iff its pipeline yields exactly one matchable key (an empty STRING
+   * counts; a dropped null/empty-Set, and a multi-value fan-out Set core's key
+   * iterator excludes, do not). Increments the shared row total.
+   */
+  add: (row: CSVRow) => void;
+  /** The per-field coverage after every fed row, in the standardization's order. */
+  result: () => Array<FieldValueCoverage>;
+}
+
+/**
+ * Build a {@link FieldCoverageAccumulator} for `standardization`, compiling each
+ * transformation's pipeline once. See {@link FieldCoverageAccumulator} for the
+ * one-computation rationale and {@link computeFieldCoverage} for the sweep
+ * semantics (empties observed, empty-string counted, fan-out excluded).
+ */
+export function createFieldCoverageAccumulator(
+  standardization: Standardization,
+): FieldCoverageAccumulator {
+  // Each field compiles once here (over an empty backing array -- rows come through
+  // add(), never by index) and its produced counter is folded per row. A field that
+  // is not all-valid, or whose compile throws, carries no StandardizedField and is
+  // reported unavailable; the compile is wrapped so a step that slips past the
+  // validity gate yet throws is caught rather than blanking the aggregate.
+  const fields = standardization.map((transformation) => {
+    const steps = transformation.steps ?? [];
+    const base = { output: transformation.output, input: transformation.input };
+    if (!steps.every(isStepValid)) return { ...base, field: null, produced: 0 };
+    try {
+      const field = new StandardizedField(
+        transformation.output,
+        transformation.input,
+        steps,
+        [],
+      );
+      return { ...base, field, produced: 0 };
+    } catch {
+      return { ...base, field: null as StandardizedField | null, produced: 0 };
+    }
+  });
+
+  let total = 0;
+  return {
+    add(row: CSVRow): void {
+      total++;
+      for (const entry of fields)
+        // One matchable key iff the value set is exactly one value -- see
+        // FieldValueCoverage.produced.
+        if (entry.field !== null && entry.field.evaluateRow(row).length === 1)
+          entry.produced++;
+    },
+    result(): Array<FieldValueCoverage> {
+      return fields.map((entry) => ({
+        output: entry.output,
+        input: entry.input,
+        total,
+        produced: entry.produced,
+        rate: total > 0 ? entry.produced / total : 0,
+        unavailable: entry.field === null,
+      }));
+    },
+  };
+}
+
+/**
  * Compute per-field value coverage over the WHOLE row set. For each transformation,
  * runs its pipeline over every row's input column and counts the rows that yield
  * exactly one matchable key (an empty STRING counts; a dropped null/empty-Set, and a
@@ -131,56 +214,17 @@ export interface FieldValueCoverage {
  * preview cannot show. A field whose transform drops every row reports `produced: 0`
  * ({@link isSilentEmpty}).
  *
- * Each field gets its own {@link StandardizedField}, which compiles the steps once
- * (so a regex/`parse_date` pipeline is not recompiled per row); the field and its
- * per-row cache fall out of scope after its loop. A field whose steps are not all
- * valid ({@link isStepValid}) is returned `unavailable` WITHOUT compiling, so one
- * mid-edit step does not blank the whole aggregate AND an in-dialect but over-length
- * regex source never reaches the compiler on this sweep -- which runs inline on the
- * main thread below the off-thread threshold, where the super-linear-in-length
- * compile the length cap exists to bound would otherwise block the tab. The compile
- * is also still wrapped, so a step that slips past the validity gate yet throws is
- * caught rather than blanking the aggregate.
+ * The whole-file batch driver over {@link createFieldCoverageAccumulator}: it feeds
+ * every row and reads the result, so it and the server's streaming pass are one
+ * computation. See that accumulator for the compile-once and `unavailable` handling.
  */
 export function computeFieldCoverage(
   rawRows: ReadonlyArray<CSVRow>,
   standardization: Standardization,
 ): Array<FieldValueCoverage> {
-  const total = rawRows.length;
-  return standardization.map((transformation) => {
-    const base = {
-      output: transformation.output,
-      input: transformation.input,
-      total,
-    };
-    const steps = transformation.steps ?? [];
-    // An invalid step is never compiled here -- see the `unavailable` doc: this keeps
-    // a malformed step from throwing and a pathological-length pattern off the
-    // main-thread compile path, mirroring the preview's gate.
-    if (!steps.every(isStepValid))
-      return { ...base, produced: 0, rate: 0, unavailable: true };
-    try {
-      const field = new StandardizedField(
-        transformation.output,
-        transformation.input,
-        steps,
-        rawRows,
-      );
-      let produced = 0;
-      for (let index = 0; index < total; index++)
-        // One matchable key iff the value set is exactly one value -- see
-        // FieldValueCoverage.produced.
-        if (field.get(index).length === 1) produced++;
-      return {
-        ...base,
-        produced,
-        rate: total > 0 ? produced / total : 0,
-        unavailable: false,
-      };
-    } catch {
-      return { ...base, produced: 0, rate: 0, unavailable: true };
-    }
-  });
+  const accumulator = createFieldCoverageAccumulator(standardization);
+  for (const row of rawRows) accumulator.add(row);
+  return accumulator.result();
 }
 
 /**

--- a/apps/web/src/psi/nonEmptyAggregate.ts
+++ b/apps/web/src/psi/nonEmptyAggregate.ts
@@ -103,15 +103,17 @@ export interface FieldValueCoverage {
   /** {@link produced} / {@link total} in [0, 1]; 0 when {@link total} is 0. */
   rate: number;
   /**
-   * True when the field's steps are not all valid, so its coverage is not computed.
-   * Two cases reach it: a step left mid-edit (e.g. a `pad_left` with no length yet),
-   * and an in-dialect but over-length regex source (rejected by the length cap).
-   * Both are caught by {@link isStepValid} BEFORE the pipeline is compiled, so a
-   * malformed step never throws at compile and a pathological-length pattern never
-   * reaches the compiler on the (inline, below-threshold) main-thread sweep. Coverage
-   * is then not computable, so it MUST NOT be read as a 0% collapse: the host already
-   * gates launch on a malformed pipeline, and a false alarm would be noise on top of
-   * that step's own inline error.
+   * True when the field's coverage is not computed. Three cases reach it: a step left
+   * mid-edit (e.g. a `pad_left` with no length yet), an in-dialect but over-length
+   * regex source (rejected by the length cap) -- both caught by {@link isStepValid}
+   * BEFORE the pipeline is compiled, so a malformed step never throws at compile and a
+   * pathological-length pattern never reaches the compiler on the (inline,
+   * below-threshold) main-thread sweep -- and a pipeline that compiles yet throws on a
+   * specific row's value, which degrades the field here rather than aborting the
+   * whole sweep (see {@link FieldCoverageAccumulator.add}). Coverage is then not
+   * computable, so it MUST NOT be read as a 0% collapse: the host already gates launch
+   * on a malformed pipeline, and a false alarm would be noise on top of that step's
+   * own inline error.
    */
   unavailable: boolean;
 }
@@ -138,7 +140,9 @@ export interface FieldCoverageAccumulator {
    * Fold one row into every field's tally: for each available field, count the row
    * as produced iff its pipeline yields exactly one matchable key (an empty STRING
    * counts; a dropped null/empty-Set, and a multi-value fan-out Set core's key
-   * iterator excludes, do not). Increments the shared row total.
+   * iterator excludes, do not). Increments the shared row total. A field whose
+   * pipeline THROWS on a row degrades to `unavailable` and is no longer evaluated,
+   * so one bad row never aborts the sweep (nor, server-side, 400s the whole request).
    */
   add: (row: CSVRow) => void;
   /** The per-field coverage after every fed row, in the standardization's order. */
@@ -162,29 +166,41 @@ export function createFieldCoverageAccumulator(
   const fields = standardization.map((transformation) => {
     const steps = transformation.steps ?? [];
     const base = { output: transformation.output, input: transformation.input };
-    if (!steps.every(isStepValid)) return { ...base, field: null, produced: 0 };
-    try {
-      const field = new StandardizedField(
-        transformation.output,
-        transformation.input,
-        steps,
-        [],
-      );
-      return { ...base, field, produced: 0 };
-    } catch {
-      return { ...base, field: null as StandardizedField | null, produced: 0 };
+    let field: StandardizedField | null = null;
+    if (steps.every(isStepValid)) {
+      try {
+        field = new StandardizedField(
+          transformation.output,
+          transformation.input,
+          steps,
+          [],
+        );
+      } catch {
+        field = null;
+      }
     }
+    return { ...base, field, produced: 0 };
   });
 
   let total = 0;
   return {
     add(row: CSVRow): void {
       total++;
-      for (const entry of fields)
-        // One matchable key iff the value set is exactly one value -- see
-        // FieldValueCoverage.produced.
-        if (entry.field !== null && entry.field.evaluateRow(row).length === 1)
-          entry.produced++;
+      for (const entry of fields) {
+        if (entry.field === null) continue;
+        // A step that passes the validity gate and compiles can still throw on a
+        // specific row's value. Degrade that field to unavailable (and stop
+        // evaluating it) rather than aborting the whole sweep, matching the old
+        // whole-file computeFieldCoverage: server-side one bad row would otherwise
+        // 400 the entire coverage request. One matchable key iff the value set is
+        // exactly one value -- see FieldValueCoverage.produced.
+        try {
+          if (entry.field.evaluateRow(row).length === 1) entry.produced++;
+        } catch {
+          entry.field = null;
+          entry.produced = 0;
+        }
+      }
     },
     result(): Array<FieldValueCoverage> {
       return fields.map((entry) => ({

--- a/apps/web/src/psi/previewSamples.ts
+++ b/apps/web/src/psi/previewSamples.ts
@@ -1,0 +1,44 @@
+import { readRowColumn } from "@psilink/core";
+
+import type { CSVRow } from "@psilink/core";
+
+/**
+ * Row-sample size for the before->after standardization preview: the first few
+ * rows with a non-empty value for a field's input column. The preview inspects the
+ * transform on representative values, so a small fixed window keeps it cheap and
+ * legible; the whole-file coverage question (does the transform collapse the
+ * field?) is answered separately and exhaustively by the non-empty-rate aggregate
+ * ({@link ./nonEmptyAggregate}), not by widening this sample. Settled at 5.
+ *
+ * The server-side file profile ({@link ../jobs/workInputs}) emits per-column
+ * samples of this same size and semantics, so the console authoring UI's preview
+ * is fed values byte-identical to what an in-browser sample would draw.
+ */
+export const PREVIEW_SAMPLE_SIZE = 5;
+
+/**
+ * Pick up to `limit` non-empty raw values for `inputColumn`, in row order. A row
+ * whose value is missing or blank after trimming carries no signal for the
+ * preview, so it is skipped rather than shown as an empty before->after pair. The
+ * raw (untrimmed) value is kept -- the preview shows the operator's own cell.
+ *
+ * Reads by own-property ({@link readRowColumn}) so a short row lacking the column
+ * reads as absent even when the column is named an `Object.prototype` member; a
+ * bare `row[inputColumn]` would surface the inherited function past the blank
+ * check.
+ */
+export function sampleInputValues(
+  rawRows: ReadonlyArray<CSVRow>,
+  inputColumn: string,
+  limit: number = PREVIEW_SAMPLE_SIZE,
+): Array<string> {
+  const values: Array<string> = [];
+  for (const row of rawRows) {
+    const raw = readRowColumn(row, inputColumn);
+    if (raw !== undefined && raw.trim() !== "") {
+      values.push(raw);
+      if (values.length >= limit) break;
+    }
+  }
+  return values;
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -25,8 +25,11 @@ import { Route as ApiPeerjsIndexRouteImport } from './routes/api/peerjs/index'
 import { Route as ApiJobsIndexRouteImport } from './routes/api/jobs/index'
 import { Route as ApiPeerjsIdRouteImport } from './routes/api/peerjs/id'
 import { Route as ApiJobsRemotesRouteImport } from './routes/api/jobs/remotes'
+import { Route as ApiJobsInputsIndexRouteImport } from './routes/api/jobs/inputs/index'
 import { Route as ApiJobsJobIdIndexRouteImport } from './routes/api/jobs/$jobId/index'
 import { Route as ApiPeerjsKeyPeersRouteImport } from './routes/api/peerjs/$key/peers'
+import { Route as ApiJobsInputsProfileRouteImport } from './routes/api/jobs/inputs/profile'
+import { Route as ApiJobsInputsCoverageRouteImport } from './routes/api/jobs/inputs/coverage'
 import { Route as ApiJobsJobIdResultRouteImport } from './routes/api/jobs/$jobId/result'
 import { Route as ApiJobsJobIdRecordRouteImport } from './routes/api/jobs/$jobId/record'
 import { Route as ApiJobsJobIdKeysRouteImport } from './routes/api/jobs/$jobId/keys'
@@ -113,6 +116,11 @@ const ApiJobsRemotesRoute = ApiJobsRemotesRouteImport.update({
   path: '/api/jobs/remotes',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiJobsInputsIndexRoute = ApiJobsInputsIndexRouteImport.update({
+  id: '/api/jobs/inputs/',
+  path: '/api/jobs/inputs/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiJobsJobIdIndexRoute = ApiJobsJobIdIndexRouteImport.update({
   id: '/api/jobs/$jobId/',
   path: '/api/jobs/$jobId/',
@@ -121,6 +129,16 @@ const ApiJobsJobIdIndexRoute = ApiJobsJobIdIndexRouteImport.update({
 const ApiPeerjsKeyPeersRoute = ApiPeerjsKeyPeersRouteImport.update({
   id: '/api/peerjs/$key/peers',
   path: '/api/peerjs/$key/peers',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiJobsInputsProfileRoute = ApiJobsInputsProfileRouteImport.update({
+  id: '/api/jobs/inputs/profile',
+  path: '/api/jobs/inputs/profile',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiJobsInputsCoverageRoute = ApiJobsInputsCoverageRouteImport.update({
+  id: '/api/jobs/inputs/coverage',
+  path: '/api/jobs/inputs/coverage',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiJobsJobIdResultRoute = ApiJobsJobIdResultRouteImport.update({
@@ -171,8 +189,11 @@ export interface FileRoutesByFullPath {
   '/api/jobs/$jobId/keys': typeof ApiJobsJobIdKeysRoute
   '/api/jobs/$jobId/record': typeof ApiJobsJobIdRecordRoute
   '/api/jobs/$jobId/result': typeof ApiJobsJobIdResultRoute
+  '/api/jobs/inputs/coverage': typeof ApiJobsInputsCoverageRoute
+  '/api/jobs/inputs/profile': typeof ApiJobsInputsProfileRoute
   '/api/peerjs/$key/peers': typeof ApiPeerjsKeyPeersRoute
   '/api/jobs/$jobId/': typeof ApiJobsJobIdIndexRoute
+  '/api/jobs/inputs/': typeof ApiJobsInputsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -195,8 +216,11 @@ export interface FileRoutesByTo {
   '/api/jobs/$jobId/keys': typeof ApiJobsJobIdKeysRoute
   '/api/jobs/$jobId/record': typeof ApiJobsJobIdRecordRoute
   '/api/jobs/$jobId/result': typeof ApiJobsJobIdResultRoute
+  '/api/jobs/inputs/coverage': typeof ApiJobsInputsCoverageRoute
+  '/api/jobs/inputs/profile': typeof ApiJobsInputsProfileRoute
   '/api/peerjs/$key/peers': typeof ApiPeerjsKeyPeersRoute
   '/api/jobs/$jobId': typeof ApiJobsJobIdIndexRoute
+  '/api/jobs/inputs': typeof ApiJobsInputsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -221,8 +245,11 @@ export interface FileRoutesById {
   '/api/jobs/$jobId/keys': typeof ApiJobsJobIdKeysRoute
   '/api/jobs/$jobId/record': typeof ApiJobsJobIdRecordRoute
   '/api/jobs/$jobId/result': typeof ApiJobsJobIdResultRoute
+  '/api/jobs/inputs/coverage': typeof ApiJobsInputsCoverageRoute
+  '/api/jobs/inputs/profile': typeof ApiJobsInputsProfileRoute
   '/api/peerjs/$key/peers': typeof ApiPeerjsKeyPeersRoute
   '/api/jobs/$jobId/': typeof ApiJobsJobIdIndexRoute
+  '/api/jobs/inputs/': typeof ApiJobsInputsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -248,8 +275,11 @@ export interface FileRouteTypes {
     | '/api/jobs/$jobId/keys'
     | '/api/jobs/$jobId/record'
     | '/api/jobs/$jobId/result'
+    | '/api/jobs/inputs/coverage'
+    | '/api/jobs/inputs/profile'
     | '/api/peerjs/$key/peers'
     | '/api/jobs/$jobId/'
+    | '/api/jobs/inputs/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -272,8 +302,11 @@ export interface FileRouteTypes {
     | '/api/jobs/$jobId/keys'
     | '/api/jobs/$jobId/record'
     | '/api/jobs/$jobId/result'
+    | '/api/jobs/inputs/coverage'
+    | '/api/jobs/inputs/profile'
     | '/api/peerjs/$key/peers'
     | '/api/jobs/$jobId'
+    | '/api/jobs/inputs'
   id:
     | '__root__'
     | '/'
@@ -297,8 +330,11 @@ export interface FileRouteTypes {
     | '/api/jobs/$jobId/keys'
     | '/api/jobs/$jobId/record'
     | '/api/jobs/$jobId/result'
+    | '/api/jobs/inputs/coverage'
+    | '/api/jobs/inputs/profile'
     | '/api/peerjs/$key/peers'
     | '/api/jobs/$jobId/'
+    | '/api/jobs/inputs/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -319,8 +355,11 @@ export interface RootRouteChildren {
   ApiJobsJobIdKeysRoute: typeof ApiJobsJobIdKeysRoute
   ApiJobsJobIdRecordRoute: typeof ApiJobsJobIdRecordRoute
   ApiJobsJobIdResultRoute: typeof ApiJobsJobIdResultRoute
+  ApiJobsInputsCoverageRoute: typeof ApiJobsInputsCoverageRoute
+  ApiJobsInputsProfileRoute: typeof ApiJobsInputsProfileRoute
   ApiPeerjsKeyPeersRoute: typeof ApiPeerjsKeyPeersRoute
   ApiJobsJobIdIndexRoute: typeof ApiJobsJobIdIndexRoute
+  ApiJobsInputsIndexRoute: typeof ApiJobsInputsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -437,6 +476,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiJobsRemotesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/jobs/inputs/': {
+      id: '/api/jobs/inputs/'
+      path: '/api/jobs/inputs'
+      fullPath: '/api/jobs/inputs/'
+      preLoaderRoute: typeof ApiJobsInputsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/jobs/$jobId/': {
       id: '/api/jobs/$jobId/'
       path: '/api/jobs/$jobId'
@@ -449,6 +495,20 @@ declare module '@tanstack/react-router' {
       path: '/api/peerjs/$key/peers'
       fullPath: '/api/peerjs/$key/peers'
       preLoaderRoute: typeof ApiPeerjsKeyPeersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/jobs/inputs/profile': {
+      id: '/api/jobs/inputs/profile'
+      path: '/api/jobs/inputs/profile'
+      fullPath: '/api/jobs/inputs/profile'
+      preLoaderRoute: typeof ApiJobsInputsProfileRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/jobs/inputs/coverage': {
+      id: '/api/jobs/inputs/coverage'
+      path: '/api/jobs/inputs/coverage'
+      fullPath: '/api/jobs/inputs/coverage'
+      preLoaderRoute: typeof ApiJobsInputsCoverageRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/jobs/$jobId/result': {
@@ -525,8 +585,11 @@ const rootRouteChildren: RootRouteChildren = {
   ApiJobsJobIdKeysRoute: ApiJobsJobIdKeysRoute,
   ApiJobsJobIdRecordRoute: ApiJobsJobIdRecordRoute,
   ApiJobsJobIdResultRoute: ApiJobsJobIdResultRoute,
+  ApiJobsInputsCoverageRoute: ApiJobsInputsCoverageRoute,
+  ApiJobsInputsProfileRoute: ApiJobsInputsProfileRoute,
   ApiPeerjsKeyPeersRoute: ApiPeerjsKeyPeersRoute,
   ApiJobsJobIdIndexRoute: ApiJobsJobIdIndexRoute,
+  ApiJobsInputsIndexRoute: ApiJobsInputsIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/api/jobs/inputs/coverage.ts
+++ b/apps/web/src/routes/api/jobs/inputs/coverage.ts
@@ -1,0 +1,72 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import {
+  JobInputDriftError,
+  JobInputParseBusyError,
+  MAX_COVERAGE_BODY_BYTES,
+  UnknownJobInputError,
+  coverageJobInput,
+  coverageRequestSchema,
+  isAdmissibleInputName,
+  useJobInputDir,
+  useJobInputParseGate,
+} from "@jobs/workInputs";
+import { gateJobRoute, readJobRequestBody } from "@jobs/routeSupport";
+import { jobEmptyResponse, jobJsonResponse } from "@jobs/gate";
+
+/**
+ * `POST /api/jobs/inputs/coverage` -- compute per-field non-empty coverage over one
+ * mounted input CSV under a submitted standardization, in a single streaming pass.
+ * Shares `gateJobRoute`.
+ *
+ * The body `{ name, sizeBytes, modifiedAt, standardization }` is read under a
+ * 1 MiB cap and validated: the standardization goes through the same bounded schema
+ * the job intent uses PLUS a route-level per-step pattern-length cap (RE2JS is
+ * linear at run time, but its compile cost lands on this event loop). The file is
+ * admitted exactly as the profile route admits it, and its open-time size/mtime
+ * must equal the submitted profiled pair or the coverage is refused as drifted.
+ * Failures are empty-bodied and never echo the name: `404` for an unset directory
+ * or unknown file, `400` for a bad body, schema failure, or drift, `413` for an
+ * oversized body, and `429` when the one-at-a-time parse gate is full.
+ */
+export const Route = createFileRoute("/api/jobs/inputs/coverage")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const gate = gateJobRoute(request);
+        if (gate.kind === "response") return gate.response;
+        const resolvedDir = useJobInputDir();
+        if (resolvedDir === undefined) return jobEmptyResponse(404);
+
+        const body = await readJobRequestBody(request, MAX_COVERAGE_BODY_BYTES);
+        if (body.kind === "too-large") return jobEmptyResponse(413);
+        if (body.kind === "invalid") return jobEmptyResponse(400);
+
+        const parsed = coverageRequestSchema.safeParse(body.value);
+        if (!parsed.success) return jobEmptyResponse(400);
+        const { name, sizeBytes, modifiedAt, standardization } = parsed.data;
+        if (!isAdmissibleInputName(name)) return jobEmptyResponse(404);
+
+        try {
+          const rates = await useJobInputParseGate().run(() =>
+            coverageJobInput(
+              resolvedDir,
+              name,
+              sizeBytes,
+              modifiedAt,
+              standardization,
+            ),
+          );
+          return jobJsonResponse({ rates });
+        } catch (error) {
+          if (error instanceof JobInputParseBusyError)
+            return jobEmptyResponse(429);
+          if (error instanceof UnknownJobInputError)
+            return jobEmptyResponse(404);
+          if (error instanceof JobInputDriftError) return jobEmptyResponse(400);
+          return jobEmptyResponse(400);
+        }
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/api/jobs/inputs/coverage.ts
+++ b/apps/web/src/routes/api/jobs/inputs/coverage.ts
@@ -1,7 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import {
-  JobInputDriftError,
   JobInputParseBusyError,
   MAX_COVERAGE_BODY_BYTES,
   UnknownJobInputError,
@@ -63,7 +62,6 @@ export const Route = createFileRoute("/api/jobs/inputs/coverage")({
             return jobEmptyResponse(429);
           if (error instanceof UnknownJobInputError)
             return jobEmptyResponse(404);
-          if (error instanceof JobInputDriftError) return jobEmptyResponse(400);
           return jobEmptyResponse(400);
         }
       },

--- a/apps/web/src/routes/api/jobs/inputs/index.ts
+++ b/apps/web/src/routes/api/jobs/inputs/index.ts
@@ -1,8 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { listJobInputs, useJobInputDir } from "@jobs/workInputs";
+import {
+  JobInputParseBusyError,
+  listJobInputs,
+  useJobInputDir,
+  useJobInputParseGate,
+} from "@jobs/workInputs";
+import { jobEmptyResponse, jobJsonResponse } from "@jobs/gate";
 import { gateJobRoute } from "@jobs/routeSupport";
-import { jobJsonResponse } from "@jobs/gate";
 
 /**
  * `GET /api/jobs/inputs` -- list the operator-mounted input CSVs the server may
@@ -16,14 +21,27 @@ import { jobJsonResponse } from "@jobs/gate";
  * mysteriously empty list. `totalEntries` (the raw readdir count before admission)
  * lets the UI distinguish an empty directory from one whose entries are all
  * inadmissible (dotfiles, directories, symlinks).
+ *
+ * The synchronous `readdir`+`lstat` scan runs through the shared parse/sweep gate,
+ * exactly as profile and coverage do, so a burst of listing requests cannot pile
+ * scans onto the event loop; the third concurrent request is refused `429`.
  */
 export const Route = createFileRoute("/api/jobs/inputs/")({
   server: {
     handlers: {
-      GET: ({ request }) => {
+      GET: async ({ request }) => {
         const gate = gateJobRoute(request);
         if (gate.kind === "response") return gate.response;
-        return jobJsonResponse(listJobInputs(useJobInputDir()));
+        try {
+          const listing = await useJobInputParseGate().run(() =>
+            Promise.resolve(listJobInputs(useJobInputDir())),
+          );
+          return jobJsonResponse(listing);
+        } catch (error) {
+          if (error instanceof JobInputParseBusyError)
+            return jobEmptyResponse(429);
+          throw error;
+        }
       },
     },
   },

--- a/apps/web/src/routes/api/jobs/inputs/index.ts
+++ b/apps/web/src/routes/api/jobs/inputs/index.ts
@@ -1,0 +1,30 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { listJobInputs, useJobInputDir } from "@jobs/workInputs";
+import { gateJobRoute } from "@jobs/routeSupport";
+import { jobJsonResponse } from "@jobs/gate";
+
+/**
+ * `GET /api/jobs/inputs` -- list the operator-mounted input CSVs the server may
+ * read (name, size, and modified time). Shares `gateJobRoute` (404 when the API is
+ * disabled, 401 on a bad bearer, no-store, no CORS).
+ *
+ * The body is `{ configured, totalEntries, truncated, files }`. When
+ * `JOB_INPUT_DIR` is unset the listing is `configured: false` with an empty list
+ * (reachable only when the job API itself is enabled), so the console UI renders an
+ * actionable "set JOB_INPUT_DIR and mount a directory" state rather than a
+ * mysteriously empty list. `totalEntries` (the raw readdir count before admission)
+ * lets the UI distinguish an empty directory from one whose entries are all
+ * inadmissible (dotfiles, directories, symlinks).
+ */
+export const Route = createFileRoute("/api/jobs/inputs/")({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        const gate = gateJobRoute(request);
+        if (gate.kind === "response") return gate.response;
+        return jobJsonResponse(listJobInputs(useJobInputDir()));
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/api/jobs/inputs/profile.ts
+++ b/apps/web/src/routes/api/jobs/inputs/profile.ts
@@ -1,0 +1,53 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import {
+  JobInputParseBusyError,
+  UnknownJobInputError,
+  isAdmissibleInputName,
+  profileJobInput,
+  useJobInputDir,
+  useJobInputParseGate,
+} from "@jobs/workInputs";
+import { jobEmptyResponse, jobJsonResponse } from "@jobs/gate";
+import { gateJobRoute } from "@jobs/routeSupport";
+
+/**
+ * `GET /api/jobs/inputs/profile?name=...` -- profile one mounted input CSV in a
+ * single streaming, constant-memory pass: columns, row count, inferred date-input
+ * format, and the first few non-empty values per column. Shares `gateJobRoute`.
+ *
+ * The name is validated for shape and then admitted only by exact-string match
+ * against the server's own directory listing, opened with `O_NOFOLLOW` and an
+ * inode recheck. Failures are empty-bodied and never echo the requested name: an
+ * unset directory or an unknown/unreadable name is `404`, an unusable file is
+ * `400`, and a request that finds the one-at-a-time parse gate full is `429`.
+ */
+export const Route = createFileRoute("/api/jobs/inputs/profile")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const gate = gateJobRoute(request);
+        if (gate.kind === "response") return gate.response;
+        const resolvedDir = useJobInputDir();
+        if (resolvedDir === undefined) return jobEmptyResponse(404);
+
+        const name = new URL(request.url).searchParams.get("name");
+        if (name === null || !isAdmissibleInputName(name))
+          return jobEmptyResponse(404);
+
+        try {
+          const profile = await useJobInputParseGate().run(() =>
+            profileJobInput(resolvedDir, name),
+          );
+          return jobJsonResponse(profile);
+        } catch (error) {
+          if (error instanceof JobInputParseBusyError)
+            return jobEmptyResponse(429);
+          if (error instanceof UnknownJobInputError)
+            return jobEmptyResponse(404);
+          return jobEmptyResponse(400);
+        }
+      },
+    },
+  },
+});

--- a/apps/web/test/unit/jobInputRoutes.unit.test.ts
+++ b/apps/web/test/unit/jobInputRoutes.unit.test.ts
@@ -49,6 +49,7 @@ const STANDARDIZATION: Standardization = [
 ];
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllEnvs();
   const manager = (globalThis as { jobManagerInstance?: JobManager })
     .jobManagerInstance;
@@ -199,6 +200,21 @@ describe("GET /api/jobs/inputs listing", () => {
     expect(body.configured).toBe(true);
     expect(body.files.map((f) => f.name)).toEqual([name]);
   });
+
+  test("is 429 when the parse gate is already full", async () => {
+    const { dir } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    const gate = useJobInputParseGate();
+    // Occupy the running slot and the depth-one queue: the listing scan shares the
+    // same gate as profile/coverage, so the third concurrent request is refused.
+    void gate.run(() => new Promise<void>(() => {}));
+    void gate.run(() => new Promise<void>(() => {}));
+    const response = (await handlersOf(InputsRoute).GET({
+      request: new Request("http://localhost/api/jobs/inputs"),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(429);
+  });
 });
 
 describe("GET /api/jobs/inputs/profile", () => {
@@ -225,6 +241,33 @@ describe("GET /api/jobs/inputs/profile", () => {
     enable({ inputDir: dir });
     const response = (await handlersOf(ProfileRoute).GET({
       request: profileRequest("../secret"),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("");
+  });
+
+  test("a symlink swapped in between admission and open is an empty-bodied 404", async () => {
+    const { dir, name } = inputDirWithFixture();
+    const secret = tempDir("route-open-race-secret");
+    fs.writeFileSync(path.join(secret, "creds"), "ssn\n9\n");
+    enable({ inputDir: dir });
+
+    const realOpen = fs.openSync;
+    // The genuine O_NOFOLLOW race: swap the admitted regular file for a symlink after
+    // admission but before open, so the real open throws ELOOP -- mapped to a 404 that
+    // never echoes the name, matching the profile route's documented posture.
+    vi.spyOn(fs, "openSync").mockImplementationOnce(((
+      filePath: fs.PathLike,
+      flags: number,
+    ) => {
+      fs.rmSync(path.join(dir, name));
+      fs.symlinkSync(path.join(secret, "creds"), path.join(dir, name));
+      return realOpen(filePath, flags);
+    }) as typeof fs.openSync);
+
+    const response = (await handlersOf(ProfileRoute).GET({
+      request: profileRequest(name),
       params: {},
     })) as Response;
     expect(response.status).toBe(404);
@@ -320,6 +363,31 @@ describe("POST /api/jobs/inputs/coverage", () => {
       params: {},
     })) as Response;
     expect(response.status).toBe(400);
+  });
+
+  test("an over-cap coalesce default is not capped (it is not a regex source)", async () => {
+    const { dir, name } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    // coalesce's default is a plain, uncompiled string, unbounded on every other
+    // path (core schema, browser preview, job-create intent); the route pattern cap
+    // must scope to compiled regex sources, so an over-length default still passes.
+    const longDefault: Standardization = [
+      {
+        output: "last_name",
+        input: "last_name",
+        steps: [
+          {
+            function: "coalesce",
+            params: { default: "x".repeat(MAX_TRANSFORM_PATTERN_LENGTH + 1) },
+          },
+        ],
+      },
+    ];
+    const response = (await handlersOf(CoverageRoute).POST({
+      request: coverageRequest(coverageBody(dir, name, longDefault)),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(200);
   });
 
   test("a drifted (size, mtime) pair is an empty-bodied 400", async () => {

--- a/apps/web/test/unit/jobInputRoutes.unit.test.ts
+++ b/apps/web/test/unit/jobInputRoutes.unit.test.ts
@@ -1,0 +1,390 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { MAX_TRANSFORM_PATTERN_LENGTH } from "@psilink/core";
+
+import {
+  MAX_COVERAGE_BODY_BYTES,
+  useJobInputParseGate,
+} from "@jobs/workInputs";
+
+import { Route as CoverageRoute } from "../../src/routes/api/jobs/inputs/coverage";
+import { Route as InputsRoute } from "../../src/routes/api/jobs/inputs/index";
+import { Route as ProfileRoute } from "../../src/routes/api/jobs/inputs/profile";
+
+import { STUB_CLI_PATH } from "../utils/jobFixtures";
+
+import type { JobManager } from "@jobs/jobManager";
+import type { Standardization } from "@psilink/core";
+
+const dirs: Array<string> = [];
+
+function tempDir(label: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `psilink-${label}-`));
+  dirs.push(dir);
+  return dir;
+}
+
+const FIXTURE_CSV =
+  "ssn,last_name,date_of_birth\n111223333,Public,1990-01-02\n222,Cole,1985-11-30\n";
+
+function inputDirWithFixture(name = "input.csv"): {
+  dir: string;
+  name: string;
+} {
+  const dir = tempDir("inputs");
+  fs.writeFileSync(path.join(dir, name), FIXTURE_CSV);
+  return { dir, name };
+}
+
+const STANDARDIZATION: Standardization = [
+  {
+    output: "last_name",
+    input: "last_name",
+    steps: [{ function: "to_upper_case" }],
+  },
+];
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  const manager = (globalThis as { jobManagerInstance?: JobManager })
+    .jobManagerInstance;
+  manager?.shutdown();
+  for (const dir of dirs.splice(0))
+    fs.rmSync(dir, { recursive: true, force: true });
+  (globalThis as { jobManagerInstance?: unknown }).jobManagerInstance =
+    undefined;
+  (globalThis as { jobInputDirConfig?: unknown }).jobInputDirConfig = undefined;
+  (globalThis as { jobInputParseGate?: unknown }).jobInputParseGate = undefined;
+});
+
+type Handlers = Record<
+  string,
+  (ctx: { request: Request; params: Record<string, string> }) => unknown
+>;
+
+function handlersOf(route: {
+  options: { server?: { handlers?: unknown } };
+}): Handlers {
+  const handlers = route.options.server?.handlers;
+  if (typeof handlers !== "object" || handlers === null)
+    throw new Error("route exposes no plain handlers object");
+  return handlers as Handlers;
+}
+
+/** Enable the job API (a real data root) and, optionally, the input directory. */
+function enable(options: { token?: string; inputDir?: string } = {}): void {
+  const dataRoot = tempDir("data");
+  vi.stubEnv("JOB_DATA_ROOT", dataRoot);
+  vi.stubEnv("JOB_CLI_BINARY", STUB_CLI_PATH);
+  if (options.token !== undefined) vi.stubEnv("JOB_API_TOKEN", options.token);
+  if (options.inputDir !== undefined)
+    vi.stubEnv("JOB_INPUT_DIR", options.inputDir);
+}
+
+function profileRequest(name: string): Request {
+  return new Request(
+    `http://localhost/api/jobs/inputs/profile?name=${encodeURIComponent(name)}`,
+  );
+}
+
+function coverageRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new Request("http://localhost/api/jobs/inputs/coverage", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function coverageBody(
+  dir: string,
+  name: string,
+  standardization = STANDARDIZATION,
+) {
+  const stat = fs.statSync(path.join(dir, name));
+  return {
+    name,
+    sizeBytes: stat.size,
+    modifiedAt: Math.trunc(stat.mtimeMs),
+    standardization,
+  };
+}
+
+describe("gating parity: every new route is dark when disabled and gated on auth", () => {
+  test("all three routes are 404 when JOB_DATA_ROOT is unset", async () => {
+    vi.stubEnv("JOB_DATA_ROOT", "");
+    const listing = (await handlersOf(InputsRoute).GET({
+      request: new Request("http://localhost/api/jobs/inputs"),
+      params: {},
+    })) as Response;
+    expect(listing.status).toBe(404);
+    const profile = (await handlersOf(ProfileRoute).GET({
+      request: profileRequest("input.csv"),
+      params: {},
+    })) as Response;
+    expect(profile.status).toBe(404);
+    const coverage = (await handlersOf(CoverageRoute).POST({
+      request: coverageRequest(coverageBodyShape()),
+      params: {},
+    })) as Response;
+    expect(coverage.status).toBe(404);
+  });
+
+  test("all three routes are 401 on a wrong bearer", async () => {
+    enable({ token: "the-token" });
+    const bad = { authorization: "Bearer wrong" };
+    const listing = (await handlersOf(InputsRoute).GET({
+      request: new Request("http://localhost/api/jobs/inputs", {
+        headers: bad,
+      }),
+      params: {},
+    })) as Response;
+    expect(listing.status).toBe(401);
+    const profile = (await handlersOf(ProfileRoute).GET({
+      request: new Request(profileRequest("input.csv"), { headers: bad }),
+      params: {},
+    })) as Response;
+    expect(profile.status).toBe(401);
+    const coverage = (await handlersOf(CoverageRoute).POST({
+      request: coverageRequest(coverageBodyShape(), bad),
+      params: {},
+    })) as Response;
+    expect(coverage.status).toBe(401);
+  });
+});
+
+/** A syntactically valid coverage body (no filesystem dependency), for gate tests
+ * that must be rejected before the body is ever inspected. */
+function coverageBodyShape() {
+  return {
+    name: "input.csv",
+    sizeBytes: 1,
+    modifiedAt: 1,
+    standardization: STANDARDIZATION,
+  };
+}
+
+describe("GET /api/jobs/inputs listing", () => {
+  test("configured:false with an empty list when JOB_INPUT_DIR is unset", async () => {
+    enable();
+    const response = (await handlersOf(InputsRoute).GET({
+      request: new Request("http://localhost/api/jobs/inputs"),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({
+      configured: false,
+      totalEntries: 0,
+      truncated: false,
+      files: [],
+    });
+  });
+
+  test("lists the mounted files when configured", async () => {
+    const { dir, name } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    const response = (await handlersOf(InputsRoute).GET({
+      request: new Request("http://localhost/api/jobs/inputs"),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      configured: boolean;
+      files: Array<{ name: string }>;
+    };
+    expect(body.configured).toBe(true);
+    expect(body.files.map((f) => f.name)).toEqual([name]);
+  });
+});
+
+describe("GET /api/jobs/inputs/profile", () => {
+  test("profiles a mounted file", async () => {
+    const { dir, name } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    const response = (await handlersOf(ProfileRoute).GET({
+      request: profileRequest(name),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      columns: Array<string>;
+      rowCount: number;
+      dateInputFormat?: string;
+    };
+    expect(body.columns).toEqual(["ssn", "last_name", "date_of_birth"]);
+    expect(body.rowCount).toBe(2);
+    expect(body.dateInputFormat).toBe("YYYY-MM-DD");
+  });
+
+  test("an unknown name is an empty-bodied 404 that never echoes the name", async () => {
+    const { dir } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    const response = (await handlersOf(ProfileRoute).GET({
+      request: profileRequest("../secret"),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("");
+  });
+
+  test("a missing name parameter is 404", async () => {
+    const { dir } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    const response = (await handlersOf(ProfileRoute).GET({
+      request: new Request("http://localhost/api/jobs/inputs/profile"),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(404);
+  });
+
+  test("an unconfigured input directory is 404", async () => {
+    enable();
+    const response = (await handlersOf(ProfileRoute).GET({
+      request: profileRequest("input.csv"),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(404);
+  });
+
+  test("is 429 when the parse gate is already full", async () => {
+    const { dir, name } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    const gate = useJobInputParseGate();
+    // Occupy the running slot and the depth-one queue with tasks that never settle.
+    void gate.run(() => new Promise<void>(() => {}));
+    void gate.run(() => new Promise<void>(() => {}));
+    const response = (await handlersOf(ProfileRoute).GET({
+      request: profileRequest(name),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(429);
+  });
+});
+
+describe("POST /api/jobs/inputs/coverage", () => {
+  test("computes coverage rates for a mounted file", async () => {
+    const { dir, name } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    const response = (await handlersOf(CoverageRoute).POST({
+      request: coverageRequest(coverageBody(dir, name)),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      rates: Array<{ output: string; produced: number; total: number }>;
+    };
+    expect(body.rates).toHaveLength(1);
+    expect(body.rates[0]).toMatchObject({
+      output: "last_name",
+      total: 2,
+      produced: 2,
+    });
+  });
+
+  test("a standardization that fails the schema is 400", async () => {
+    const { dir, name } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    const bad = coverageBody(dir, name, [
+      // A duplicate output violates the standardization schema refine.
+      { output: "x", input: "a", steps: [] },
+      { output: "x", input: "b", steps: [] },
+    ]);
+    const response = (await handlersOf(CoverageRoute).POST({
+      request: coverageRequest(bad),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(400);
+  });
+
+  test("a step pattern past the length cap is 400", async () => {
+    const { dir, name } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    const oversized: Standardization = [
+      {
+        output: "last_name",
+        input: "last_name",
+        steps: [
+          {
+            function: "replace_regex",
+            params: { pattern: "a".repeat(MAX_TRANSFORM_PATTERN_LENGTH + 1) },
+          },
+        ],
+      },
+    ];
+    const response = (await handlersOf(CoverageRoute).POST({
+      request: coverageRequest(coverageBody(dir, name, oversized)),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(400);
+  });
+
+  test("a drifted (size, mtime) pair is an empty-bodied 400", async () => {
+    const { dir, name } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    const drifted = coverageBody(dir, name);
+    drifted.sizeBytes += 1;
+    const response = (await handlersOf(CoverageRoute).POST({
+      request: coverageRequest(drifted),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("");
+  });
+
+  test("an unknown name is 404", async () => {
+    const { dir, name } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    const body = coverageBody(dir, name);
+    body.name = "absent.csv";
+    const response = (await handlersOf(CoverageRoute).POST({
+      request: coverageRequest(body),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(404);
+  });
+
+  test("a body past the 1 MiB cap is 413", async () => {
+    const { dir, name } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    // A huge (but valid-shaped) standardization output name pushes the body past
+    // the cap; the streamed read trips before the schema runs.
+    const huge = coverageBody(dir, name, [
+      {
+        output: "x".repeat(MAX_COVERAGE_BODY_BYTES + 16),
+        input: "last_name",
+        steps: [],
+      },
+    ]);
+    const response = (await handlersOf(CoverageRoute).POST({
+      request: coverageRequest(huge),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(413);
+  });
+
+  test("an unconfigured input directory is 404", async () => {
+    enable();
+    const response = (await handlersOf(CoverageRoute).POST({
+      request: coverageRequest(coverageBodyShape()),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(404);
+  });
+
+  test("is 429 when the parse gate is already full", async () => {
+    const { dir, name } = inputDirWithFixture();
+    enable({ inputDir: dir });
+    const gate = useJobInputParseGate();
+    void gate.run(() => new Promise<void>(() => {}));
+    void gate.run(() => new Promise<void>(() => {}));
+    const response = (await handlersOf(CoverageRoute).POST({
+      request: coverageRequest(coverageBody(dir, name)),
+      params: {},
+    })) as Response;
+    expect(response.status).toBe(429);
+  });
+});

--- a/apps/web/test/unit/jobWorkInputs.unit.test.ts
+++ b/apps/web/test/unit/jobWorkInputs.unit.test.ts
@@ -1,0 +1,439 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { columnValues, inferDateFormat, loadCSVFile } from "@psilink/core";
+
+import {
+  JobInputDriftError,
+  JobInputParseBusyError,
+  JobInputParseGate,
+  MAX_INPUT_LISTING_ENTRIES,
+  UnknownJobInputError,
+  coverageJobInput,
+  isAdmissibleInputName,
+  listJobInputs,
+  loadJobInputDirFromEnv,
+  logJobInputDirBoot,
+  profileJobInput,
+  useJobInputDir,
+} from "@jobs/workInputs";
+import { PREVIEW_SAMPLE_SIZE, sampleInputValues } from "@psi/previewSamples";
+import { JobApiConfigError } from "@jobs/gate";
+import { computeFieldCoverage } from "@psi/nonEmptyAggregate";
+
+import type { CSVRow, Standardization } from "@psilink/core";
+
+const dirs: Array<string> = [];
+
+function tempDir(label: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `psilink-${label}-`));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  for (const dir of dirs.splice(0))
+    fs.rmSync(dir, { recursive: true, force: true });
+  (globalThis as { jobInputDirConfig?: unknown }).jobInputDirConfig = undefined;
+  (globalThis as { jobInputParseGate?: unknown }).jobInputParseGate = undefined;
+});
+
+// A CSV with blanks interspersed so the first-5-non-empty sample differs from the
+// first five rows -- exercising the sampleInputValues semantics, not a row slice.
+const FIXTURE_CSV = [
+  "ssn,first_name,last_name,date_of_birth",
+  "111223333,Jane,Public,1990-01-02",
+  "222334444,John,,1985-11-30",
+  "333445555,Amy,Adams,2000-05-14",
+  "444556666,,Baker,1972-03-08",
+  "555667777,Cara,Cole,1995-07-21",
+  "666778888,Dan,Diaz,1980-12-01",
+  "777889999,Eve,East,1969-09-09",
+  "888990000,Fay,Frost,2001-02-28",
+].join("\n");
+
+function writeFixture(dir: string, name = "input.csv"): string {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, `${FIXTURE_CSV}\n`);
+  return name;
+}
+
+async function fullRows(dir: string, name: string): Promise<Array<CSVRow>> {
+  const parsed = await loadCSVFile(fs.createReadStream(path.join(dir, name)));
+  return parsed.data;
+}
+
+describe("isAdmissibleInputName", () => {
+  test("admits ordinary single-segment names", () => {
+    for (const name of ["input.csv", "a", "A_b-1.CSV", "data 2026.csv"])
+      expect(isAdmissibleInputName(name)).toBe(true);
+  });
+
+  test("rejects traversal, dotfiles, non-segments, and control characters", () => {
+    for (const name of [
+      "",
+      ".",
+      "..",
+      ".hidden",
+      ".psilink.key",
+      "a/b",
+      "a\\b",
+      "a\u0000b",
+      "a\tb",
+      "a\nb",
+      "a\u007fb",
+      "x".repeat(256),
+    ])
+      expect(isAdmissibleInputName(name)).toBe(false);
+  });
+});
+
+describe("listJobInputs admission", () => {
+  test("unset directory is configured:false with an empty list", () => {
+    expect(listJobInputs(undefined)).toEqual({
+      configured: false,
+      totalEntries: 0,
+      truncated: false,
+      files: [],
+    });
+  });
+
+  test("admits regular files and skips directories, dotfiles, and symlinks", () => {
+    const dir = tempDir("listing");
+    fs.writeFileSync(path.join(dir, "a.csv"), "x\n1\n");
+    fs.writeFileSync(path.join(dir, "b.csv"), "x\n1\n2\n");
+    fs.writeFileSync(path.join(dir, ".hidden.csv"), "secret\n");
+    fs.mkdirSync(path.join(dir, "subdir"));
+    // A symlink pointing at a secret OUTSIDE the directory must never be listed.
+    const secret = tempDir("secret");
+    fs.writeFileSync(path.join(secret, "creds"), "TOP SECRET\n");
+    fs.symlinkSync(path.join(secret, "creds"), path.join(dir, "link.csv"));
+
+    const listing = listJobInputs(dir);
+    expect(listing.configured).toBe(true);
+    // Five raw readdir entries (2 files, 1 dotfile, 1 subdir, 1 symlink);
+    // only the two regular non-dot files are admitted.
+    expect(listing.totalEntries).toBe(5);
+    expect(listing.files.map((f) => f.name)).toEqual(["a.csv", "b.csv"]);
+    expect(listing.truncated).toBe(false);
+  });
+
+  test("totalEntries distinguishes an all-inadmissible directory from an empty one", () => {
+    const empty = tempDir("empty");
+    expect(listJobInputs(empty)).toMatchObject({
+      configured: true,
+      totalEntries: 0,
+      files: [],
+    });
+
+    const inadmissible = tempDir("inadmissible");
+    fs.mkdirSync(path.join(inadmissible, "sub"));
+    fs.writeFileSync(path.join(inadmissible, ".dot"), "x\n");
+    const listing = listJobInputs(inadmissible);
+    expect(listing.totalEntries).toBe(2);
+    expect(listing.files).toEqual([]);
+  });
+
+  test("size and mtime are reported as integer epoch milliseconds", () => {
+    const dir = tempDir("meta");
+    const name = writeFixture(dir);
+    const stat = fs.statSync(path.join(dir, name));
+    const entry = listJobInputs(dir).files[0];
+    expect(entry.sizeBytes).toBe(stat.size);
+    expect(entry.modifiedAt).toBe(Math.trunc(stat.mtimeMs));
+    expect(Number.isInteger(entry.modifiedAt)).toBe(true);
+  });
+
+  test("admitted names are sorted and truncated deterministically at the cap", () => {
+    const dir = tempDir("truncate");
+    const count = MAX_INPUT_LISTING_ENTRIES + 88;
+    // Zero-padded names so lexicographic order equals numeric order.
+    for (let i = 0; i < count; i++)
+      fs.writeFileSync(
+        path.join(dir, `file${String(i).padStart(4, "0")}.csv`),
+        "x\n1\n",
+      );
+    const listing = listJobInputs(dir);
+    expect(listing.totalEntries).toBe(count);
+    expect(listing.truncated).toBe(true);
+    expect(listing.files).toHaveLength(MAX_INPUT_LISTING_ENTRIES);
+    expect(listing.files[0].name).toBe("file0000.csv");
+    expect(listing.files[MAX_INPUT_LISTING_ENTRIES - 1].name).toBe(
+      `file${String(MAX_INPUT_LISTING_ENTRIES - 1).padStart(4, "0")}.csv`,
+    );
+    const names = listing.files.map((f) => f.name);
+    expect(names).toEqual([...names].sort());
+  });
+});
+
+describe("profileJobInput", () => {
+  test("computes columns, rowCount, dateInputFormat, and samples in one pass", async () => {
+    const dir = tempDir("profile");
+    const name = writeFixture(dir);
+    const rows = await fullRows(dir, name);
+    const profile = await profileJobInput(dir, name);
+
+    expect(profile.name).toBe(name);
+    expect(profile.columns).toEqual([
+      "ssn",
+      "first_name",
+      "last_name",
+      "date_of_birth",
+    ]);
+    expect(profile.rowCount).toBe(rows.length);
+
+    // dateInputFormat equals inferDateFormat over the FULL date column.
+    expect(profile.dateInputFormat).toBe("YYYY-MM-DD");
+    expect(profile.dateInputFormat).toBe(
+      inferDateFormat(columnValues(rows, "date_of_birth")),
+    );
+
+    // columnSamples equals sampleInputValues (first N non-empty, row order) over
+    // the full rows -- proving the blank-skipping semantics, not a row slice.
+    for (const column of profile.columns)
+      expect(profile.columnSamples[column]).toEqual(
+        sampleInputValues(rows, column, PREVIEW_SAMPLE_SIZE),
+      );
+    // The blank last_name rows are skipped, so its sample is not a row prefix.
+    expect(profile.columnSamples.last_name).toEqual([
+      "Public",
+      "Adams",
+      "Baker",
+      "Cole",
+      "Diaz",
+    ]);
+  });
+
+  test("a file with no date column yields no dateInputFormat", async () => {
+    const dir = tempDir("nodate");
+    fs.writeFileSync(path.join(dir, "in.csv"), "a,b\n1,2\n3,4\n");
+    const profile = await profileJobInput(dir, "in.csv");
+    expect(profile.dateInputFormat).toBeUndefined();
+    expect(profile.rowCount).toBe(2);
+  });
+
+  test("an unknown name is an UnknownJobInputError", async () => {
+    const dir = tempDir("unknown");
+    writeFixture(dir);
+    await expect(profileJobInput(dir, "absent.csv")).rejects.toBeInstanceOf(
+      UnknownJobInputError,
+    );
+  });
+
+  test("a symlinked entry is never resolvable by name", async () => {
+    const dir = tempDir("symlink-open");
+    const secret = tempDir("symlink-secret");
+    fs.writeFileSync(path.join(secret, "creds"), "ssn\n999\n");
+    fs.symlinkSync(path.join(secret, "creds"), path.join(dir, "link.csv"));
+    await expect(profileJobInput(dir, "link.csv")).rejects.toBeInstanceOf(
+      UnknownJobInputError,
+    );
+  });
+
+  test("a dev/ino mismatch at open time is refused (swap detection)", async () => {
+    const dir = tempDir("devino");
+    const name = writeFixture(dir);
+    const realFstat = fs.fstatSync;
+    // Simulate the file being swapped for a different inode between the admission
+    // lstat and the open-time fstat: the (dev, ino) recheck must reject it.
+    vi.spyOn(fs, "fstatSync").mockImplementationOnce((fd: number) => {
+      const real = realFstat(fd);
+      return { ...real, ino: real.ino + 1 };
+    });
+    await expect(profileJobInput(dir, name)).rejects.toBeInstanceOf(
+      UnknownJobInputError,
+    );
+  });
+});
+
+describe("coverageJobInput", () => {
+  const standardization: Standardization = [
+    {
+      output: "last_name",
+      input: "last_name",
+      steps: [{ function: "to_upper_case" }],
+    },
+    {
+      output: "birth_date",
+      input: "date_of_birth",
+      steps: [
+        { function: "parse_date", params: { inputFormat: "YYYY-MM-DD" } },
+      ],
+    },
+  ];
+
+  test("streaming coverage equals computeFieldCoverage over the same fixture", async () => {
+    const dir = tempDir("coverage");
+    const name = writeFixture(dir);
+    const rows = await fullRows(dir, name);
+    const profile = await profileJobInput(dir, name);
+
+    const streamed = await coverageJobInput(
+      dir,
+      name,
+      profile.sizeBytes,
+      profile.modifiedAt,
+      standardization,
+    );
+    expect(streamed).toEqual(computeFieldCoverage(rows, standardization));
+    // The batch and streaming drivers agree on the participating count too.
+    expect(streamed[0].total).toBe(rows.length);
+  });
+
+  test("a drifted (size, mtime) pair is refused", async () => {
+    const dir = tempDir("drift");
+    const name = writeFixture(dir);
+    const profile = await profileJobInput(dir, name);
+    await expect(
+      coverageJobInput(
+        dir,
+        name,
+        profile.sizeBytes + 1,
+        profile.modifiedAt,
+        standardization,
+      ),
+    ).rejects.toBeInstanceOf(JobInputDriftError);
+    await expect(
+      coverageJobInput(
+        dir,
+        name,
+        profile.sizeBytes,
+        profile.modifiedAt + 1000,
+        standardization,
+      ),
+    ).rejects.toBeInstanceOf(JobInputDriftError);
+  });
+});
+
+describe("JobInputParseGate", () => {
+  test("runs one at a time, queues one, and refuses a third", async () => {
+    const gate = new JobInputParseGate();
+    let releaseA!: () => void;
+    const a = gate.run(
+      () =>
+        new Promise<string>((resolve) => {
+          releaseA = () => resolve("a");
+        }),
+    );
+    const b = gate.run(() => Promise.resolve("b"));
+    await expect(gate.run(() => Promise.resolve("c"))).rejects.toBeInstanceOf(
+      JobInputParseBusyError,
+    );
+    releaseA();
+    expect(await a).toBe("a");
+    expect(await b).toBe("b");
+    // The gate is free again once both settle.
+    expect(await gate.run(() => Promise.resolve("d"))).toBe("d");
+  });
+});
+
+describe("loadJobInputDirFromEnv startup checks", () => {
+  test("unset returns undefined (feature off)", () => {
+    expect(loadJobInputDirFromEnv({})).toBeUndefined();
+  });
+
+  test("set without a data root refuses", () => {
+    const dir = tempDir("nodataroot");
+    expect(() => loadJobInputDirFromEnv({ JOB_INPUT_DIR: dir })).toThrow(
+      JobApiConfigError,
+    );
+  });
+
+  test("a nonexistent directory refuses", () => {
+    const root = tempDir("root");
+    expect(() =>
+      loadJobInputDirFromEnv({
+        JOB_INPUT_DIR: path.join(root, "missing"),
+        JOB_DATA_ROOT: path.join(root, "data"),
+      }),
+    ).toThrow(JobApiConfigError);
+  });
+
+  test("a path that is a file, not a directory, refuses", () => {
+    const dir = tempDir("filenotdir");
+    const file = path.join(dir, "f.csv");
+    fs.writeFileSync(file, "x\n");
+    expect(() =>
+      loadJobInputDirFromEnv({
+        JOB_INPUT_DIR: file,
+        JOB_DATA_ROOT: path.join(dir, "data"),
+      }),
+    ).toThrow(JobApiConfigError);
+  });
+
+  test("mutual containment with the data root refuses both directions", () => {
+    const base = tempDir("containment");
+    const inputInside = path.join(base, "inputs");
+    const dataOutside = path.join(base, "data");
+    fs.mkdirSync(inputInside);
+    fs.mkdirSync(dataOutside);
+    // input dir contained by data root
+    expect(() =>
+      loadJobInputDirFromEnv({
+        JOB_INPUT_DIR: inputInside,
+        JOB_DATA_ROOT: base,
+      }),
+    ).toThrow(JobApiConfigError);
+    // data root contained by input dir
+    expect(() =>
+      loadJobInputDirFromEnv({
+        JOB_INPUT_DIR: base,
+        JOB_DATA_ROOT: dataOutside,
+      }),
+    ).toThrow(JobApiConfigError);
+    // equal
+    expect(() =>
+      loadJobInputDirFromEnv({ JOB_INPUT_DIR: base, JOB_DATA_ROOT: base }),
+    ).toThrow(JobApiConfigError);
+  });
+
+  test("a valid disjoint directory resolves to its realpath", () => {
+    const base = tempDir("disjoint");
+    const input = path.join(base, "inputs");
+    const data = path.join(base, "data");
+    fs.mkdirSync(input);
+    fs.mkdirSync(data);
+    const resolved = loadJobInputDirFromEnv({
+      JOB_INPUT_DIR: input,
+      JOB_DATA_ROOT: data,
+    });
+    expect(resolved).toBe(fs.realpathSync(input));
+  });
+});
+
+describe("useJobInputDir and boot log", () => {
+  test("memoizes the resolved directory across calls", () => {
+    const base = tempDir("memo");
+    const input = path.join(base, "inputs");
+    const data = path.join(base, "data");
+    fs.mkdirSync(input);
+    fs.mkdirSync(data);
+    vi.stubEnv("JOB_INPUT_DIR", input);
+    vi.stubEnv("JOB_DATA_ROOT", data);
+    const first = useJobInputDir();
+    expect(first).toBe(fs.realpathSync(input));
+    // A later env change is not re-read: the directory is boot-resolved once.
+    vi.stubEnv("JOB_INPUT_DIR", "");
+    expect(useJobInputDir()).toBe(first);
+  });
+
+  test("the boot log line names the realpath and the readdir/admissible counts", () => {
+    const dir = tempDir("bootlog");
+    writeFixture(dir);
+    fs.mkdirSync(path.join(dir, "sub"));
+    const info = vi.fn();
+    logJobInputDirBoot(dir, {
+      info,
+    } as unknown as Parameters<typeof logJobInputDirBoot>[1]);
+    expect(info).toHaveBeenCalledTimes(1);
+    const line = info.mock.calls[0][0] as string;
+    expect(line).toContain(fs.realpathSync(dir));
+    expect(line).toContain("2 readdir entries");
+    expect(line).toContain("1 admissible");
+  });
+});

--- a/apps/web/test/unit/jobWorkInputs.unit.test.ts
+++ b/apps/web/test/unit/jobWorkInputs.unit.test.ts
@@ -249,6 +249,34 @@ describe("profileJobInput", () => {
       UnknownJobInputError,
     );
   });
+
+  test("a symlink swapped in between admission and open is UnknownJobInputError, no fd leak", async () => {
+    const dir = tempDir("open-race");
+    const name = writeFixture(dir);
+    const secret = tempDir("open-race-secret");
+    fs.writeFileSync(path.join(secret, "creds"), "ssn\n999\n");
+
+    const realOpen = fs.openSync;
+    const closeSpy = vi.spyOn(fs, "closeSync");
+    // The genuine race O_NOFOLLOW exists to close: after the admission lstat has
+    // accepted the regular file, swap it for a symlink, then let the REAL open run
+    // -- O_NOFOLLOW makes it throw a genuine ELOOP, which must map to
+    // UnknownJobInputError (the 404 posture) rather than escape as a generic error.
+    vi.spyOn(fs, "openSync").mockImplementationOnce(((
+      filePath: fs.PathLike,
+      flags: number,
+    ) => {
+      fs.rmSync(path.join(dir, name));
+      fs.symlinkSync(path.join(secret, "creds"), path.join(dir, name));
+      return realOpen(filePath, flags);
+    }) as typeof fs.openSync);
+
+    await expect(profileJobInput(dir, name)).rejects.toBeInstanceOf(
+      UnknownJobInputError,
+    );
+    // The open threw before any descriptor existed, so nothing is closed: no leak.
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe("coverageJobInput", () => {

--- a/apps/web/test/unit/nonEmptyAggregate.test.ts
+++ b/apps/web/test/unit/nonEmptyAggregate.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { StandardizedField } from "@psilink/core";
 
 import {
   NON_EMPTY_WORKER_CHAR_THRESHOLD,
@@ -18,6 +20,10 @@ import type {
 } from "../../src/psi/nonEmptyAggregateController.js";
 
 import type { CSVRow, Standardization } from "@psilink/core";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("computeFieldCoverage: the silent-empty defense", () => {
   test("a transform that collapses every row to null surfaces a 0% coverage alarm", () => {
@@ -365,5 +371,40 @@ describe("createFieldCoverageAccumulator: streaming equals batch", () => {
     expect(accumulator.result()).toEqual(
       computeFieldCoverage([], standardization),
     );
+  });
+
+  test("a field whose pipeline throws on a row degrades to unavailable, not a sweep abort", () => {
+    const rows: Array<CSVRow> = [
+      { last_name: "Public" },
+      { last_name: "boom" },
+      { last_name: "Adams" },
+    ];
+    const realEvaluateRow = StandardizedField.prototype.evaluateRow;
+    // A compiled pipeline can still throw on a specific row's value (a step that
+    // slips past the validity gate). That row must degrade the field to unavailable
+    // and stop its evaluation, never abort the whole sweep -- server-side one bad row
+    // would otherwise 400 the entire coverage request.
+    vi.spyOn(StandardizedField.prototype, "evaluateRow").mockImplementation(
+      function (this: StandardizedField, row: CSVRow): Array<string> {
+        if (row.last_name === "boom")
+          throw new Error("row-time pipeline throw");
+        return realEvaluateRow.call(this, row);
+      },
+    );
+    const accumulator = createFieldCoverageAccumulator([
+      {
+        output: "last_name",
+        input: "last_name",
+        steps: [{ function: "to_upper_case" }],
+      },
+    ]);
+    expect(() => {
+      for (const row of rows) accumulator.add(row);
+    }).not.toThrow();
+    const [coverage] = accumulator.result();
+    expect(coverage.total).toBe(3);
+    expect(coverage.produced).toBe(0);
+    expect(coverage.unavailable).toBe(true);
+    expect(isSilentEmpty(coverage)).toBe(false);
   });
 });

--- a/apps/web/test/unit/nonEmptyAggregate.test.ts
+++ b/apps/web/test/unit/nonEmptyAggregate.test.ts
@@ -4,6 +4,7 @@ import {
   NON_EMPTY_WORKER_CHAR_THRESHOLD,
   NON_EMPTY_WORKER_ROW_THRESHOLD,
   computeFieldCoverage,
+  createFieldCoverageAccumulator,
   isSilentEmpty,
   shouldComputeOffThread,
 } from "../../src/psi/nonEmptyAggregate.js";
@@ -320,5 +321,49 @@ describe("NonEmptyRateController: off-main-thread dispatch above the threshold",
     await Promise.resolve();
     expect(settled).not.toHaveBeenCalled();
     expect(fake.received.filter((m) => m.kind === "compute")).toHaveLength(0);
+  });
+});
+
+describe("createFieldCoverageAccumulator: streaming equals batch", () => {
+  const standardization: Standardization = [
+    {
+      output: "last_name",
+      input: "last_name",
+      steps: [{ function: "to_upper_case" }],
+    },
+    {
+      output: "birth_date",
+      input: "dob",
+      steps: [
+        { function: "parse_date", params: { inputFormat: "YYYY-MM-DD" } },
+      ],
+    },
+    // A field left mid-edit stays `unavailable` on both drivers.
+    {
+      output: "pad",
+      input: "last_name",
+      steps: [{ function: "pad_left", params: {} }],
+    },
+  ];
+
+  test("feeding rows one at a time equals computeFieldCoverage over the whole set", () => {
+    const rows: Array<CSVRow> = [
+      { last_name: "Public", dob: "1990-01-02" },
+      { last_name: "", dob: "not-a-date" },
+      { last_name: "Adams", dob: "2000-05-14" },
+      { dob: "1972-03-08" },
+    ];
+    const accumulator = createFieldCoverageAccumulator(standardization);
+    for (const row of rows) accumulator.add(row);
+    expect(accumulator.result()).toEqual(
+      computeFieldCoverage(rows, standardization),
+    );
+  });
+
+  test("an empty stream reports zero totals, not a divide-by-zero", () => {
+    const accumulator = createFieldCoverageAccumulator(standardization);
+    expect(accumulator.result()).toEqual(
+      computeFieldCoverage([], standardization),
+    );
   });
 });

--- a/docs/spec/SERVER_JOB_API.md
+++ b/docs/spec/SERVER_JOB_API.md
@@ -170,7 +170,11 @@ like the remotes table:
 - Mutual containment with the resolved data root refuses startup: the input
   directory must not equal, contain, or be contained by `JOB_DATA_ROOT`. Otherwise
   the listing could expose job workdirs, or a job could be fed its own artifacts or
-  another job's key material.
+  another job's key material. When the data root does not yet exist at boot, its
+  side of the comparison is lexical (`path.resolve`, no symlink resolution), so a
+  `JOB_DATA_ROOT` routed through a symlinked intermediate component is on the
+  operator -- the same disjoint-mounts model as the boot-time realpath caveat
+  below.
 
 After the checks pass, the server logs one boot-diagnostic line -- the resolved
 realpath, the total `readdir` entry count, and the admissible file count -- so an

--- a/docs/spec/SERVER_JOB_API.md
+++ b/docs/spec/SERVER_JOB_API.md
@@ -4,7 +4,7 @@ title: "Web Server Job API"
 
 # Web server job API
 
-This document specifies the web application's server-side job API: the HTTP endpoints through which a supervisor creates, observes, cancels, and deletes an exchange job that the Nitro server drives as a `psilink` CLI subprocess, the typed intent the client submits and the validation that makes it injection-closed, the operator-provisioned SFTP remotes table and its validation, the on-disk workdir layout and modes, the SSE event relay and its full-history replay, the exit-code reconciliation and cancellation escalation, the environment variables that gate and configure the feature, and the memory-only job lifetime. It is the spec-tier complement to the operator-facing overview in [DEPLOYMENT.md](../DEPLOYMENT.md#server-job-api), which says what the feature is for and how to turn it on; this document says how each request, file, and event is constructed. It consumes -- and re-validates at the trust boundary -- the CLI's fd-3 event stream specified in [CLI_EVENTS.md](CLI_EVENTS.md); it does not respecify that stream's construction (see there). It does not cover the exchange protocol that produces the events (see [PROTOCOL.md](PROTOCOL.md)) or the display-sanitization escape format the fields reuse (see [CHANNEL_SECURITY.md](CHANNEL_SECURITY.md#display-sanitization-escape-format)). Intended readers are implementors writing a supervisor against this API and security auditors.
+This document specifies the web application's server-side job API: the HTTP endpoints through which a supervisor creates, observes, cancels, and deletes an exchange job that the Nitro server drives as a `psilink` CLI subprocess, the typed intent the client submits and the validation that makes it injection-closed, the operator-provisioned SFTP remotes table and its validation, the operator-mounted work-input directory and its listing/profile/coverage surface, the on-disk workdir layout and modes, the SSE event relay and its full-history replay, the exit-code reconciliation and cancellation escalation, the environment variables that gate and configure the feature, and the memory-only job lifetime. It is the spec-tier complement to the operator-facing overview in [DEPLOYMENT.md](../DEPLOYMENT.md#server-job-api), which says what the feature is for and how to turn it on; this document says how each request, file, and event is constructed. It consumes -- and re-validates at the trust boundary -- the CLI's fd-3 event stream specified in [CLI_EVENTS.md](CLI_EVENTS.md); it does not respecify that stream's construction (see there). It does not cover the exchange protocol that produces the events (see [PROTOCOL.md](PROTOCOL.md)) or the display-sanitization escape format the fields reuse (see [CHANNEL_SECURITY.md](CHANNEL_SECURITY.md#display-sanitization-escape-format)). Intended readers are implementors writing a supervisor against this API and security auditors.
 
 The job API exists for the console-appliance deployment: a container serving one party, inside that party's trust boundary, that drives the party's own `psilink exchange` runs without the operator invoking the CLI by hand. It is not a shared rendezvous between parties; the trust invariant it rests on and what would violate it are in [SECURITY_DESIGN.md](../SECURITY_DESIGN.md#single-party-appliance-trust-boundary). The API is off unless a data root is configured, and its whole design -- server-composed CLI inputs, memory-only state, loopback-or-token auth -- is calibrated to that single-operator posture.
 
@@ -31,6 +31,9 @@ Every job response carries `Cache-Control: no-store` and no CORS headers -- the 
 | `GET` | `/api/jobs/:jobId/record` | `200` `application/json` | The self-attested exchange record, only after the job succeeded. `404` otherwise. |
 | `GET` | `/api/jobs/:jobId/keys` | `200` `application/json` | The private verification keys paired with the record, only after the job succeeded. `404` otherwise. |
 | `GET` | `/api/jobs/remotes` | `200` JSON array | The operator-provisioned SFTP remotes as a credential-free projection; `[]` when none are configured. See [SFTP remotes](#sftp-remotes). |
+| `GET` | `/api/jobs/inputs` | `200` listing JSON | The operator-mounted input CSVs the server may read. `configured: false` with an empty list when `JOB_INPUT_DIR` is unset. See [Work-input files](#work-input-files). |
+| `GET` | `/api/jobs/inputs/profile` | `200` profile JSON | A single-pass profile of one named input (columns, row count, inferred date format, bounded samples). `404` when the directory is unconfigured or the name is unknown, `400` on an unusable file, `429` when the parse gate is full. |
+| `POST` | `/api/jobs/inputs/coverage` | `200` `{ "rates": [...] }` | Per-field non-empty coverage over one named input under a submitted standardization. `413` (body over 1 MiB), `400` (bad body, schema failure, or size/mtime drift), `404` (unconfigured or unknown name), `429` (parse gate full). |
 
 Auth applies to every endpoint uniformly: a disabled API is `404` and a bad bearer is `401` on all of them, resolved before the id is even parsed.
 
@@ -144,6 +147,165 @@ The table is startup-frozen: changing hosts, names, or pins requires a restart. 
 
 Returns the provisioned remotes as an explicitly mapped, credential-free projection -- `[{ "name": "...", "host": "...", "port"?: <int>, "path"?: "..." }]` and nothing else: no username, no credential references (which would reveal the secret-mount filesystem layout), no fingerprints. An enabled API with no remotes configured serves `200 []` (a `404` would be indistinguishable from the disabled-API gate). The console web build uses this to offer the remote picker and to author an invitation's sftp endpoint from the picked remote's locator. The static `remotes` segment cannot be captured as a job id: ids are validated as canonical v4 UUIDs before any use, which `remotes` is not.
 
+## Work-input files
+
+The console appliance reads its input CSVs from one operator-mounted directory
+rather than accepting them uploaded through the browser. `JOB_INPUT_DIR` names that
+directory; the server lists it, profiles a chosen file, and computes coverage over
+it, all as streaming passes that retain no rows. This surface is off unless
+`JOB_INPUT_DIR` is set, and -- like every job route -- dark unless `JOB_DATA_ROOT`
+enables the API at all.
+
+### Startup resolution and containment
+
+`JOB_INPUT_DIR` is resolved once at startup with `fs.realpathSync`, fail-closed
+like the remotes table:
+
+- A configured directory that does not exist, or is not a directory, refuses
+  startup.
+- `JOB_INPUT_DIR` set without `JOB_DATA_ROOT` refuses startup -- the directory
+  serves only the job API, which the data root enables, exactly the
+  `JOB_SFTP_REMOTES` rule. Because neither variable is ever baked into the image,
+  the two provisioning vars behave identically.
+- Mutual containment with the resolved data root refuses startup: the input
+  directory must not equal, contain, or be contained by `JOB_DATA_ROOT`. Otherwise
+  the listing could expose job workdirs, or a job could be fed its own artifacts or
+  another job's key material.
+
+After the checks pass, the server logs one boot-diagnostic line -- the resolved
+realpath, the total `readdir` entry count, and the admissible file count -- so an
+operator who mounted the wrong host path, or whose entries are all filtered out,
+sees it at boot without touching the API.
+
+`O_NOFOLLOW` (below) protects only the final path component, and the root's
+realpath is resolved once at boot. A post-boot remount, or replacement of an
+intermediate path component, is out of model for the single-party appliance.
+
+### Listing and admission
+
+The listing is the ONLY source of truth for admissible names. `GET
+/api/jobs/inputs` returns:
+
+```json
+{
+  "configured": <bool>,
+  "totalEntries": <int>,
+  "truncated": <bool>,
+  "files": [{ "name": "<segment>", "sizeBytes": <int>, "modifiedAt": <int> }]
+}
+```
+
+`configured` is `false` (with an empty list) when `JOB_INPUT_DIR` is unset -- a
+state reachable only when the job API itself is enabled -- so the console UI can
+render an actionable "set `JOB_INPUT_DIR` and mount a directory" state rather than a
+mysteriously empty list. `totalEntries` is the raw `readdir` count BEFORE admission,
+so the UI can tell an empty directory from one whose entries are all inadmissible.
+`modifiedAt` is integer epoch milliseconds everywhere.
+
+Admission, applied to a non-recursive `readdir` of the resolved root:
+
+- **Name shape.** A single path segment: no `/`, `\`, or NUL; not `.` or `..`; no
+  leading dot (so a `.psilink.key`-shaped file is excluded by construction); no
+  control characters; length 1..255.
+- **Regular files only.** `lstat` must report a regular file. A symlink's `lstat`
+  is a symlink, so `isFile()` is false and it is never admitted -- a symlink in the
+  input directory pointing at `/run/secrets/...` or the data root is neither
+  listable nor readable.
+- **Deterministic cap.** Admitted entries are sorted by name BEFORE the 512-entry
+  cap, so truncation (`truncated: true`) is deterministic across `readdir`
+  orderings.
+
+There is no `.csv` extension filter (the profile parse is the real gate; operators
+name files unpredictably) and NO total-size cap: mounted inputs are the CLI-scale
+files the CLI is specced for (millions of rows, gigabytes). Memory stays flat
+because every reader streams; time scales linearly and is governed by the
+one-parse-at-a-time gate. `MAX_CSV_FILE_BYTES` is the hosted browser-upload bound
+and does not apply here.
+
+### By-name admission and the open recipe
+
+Every by-name operation (profile, coverage) re-runs the listing and requires the
+requested name to match an admitted entry by exact string equality -- the
+remotes-table `Map.get` discipline. The server only ever opens names it itself
+enumerated, so a crafted name never reaches `path.join`. To read, it then:
+
+1. `open(join(root, name), O_RDONLY | O_NOFOLLOW)`.
+2. `fstat` the descriptor and require `(dev, ino)` to equal the admission `lstat`.
+
+`O_NOFOLLOW` closes the symlink-swap window on the final component; the `(dev, ino)`
+recheck closes the file-swap window between the admission `lstat` and the open. The
+open-time `fstat` size/mtime are what the profile reports and what coverage compares
+for drift. Failures never echo the requested name: an unset directory or unknown
+name is an empty-bodied `404`, an unusable file (parse error, ceiling trip) a `400`.
+
+### Profile
+
+`GET /api/jobs/inputs/profile?name=...` returns, in ONE streaming constant-memory
+pass:
+
+```json
+{
+  "name": "<segment>",
+  "sizeBytes": <int>,
+  "modifiedAt": <int>,
+  "rowCount": <int>,
+  "columns": ["..."],
+  "dateInputFormat": "<format>",
+  "columnSamples": { "<column>": ["..."] }
+}
+```
+
+- `columns` from the header; `rowCount` by counting.
+- `dateInputFormat` (omitted when there is no date-of-birth column or the sample
+  yields no signal) via the shared core composition: the DOB column is picked by
+  `inferMetadata`, its first `INFER_DATE_SCAN_CAP` (1000) non-empty values are
+  sampled, and `inferDateFormat` runs over the sample. The bound is exact -- that
+  cap is where `inferDateFormat` stops its own scan -- so the profiled format
+  equals a full-column read, the same cap-exactness the CLI's `init` relies on.
+- `columnSamples` is the first `PREVIEW_SAMPLE_SIZE` (5) non-empty values per column
+  in row order, the same `sampleInputValues` semantics the browser preview uses.
+
+`sizeBytes`/`modifiedAt` are the open-time `fstat` values the client keeps for the
+authoring-time drift signal.
+
+### Coverage
+
+`POST /api/jobs/inputs/coverage` with body `{ name, sizeBytes, modifiedAt,
+standardization }` returns `{ "rates": FieldValueCoverage[] }` from one streaming
+sweep of the named file under the submitted standardization. The `standardization`
+is validated through the SAME bounded schema the job intent uses (the transformation
+and step counts, and the output/input name lengths) PLUS a route-level per-step
+pattern/delimiter source length cap reusing `MAX_TRANSFORM_PATTERN_LENGTH`. The
+intent-level schema bounds counts, not pattern length, and while RE2JS execution is
+linear-time, its compile cost lands on this process's event loop before any row
+streams -- so this in-process endpoint caps the source length; the shared intent
+schema (and the job-create path) is unchanged.
+
+The body is read through `readJobRequestBody` under a 1 MiB cap. The submitted
+`sizeBytes`/`modifiedAt` are the client's profiled snapshot: the server's open-time
+`fstat` size/mtime must equal that pair, else the coverage is refused as drifted
+(empty-bodied `400`) -- coverage is never silently computed over content that
+changed since profiling.
+
+### Resource posture and the in-process tradeoff
+
+- **No cache.** The profile is one streaming pass per request; coverage is a
+  streaming recompute per request. The memory ceiling is flat regardless of file
+  size, and no parsed PII rests in server memory between requests.
+- **One at a time.** A single-flight gate serializes all parse/sweep work across
+  the profile and coverage routes (the single-operator appliance bound doing double
+  duty as the memory bound). A second request waits in a depth-one queue; a third
+  is refused `429`, which the client treats like a superseded response. The stream
+  yields between chunks, so a worst-case event-loop stall is one chunk's pipeline
+  work, not the whole file.
+- **In-process pipeline execution.** The coverage sweep runs client-supplied
+  standardization pipelines in the web-server process, whereas the existing homes of
+  that computation are the operator's own browser and the CLI child process. The
+  pipelines are count-bounded, pattern-length-capped at this endpoint, and
+  linear-regex-compiled (RE2JS -- no backtracking): this is a resource bound, not a
+  ReDoS hole, and no metadata or standardization value becomes an argv fragment, a
+  path, a host, or a credential.
+
 ## Workdir layout
 
 Each job gets a workdir at `<dataRoot>/<jobId>/`, created mode `0o700` (owner-only, `rwx------`), with an explicit `chmod` after `mkdir` because a restrictive umask is not guaranteed. Creation fails if the directory already exists, so a reused id cannot clobber an existing job. The data root itself is created (recursively) if missing. Inside the workdir, files are written at fixed, server-chosen names, each mode `0o600` (owner-only, `rw-------`, again `chmod`-enforced after write):
@@ -241,12 +403,13 @@ The escalation timers are cleared when the child exits, so a child that stops on
 | `JOB_API_TOKEN` | The bearer token. Non-empty -> every endpoint requires a matching `Authorization: Bearer` header (constant-time compared). Empty -> unauthenticated, permitted only on a loopback bind (see the startup rule). |
 | `JOB_CLI_BINARY` | Overrides the CLI entry path the driver spawns. Unset -> the workspace-relative built entry (`apps/cli/dist/index.js`, resolved four levels up from the jobs module). Used by production overrides and by tests pointing the driver at a stub. It is set only server-side, never derived from a request. |
 | `JOB_SFTP_REMOTES` | The SFTP remotes table (see [SFTP remotes](#sftp-remotes)). Empty or unset -> every sftp intent is rejected; the API is otherwise unchanged. Non-empty -> the named YAML file is loaded and validated at startup, fail-closed. Requires `JOB_DATA_ROOT`; set only server-side, never derived from a request. |
+| `JOB_INPUT_DIR` | The one directory the server may list and read input CSVs from (see [Work-input files](#work-input-files)). Empty or unset -> the input-file feature is off (the listing is `configured: false`, profile/coverage `404`); the API is otherwise unchanged. Non-empty -> the directory is `realpath`-resolved and containment-checked at startup, fail-closed. Requires `JOB_DATA_ROOT`; set only server-side, never derived from a request, never baked into the image. |
 
 ### Fail-closed startup rule
 
 Before the server binds, if the API is enabled (`JOB_DATA_ROOT` set) and no token is configured (`JOB_API_TOKEN` empty) and the bind host is not loopback, startup is refused with a configuration error rather than exposing an unauthenticated CLI driver on a public interface. A bind host is loopback when it is `localhost`, `::1`/`[::1]`, or a `127.` address; an unset host (the default all-interfaces bind) is treated as non-loopback and fails closed rather than assuming loopback. A unix-socket bind is appliance-local and treated as loopback for this check. The safe configurations -- disabled, loopback, or token-protected -- start normally.
 
-The same posture covers the remotes table: a configured `JOB_SFTP_REMOTES` that is unreadable or invalid, or one configured without `JOB_DATA_ROOT`, refuses startup.
+The same posture covers the remotes table: a configured `JOB_SFTP_REMOTES` that is unreadable or invalid, or one configured without `JOB_DATA_ROOT`, refuses startup. It covers the work-input directory too: a configured `JOB_INPUT_DIR` that does not resolve to a directory, is set without `JOB_DATA_ROOT`, or overlaps the resolved data root (mutual containment) refuses startup (see [Work-input files](#work-input-files)). The loopback requirement is a startup bind invariant, not a per-request check.
 
 ## Job lifetime and orphan handling
 

--- a/docs/spec/SERVER_JOB_API.md
+++ b/docs/spec/SERVER_JOB_API.md
@@ -239,8 +239,11 @@ enumerated, so a crafted name never reaches `path.join`. To read, it then:
 `O_NOFOLLOW` closes the symlink-swap window on the final component; the `(dev, ino)`
 recheck closes the file-swap window between the admission `lstat` and the open. The
 open-time `fstat` size/mtime are what the profile reports and what coverage compares
-for drift. Failures never echo the requested name: an unset directory or unknown
-name is an empty-bodied `404`, an unusable file (parse error, ceiling trip) a `400`.
+for drift. Failures never echo the requested name: an unset directory, an unknown
+name, or an open-time race indistinguishable from one -- the `O_NOFOLLOW` `ELOOP` on
+a symlink swapped in after the admission `lstat`, an `ENOENT` on a vanished file, or
+an `EACCES` on one made unreadable -- is an empty-bodied `404`; an unusable file
+(parse error, ceiling trip) a `400`.
 
 ### Profile
 

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -262,103 +262,109 @@ function normalizeCSVRow(row: unknown): CSVRow {
 }
 
 /**
- * Parse a CSV file to its COMPLETE row set. Resolves a {@link Papa.ParseResult}
- * whose `data` and `errors` are accumulated across every PapaParse chunk, so a
- * file larger than one `Papa.LocalChunkSize` chunk is returned whole rather than
- * truncated to its final chunk (see the accumulation note in the body). Rejects
- * on a read/stream error.
+ * The PapaParse configuration every CSV read in this module shares -- the ONE
+ * config object behind both the whole-file loader ({@link loadCSVFile}) and the
+ * streaming row-consumer ({@link streamCSVRows}). Config identity is what makes
+ * the two drivers parse-equivalent: the web browser worker wraps loadCSVFile and
+ * the server streams over the same header/skip-empty/inline semantics, so a row
+ * one driver produces is byte-identical to the other's, and neither can silently
+ * drift from the browser's parse.
+ *
+ * Parse INLINE, never in a Web Worker. PapaParse's `worker: true` spawns its
+ * worker from its own bundled source by reading the running script's URL -- a
+ * self-location trick that survives a dev server (the module is a real,
+ * URL-addressable file) but breaks once Vite bundles and minifies PapaParse into a
+ * chunk: the spawned worker runs a broken bootstrap that mis-applies `header:
+ * true`, so the header row AND the first data row both land in `meta.fields` while
+ * `data` comes back empty. The malformed header then crashes the first consumer
+ * that treats a field as a string (inferMetadata's `name.toLowerCase()`), so the
+ * production web inviter could not generate an invitation of any kind. Dev and the
+ * real-Chromium browser tests pass because the worker resolves there -- the failure
+ * is specific to the bundled build, so no unit/browser test catches it; the header
+ * guard in {@link runSharedCSVParse} is the executable backstop. Inline parsing
+ * blocks the main thread for the parse, acceptable for the once-per-exchange
+ * invite/accept file; an off-main-thread parse, if ever wanted for very large
+ * files, must go through a Vite-native worker in the web app, not PapaParse's
+ * self-hosted one. Under Node (the CLI and the web server) PapaParse never honored
+ * the worker anyway (`WORKERS_SUPPORTED` is `!!global.Worker`, false there), so
+ * this changes only the web build.
+ */
+const SHARED_CSV_PARSE_CONFIG = {
+  worker: false,
+  header: true,
+  skipEmptyLines: true,
+} as const;
+
+/**
+ * Drive a PapaParse read of `file` under {@link SHARED_CSV_PARSE_CONFIG} and the
+ * single-line byte ceiling, handing each chunk's normalized rows to
+ * `consumeChunk`. The whole-file loader ({@link loadCSVFile}) and the streaming
+ * row-consumer ({@link streamCSVRows}) are the two drivers over this one runner,
+ * so neither can drift to different parse semantics. Resolves with the final
+ * {@link Papa.ParseMeta} once the parse settles; rejects on a read/parse error or
+ * a ceiling trip.
  *
  * `byteCeiling` bounds a single logical line -- the partial line PapaParse must
  * buffer whole before it yields a chunk -- so a no-newline file, an oversized
  * header, or one enormous field fails fast with a clear, operator-readable error
- * rather than driving memory and CPU with that span; see
- * {@link CSV_LINE_BYTE_CEILING}. Unlike loadCSVColumnSample (whose row cap also
- * removes real waste), this read genuinely consumes every row of the operator's
- * own file (invite/accept/exchange), so the ceiling is a robustness backstop on a
- * single pathological line, not a memory saving for well-formed input -- a normal
- * file reads exactly as it did before.
- *
- * Two complementary mechanisms enforce it across the inputs this read serves, both
- * on public API only. For the Node stream every CLI caller passes,
- * {@link guardStreamLineByteCeiling} scans the source's own `data` events and
- * destroys it past the ceiling, which PapaParse surfaces through its `error`
- * callback -- bounding every line (header or any data row). For the browser `File`
- * the web caller passes -- which PapaParse reads whole through FileReader, with no
- * `data` events to scan -- a bounded pre-read
+ * rather than driving memory and CPU with that span; see {@link CSV_LINE_BYTE_CEILING}.
+ * Two complementary mechanisms enforce it, both on public API only. For the Node
+ * stream a CLI or server caller passes, {@link guardStreamLineByteCeiling} scans
+ * the source's own `data` events and destroys it past the ceiling, which PapaParse
+ * surfaces through its `error` callback -- bounding every line (header or any data
+ * row). For the browser `File` the web caller passes -- read whole through
+ * FileReader, with no `data` events to scan -- the bounded pre-read
  * ({@link assertLeadingLineWithinByteCeiling}) instead rejects an oversized LEADING
- * line (the header, or a no-newline file) before parsing; a giant field in a LATER
- * row on that path stays bounded by the web app's intake cap (apps/web's
- * `MAX_CSV_FILE_BYTES`) rather than scanned for here. See that helper for why the
- * web path is bounded only at its leading line, not every row.
+ * line before parsing; a giant field in a LATER row on that path stays bounded by
+ * the web app's intake cap (`MAX_CSV_FILE_BYTES`).
  *
- * Caveat on `meta`: only `meta.fields` (the header) is whole-file-stable. The
- * rest of `meta` (`cursor`, `truncated`, `aborted`, ...) is the FINAL chunk's --
- * it is captured per chunk and only `fields` persists across chunks -- so a
- * consumer must not read whole-file position or truncation state off it. Every
- * current consumer reads only `data` and `meta.fields`.
+ * PapaParse's per-chunk `chunk` callback is the only place every row is seen: in
+ * BOTH inline and worker mode `complete`'s argument is the FINAL chunk (worker) or
+ * `undefined` (inline once a `chunk` callback is present), never the whole file, so
+ * a driver that read `complete` alone would silently truncate a >1-chunk file.
+ * Rows are normalized to {@link CSVRow} at this single boundary -- dropping the
+ * non-string `__parsed_extra` PapaParse attaches to an over-long row -- so both
+ * drivers see the honest row type without a per-site cast.
+ *
+ * Caveat on `meta`: only `meta.fields` (the header) is whole-file-stable; the rest
+ * (`cursor`, `truncated`, `aborted`, ...) is the FINAL chunk's, so a consumer must
+ * not read whole-file position or truncation state off it.
  */
-export async function loadCSVFile(
+async function runSharedCSVParse(
   file: LocalFile,
-  byteCeiling: number = CSV_LINE_BYTE_CEILING,
-): Promise<Papa.ParseResult<CSVRow>> {
+  byteCeiling: number,
+  consumeChunk: (
+    rows: Array<CSVRow>,
+    errors: Array<Papa.ParseError>,
+    meta: Papa.ParseMeta,
+  ) => void,
+): Promise<Papa.ParseMeta> {
   // Bound the non-stream (browser File) path's leading line before parsing: a File
   // exposes no `data` events for the stream guard below to scan, since PapaParse
   // reads it whole through FileReader. A Node stream or string is a no-op here.
   await assertLeadingLineWithinByteCeiling(file, byteCeiling);
   return new Promise((resolve, reject) => {
-    // Accumulate every chunk's rows on THIS thread. PapaParse splits a file into
-    // `Papa.LocalChunkSize` chunks, and neither mode's `complete` argument is the
-    // whole file: worker mode posts each chunk back separately and hands
-    // `complete` only the FINAL chunk (it accumulates across chunks solely inside
-    // the worker, where `complete` is a boolean and never fires), and the inline
-    // path hands `complete` `undefined` once a `chunk` callback is present. The
-    // per-chunk `chunk` callback -- which fires on this thread in BOTH modes -- is
-    // the only place every row is seen, so collect there and resolve the union. A
-    // missing `chunk` callback is exactly the silent multi-chunk truncation this
-    // accumulation removes (the older single-chunk-only contract); a >1-chunk file
-    // therefore parses whole rather than to a truncated subset with no error.
-    const data: Array<CSVRow> = [];
-    const errors: Array<Papa.ParseError> = [];
     let meta: Papa.ParseMeta | undefined;
 
-    // Bound a single logical line on the Node stream path (the CLI's file/stdin
-    // input): the guard scans the source's own `data` events and destroys it past
-    // the ceiling, which PapaParse -- reading the same source -- reports through the
-    // `error` callback below. Inert for a non-stream LocalFile (a browser File has
-    // no `data` events); that path is bounded by the pre-read above instead.
+    // Bound a single logical line on the Node stream path (CLI file/stdin, or the
+    // server's opened input file): the guard scans the source's own `data` events
+    // and destroys it past the ceiling, which PapaParse -- reading the same source
+    // -- reports through the `error` callback below. Inert for a non-stream
+    // LocalFile (a browser File has no `data` events); that path is bounded by the
+    // pre-read above instead.
     const source = file as StreamSource;
     const detachGuard = guardStreamLineByteCeiling(source, byteCeiling);
 
     Papa.parse(file, {
-      // Parse INLINE, never in a Web Worker. PapaParse's `worker: true` spawns its
-      // worker from its own bundled source by reading the running script's URL -- a
-      // self-location trick that survives a dev server (the module is a real,
-      // URL-addressable file) but breaks once Vite bundles and minifies PapaParse
-      // into a chunk: the spawned worker runs a broken bootstrap that mis-applies
-      // `header: true`, so the header row AND the first data row both land in
-      // `meta.fields` while `data` comes back empty. The malformed header then
-      // crashes the first consumer that treats a field as a string (inferMetadata's
-      // `name.toLowerCase()`), so the production web inviter could not generate an
-      // invitation of any kind. Dev and the real-Chromium browser tests pass because
-      // the worker resolves there -- the failure is specific to the bundled build, so
-      // no unit/browser test catches it; the header guard in `complete` below is the
-      // executable backstop. Inline parsing blocks the main thread for the parse,
-      // acceptable for the once-per-exchange invite/accept file; an off-main-thread
-      // parse, if ever wanted for very large files, must go through a Vite-native
-      // worker in the web app, not PapaParse's self-hosted one. Under Node (the CLI)
-      // PapaParse never honored the worker anyway (`WORKERS_SUPPORTED` is
-      // `!!global.Worker`, false there), so this changes only the web build.
-      worker: false,
-      header: true,
-      skipEmptyLines: true,
+      ...SHARED_CSV_PARSE_CONFIG,
       chunk: (results) => {
         // Spread-push would pass one argument per row and can overflow the call
-        // stack for a chunk holding hundreds of thousands of short rows, so append
-        // in a loop (O(n) total, stack-safe). Normalize each row to a CSVRow at this
-        // single boundary -- dropping PapaParse's non-string __parsed_extra -- so the
-        // honest row type holds for every consumer without a per-site cast.
-        for (const row of results.data) data.push(normalizeCSVRow(row));
-        for (const error of results.errors) errors.push(error);
+        // stack for a chunk holding hundreds of thousands of short rows, so build
+        // the chunk's row array in a loop (O(n) total, stack-safe), normalizing
+        // each row here at the single boundary.
+        const rows: Array<CSVRow> = [];
+        for (const row of results.data) rows.push(normalizeCSVRow(row));
+        consumeChunk(rows, results.errors, results.meta);
         // Every chunk's meta carries the header field list (the parser's fields
         // persist across chunks), so keep the latest for `complete`, whose own
         // argument is only the final chunk (worker) or undefined (inline).
@@ -377,10 +383,11 @@ export async function loadCSVFile(
         }
         // The header must be a flat list of string column names. A correct
         // `header: true` parse always produces that; a non-string field means the
-        // parse itself malfunctioned (the bundled-worker corruption the `worker:
-        // false` note above describes leaks a data row -- an array -- into
-        // `meta.fields`). Reject loudly here rather than letting the malformed header
-        // flow into inferMetadata and surface as a deep, opaque `toLowerCase` crash.
+        // parse itself malfunctioned (the bundled-worker corruption the shared
+        // config note above describes leaks a data row -- an array -- into
+        // `meta.fields`). Reject loudly here rather than letting the malformed
+        // header flow into inferMetadata and surface as a deep, opaque
+        // `toLowerCase` crash.
         if (meta.fields?.some((field) => typeof field !== "string")) {
           reject(
             new Error(
@@ -390,7 +397,7 @@ export async function loadCSVFile(
           );
           return;
         }
-        resolve({ data, errors, meta });
+        resolve(meta);
       },
       error: (error) => {
         // The guard's ceiling trip surfaces here -- it destroys the source with
@@ -401,6 +408,70 @@ export async function loadCSVFile(
       },
     });
   });
+}
+
+/**
+ * Parse a CSV file to its COMPLETE row set. Resolves a {@link Papa.ParseResult}
+ * whose `data` and `errors` are accumulated across every PapaParse chunk, so a
+ * file larger than one `Papa.LocalChunkSize` chunk is returned whole rather than
+ * truncated to its final chunk. Rejects on a read/stream error.
+ *
+ * The single-line `byteCeiling` and the parse semantics are the shared runner's
+ * ({@link runSharedCSVParse}); this driver's whole contribution is to accumulate
+ * every chunk's rows on this thread. Unlike loadCSVColumnSample (whose row cap
+ * also removes real waste), this read genuinely consumes every row of the
+ * operator's own file, so the ceiling is a robustness backstop on a single
+ * pathological line, not a memory saving for well-formed input. The whole-file
+ * streaming counterpart that retains NOTHING is {@link streamCSVRows}.
+ *
+ * Caveat on `meta`: only `meta.fields` is whole-file-stable (see the runner);
+ * every current consumer reads only `data` and `meta.fields`.
+ */
+export async function loadCSVFile(
+  file: LocalFile,
+  byteCeiling: number = CSV_LINE_BYTE_CEILING,
+): Promise<Papa.ParseResult<CSVRow>> {
+  const data: Array<CSVRow> = [];
+  const errors: Array<Papa.ParseError> = [];
+  const meta = await runSharedCSVParse(
+    file,
+    byteCeiling,
+    (rows, chunkErrors) => {
+      for (const row of rows) data.push(row);
+      for (const error of chunkErrors) errors.push(error);
+    },
+  );
+  return { data, errors, meta };
+}
+
+/**
+ * Stream a CSV file to `consumeChunk`, retaining NOTHING: each PapaParse chunk's
+ * normalized rows are handed to the consumer and then dropped, so peak memory is
+ * one chunk regardless of file size. The server-side profile and coverage passes
+ * over CLI-scale mounted inputs (millions of rows, gigabytes) use this -- they
+ * accumulate only constant-size summaries (a row counter, bounded per-column
+ * samples, a running coverage count), never the rows. `consumeChunk` also receives
+ * the header column list (`meta.fields`, stable across chunks) so a consumer can
+ * key per-column state without a separate read.
+ *
+ * The SAME shared runner ({@link runSharedCSVParse}), config, single-line byte
+ * ceiling, and row normalization as {@link loadCSVFile} -- one config, two drivers
+ * -- so a streaming server pass and a browser worker wrapping loadCSVFile parse
+ * identically. Resolves with the header column list once the parse settles;
+ * rejects on a read/parse error or a ceiling trip, the same contract as
+ * loadCSVFile.
+ */
+export async function streamCSVRows(
+  file: LocalFile,
+  consumeChunk: (rows: Array<CSVRow>, columns: Array<string>) => void,
+  byteCeiling: number = CSV_LINE_BYTE_CEILING,
+): Promise<Array<string>> {
+  const meta = await runSharedCSVParse(
+    file,
+    byteCeiling,
+    (rows, _errors, chunkMeta) => consumeChunk(rows, chunkMeta.fields ?? []),
+  );
+  return meta.fields ?? [];
 }
 
 /**

--- a/packages/core/src/inferDateInputFormat.ts
+++ b/packages/core/src/inferDateInputFormat.ts
@@ -1,0 +1,73 @@
+import type { LocalFile } from "papaparse";
+
+import { CSV_LINE_BYTE_CEILING, loadCSVColumnSample } from "./file.js";
+import { inferMetadata } from "./config/metadata.js";
+import { INFER_DATE_SCAN_CAP, inferDateFormat } from "./utils/date.js";
+
+/**
+ * Resolve the date-of-birth column of a header, by running {@link inferMetadata}
+ * over the column names and taking the first column it types `date_of_birth`, or
+ * `undefined` when none is. The ONE definition of that selection, so every caller
+ * that needs to locate the DOB column for date-format inference -- the CLI's init
+ * path, the shared {@link inferDateInputFormatFromSource} below, and the web
+ * server's streaming file profile -- picks the same column and cannot drift.
+ */
+export function inferDateOfBirthColumn(
+  columns: Array<string>,
+): string | undefined {
+  return inferMetadata(columns).find((c) => c.type === "date_of_birth")?.name;
+}
+
+/** The header columns plus the inferred date-input format of a source's
+ * date-of-birth column, as {@link inferDateInputFormatFromSource} resolves them. */
+export interface InferredDateInputFormat {
+  /** The CSV header field names. */
+  columns: Array<string>;
+  /** The date-of-birth column the format was inferred from, absent when the
+   * header has none. */
+  dobColumn?: string;
+  /** The inferred `parse_date` input format for {@link dobColumn}, absent when
+   * there is no DOB column or its values yield no format signal. */
+  dateInputFormat?: string;
+}
+
+/**
+ * Read a CSV source's header and infer its date-of-birth column's date-input
+ * format, in one bounded streaming pass -- the composition every "derive a config
+ * from a file" path shares. It locates the DOB column with
+ * {@link inferDateOfBirthColumn}, samples that column's first
+ * {@link INFER_DATE_SCAN_CAP} non-empty values through {@link loadCSVColumnSample}
+ * (which stops as soon as the sample is full), and runs {@link inferDateFormat}
+ * over the sample.
+ *
+ * The bound is exact, not heuristic: the sample caps at {@link INFER_DATE_SCAN_CAP}
+ * non-empty values, the same cap {@link inferDateFormat} stops its own scan at, so
+ * the format inferred from the bounded sample is IDENTICAL to one inferred from a
+ * full-column read. That cap-exactness is what lets a caller infer the format
+ * without materializing the file: the CLI's `init` and the web server's file
+ * profile both rely on it, so a mounted CLI-scale file (millions of rows) profiles
+ * at header-plus-one-chunk peak memory rather than scaling with the file.
+ *
+ * Resolves the header columns, the resolved DOB column (absent when the header has
+ * none), and the inferred format (absent when there is no DOB column or the
+ * sample yields no format signal); rejects on a read/parse error or a single-line
+ * ceiling trip, the same contract as {@link loadCSVColumnSample}.
+ */
+export async function inferDateInputFormatFromSource(
+  file: LocalFile,
+  byteCeiling: number = CSV_LINE_BYTE_CEILING,
+): Promise<InferredDateInputFormat> {
+  const { columns, sampledColumn, sample } = await loadCSVColumnSample(
+    file,
+    inferDateOfBirthColumn,
+    INFER_DATE_SCAN_CAP,
+    byteCeiling,
+  );
+  const dateInputFormat =
+    sampledColumn !== undefined ? inferDateFormat(sample) : undefined;
+  return {
+    columns,
+    ...(sampledColumn !== undefined ? { dobColumn: sampledColumn } : {}),
+    ...(dateInputFormat !== undefined ? { dateInputFormat } : {}),
+  };
+}

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -75,10 +75,16 @@ export {
   loadCSVFile,
   loadCSVColumns,
   loadCSVColumnSample,
+  streamCSVRows,
   readRowColumn,
   CSV_LINE_BYTE_CEILING,
 } from "./file";
 export type { CSVRow } from "./file";
+export {
+  inferDateInputFormatFromSource,
+  inferDateOfBirthColumn,
+} from "./inferDateInputFormat";
+export type { InferredDateInputFormat } from "./inferDateInputFormat";
 
 export {
   inferDateFormat,

--- a/packages/core/src/standardization.ts
+++ b/packages/core/src/standardization.ts
@@ -1214,6 +1214,25 @@ export class StandardizedField {
   }
 
   /**
+   * Standardize a SINGLE row's value for this field, using the pipeline compiled
+   * once in the constructor and consulting no cache. An empty array signals the
+   * record has no valid value for this field.
+   *
+   * This is the compile-once, feed-a-row entry point a STREAMING consumer uses:
+   * it can construct the field once (paying the pipeline compile a single time)
+   * over an empty backing row set and then hand rows in as they arrive, retaining
+   * none -- the server-side coverage sweep over a CLI-scale mounted file does
+   * exactly this. {@link get} is the cached, by-index counterpart for a consumer
+   * that holds the whole row set in memory; both run the same compiled pipeline,
+   * so the two drivers cannot diverge.
+   */
+  evaluateRow(row: CSVRow): string[] {
+    const raw = readRowColumn(row, this.inputColumn);
+    if (raw === undefined) return [];
+    return toValueSet(runCompiledPipeline(raw, this.compiledSteps));
+  }
+
+  /**
    * Return the standardized values for the row at `index`.
    *
    * The result is computed on first access and cached for subsequent calls.
@@ -1224,12 +1243,7 @@ export class StandardizedField {
     if (cached !== undefined) return cached;
 
     const row = this.rawRows[index];
-    const raw = row ? readRowColumn(row, this.inputColumn) : undefined;
-    if (raw === undefined) {
-      this.cache.set(index, []);
-      return [];
-    }
-    const values = toValueSet(runCompiledPipeline(raw, this.compiledSteps));
+    const values = row ? this.evaluateRow(row) : [];
     this.cache.set(index, values);
     return values;
   }

--- a/packages/core/test/inferDateInputFormat.test.ts
+++ b/packages/core/test/inferDateInputFormat.test.ts
@@ -1,0 +1,72 @@
+import { Readable } from "node:stream";
+
+import { expect, test } from "vitest";
+
+import { inferMetadata } from "../src/config/metadata";
+import {
+  columnValues,
+  inferDateFormat,
+  INFER_DATE_SCAN_CAP,
+} from "../src/utils/date";
+import { loadCSVFile } from "../src/file";
+import {
+  inferDateInputFormatFromSource,
+  inferDateOfBirthColumn,
+} from "../src/inferDateInputFormat";
+
+function streamOf(content: string): Readable {
+  const s = new Readable({ read() {} });
+  if (content.length > 0) s.push(Buffer.from(content, "utf8"));
+  s.push(null);
+  return s;
+}
+
+const COLUMNS = ["first_name", "last_name", "dob", "member_id"];
+
+function csvWithRows(rows: number): string {
+  const body = Array.from(
+    { length: rows },
+    (_v, i) =>
+      `First${i},Last${i},1990-01-${String((i % 28) + 1).padStart(2, "0")},${i}`,
+  ).join("\n");
+  return `${COLUMNS.join(",")}\n${body}\n`;
+}
+
+test("inferDateOfBirthColumn resolves the date_of_birth column via inferMetadata", () => {
+  expect(inferDateOfBirthColumn(COLUMNS)).toBe("dob");
+  expect(
+    inferDateOfBirthColumn(COLUMNS),
+    // The one definition every caller shares.
+  ).toBe(inferMetadata(COLUMNS).find((c) => c.type === "date_of_birth")?.name);
+  expect(inferDateOfBirthColumn(["a", "b"])).toBeUndefined();
+});
+
+test("the inferred format equals inferDateFormat over the full date column", async () => {
+  const csv = csvWithRows(40);
+  const full = await loadCSVFile(streamOf(csv));
+  const inferred = await inferDateInputFormatFromSource(streamOf(csv));
+  expect(inferred.columns).toEqual(full.meta.fields);
+  expect(inferred.dobColumn).toBe("dob");
+  expect(inferred.dateInputFormat).toBe("YYYY-MM-DD");
+  expect(inferred.dateInputFormat).toBe(
+    inferDateFormat(columnValues(full.data, "dob")),
+  );
+});
+
+test("a file with no date-of-birth column yields no dobColumn and no format", async () => {
+  const inferred = await inferDateInputFormatFromSource(
+    streamOf("first_name,member_id\nAlice,1\n"),
+  );
+  expect(inferred.columns).toEqual(["first_name", "member_id"]);
+  expect(inferred.dobColumn).toBeUndefined();
+  expect(inferred.dateInputFormat).toBeUndefined();
+});
+
+test("the DOB sample is bounded to the scan cap, matching a full read's format", async () => {
+  const csv = csvWithRows(INFER_DATE_SCAN_CAP + 500);
+  const full = await loadCSVFile(streamOf(csv));
+  const inferred = await inferDateInputFormatFromSource(streamOf(csv));
+  expect(inferred.dateInputFormat).toBe(
+    inferDateFormat(columnValues(full.data, "dob")),
+  );
+});

--- a/packages/core/test/streamCSVRows.test.ts
+++ b/packages/core/test/streamCSVRows.test.ts
@@ -1,0 +1,58 @@
+import { Readable } from "node:stream";
+
+import { expect, test } from "vitest";
+
+import { CSV_LINE_BYTE_CEILING, loadCSVFile, streamCSVRows } from "../src/file";
+import type { CSVRow } from "../src/file";
+
+/** A readable emitting `content` then EOF, standing in for a CSV file/stream. */
+function streamOf(content: string): Readable {
+  const s = new Readable({ read() {} });
+  if (content.length > 0) s.push(Buffer.from(content, "utf8"));
+  s.push(null);
+  return s;
+}
+
+/** A CSV over four columns with `rows` data rows, some blanks interspersed. */
+function csvWithRows(rows: number): string {
+  const body = Array.from({ length: rows }, (_v, i) => {
+    const last = i % 5 === 0 ? "" : `Last${i}`;
+    return `First${i},${last},1990-01-${String((i % 28) + 1).padStart(2, "0")},${i}`;
+  }).join("\n");
+  return `first_name,last_name,dob,member_id\n${body}\n`;
+}
+
+test("streamCSVRows yields exactly the rows and columns loadCSVFile accumulates", async () => {
+  const csv = csvWithRows(2000);
+  const collected: Array<CSVRow> = [];
+  const columns = await streamCSVRows(streamOf(csv), (rows) => {
+    for (const row of rows) collected.push(row);
+  });
+  const full = await loadCSVFile(streamOf(csv));
+  expect(collected).toEqual(full.data);
+  expect(columns).toEqual(full.meta.fields);
+});
+
+test("streamCSVRows retains nothing: it hands each chunk's rows to the consumer", async () => {
+  const csv = csvWithRows(50);
+  let seen = 0;
+  const columns = await streamCSVRows(streamOf(csv), (rows, cols) => {
+    seen += rows.length;
+    // The header column list is available on every chunk.
+    expect(cols).toEqual(["first_name", "last_name", "dob", "member_id"]);
+  });
+  expect(seen).toBe(50);
+  expect(columns).toEqual(["first_name", "last_name", "dob", "member_id"]);
+});
+
+test("streamCSVRows resolves an empty header list for a headerless empty input", async () => {
+  const columns = await streamCSVRows(streamOf("\n"), () => undefined);
+  expect(columns).toEqual([]);
+});
+
+test("streamCSVRows enforces the single-line byte ceiling like loadCSVFile", async () => {
+  const giant = "x".repeat(CSV_LINE_BYTE_CEILING + 1024);
+  await expect(streamCSVRows(streamOf(giant), () => undefined)).rejects.toThrow(
+    /single-line limit/,
+  );
+});


### PR DESCRIPTION
## Summary

Give the console appliance its work-input surface: the server lists, profiles, and sweeps operator-mounted input CSVs through three new job-API routes, so the browser can act as control plane over a file it never holds. Admission is enumerate-then-select-by-name (the SFTP-remotes discipline generalized to a directory), reads are streaming with a flat memory ceiling at CLI scale, and the whole surface is dark unless JOB_INPUT_DIR is explicitly configured.

Implements [214995280](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=214995280).

## Changes

- packages/core: streamCSVRows, a row-consumer CSV read sharing loadCSVFile's PapaParse config and line-byte ceiling (one config, two drivers); inferDateInputFormatFromSource hoisting the CLI's DOB-pick + capped-scan + inferDateFormat composition (cap-exactness argument moves with it); StandardizedField.evaluateRow enabling per-row evaluation.
- apps/cli: init/onlineBootstrap rebased onto the core helper; loadInputRowsForInference retired; buildDataSpec gains an optional pre-inferred date format. Behavior pinned by the existing fixtures.
- apps/web/src/jobs/workInputs.ts: JOB_INPUT_DIR configuration with fail-closed startup checks (realpath once; missing/non-directory refuses boot; mutual containment with JOB_DATA_ROOT refused; set without JOB_DATA_ROOT refused), the admission discipline (lstat-regular, single-segment, no dotfiles/control chars, sorted 512-cap listing; every by-name operation re-matched against a fresh enumeration), the open recipe (O_NOFOLLOW + dev/ino fstat recheck; open-time ELOOP/ENOENT/EACCES map to the empty-bodied 404 posture), a boot diagnostic line, and a depth-one parse gate.
- apps/web/src/routes/api/jobs/inputs/: listing (configured/totalEntries/truncated), profile (one streaming constant-memory pass: columns, row count, inferred date format, first-5 samples per column), coverage (streaming per-field sweep under a submitted standardization; drift refusal against the profiled size/mtime; 1 MiB body cap; regex-source pattern-length cap; 429 backpressure). All behind the existing gate: dark 404, bad bearer 401, no-store, no CORS.
- apps/web/src/psi/nonEmptyAggregate.ts: per-row coverage accumulator shared by the browser path and the server sweep (one computation, two drivers; a row-time pipeline throw degrades that field to unavailable); previewSamples.ts extraction so server and preview share sampling semantics.
- docs/spec/SERVER_JOB_API.md: work-input endpoint sections, admission/open recipe, error semantics, O_NOFOLLOW-final-component and boot-realpath caveats, streaming/no-cache posture, the in-process pipeline tradeoff, JOB_INPUT_DIR env row.
- Tests: admission matrix, symlink/dev-ino swap and a genuine open-time race test (regular file swapped for a symlink between admission and open), gating parity, equivalence pins (profile date format equals full-rows inference; samples equal preview semantics; streaming coverage equals the batch entry point; core helper equals the CLI's prior composition).

## Test plan

Ran: root npm run test (core 2261, cli 1205, web unit 1439), web browser suite locally (483), npm run test:scripts (64), typecheck/lint/format.
New tests cover: the admission and open-recipe matrix including the genuine TOCTOU race, startup containment refusals, route gating parity, coverage schema bounds and drift refusal, and the four cross-surface equivalence pins.

## Background

Measured on a generated 5,000,000-row / 217 MB CSV: profile 6.7 s wall with 2.1 ms max event-loop stall; coverage sweep 16.1 s wall with 5.1 ms max stall. Streaming holds stalls to single-digit milliseconds at CLI scale, so no worker-thread offload is taken; the wall times inform the pending-state copy in the console UI package.

Review history: independent security review of the full branch (no findings); a three-reviewer round (7 confirmed findings, all fixed in 1eed4f7); an independent focused re-review of the fix delta (no findings).

## Out of scope / follow-on

- DEPLOYMENT.md operator story -- [214995291](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=214995291), in progress.
- The coverage route re-states intent.ts's bounded-standardization refines (kept in sync via the shared MAX_STANDARDIZATION_* constants): direct reuse creates an import cycle, and the follow-on intent package carries the shared-module extraction where it stays acyclic.
- Overlaps PR #528 in StandardizationPreview.tsx (both extract the sampling helper); whichever merges second gets rebased to unify on one module.

## Checklist

- [x] Docs: enumerated docs/ and docs/spec/ against the diff -- updated docs/spec/SERVER_JOB_API.md (endpoints, admission/open recipe, caveats, env row); the operator-facing DEPLOYMENT.md story is the docs package above, and no other page documents affected behavior.
- [x] CHANGELOG.md [Unreleased] updated -- n/a: server-side slice of a capability whose reader-facing entry is decided at the program's final docs sweep; not independently a headline feature.
- [x] Security review -- disclosure-surface review done: independent full-branch security review plus an independent re-review of the fix delta (new filesystem-read surface; what is disclosed, read from disk, and displayed).