### PR TITLE
Gate console accept to runnable exchange types

### DIFF
--- a/apps/web/src/bench/AcceptorBench.tsx
+++ b/apps/web/src/bench/AcceptorBench.tsx
@@ -13,17 +13,19 @@ import {
 
 import { emptyColumnPositions, unnameableColumnsAlert } from "@psi/columnNames";
 import { capturedInputHandle } from "@psi/managedInputHandle";
+import { columnSamplesFromRows } from "@psi/columnSamples";
 import { createManagedExchange } from "@psi/managedExchangeStore";
 import { loadCSVFileOffMainThread } from "@psi/csvParseController";
 import { prepareAcceptedInvitation } from "@psi/acceptInvitation";
 
-import { deploymentProfile } from "@utils/clientConfig";
+import { deploymentProfile, isConsoleBuild } from "@utils/clientConfig";
 import { whenDiagnostic } from "@utils/diagnostics";
 
 import {
-  rowsCoverageProvider,
+  benchCoverageProvider,
   useNonEmptyRates,
 } from "@components/useNonEmptyRates";
+import { CONSOLE_COVERAGE_PENDING_LABEL } from "@components/FieldCoverage";
 import { InvitationTerms } from "@components/InvitationTerms";
 import { MAX_CSV_FILE_BYTES } from "@components/csvIntake";
 import { setColumnTypeForMatching } from "@psi/metadataEditing";
@@ -32,6 +34,8 @@ import {
   ACCEPTOR_COLUMNS_LEDGER_FOOTER,
   ACCEPTOR_DONE_LEDGER_FOOTER,
   ACCEPTOR_LEDGER_FOOTER,
+  ACCEPT_UNSUPPORTED_MESSAGE,
+  ACCEPT_UNSUPPORTED_TITLE,
   acceptorConsentName,
   acceptorConsentReady,
   acceptorDoneLedgerRows,
@@ -41,8 +45,10 @@ import {
   acceptorLegalAgreementDisplay,
   acceptorRailFacts,
   acceptorSpine,
+  applianceRunsAccept,
   invitingPartyName,
 } from "./acceptorModel";
+import { APPLIANCE_FILE_ASSURANCE, FILE_ASSURANCE_LINE } from "./fileAssurance";
 import {
   acceptorCleaningAttention,
   acceptorColumnsEditorState,
@@ -59,13 +65,15 @@ import { AcceptorCleaningStep } from "./AcceptorCleaningStep";
 import { AcceptorColumnsStep } from "./AcceptorColumnsStep";
 import { AcceptorExchangeSection } from "./AcceptorExchangeSection";
 import { BenchShell } from "./BenchShell";
-import { FILE_ASSURANCE_LINE } from "./fileAssurance";
 import { Ledger } from "./Ledger";
 import { ManageExchangeOffer } from "./ManageExchangeOffer";
 import { Problems } from "./Problems";
+import { ServerFilePicker } from "./ServerFilePicker";
 import { TopBar } from "./TopBar";
 import { acceptorTimelineSteps } from "./exchangeRun";
+import { consoleAcquiredCsv } from "./consoleAcquiredCsv";
 import { restorablePosition } from "./stepRestore";
+import { seedRows } from "./inviterModel";
 import styles from "./bench.module.css";
 import { useAcceptorExchange } from "./useAcceptorExchange";
 import { useStepHistory } from "./useStepHistory";
@@ -86,11 +94,15 @@ import type {
   Standardization,
   StandardizationStep,
 } from "@psilink/core";
+import type { AcceptorLaunchSource } from "./useAcceptorExchange";
 import type { AcceptorStep } from "./acceptorModel";
 import type { AlertContent } from "@components/csvIntake";
+import type { BenchCoverageInput } from "@components/useNonEmptyRates";
+import type { ColumnSamples } from "@psi/columnSamples";
 import type { FieldStepOverride } from "@psi/standardizationAuthoring";
 import type { FileRejection } from "@mantine/dropzone";
 import type { IntakeAlert } from "./YourFileSection";
+import type { JobInputProfile } from "@jobs/workInputs";
 import type { ManageOfferChoices } from "./manageOfferModel";
 import type { ManageOfferStatus } from "./ManageExchangeOffer";
 import type { RailStep } from "./inviterModel";
@@ -99,6 +111,16 @@ import type { RailStep } from "./inviterModel";
  * hook's controller is not rebuilt every render on a fresh `[]` identity. */
 const EMPTY_ROWS: ReadonlyArray<CSVRow> = [];
 const EMPTY_STANDARDIZATION: Standardization = [];
+
+/** Stable "no file yet" coverage input and preview samples, so the coverage hook's
+ * provider is not rebuilt every render on a fresh identity before a file is acquired.
+ * The empty-rows coverage input drives the hosted worker provider over no rows, never
+ * a console fetch (mirrors {@link InviterBench}). */
+const EMPTY_COVERAGE_INPUT: BenchCoverageInput = {
+  kind: "rows",
+  rows: EMPTY_ROWS,
+};
+const EMPTY_COLUMN_SAMPLES: ColumnSamples = new Map();
 
 /** The columns-step sub-section: the main confirm surface, or the Cleaning tab the
  * Customize menu navigates to (mirroring how InviterBench mounts its
@@ -155,8 +177,11 @@ function fileSizeLabel(sizeBytes: number): string {
  * The acceptor's pre-columns working surface. It decodes the invitation from the
  * URL fragment (failing closed before anything renders), reviews the partner's
  * terms, captures explicit consent and a name, and takes the acceptor's file --
- * then parses it behind the consent gate and hands off to the (stubbed) confirm-
- * columns step.
+ * then commits it behind the consent gate (parsing it in the browser on the hosted
+ * build, or referencing the appliance-profiled mounted file on the console) and
+ * hands off to the confirm-columns step. On the console an invitation whose endpoint
+ * the appliance cannot run (a WebRTC accept) is stopped at the review step with an
+ * honest state before consent or intake.
  *
  * The consent semantics are re-surfaced from the hardened legacy flow, never
  * re-derived: {@link InvitationTerms} renders the full, never-condensed terms at
@@ -165,6 +190,7 @@ function fileSizeLabel(sizeBytes: number): string {
  * re-check inside the handler, exactly as the legacy accept flow did.
  */
 export function AcceptorBench() {
+  const consoleBuild = isConsoleBuild();
   const [decode, setDecode] = useState<DecodeState>({ status: "pending" });
   const [step, setStep] = useState<AcceptorStep>("review");
   // The columns-step sub-section: the confirm surface, or the Cleaning tab the
@@ -197,6 +223,13 @@ export function AcceptorBench() {
   // managed deposit can persist a reusable pointer to the input without a second
   // picker dialog. Absent for a click-selected file and a browser without the API.
   const [sourceHandle, setSourceHandle] = useState<FileSystemFileHandle>();
+  // The console profile behind the acquired shape: the appliance reads the file, so
+  // the browser holds only the profile (name, size, mtime, columns, samples, date
+  // format), committed via the picker's "Use this file" before consent. It backs the
+  // columns seed, the run's mounted-file reference, the coverage sweep, the preview
+  // samples, and the authoring-time drift signal. Undefined on the hosted build, which
+  // reads the file in the browser behind the consent gate instead.
+  const [consoleSource, setConsoleSource] = useState<JobInputProfile>();
   const [columnsState, setColumnsState] = useState<AcceptorColumnsState>();
   const [manageStatus, setManageStatus] = useState<ManageOfferStatus>("idle");
   // The launched exchange (the assembled edits + optional advisory); rendering the
@@ -237,17 +270,31 @@ export function AcceptorBench() {
     return () => controller.abort();
   }, []);
 
+  // A console accept whose endpoint the appliance cannot run today (a WebRTC
+  // invitation: the appliance has no in-tab exchange yet and holds no file rows in
+  // the browser to run one with). Surfaced at the review step BEFORE consent or
+  // intake, so the operator meets an honest "this appliance cannot run this exchange
+  // type yet" state naming what it CAN run rather than a doomed run. Off the console
+  // every admitted endpoint runs in the browser, so this is always false there.
+  const unsupported =
+    consoleBuild &&
+    decode.status === "ready" &&
+    !applianceRunsAccept(decode.invitation.endpoint.channel);
+
   // On the review step, move focus to the terms heading once the decode resolves
-  // to ready, or to the error alert once it resolves to error, so a screen-reader
-  // user is taken to the revealed terms or the failure rather than left on the
+  // to ready, to the unsupported notice when the appliance cannot run this accept,
+  // or to the error alert once it resolves to error, so a screen-reader user is
+  // taken to the revealed terms, the block, or the failure rather than left on the
   // spinner. The consent and columns steps own their own heading focus below.
   const termsHeadingRef = useRef<HTMLHeadingElement>(null);
+  const unsupportedRef = useRef<HTMLDivElement>(null);
   const errorRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (step !== "review") return;
-    if (decode.status === "ready") termsHeadingRef.current?.focus();
+    if (decode.status === "ready")
+      (unsupported ? unsupportedRef : termsHeadingRef).current?.focus();
     else if (decode.status === "error") errorRef.current?.focus();
-  }, [decode.status, step]);
+  }, [decode.status, step, unsupported]);
 
   // Moving to the consent step replaces the work column, so focus is sent to the
   // incoming h1 (it carries tabIndex -1) or a screen-reader user is left on a control
@@ -315,11 +362,12 @@ export function AcceptorBench() {
 
   const { pushStep } = useStepHistory("review", restorePosition);
 
-  // The unload guard arms once the acceptor's file is chosen and disarms once
-  // the exchange is launched (the run is dialing); leaving a launched exchange
-  // costs nothing the acceptor has not already committed.
+  // The unload guard arms once the acceptor's file is chosen -- a browser drop on
+  // the hosted build, or a committed mounted-file profile on the console -- and
+  // disarms once the exchange is launched (the run is dialing); leaving a launched
+  // exchange costs nothing the acceptor has not already committed.
   useUnloadGuard({
-    hasFile: file !== undefined,
+    hasFile: file !== undefined || consoleSource !== undefined,
     finalized: launched !== undefined,
   });
 
@@ -342,6 +390,15 @@ export function AcceptorBench() {
     setFile(chosen);
   }
 
+  // The file-assurance line for the acceptor's own intake: with the console now
+  // reading the file on the appliance, the acceptor opts into the mounted-directory
+  // claim explicitly (as the inviter's YourFileSection does), while the hosted build
+  // keeps the browser-only line. Not FILE_ASSURANCE_LINE alone -- that resolves to no
+  // claim on the console, which would leave this truthful surface silent.
+  const acceptAssuranceLine = consoleBuild
+    ? APPLIANCE_FILE_ASSURANCE
+    : FILE_ASSURANCE_LINE;
+
   // The dropzone enforces the size cap and type list itself but only flashes a
   // reject icon; name why. Codes only in the log -- a rejected file's NAME can
   // itself be sensitive here.
@@ -363,22 +420,81 @@ export function AcceptorBench() {
     );
   }
 
+  // Commit a profiled mounted file (the console picker's "Use this file") to the
+  // consent step. A blank header cell is refused early with the shared unnameable
+  // alert -- core's inferMetadata would otherwise throw when the columns-step editor
+  // seeds and unmount the bench. The editor is seeded here from the profile's column
+  // NAMES (which the operator already saw in the picker's confirm panel, not from
+  // file content), reconciling a re-profile of the committed file the way the inviter
+  // does: unchanged columns keep the operator's remaps and cleaning edits, changed
+  // columns reseed. `acquired` stays unset until the consent gate passes, so the
+  // columns step is still gated on "Accept and continue".
+  function commitConsoleAcceptFile(profile: JobInputProfile) {
+    const emptyPositions = emptyColumnPositions(profile.columns);
+    if (emptyPositions.length > 0) {
+      setParseAlert(unnameableColumnsAlert(emptyPositions));
+      return;
+    }
+    setParseAlert(undefined);
+    setFieldErrors((current) => ({ ...current, file: false }));
+    const columnsUnchanged =
+      consoleSource !== undefined &&
+      consoleSource.name === profile.name &&
+      columnsState !== undefined &&
+      consoleSource.columns.length === profile.columns.length &&
+      consoleSource.columns.every(
+        (column, index) => column === profile.columns[index],
+      );
+    setConsoleSource(profile);
+    if (!columnsUnchanged)
+      setColumnsState(acceptorInitialColumnsState(profile.columns));
+  }
+
   // "Accept and continue": re-check the consent gate in the handler (not the
   // disabled state alone), surface the mockup's inline errors when a submit slips
-  // past it, then parse the file behind the gate with the inviter bench's intake
-  // checks. Only a clean parse advances to the confirm-columns step.
+  // past it, then commit the file behind the gate. On the hosted build the file is
+  // parsed here (the browser holds the rows); on the console the appliance already
+  // profiled it, so the acquired shape is built from the committed profile (no rows,
+  // no parse). Only a clean commit advances to the confirm-columns step.
   async function acceptAndContinue() {
     if (decode.status !== "ready") return;
     const name = acceptorConsentName({ consented, name: acceptorName });
-    const nextErrors: FieldErrors = {};
-    if (name === undefined && acceptorName.trim() === "")
-      nextErrors.name = "Your name is required";
-    if (file === undefined) nextErrors.file = true;
-    if (name === undefined || file === undefined) {
+    const fileChosen = consoleBuild
+      ? consoleSource !== undefined
+      : file !== undefined;
+    if (name === undefined || !fileChosen) {
+      const nextErrors: FieldErrors = {};
+      if (name === undefined && acceptorName.trim() === "")
+        nextErrors.name = "Your name is required";
+      if (!fileChosen) nextErrors.file = true;
       setFieldErrors(nextErrors);
       return;
     }
     setFieldErrors({});
+
+    if (consoleBuild) {
+      // The console reads the file on the appliance: the profile was committed and
+      // the columns seeded via the picker, so there is no browser parse behind the
+      // gate. Build the acquired shape from the profile (rows withheld) and advance,
+      // committing the gate-checked name so the run records it even if the input is
+      // later edited.
+      if (consoleSource === undefined) return;
+      setCommittedName(name);
+      setAcquired(
+        consoleAcquiredCsv({
+          fileName: consoleSource.name,
+          sizeBytes: consoleSource.sizeBytes,
+          columns: consoleSource.columns,
+          rowCount: consoleSource.rowCount,
+          dateInputFormat: consoleSource.dateInputFormat,
+        }),
+      );
+      goToStep("columns");
+      return;
+    }
+
+    // Narrows `file` for the hosted parse below (the `fileChosen` boolean does not).
+    if (file === undefined) return;
     const id = ++parseId.current;
     parseAbort.current?.abort();
     const controller = new AbortController();
@@ -444,7 +560,7 @@ export function AcceptorBench() {
       ? acceptorColumnsEditorState(
           columnsState,
           linkageTerms,
-          acquired.rawRows,
+          seedRows(acquired),
           acquired.dateInputFormat,
         )
       : undefined;
@@ -465,32 +581,77 @@ export function AcceptorBench() {
     if (
       launched === undefined ||
       decode.status !== "ready" ||
-      acquired === undefined ||
-      acceptedFile === undefined
+      acquired === undefined
     )
       return undefined;
+    // The run's input source: the console's mounted-file reference (no content
+    // transits the browser), or the hosted browser File the server-job inline path
+    // reads. The WebRTC path uses the retained rows and never reads it.
+    const inputSource: AcceptorLaunchSource | undefined =
+      consoleSource !== undefined
+        ? {
+            kind: "workFile",
+            name: consoleSource.name,
+            sizeBytes: consoleSource.sizeBytes,
+            modifiedAt: consoleSource.modifiedAt,
+          }
+        : acceptedFile !== undefined
+          ? { kind: "inline", file: acceptedFile }
+          : undefined;
+    if (inputSource === undefined) return undefined;
     return {
       invitation: decode.invitation,
       acceptorName: committedName,
-      rawRows: acquired.rawRows,
+      rawRows: seedRows(acquired),
       columns: acquired.columns,
       edits: launched.edits,
-      sourceFile: acceptedFile,
+      inputSource,
     };
     // `launched` is the launch key: it is set once, from the same render that
-    // fixes the acquired CSV, its source file, the committed name, and the ready
+    // fixes the acquired CSV, its input source, the committed name, and the ready
     // decode, so keying the memo on it alone cannot go stale.
   }, [launched]);
 
   const { run, outputs, failure, tryAgain } = useAcceptorExchange({ launch });
 
+  // The coverage input, unified across builds: the browser's parsed rows on the
+  // hosted build, the mounted-file reference on the console (whose sweep is a fetch
+  // to the appliance). Memoized so a standardization edit reuses the provider and
+  // only a new file rebuilds it. The console reads no rows -- `acquired.rawRows` is a
+  // throwing getter there -- so this never touches it on that path.
+  const coverageInput = useMemo<BenchCoverageInput>(() => {
+    if (consoleSource !== undefined)
+      return {
+        kind: "workFile",
+        reference: {
+          name: consoleSource.name,
+          sizeBytes: consoleSource.sizeBytes,
+          modifiedAt: consoleSource.modifiedAt,
+        },
+      };
+    if (!consoleBuild && acquired !== undefined)
+      return { kind: "rows", rows: acquired.rawRows };
+    return EMPTY_COVERAGE_INPUT;
+  }, [acquired, consoleSource, consoleBuild]);
+
+  // The per-column preview samples the Cleaning tab reads: computed from the browser
+  // rows on the hosted build, read from the server-side profile on the console. Kept
+  // off `acquired.rawRows` on the console for the same reason as the coverage input.
+  const columnSamples = useMemo<ColumnSamples>(() => {
+    if (consoleSource !== undefined)
+      return new Map(Object.entries(consoleSource.columnSamples));
+    if (!consoleBuild && acquired !== undefined)
+      return columnSamplesFromRows(acquired.rawRows, acquired.columns);
+    return EMPTY_COLUMN_SAMPLES;
+  }, [acquired, consoleSource, consoleBuild]);
+
   // Full-CSV coverage for the cleaning tab and the Customize menu's
   // Cleaning-attention value, one sweep shared by both. The hook must run
-  // every render, so it takes empty inputs until a file is acquired.
+  // every render, so it takes stable empty inputs until a file is acquired.
   const { rates, pending: ratesPending } = useNonEmptyRates(
-    acquired?.rawRows ?? EMPTY_ROWS,
+    coverageInput,
     editorState?.standardization ?? EMPTY_STANDARDIZATION,
-    rowsCoverageProvider,
+    benchCoverageProvider,
   );
   const cleaningAttention =
     editorState !== undefined && verdict !== undefined
@@ -671,6 +832,17 @@ export function AcceptorBench() {
     goToStep("columns");
   };
 
+  // The console mounted-file recovery: a create rejected the file (drifted, removed,
+  // or out of space since selection), so the recovery lives back at the consent-and-
+  // file step, where a re-profile refreshes it. Discards the launch exactly as
+  // backToColumns does, but lands on the file step -- the fault is the file, not the
+  // terms.
+  const backToFile = () => {
+    setLaunched(undefined);
+    setManageStatus("idle");
+    goToStep("consent");
+  };
+
   // Deposit a managed-exchange record for this exchange as the acceptor: this
   // party's own perspective of the terms plus the secret carried in the
   // invitation link, so the same partnership can run again later. The connection
@@ -772,11 +944,27 @@ export function AcceptorBench() {
               headingOrder={1}
               headingRef={termsHeadingRef}
             />
-            <div className={styles.workFoot}>
-              <Button onClick={() => goToStep("consent")}>
-                Continue: consent &amp; your file
-              </Button>
-            </div>
+            {/* The appliance cannot run this endpoint (a WebRTC accept on the
+                console): stop here, before consent or intake, with an honest state
+                naming what the appliance CAN run rather than a doomed run. */}
+            {unsupported ? (
+              <Alert
+                color="orange"
+                icon={<IconAlertCircle aria-hidden />}
+                title={ACCEPT_UNSUPPORTED_TITLE}
+                ref={unsupportedRef}
+                tabIndex={-1}
+                mt="md"
+              >
+                {ACCEPT_UNSUPPORTED_MESSAGE}
+              </Alert>
+            ) : (
+              <div className={styles.workFoot}>
+                <Button onClick={() => goToStep("consent")}>
+                  Continue: consent &amp; your file
+                </Button>
+              </div>
+            )}
           </>
         )}
         {decode.status === "ready" && step === "consent" && (
@@ -785,7 +973,9 @@ export function AcceptorBench() {
             <h1 tabIndex={-1}>Consent &amp; your file</h1>
             <p className={`${styles.small} ${styles.sub}`}>
               This invitation should have reached you over a trusted channel.
-              Your browser connects directly to your partner.
+              {consoleBuild
+                ? " This appliance runs the exchange from its mounted work directory."
+                : " Your browser connects directly to your partner."}
             </p>
             <Checkbox
               mt="md"
@@ -811,64 +1001,87 @@ export function AcceptorBench() {
                   }));
               }}
             />
-            <Dropzone
-              className={styles.dropzone}
-              openRef={openFilePicker}
-              onDrop={(files) => {
-                const chosen = files.at(0);
-                if (chosen !== undefined) selectFile(chosen);
-              }}
-              onReject={handleReject}
-              accept={["text/plain", "text/csv", "application/vnd.ms-excel"]}
-              maxSize={MAX_CSV_FILE_BYTES}
-              multiple={false}
-              loading={parsing}
-              aria-label="Your data file"
-              mt="md"
-            >
-              <p>
-                <strong>Drag files here or click to select</strong>
-              </p>
-              <p className={styles.dropzoneMax}>(Max file size: {maxMb} MB)</p>
-            </Dropzone>
-            {rejectionMessage !== undefined && (
-              <Text role="alert" c="red" size="sm" mt="xs">
-                {rejectionMessage}
-              </Text>
-            )}
-            {file !== undefined && (
-              <div className={styles.fileCard}>
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.8"
-                  aria-hidden="true"
+            {consoleBuild ? (
+              <ServerFilePicker
+                committed={
+                  consoleSource !== undefined
+                    ? {
+                        name: consoleSource.name,
+                        sizeBytes: consoleSource.sizeBytes,
+                        modifiedAt: consoleSource.modifiedAt,
+                      }
+                    : undefined
+                }
+                onUse={commitConsoleAcceptFile}
+              />
+            ) : (
+              <>
+                <Dropzone
+                  className={styles.dropzone}
+                  openRef={openFilePicker}
+                  onDrop={(files) => {
+                    const chosen = files.at(0);
+                    if (chosen !== undefined) selectFile(chosen);
+                  }}
+                  onReject={handleReject}
+                  accept={[
+                    "text/plain",
+                    "text/csv",
+                    "application/vnd.ms-excel",
+                  ]}
+                  maxSize={MAX_CSV_FILE_BYTES}
+                  multiple={false}
+                  loading={parsing}
+                  aria-label="Your data file"
+                  mt="md"
                 >
-                  <path d="M13 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V9z" />
-                  <path d="M13 3v6h6" />
-                </svg>
-                <div>
-                  <div className={`${styles.fileName} ${styles.mono}`}>
-                    {file.name}
+                  <p>
+                    <strong>Drag files here or click to select</strong>
+                  </p>
+                  <p className={styles.dropzoneMax}>
+                    (Max file size: {maxMb} MB)
+                  </p>
+                </Dropzone>
+                {rejectionMessage !== undefined && (
+                  <Text role="alert" c="red" size="sm" mt="xs">
+                    {rejectionMessage}
+                  </Text>
+                )}
+                {file !== undefined && (
+                  <div className={styles.fileCard}>
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      aria-hidden="true"
+                    >
+                      <path d="M13 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V9z" />
+                      <path d="M13 3v6h6" />
+                    </svg>
+                    <div>
+                      <div className={`${styles.fileName} ${styles.mono}`}>
+                        {file.name}
+                      </div>
+                      <div className={`${styles.fileMeta} ${styles.mono}`}>
+                        {fileSizeLabel(file.size)}
+                      </div>
+                    </div>
+                    <Button
+                      variant="subtle"
+                      size="compact-sm"
+                      ml="auto"
+                      onClick={() => openFilePicker.current?.()}
+                    >
+                      Choose a different file
+                    </Button>
                   </div>
-                  <div className={`${styles.fileMeta} ${styles.mono}`}>
-                    {fileSizeLabel(file.size)}
-                  </div>
-                </div>
-                <Button
-                  variant="subtle"
-                  size="compact-sm"
-                  ml="auto"
-                  onClick={() => openFilePicker.current?.()}
-                >
-                  Choose a different file
-                </Button>
-              </div>
+                )}
+              </>
             )}
-            {FILE_ASSURANCE_LINE !== undefined && (
+            {acceptAssuranceLine !== undefined && (
               <p className={`${styles.small} ${styles.sub}`}>
-                {FILE_ASSURANCE_LINE}
+                {acceptAssuranceLine}
               </p>
             )}
             {fieldErrors.file === true && (
@@ -878,8 +1091,9 @@ export function AcceptorBench() {
                 icon={<IconAlertCircle aria-hidden />}
                 mt="md"
               >
-                A file is needed before the exchange can be set up. Drag one
-                into the dropzone or click it to select.
+                {consoleBuild
+                  ? "A file is needed before the exchange can be set up. Choose one from the work directory above."
+                  : "A file is needed before the exchange can be set up. Drag one into the dropzone or click it to select."}
               </Alert>
             )}
             {parseAlert !== undefined && (
@@ -968,11 +1182,14 @@ export function AcceptorBench() {
               declaredFields={linkageTerms.linkageFields}
               metadata={editorState.metadata}
               standardization={editorState.standardization}
-              rawRows={acquired.rawRows}
+              columnSamples={columnSamples}
               rates={rates}
               ratesPending={ratesPending}
               deadKeyCount={verdict.deadKeyCount}
               cleaningResetKey={cleaningResetKey}
+              {...(consoleSource !== undefined
+                ? { coveragePendingLabel: CONSOLE_COVERAGE_PENDING_LABEL }
+                : {})}
               onFieldSteps={setFieldSteps}
               onFieldInput={setFieldInput}
               onReset={resetColumns}
@@ -989,6 +1206,7 @@ export function AcceptorBench() {
               warning={launched?.warning}
               onTryAgain={tryAgain}
               onFixColumns={backToColumns}
+              onRefreshFile={backToFile}
             />
             {/* The manage offer is webrtc-only (its record composes a webrtc
                 locator from the invitation's endpoint) and is skippable: leaving

--- a/apps/web/src/bench/AcceptorBench.tsx
+++ b/apps/web/src/bench/AcceptorBench.tsx
@@ -34,8 +34,8 @@ import {
   ACCEPTOR_COLUMNS_LEDGER_FOOTER,
   ACCEPTOR_DONE_LEDGER_FOOTER,
   ACCEPTOR_LEDGER_FOOTER,
-  ACCEPT_UNSUPPORTED_MESSAGE,
   ACCEPT_UNSUPPORTED_TITLE,
+  acceptUnsupportedMessage,
   acceptorConsentName,
   acceptorConsentReady,
   acceptorDoneLedgerRows,
@@ -180,8 +180,8 @@ function fileSizeLabel(sizeBytes: number): string {
  * then commits it behind the consent gate (parsing it in the browser on the hosted
  * build, or referencing the appliance-profiled mounted file on the console) and
  * hands off to the confirm-columns step. On the console an invitation whose endpoint
- * the appliance cannot run (a WebRTC accept) is stopped at the review step with an
- * honest state before consent or intake.
+ * the appliance cannot run -- no accept channel is appliance-runnable today -- is
+ * stopped at the review step with an honest state before consent or intake.
  *
  * The consent semantics are re-surfaced from the hardened legacy flow, never
  * re-derived: {@link InvitationTerms} renders the full, never-condensed terms at
@@ -270,12 +270,13 @@ export function AcceptorBench() {
     return () => controller.abort();
   }, []);
 
-  // A console accept whose endpoint the appliance cannot run today (a WebRTC
-  // invitation: the appliance has no in-tab exchange yet and holds no file rows in
-  // the browser to run one with). Surfaced at the review step BEFORE consent or
-  // intake, so the operator meets an honest "this appliance cannot run this exchange
-  // type yet" state naming what it CAN run rather than a doomed run. Off the console
-  // every admitted endpoint runs in the browser, so this is always false there.
+  // A console accept whose endpoint the appliance cannot run today. No admitted
+  // channel is runnable on the appliance yet: a WebRTC accept has no in-tab exchange,
+  // and a file-drop accept's server job polls a private per-job directory the partner
+  // cannot reach ({@link applianceRunsAccept}). Surfaced at the review step BEFORE
+  // consent or intake, so the operator meets an honest "this appliance cannot run this
+  // exchange type yet" state naming where it CAN run rather than a doomed run. Off the
+  // console every admitted endpoint runs in the browser, so this is always false there.
   const unsupported =
     consoleBuild &&
     decode.status === "ready" &&
@@ -944,9 +945,10 @@ export function AcceptorBench() {
               headingOrder={1}
               headingRef={termsHeadingRef}
             />
-            {/* The appliance cannot run this endpoint (a WebRTC accept on the
-                console): stop here, before consent or intake, with an honest state
-                naming what the appliance CAN run rather than a doomed run. */}
+            {/* The appliance cannot run this endpoint (no console accept channel
+                runs today): stop here, before consent or intake, with an honest
+                per-channel state naming where the operator CAN run it rather than a
+                doomed run. */}
             {unsupported ? (
               <Alert
                 color="orange"
@@ -956,7 +958,7 @@ export function AcceptorBench() {
                 tabIndex={-1}
                 mt="md"
               >
-                {ACCEPT_UNSUPPORTED_MESSAGE}
+                {acceptUnsupportedMessage(decode.invitation.endpoint.channel)}
               </Alert>
             ) : (
               <div className={styles.workFoot}>

--- a/apps/web/src/bench/AcceptorCleaningStep.tsx
+++ b/apps/web/src/bench/AcceptorCleaningStep.tsx
@@ -9,17 +9,16 @@ import { isSilentEmpty } from "@psi/nonEmptyAggregate";
 import { CleaningErrorBoundary } from "@components/CleaningErrorBoundary";
 import { FieldCoverage } from "@components/FieldCoverage";
 import { StandardizationCards } from "@components/StandardizationCards";
-import { columnSamplesFromRows } from "@psi/columnSamples";
 
 import styles from "./bench.module.css";
 
 import type {
-  CSVRow,
   LinkageField,
   Metadata,
   Standardization,
   StandardizationStep,
 } from "@psilink/core";
+import type { ColumnSamples } from "@psi/columnSamples";
 import type { FieldValueCoverage } from "@psi/nonEmptyAggregate";
 
 /**
@@ -31,18 +30,21 @@ import type { FieldValueCoverage } from "@psi/nonEmptyAggregate";
  * amber not red, routing the fix to the partner.
  *
  * Presentational over the shared column-step state the bench owns; the full-CSV
- * coverage (`rates`) is computed by the bench's `useNonEmptyRates` and passed in, so
- * one sweep drives both this tab and the Customize menu's Cleaning-attention value.
+ * coverage (`rates`) and the per-column preview samples are computed by the bench
+ * (from the browser rows on the hosted build, read from the server-side profile on
+ * the console) and passed in, so one sweep drives both this tab and the Customize
+ * menu's Cleaning-attention value and the console never reads rows it does not hold.
  */
 export function AcceptorCleaningStep({
   declaredFields,
   metadata,
   standardization,
-  rawRows,
+  columnSamples,
   rates,
   ratesPending,
   deadKeyCount,
   cleaningResetKey,
+  coveragePendingLabel,
   onFieldSteps,
   onFieldInput,
   onReset,
@@ -53,7 +55,9 @@ export function AcceptorCleaningStep({
   declaredFields: Array<LinkageField>;
   metadata: Metadata;
   standardization: Standardization;
-  rawRows: Array<CSVRow>;
+  /** The per-column preview samples, keyed by input-column name: the browser rows'
+   * samples on the hosted build, the profiled samples on the console. */
+  columnSamples: ColumnSamples;
   /** Full-CSV per-field coverage, or null before the first sweep settles. */
   rates: ReadonlyMap<string, FieldValueCoverage> | null;
   ratesPending: boolean;
@@ -62,6 +66,10 @@ export function AcceptorCleaningStep({
   /** A signature of each field's input binding, so a remap or reset auto-recovers
    * the cleaning error boundary. */
   cleaningResetKey: string;
+  /** The coverage pending-placeholder copy: the console passes the whole-file
+   * appliance-sweep phrasing, so the readout does not read as an instant local
+   * check. Undefined keeps the default local copy. */
+  coveragePendingLabel?: string;
   onFieldSteps: (output: string, steps: Array<StandardizationStep>) => void;
   onFieldInput: (output: string, column: string) => void;
   onReset: () => void;
@@ -75,16 +83,6 @@ export function AcceptorCleaningStep({
   const fieldByName = useMemo(
     () => new Map(declaredFields.map((field) => [field.name, field])),
     [declaredFields],
-  );
-  // The per-column preview samples, drawn from the rows once for the whole tab so a
-  // field rebound to another column finds its sample by lookup.
-  const columnSamples = useMemo(
-    () =>
-      columnSamplesFromRows(
-        rawRows,
-        metadata.map((column) => column.name),
-      ),
-    [rawRows, metadata],
   );
 
   // The safe labels of the fields whose transform drops every row, for the one
@@ -159,6 +157,9 @@ export function AcceptorCleaningStep({
             <FieldCoverage
               rate={rates?.get(output)}
               pending={rates !== null && ratesPending}
+              {...(coveragePendingLabel !== undefined
+                ? { pendingLabel: coveragePendingLabel }
+                : {})}
             />
           )}
           isFieldSilentEmpty={(output) => {

--- a/apps/web/src/bench/AcceptorExchangeSection.tsx
+++ b/apps/web/src/bench/AcceptorExchangeSection.tsx
@@ -45,6 +45,7 @@ export function AcceptorExchangeSection({
   warning,
   onTryAgain,
   onFixColumns,
+  onRefreshFile,
 }: {
   invitation: AcceptableInvitation;
   run: ExchangeRun;
@@ -54,9 +55,13 @@ export function AcceptorExchangeSection({
    * the run and cleared on a failure. */
   warning: AlertContent | undefined;
   onTryAgain: () => void;
-  /** Return to the confirm-columns step with every setting intact -- the config
-   * failure's recovery, since the acceptor fixes its own settings there. */
+  /** Return to the confirm-columns step with every setting intact -- a prepare-time
+   * config failure's recovery, since the acceptor fixes its own settings there. */
   onFixColumns: () => void;
+  /** Return to the consent-and-file step to re-profile the mounted file -- the
+   * console mounted-file create rejection's recovery ({@link RunFailure.recovery}
+   * `refresh-file`), where the fault is the file, not the terms. */
+  onRefreshFile: () => void;
 }) {
   const phase = outputs !== undefined ? "done" : "running";
 
@@ -132,14 +137,34 @@ export function AcceptorExchangeSection({
                 Start over with a fresh invitation
               </Button>
             )}
+          {/* A console mounted-file create rejection (drifted, removed, or out of
+              space): the fault is the file, so recovery returns to the consent-and-
+              file step to re-profile it, not to the columns the operator authored. */}
+          {failure.category === "config" &&
+            failure.recovery === "refresh-file" && (
+              <Button
+                color="red"
+                variant="light"
+                mt="sm"
+                onClick={onRefreshFile}
+              >
+                Return to your file
+              </Button>
+            )}
           {/* A prepare-time fault in this party's own settings: the acceptor
               fixes it on the confirm-columns step with every input intact, so
               the recovery returns there rather than re-running as-is. */}
-          {failure.category === "config" && (
-            <Button color="red" variant="light" mt="sm" onClick={onFixColumns}>
-              Back to your columns
-            </Button>
-          )}
+          {failure.category === "config" &&
+            failure.recovery !== "refresh-file" && (
+              <Button
+                color="red"
+                variant="light"
+                mt="sm"
+                onClick={onFixColumns}
+              >
+                Back to your columns
+              </Button>
+            )}
         </FailureAlert>
       )}
       {/* The confirm-columns partial-coverage advisory, kept visible through the

--- a/apps/web/src/bench/acceptorModel.ts
+++ b/apps/web/src/bench/acceptorModel.ts
@@ -395,18 +395,21 @@ type AcceptEndpointChannel = AcceptableInvitation["endpoint"]["channel"];
 
 /**
  * Whether the console appliance can carry out an accepted invitation's endpoint
- * itself. The appliance runs a file-drop accept as a server job over its mounted
- * work directory, but has no in-tab WebRTC exchange yet (that awaits the Node WebRTC
- * and proxy interconnectivity work) and holds no file rows in the browser to run one
- * with, so a WebRTC accept cannot run on a console build. Keyed exhaustively off the
- * admitted channel so a widened accept-endpoint union fails to compile until its
- * appliance-runnability is decided -- the allowlist discipline CONTRIBUTING requires
- * for transport branching. Off the console every admitted endpoint runs in the
- * browser, so the caller consults this only on a console build.
+ * itself. Neither admitted channel is runnable on a console build today: a WebRTC
+ * accept has no in-tab exchange (that awaits the Node WebRTC and proxy
+ * interconnectivity work) and holds no file rows in the browser to run one with, and
+ * a file-drop accept's server job polls a private per-job directory the partner
+ * cannot reach -- the invitation's own shared-directory locator is never routed into
+ * the run (that awaits the shared-rendezvous interconnectivity work), so it would
+ * hang rather than rendezvous. Keyed exhaustively off the admitted channel so a
+ * widened accept-endpoint union fails to compile until its appliance-runnability is
+ * decided -- the allowlist discipline CONTRIBUTING requires for transport branching.
+ * Off the console every admitted endpoint runs in the browser, so the caller consults
+ * this only on a console build.
  */
 const APPLIANCE_RUNS_ACCEPT: Record<AcceptEndpointChannel, boolean> = {
   webrtc: false,
-  filedrop: true,
+  filedrop: false,
 };
 
 /** Whether the console appliance can run an accepted invitation's endpoint channel
@@ -416,16 +419,35 @@ export function applianceRunsAccept(channel: AcceptEndpointChannel): boolean {
 }
 
 /** The honest title for a console accept whose endpoint the appliance cannot run
- * today ({@link applianceRunsAccept}), in the inviter chooser's
- * "planned capability for this appliance" register. */
+ * today ({@link applianceRunsAccept}), in the "planned capability for this
+ * appliance" register. */
 export const ACCEPT_UNSUPPORTED_TITLE =
   "This appliance cannot run this exchange type yet";
 
-/** The unsupported-accept body: names what the appliance CAN run (shared-directory
- * exchanges from the mounted work directory) so the operator is not left at a dead
- * end with a doomed run. */
-export const ACCEPT_UNSUPPORTED_MESSAGE =
-  "This invitation runs an in-browser (WebRTC) exchange. This appliance runs " +
-  "shared-directory exchanges from its mounted work directory, and its in-browser " +
-  "exchange support is a planned capability. Ask your partner for a shared-directory " +
-  "invitation to run it on this appliance.";
+/**
+ * The honest unsupported-accept body per admitted channel: each names why the
+ * appliance cannot run the exchange and where the operator CAN run it, so the
+ * operator is not left at a dead end with a doomed run. A WebRTC accept needs a
+ * browser, so it points at a standard web deployment; a file-drop accept runs in
+ * the command-line tool, which reaches the partner's shared directory the appliance
+ * cannot.
+ */
+const ACCEPT_UNSUPPORTED_MESSAGE: Record<AcceptEndpointChannel, string> = {
+  webrtc:
+    "This invitation runs an in-browser (WebRTC) exchange. Running an in-tab " +
+    "exchange on this appliance is a planned capability; until it ships, accept " +
+    "this invitation from a standard psilink web app in your browser.",
+  filedrop:
+    "This invitation runs over a shared directory both parties reach. This " +
+    "appliance runs each exchange in a private working directory your partner " +
+    "cannot reach, so it cannot complete a shared-directory accept yet. Accept it " +
+    "with the psilink command-line tool instead.",
+};
+
+/** The honest unsupported-accept body for an accepted endpoint's channel
+ * ({@link ACCEPT_UNSUPPORTED_MESSAGE}). */
+export function acceptUnsupportedMessage(
+  channel: AcceptEndpointChannel,
+): string {
+  return ACCEPT_UNSUPPORTED_MESSAGE[channel];
+}

--- a/apps/web/src/bench/acceptorModel.ts
+++ b/apps/web/src/bench/acceptorModel.ts
@@ -7,6 +7,7 @@ import { dateTimeLabel } from "./inviterModel";
 
 import type { InvitationToken, LinkageTerms, Metadata } from "@psilink/core";
 import type { RailFact, RailStepState } from "./inviterModel";
+import type { AcceptableInvitation } from "@psi/acceptInvitation";
 
 /**
  * The pure model behind the acceptor bench's three-step spine: the step
@@ -386,3 +387,45 @@ export function acceptorLegalAgreementDisplay(
       sanitized.expirationDate !== raw.expirationDate,
   };
 }
+
+/** The connection-endpoint channels an accepted invitation can carry, narrowed
+ * from the token by {@link prepareAcceptedInvitation}: WebRTC always, file-drop on
+ * a console build. */
+type AcceptEndpointChannel = AcceptableInvitation["endpoint"]["channel"];
+
+/**
+ * Whether the console appliance can carry out an accepted invitation's endpoint
+ * itself. The appliance runs a file-drop accept as a server job over its mounted
+ * work directory, but has no in-tab WebRTC exchange yet (that awaits the Node WebRTC
+ * and proxy interconnectivity work) and holds no file rows in the browser to run one
+ * with, so a WebRTC accept cannot run on a console build. Keyed exhaustively off the
+ * admitted channel so a widened accept-endpoint union fails to compile until its
+ * appliance-runnability is decided -- the allowlist discipline CONTRIBUTING requires
+ * for transport branching. Off the console every admitted endpoint runs in the
+ * browser, so the caller consults this only on a console build.
+ */
+const APPLIANCE_RUNS_ACCEPT: Record<AcceptEndpointChannel, boolean> = {
+  webrtc: false,
+  filedrop: true,
+};
+
+/** Whether the console appliance can run an accepted invitation's endpoint channel
+ * ({@link APPLIANCE_RUNS_ACCEPT}). */
+export function applianceRunsAccept(channel: AcceptEndpointChannel): boolean {
+  return APPLIANCE_RUNS_ACCEPT[channel];
+}
+
+/** The honest title for a console accept whose endpoint the appliance cannot run
+ * today ({@link applianceRunsAccept}), in the inviter chooser's
+ * "planned capability for this appliance" register. */
+export const ACCEPT_UNSUPPORTED_TITLE =
+  "This appliance cannot run this exchange type yet";
+
+/** The unsupported-accept body: names what the appliance CAN run (shared-directory
+ * exchanges from the mounted work directory) so the operator is not left at a dead
+ * end with a doomed run. */
+export const ACCEPT_UNSUPPORTED_MESSAGE =
+  "This invitation runs an in-browser (WebRTC) exchange. This appliance runs " +
+  "shared-directory exchanges from its mounted work directory, and its in-browser " +
+  "exchange support is a planned capability. Ask your partner for a shared-directory " +
+  "invitation to run it on this appliance.";

--- a/apps/web/src/bench/fileAssurance.ts
+++ b/apps/web/src/bench/fileAssurance.ts
@@ -12,11 +12,13 @@ export const BROWSER_ONLY_FILE_ASSURANCE =
 /**
  * The console appliance's truthful file-assurance line, for a surface whose intake
  * reads the input from the appliance's mounted work directory rather than the
- * browser (the console inviter's server-file picker). It is deliberately NOT the
- * value {@link fileAssuranceLine} resolves for the console build: a surface that
- * has not yet switched to the mounted-directory intake (the acceptor, pending its
- * own work package) would state a claim that is false for it, so each mounted-input
- * surface opts into this copy explicitly rather than inheriting it.
+ * browser (the console inviter's and acceptor's server-file pickers). It is
+ * deliberately NOT the value {@link fileAssuranceLine} resolves for the console
+ * build: surfaces that never switch to the mounted-directory intake -- the lobby,
+ * which makes no per-file claim, and the receipt verifier, which parses locally in
+ * the browser on every build -- would state a claim false for them if this were the
+ * blanket console line, so each mounted-input surface opts into this copy explicitly
+ * rather than inheriting it.
  */
 export const APPLIANCE_FILE_ASSURANCE =
   "Files are read from this appliance's mounted work directory; your browser " +

--- a/apps/web/src/bench/fileAssurance.ts
+++ b/apps/web/src/bench/fileAssurance.ts
@@ -43,9 +43,11 @@ export function fileAssuranceLine(
 /**
  * The single resolved file-assurance line (or its absence) for this build. The
  * server receives files exactly on the console appliance ({@link isConsoleBuild}),
- * where the browser-only claim no longer holds. All three bench surfaces that
- * show the assurance copy (AcceptorBench, BenchLobby, YourFileSection) render
- * this constant rather than each reading the profile or hardcoding the claim,
- * so the deployment-awareness lives in one place.
+ * where the browser-only claim no longer holds. BenchLobby (which makes no per-file
+ * claim of its own) renders this constant directly; the two mounted-input surfaces
+ * (AcceptorBench, YourFileSection) render it on the hosted build but opt into
+ * {@link APPLIANCE_FILE_ASSURANCE} on the console, where their intake reads the file
+ * from the appliance rather than the browser. The deployment-awareness lives here
+ * rather than in each surface reading the profile or hardcoding the claim.
  */
 export const FILE_ASSURANCE_LINE = fileAssuranceLine(isConsoleBuild());

--- a/apps/web/src/bench/useAcceptorExchange.ts
+++ b/apps/web/src/bench/useAcceptorExchange.ts
@@ -38,11 +38,14 @@ import type {
 } from "@psi/acceptInvitation";
 import type { Acquire, GenerateOutput } from "@psi/exchangeLifecycle";
 import type { CSVRow, InvitationToken } from "@psilink/core";
+import type {
+  JobInputSource,
+  ServerJobExchangeDriverConfig,
+} from "@psi/serverJobExchangeDriver";
 import type { ExchangeDriver } from "@psi/exchangeDriver";
 import type { ExchangeRun } from "./exchangeRun";
 import type { RunFailure } from "./useInviterExchange";
 import type { RunOutputs } from "./runOutputs";
-import type { ServerJobExchangeDriverConfig } from "@psi/serverJobExchangeDriver";
 import type { Transport } from "./inviterModel";
 
 /** The connection-endpoint channels the acceptor can drive, narrowed from the
@@ -99,18 +102,18 @@ export function acceptorServerJobConfig({
   token,
   acceptorName,
   edits,
-  inputCsv,
+  inputSource,
 }: {
   token: InvitationToken;
   acceptorName: string;
   edits: AcceptorDataEdits;
-  inputCsv: string;
+  inputSource: JobInputSource;
 }): ServerJobExchangeDriverConfig {
   return {
     transport: { channel: "filedrop" },
     linkageTerms: deriveAcceptedLinkageTerms(token.linkageTerms, acceptorName),
     sharedSecret: token.sharedSecret,
-    inputSource: { kind: "inline", csv: inputCsv },
+    inputSource,
     metadata: edits.metadata,
     standardization: edits.standardization,
     // The received-payload lock-in, mirrored from the invitation's disclosed set
@@ -125,9 +128,20 @@ export function acceptorServerJobConfig({
   };
 }
 
+/** Where the acceptor's own input comes from on a server-job run. `inline` carries
+ * the browser's File, whose text the hook reads at run time (the hosted-shaped path);
+ * `workFile` carries only a REFERENCE to a file in the appliance's mounted work-input
+ * directory (the console picker's profiled snapshot), so no content transits the
+ * browser. The hook resolves this to the driver's {@link JobInputSource} -- reading
+ * `inline`'s text into `{kind:"inline",csv}`, passing `workFile` through -- and the
+ * browser (WebRTC) path uses the retained `rawRows`/`columns` and never reads it. */
+export type AcceptorLaunchSource =
+  | { kind: "inline"; file: File }
+  | { kind: "workFile"; name: string; sizeBytes: number; modifiedAt: number };
+
 /** The launch the acceptor commits to on "Start the exchange": the decoded
  * invitation, the committed name recorded in the exchange record, the acquired
- * CSV, the confirm-columns edits, and the original file. A fresh object per
+ * CSV, the confirm-columns edits, and the input source. A fresh object per
  * launch keys the run effect, so a superseded or discarded launch aborts and
  * resets. */
 export interface AcceptorLaunch {
@@ -136,11 +150,29 @@ export interface AcceptorLaunch {
   rawRows: Array<CSVRow>;
   columns: Array<string>;
   edits: AcceptorDataEdits;
-  /** The original CSV file, the server-job driver's `inputCsv` source. The
-   * server-job path submits the file's raw text; the browser path uses the
-   * retained `rawRows`/`columns` and never reads this. Mirrors the inviter's
-   * `sourceFile`. */
-  sourceFile: File;
+  /** Where the appliance reads this party's input from on a server-job run
+   * ({@link AcceptorLaunchSource}): the browser File on the hosted-shaped inline
+   * path, or the console picker's mounted-file reference. The browser (WebRTC) path
+   * uses the retained `rawRows`/`columns` and never reads it. Mirrors the inviter's
+   * `inputSource`. */
+  inputSource: AcceptorLaunchSource;
+}
+
+/** Resolve an {@link AcceptorLaunchSource} to the driver's {@link JobInputSource}:
+ * an `inline` File is read to its text (the hosted path keeps File + text()), a
+ * `workFile` reference passes through unchanged (the console path submits no
+ * content). */
+async function resolveJobInputSource(
+  source: AcceptorLaunchSource,
+): Promise<JobInputSource> {
+  return source.kind === "inline"
+    ? { kind: "inline", csv: await source.file.text() }
+    : {
+        kind: "workFile",
+        name: source.name,
+        sizeBytes: source.sizeBytes,
+        modifiedAt: source.modifiedAt,
+      };
 }
 
 /**
@@ -163,8 +195,9 @@ export interface AcceptorLaunch {
  * On a console build accepting a filedrop invitation the appliance runs the
  * exchange through the job API instead ({@link acceptorServerJobConfig} ->
  * {@link createServerJobExchangeDriver}), mirroring the inviter's server-job
- * path: no dial, no PSI library here, and the acceptor's own-perspective terms
- * and raw CSV text go to the appliance.
+ * path: no dial, no PSI library here, and the acceptor's own-perspective terms go
+ * to the appliance alongside its mounted-file reference (no file content transits
+ * the browser).
  *
  * Try again (the retryable "exchange" category only) re-dials the same invitation
  * while it is still usable, exactly like the inviter's re-listen.
@@ -219,9 +252,14 @@ export function useAcceptorExchange({
     setOutputs(undefined);
     setFailure(undefined);
 
-    const { invitation, acceptorName, rawRows, columns, edits, sourceFile } =
+    const { invitation, acceptorName, rawRows, columns, edits, inputSource } =
       current;
     const { token, endpoint } = invitation;
+    // The bench transport this endpoint runs over, threaded to failureFor so a
+    // console mounted-file create rejection (a workFile 400) names the file cause
+    // and routes recovery to the file step. The accept guard admits no sftp
+    // endpoint, so this is `filedrop` (-> server-job) or `browser` (-> WebRTC).
+    const channel = transportForEndpointChannel(endpoint.channel);
 
     // Output-generation half. The URLs the build creates are revoked when the
     // outputs are replaced or the bench unmounts (effect above); a throw
@@ -288,16 +326,25 @@ export function useAcceptorExchange({
       });
 
     // The console appliance carries out the filedrop exchange: the driver POSTs
-    // the acceptor's OWN-PERSPECTIVE terms, the shared secret, and the file's raw
-    // text to the job API and maps the server's event stream onto the same
-    // lifecycle events. It owns no peer connection or PSI library, so
-    // `acquire`/`generateOutput` and the dial go unused on this path. Reading the
-    // file's text is the only async step before the run, so it precedes the
-    // driver build.
+    // the acceptor's OWN-PERSPECTIVE terms, the shared secret, and the input source
+    // to the job API and maps the server's event stream onto the same lifecycle
+    // events. It owns no peer connection or PSI library, so `acquire`/`generateOutput`
+    // and the dial go unused on this path. On the console the input source is a
+    // REFERENCE to the operator-mounted file (no content transits the browser);
+    // resolving it (a `workFile` passes through, an inline File is read to text) is
+    // the only async step before the run, so it precedes the driver build. The
+    // resolved source is captured so failureFor can name the file cause on a create
+    // rejection.
+    let jobInputSource: JobInputSource | undefined;
     const serverJobDriver = async (): Promise<ExchangeDriver<RunOutputs>> => {
-      const inputCsv = await sourceFile.text();
+      jobInputSource = await resolveJobInputSource(inputSource);
       return createServerJobExchangeDriver(
-        acceptorServerJobConfig({ token, acceptorName, edits, inputCsv }),
+        acceptorServerJobConfig({
+          token,
+          acceptorName,
+          edits,
+          inputSource: jobInputSource,
+        }),
       );
     };
 
@@ -310,11 +357,7 @@ export function useAcceptorExchange({
     // The remotes flag is the selector's sftp-only input; the accept guard
     // admits no sftp endpoint (webrtc and console filedrop only), so it is
     // constant false here.
-    const selection = selectExchangeDriver(
-      transportForEndpointChannel(endpoint.channel),
-      deploymentProfile(),
-      false,
-    );
+    const selection = selectExchangeDriver(channel, deploymentProfile(), false);
     if (selection.kind === "save-file") {
       setFailure(
         failureFor(
@@ -356,7 +399,7 @@ export function useAcceptorExchange({
           // on) keeps the full object. The user-facing alert is separately
           // sanitized in failureFor.
           whenDiagnostic(() => console.error(error));
-          setFailure(failureFor(category, error));
+          setFailure(failureFor(category, error, jobInputSource, channel));
           setRun((prev) => runWithFailure(prev));
         },
       });

--- a/apps/web/test/browser/benchConsoleAcceptor.test.ts
+++ b/apps/web/test/browser/benchConsoleAcceptor.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { page, userEvent } from "vitest/browser";
+import { page } from "vitest/browser";
 
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
@@ -12,7 +12,10 @@ import "@mantine/core/styles.css";
 
 import { encodeInvitation, generateSharedSecret } from "@psilink/core";
 
-import { ACCEPT_UNSUPPORTED_TITLE } from "@bench/acceptorModel";
+import {
+  ACCEPT_UNSUPPORTED_TITLE,
+  acceptUnsupportedMessage,
+} from "@bench/acceptorModel";
 import { AcceptorBench } from "@bench/AcceptorBench";
 
 import { renderApp } from "./renderApp";
@@ -26,11 +29,14 @@ import type {
   LinkageTerms,
 } from "@psilink/core";
 
-// This suite exercises the CONSOLE acceptor seat: the mounted-directory intake at
-// the consent step, the launch that sources a server-job accept from the mounted
-// file (inputFile, never inline content), and the honest unsupported-channel state
-// for an endpoint the appliance cannot run. The hosted acceptor journey stays pinned
-// by acceptJourney.test.ts, which runs on the real default profile.
+// This suite exercises the CONSOLE acceptor seat's honest unsupported-channel gate.
+// No accept channel is appliance-runnable today: a WebRTC accept has no in-tab
+// exchange, and a file-drop accept's server job polls a private per-job directory the
+// partner cannot reach, so the invitation's own shared-directory locator never
+// rendezvous with the run. Both are stopped at the review step -- before consent or
+// intake -- with an honest per-channel state naming where the operator CAN run the
+// exchange, rather than leading them into a doomed run. The hosted acceptor journey
+// stays pinned by acceptJourney.test.ts, which runs on the real default profile.
 
 // Stub the router seam the bench and its recovery links touch.
 vi.mock("@tanstack/react-router", () => ({
@@ -57,31 +63,14 @@ vi.mock("@utils/clientConfig", () => ({
 }));
 
 // Stub the rendezvous module: importing it runs a top-level config load that reads
-// `process` (absent in the browser runner). The console filedrop accept drives the
-// server-job path, which never dials, so its functions are never called.
+// `process` (absent in the browser runner). The unsupported gate never dials.
 vi.mock("@psi/rendezvous", () => ({
   dialAsAcceptor: vi.fn(),
   listenAsInviter: vi.fn(),
 }));
 
-const COHORT_FILE = {
-  name: "cohort.csv",
-  sizeBytes: 4096,
-  modifiedAt: 1_700_000_000_000,
-};
-
-const COHORT_PROFILE = {
-  ...COHORT_FILE,
-  rowCount: 2,
-  columns: ["first_name", "last_name"],
-  columnSamples: {
-    first_name: ["Ann", "Bo"],
-    last_name: ["Lee", "Ray"],
-  },
-};
-
-// The inviter-perspective terms the accepted invitation carries: two keys the
-// mounted file's columns satisfy, so the columns step lands all-clear.
+// The inviter-perspective terms the accepted invitation carries. The terms render at
+// the review step for transparency even though the appliance cannot run the exchange.
 const inviterTerms: LinkageTerms = {
   version: "1.0.0",
   identity: "County Health Department",
@@ -111,85 +100,10 @@ async function encodeToken(endpoint: ConnectionEndpoint): Promise<string> {
   return encodeInvitation(token);
 }
 
-interface CapturedRequest {
-  url: string;
-  method: string;
-  body?: string;
-}
-
-/** The same-origin job API, stubbed at the global fetch seam. Unmatched URLs fall
- * through to the real fetch so the runner's own traffic is untouched. */
-function stubJobApi(options: { listing?: unknown } = {}): {
-  captured: Array<CapturedRequest>;
-  setListing: (listing: unknown) => void;
-  emitEvent: (event: object) => void;
-  closeEvents: () => void;
-} {
-  const captured: Array<CapturedRequest> = [];
-  const encoder = new TextEncoder();
-  let sse: ReadableStreamDefaultController<Uint8Array> | undefined;
-  const realFetch = window.fetch.bind(window);
-  let listing: unknown = options.listing ?? {
-    configured: true,
-    totalEntries: 1,
-    truncated: false,
-    files: [COHORT_FILE],
-  };
-
-  const jsonResponse = (body: unknown, status = 200) =>
-    new Response(JSON.stringify(body), {
-      status,
-      headers: { "Content-Type": "application/json" },
-    });
-
-  vi.stubGlobal(
-    "fetch",
-    (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-      const url = String(input);
-      if (!url.startsWith("/api/jobs")) return realFetch(input, init);
-      captured.push({
-        url,
-        method: init?.method ?? "GET",
-        body: typeof init?.body === "string" ? init.body : undefined,
-      });
-      if (url === "/api/jobs/inputs")
-        return Promise.resolve(jsonResponse(listing));
-      if (url.startsWith("/api/jobs/inputs/profile"))
-        return Promise.resolve(jsonResponse(COHORT_PROFILE));
-      if (url === "/api/jobs/inputs/coverage")
-        return Promise.resolve(jsonResponse({ rates: [] }));
-      if (url === "/api/jobs")
-        return Promise.resolve(jsonResponse({ id: "job-9" }, 201));
-      if (url === "/api/jobs/job-9/events")
-        return Promise.resolve(
-          new Response(
-            new ReadableStream<Uint8Array>({
-              start(controller) {
-                sse = controller;
-              },
-            }),
-            { status: 200, headers: { "Content-Type": "text/event-stream" } },
-          ),
-        );
-      if (url === "/api/jobs/job-9")
-        return Promise.resolve(jsonResponse({ recordAvailable: false }));
-      if (url === "/api/jobs/job-9/cancel")
-        return Promise.resolve(new Response(null, { status: 200 }));
-      return Promise.resolve(new Response(null, { status: 404 }));
-    },
-  );
-
-  return {
-    captured,
-    setListing: (next) => {
-      listing = next;
-    },
-    emitEvent: (event) =>
-      sse?.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`)),
-    closeEvents: () => sse?.close(),
-  };
-}
-
+// A file-drop endpoint carrying a real external locator -- the shipped shape of a
+// CLI-minted shared-directory invitation. The appliance ignores this path and polls
+// its own private per-job directory, so the run could never rendezvous; the gate must
+// refuse it rather than assert a (mock-only) successful run.
 const FILEDROP_ENDPOINT: ConnectionEndpoint = {
   channel: "filedrop",
   path: "/drops/psilink",
@@ -212,204 +126,52 @@ function mount(content: ReactNode) {
 }
 
 afterEach(async () => {
-  // Let any in-flight fetch resolution and its state update flush before the
-  // synchronous unmount, so teardown never races a render (the picker and coverage
-  // seams are fetch-driven).
+  // Let the async decode's state update flush before the synchronous unmount, so
+  // teardown never races a render.
   await new Promise((resolve) => setTimeout(resolve, 0));
   root?.unmount();
   container?.remove();
   root = undefined;
   container = undefined;
   window.location.hash = "";
-  vi.unstubAllGlobals();
 });
 
-/** From a decoded filedrop invitation: review terms, then pick and confirm the
- * mounted file at the consent step, consent and name, and accept. Leaves the bench
- * on the confirm-columns step. */
-async function reachColumnsFromFiledrop() {
-  window.location.hash = await encodeToken(FILEDROP_ENDPOINT);
-  mount(createElement(AcceptorBench));
-
-  await expect
-    .element(page.getByText("Invitation from County Health Department"))
-    .toBeInTheDocument();
-  await userEvent.click(
-    page.getByRole("button", { name: "Continue: consent & your file" }),
-  );
-  await expect
-    .element(page.getByRole("heading", { level: 1 }))
-    .toHaveTextContent("Consent & your file");
-
-  // The mounted-directory picker's two-stage pick, in place of the dropzone.
-  await page.getByRole("button", { name: "Select cohort.csv" }).click();
-  await expect.element(page.getByText("Confirm this file")).toBeInTheDocument();
-  await page.getByRole("button", { name: "Use this file" }).click();
-  await expect.element(page.getByText("Selected")).toBeInTheDocument();
-
-  await userEvent.click(page.getByRole("checkbox"));
-  await userEvent.fill(page.getByLabelText("Your name"), "Sam Alvarez");
-  await userEvent.click(
-    page.getByRole("button", { name: "Accept and continue" }),
-  );
-  await expect
-    .element(page.getByRole("heading", { name: "Confirm your columns" }))
-    .toBeInTheDocument();
-}
-
-describe("console acceptor mounted-file intake and launch", () => {
-  test("a server-job accept sources the mounted file (inputFile, not inputCsv)", async () => {
-    const api = stubJobApi();
-    await reachColumnsFromFiledrop();
-
-    // The seeded columns satisfy the adopted keys.
-    await expect
-      .element(page.getByText("All 2 keys can match"))
-      .toBeInTheDocument();
-
-    await userEvent.click(
-      page.getByRole("button", { name: "Start the exchange" }),
-    );
-
-    // The run POSTs a filedrop intent carrying the mounted-file REFERENCE, never
-    // inline content.
-    await vi.waitFor(() => {
-      expect(
-        api.captured.some(
-          (request) => request.url === "/api/jobs" && request.method === "POST",
-        ),
-      ).toBe(true);
-    });
-    const post = api.captured.find(
-      (request) => request.url === "/api/jobs" && request.method === "POST",
-    );
-    const intent = JSON.parse(post?.body ?? "{}") as Record<string, unknown>;
-    expect(intent.channel).toBe("filedrop");
-    expect(intent.inputCsv).toBeUndefined();
-    expect(intent.inputFile).toEqual(COHORT_FILE);
-
-    // The result completes the run on the appliance's endpoint.
-    await vi.waitFor(() =>
-      expect(
-        api.captured.some(
-          (request) => request.url === "/api/jobs/job-9/events",
-        ),
-      ).toBe(true),
-    );
-    api.emitEvent({ v: 1, type: "result", resultWritten: true });
-    api.closeEvents();
-    await expect
-      .element(page.getByRole("heading", { level: 1 }))
-      .toHaveTextContent("Exchange complete");
-  });
-
-  test("the coverage sweep posts the mounted-file freshness reference", async () => {
-    const api = stubJobApi();
+describe("console acceptor unsupported-channel gate", () => {
+  test("a filedrop invitation is blocked before consent, pointing at the command-line tool", async () => {
     window.location.hash = await encodeToken(FILEDROP_ENDPOINT);
     mount(createElement(AcceptorBench));
 
-    await userEvent.click(
-      page.getByRole("button", { name: "Continue: consent & your file" }),
-    );
-    await page.getByRole("button", { name: "Select cohort.csv" }).click();
-    await page.getByRole("button", { name: "Use this file" }).click();
-    await expect.element(page.getByText("Selected")).toBeInTheDocument();
-
-    // The bench's coverage provider posts to the appliance sweep with the file's
-    // profiled freshness pair (no inline content).
-    await vi.waitFor(() => {
-      expect(
-        api.captured.some(
-          (request) =>
-            request.url === "/api/jobs/inputs/coverage" &&
-            request.method === "POST",
-        ),
-      ).toBe(true);
-    });
-    const post = api.captured.find(
-      (request) => request.url === "/api/jobs/inputs/coverage",
-    );
-    const body = JSON.parse(post?.body ?? "{}") as Record<string, unknown>;
-    expect(body.name).toBe("cohort.csv");
-    expect(body.sizeBytes).toBe(COHORT_FILE.sizeBytes);
-    expect(body.modifiedAt).toBe(COHORT_FILE.modifiedAt);
-  });
-
-  test("a listing refresh that finds a changed size/mtime shows the drift notice", async () => {
-    const api = stubJobApi();
-    window.location.hash = await encodeToken(FILEDROP_ENDPOINT);
-    mount(createElement(AcceptorBench));
-
-    await userEvent.click(
-      page.getByRole("button", { name: "Continue: consent & your file" }),
-    );
-    await page.getByRole("button", { name: "Select cohort.csv" }).click();
-    await page.getByRole("button", { name: "Use this file" }).click();
-    await expect.element(page.getByText("Selected")).toBeInTheDocument();
-
-    // The file changes on disk (size and mtime), then the operator refreshes.
-    api.setListing({
-      configured: true,
-      totalEntries: 1,
-      truncated: false,
-      files: [
-        { ...COHORT_FILE, sizeBytes: 9000, modifiedAt: 1_700_000_999_000 },
-      ],
-    });
-    await page.getByRole("button", { name: "Refresh" }).click();
-    await expect
-      .element(
-        page.getByText("This file changed on disk since you profiled it"),
-      )
-      .toBeInTheDocument();
-  });
-
-  test("re-profiling the committed file re-commits and still reaches the columns step", async () => {
-    stubJobApi();
-    window.location.hash = await encodeToken(FILEDROP_ENDPOINT);
-    mount(createElement(AcceptorBench));
-
-    await userEvent.click(
-      page.getByRole("button", { name: "Continue: consent & your file" }),
-    );
-    await page.getByRole("button", { name: "Select cohort.csv" }).click();
-    await page.getByRole("button", { name: "Use this file" }).click();
-    await expect.element(page.getByText("Selected")).toBeInTheDocument();
-
-    // The committed row offers a re-profile; with the same columns it re-commits
-    // through the acceptor's own commit path (reconcile-vs-reseed) without stranding
-    // the intake, and the gate still advances to the columns step.
-    await page.getByRole("button", { name: "Re-profile cohort.csv" }).click();
-    await page.getByRole("button", { name: "Use this file" }).click();
-    await expect.element(page.getByText("Selected")).toBeInTheDocument();
-
-    await userEvent.click(page.getByRole("checkbox"));
-    await userEvent.fill(page.getByLabelText("Your name"), "Sam Alvarez");
-    await userEvent.click(
-      page.getByRole("button", { name: "Accept and continue" }),
-    );
-    await expect
-      .element(page.getByRole("heading", { name: "Confirm your columns" }))
-      .toBeInTheDocument();
-    await expect
-      .element(page.getByText("All 2 keys can match"))
-      .toBeInTheDocument();
-  });
-});
-
-describe("console acceptor unsupported-channel state", () => {
-  test("a webrtc invitation is blocked before consent, naming what the appliance can run", async () => {
-    stubJobApi();
-    window.location.hash = await encodeToken(WEBRTC_ENDPOINT);
-    mount(createElement(AcceptorBench));
-
-    // The terms still render (transparency), but the appliance cannot run an in-tab
-    // WebRTC exchange, so the honest block replaces the Continue action.
+    // The terms still render (transparency), but the appliance cannot rendezvous a
+    // shared-directory accept, so the honest block replaces the Continue action and
+    // points at the command-line tool, which can reach the partner's directory.
     await expect
       .element(page.getByText("Invitation from County Health Department"))
       .toBeInTheDocument();
     await expect
       .element(page.getByText(ACCEPT_UNSUPPORTED_TITLE))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText(acceptUnsupportedMessage("filedrop")))
+      .toBeInTheDocument();
+    expect(
+      page
+        .getByRole("button", { name: "Continue: consent & your file" })
+        .query(),
+    ).toBeNull();
+  });
+
+  test("a webrtc invitation is blocked before consent, pointing at a web deployment", async () => {
+    window.location.hash = await encodeToken(WEBRTC_ENDPOINT);
+    mount(createElement(AcceptorBench));
+
+    await expect
+      .element(page.getByText("Invitation from County Health Department"))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText(ACCEPT_UNSUPPORTED_TITLE))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText(acceptUnsupportedMessage("webrtc")))
       .toBeInTheDocument();
     expect(
       page

--- a/apps/web/test/browser/benchConsoleAcceptor.test.ts
+++ b/apps/web/test/browser/benchConsoleAcceptor.test.ts
@@ -1,0 +1,420 @@
+/// <reference types="@vitest/browser-playwright/context" />
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { page, userEvent } from "vitest/browser";
+
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+
+// Load Mantine's stylesheet so components render with their real geometry.
+import "@mantine/core/styles.css";
+
+import { encodeInvitation, generateSharedSecret } from "@psilink/core";
+
+import { ACCEPT_UNSUPPORTED_TITLE } from "@bench/acceptorModel";
+import { AcceptorBench } from "@bench/AcceptorBench";
+
+import { renderApp } from "./renderApp";
+
+import type { ReactNode } from "react";
+import type { Root } from "react-dom/client";
+
+import type {
+  ConnectionEndpoint,
+  InvitationToken,
+  LinkageTerms,
+} from "@psilink/core";
+
+// This suite exercises the CONSOLE acceptor seat: the mounted-directory intake at
+// the consent step, the launch that sources a server-job accept from the mounted
+// file (inputFile, never inline content), and the honest unsupported-channel state
+// for an endpoint the appliance cannot run. The hosted acceptor journey stays pinned
+// by acceptJourney.test.ts, which runs on the real default profile.
+
+// Stub the router seam the bench and its recovery links touch.
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    className,
+    children,
+  }: {
+    to?: string;
+    className?: string;
+    children?: ReactNode;
+  }) =>
+    createElement(
+      "a",
+      { href: typeof to === "string" ? to : "#", className },
+      children,
+    ),
+  useNavigate: () => () => undefined,
+}));
+
+vi.mock("@utils/clientConfig", () => ({
+  deploymentProfile: () => "console" as const,
+  isConsoleBuild: () => true,
+}));
+
+// Stub the rendezvous module: importing it runs a top-level config load that reads
+// `process` (absent in the browser runner). The console filedrop accept drives the
+// server-job path, which never dials, so its functions are never called.
+vi.mock("@psi/rendezvous", () => ({
+  dialAsAcceptor: vi.fn(),
+  listenAsInviter: vi.fn(),
+}));
+
+const COHORT_FILE = {
+  name: "cohort.csv",
+  sizeBytes: 4096,
+  modifiedAt: 1_700_000_000_000,
+};
+
+const COHORT_PROFILE = {
+  ...COHORT_FILE,
+  rowCount: 2,
+  columns: ["first_name", "last_name"],
+  columnSamples: {
+    first_name: ["Ann", "Bo"],
+    last_name: ["Lee", "Ray"],
+  },
+};
+
+// The inviter-perspective terms the accepted invitation carries: two keys the
+// mounted file's columns satisfy, so the columns step lands all-clear.
+const inviterTerms: LinkageTerms = {
+  version: "1.0.0",
+  identity: "County Health Department",
+  date: "2026-01-01",
+  algorithm: "psi",
+  linkageStrategy: "cascade",
+  output: { expectsOutput: false, shareWithPartner: true },
+  deduplicate: false,
+  linkageFields: [
+    { name: "firstName", type: "first_name" },
+    { name: "lastName", type: "last_name" },
+  ],
+  linkageKeys: [
+    { name: "first", elements: [{ field: "firstName" }] },
+    { name: "last", elements: [{ field: "lastName" }] },
+  ],
+};
+
+async function encodeToken(endpoint: ConnectionEndpoint): Promise<string> {
+  const token: InvitationToken = {
+    version: "1",
+    linkageTerms: inviterTerms,
+    sharedSecret: generateSharedSecret(),
+    expires: new Date(Date.now() + 3600 * 1000).toISOString(),
+    connectionEndpoint: endpoint,
+  };
+  return encodeInvitation(token);
+}
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  body?: string;
+}
+
+/** The same-origin job API, stubbed at the global fetch seam. Unmatched URLs fall
+ * through to the real fetch so the runner's own traffic is untouched. */
+function stubJobApi(options: { listing?: unknown } = {}): {
+  captured: Array<CapturedRequest>;
+  setListing: (listing: unknown) => void;
+  emitEvent: (event: object) => void;
+  closeEvents: () => void;
+} {
+  const captured: Array<CapturedRequest> = [];
+  const encoder = new TextEncoder();
+  let sse: ReadableStreamDefaultController<Uint8Array> | undefined;
+  const realFetch = window.fetch.bind(window);
+  let listing: unknown = options.listing ?? {
+    configured: true,
+    totalEntries: 1,
+    truncated: false,
+    files: [COHORT_FILE],
+  };
+
+  const jsonResponse = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  vi.stubGlobal(
+    "fetch",
+    (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      if (!url.startsWith("/api/jobs")) return realFetch(input, init);
+      captured.push({
+        url,
+        method: init?.method ?? "GET",
+        body: typeof init?.body === "string" ? init.body : undefined,
+      });
+      if (url === "/api/jobs/inputs")
+        return Promise.resolve(jsonResponse(listing));
+      if (url.startsWith("/api/jobs/inputs/profile"))
+        return Promise.resolve(jsonResponse(COHORT_PROFILE));
+      if (url === "/api/jobs/inputs/coverage")
+        return Promise.resolve(jsonResponse({ rates: [] }));
+      if (url === "/api/jobs")
+        return Promise.resolve(jsonResponse({ id: "job-9" }, 201));
+      if (url === "/api/jobs/job-9/events")
+        return Promise.resolve(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                sse = controller;
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "text/event-stream" } },
+          ),
+        );
+      if (url === "/api/jobs/job-9")
+        return Promise.resolve(jsonResponse({ recordAvailable: false }));
+      if (url === "/api/jobs/job-9/cancel")
+        return Promise.resolve(new Response(null, { status: 200 }));
+      return Promise.resolve(new Response(null, { status: 404 }));
+    },
+  );
+
+  return {
+    captured,
+    setListing: (next) => {
+      listing = next;
+    },
+    emitEvent: (event) =>
+      sse?.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`)),
+    closeEvents: () => sse?.close(),
+  };
+}
+
+const FILEDROP_ENDPOINT: ConnectionEndpoint = {
+  channel: "filedrop",
+  path: "/drops/psilink",
+};
+const WEBRTC_ENDPOINT: ConnectionEndpoint = {
+  channel: "webrtc",
+  host: "127.0.0.1",
+  port: 3000,
+  path: "/api/",
+};
+
+let container: HTMLElement | undefined;
+let root: Root | undefined;
+
+function mount(content: ReactNode) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  root.render(renderApp(content));
+}
+
+afterEach(async () => {
+  // Let any in-flight fetch resolution and its state update flush before the
+  // synchronous unmount, so teardown never races a render (the picker and coverage
+  // seams are fetch-driven).
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  root?.unmount();
+  container?.remove();
+  root = undefined;
+  container = undefined;
+  window.location.hash = "";
+  vi.unstubAllGlobals();
+});
+
+/** From a decoded filedrop invitation: review terms, then pick and confirm the
+ * mounted file at the consent step, consent and name, and accept. Leaves the bench
+ * on the confirm-columns step. */
+async function reachColumnsFromFiledrop() {
+  window.location.hash = await encodeToken(FILEDROP_ENDPOINT);
+  mount(createElement(AcceptorBench));
+
+  await expect
+    .element(page.getByText("Invitation from County Health Department"))
+    .toBeInTheDocument();
+  await userEvent.click(
+    page.getByRole("button", { name: "Continue: consent & your file" }),
+  );
+  await expect
+    .element(page.getByRole("heading", { level: 1 }))
+    .toHaveTextContent("Consent & your file");
+
+  // The mounted-directory picker's two-stage pick, in place of the dropzone.
+  await page.getByRole("button", { name: "Select cohort.csv" }).click();
+  await expect.element(page.getByText("Confirm this file")).toBeInTheDocument();
+  await page.getByRole("button", { name: "Use this file" }).click();
+  await expect.element(page.getByText("Selected")).toBeInTheDocument();
+
+  await userEvent.click(page.getByRole("checkbox"));
+  await userEvent.fill(page.getByLabelText("Your name"), "Sam Alvarez");
+  await userEvent.click(
+    page.getByRole("button", { name: "Accept and continue" }),
+  );
+  await expect
+    .element(page.getByRole("heading", { name: "Confirm your columns" }))
+    .toBeInTheDocument();
+}
+
+describe("console acceptor mounted-file intake and launch", () => {
+  test("a server-job accept sources the mounted file (inputFile, not inputCsv)", async () => {
+    const api = stubJobApi();
+    await reachColumnsFromFiledrop();
+
+    // The seeded columns satisfy the adopted keys.
+    await expect
+      .element(page.getByText("All 2 keys can match"))
+      .toBeInTheDocument();
+
+    await userEvent.click(
+      page.getByRole("button", { name: "Start the exchange" }),
+    );
+
+    // The run POSTs a filedrop intent carrying the mounted-file REFERENCE, never
+    // inline content.
+    await vi.waitFor(() => {
+      expect(
+        api.captured.some(
+          (request) => request.url === "/api/jobs" && request.method === "POST",
+        ),
+      ).toBe(true);
+    });
+    const post = api.captured.find(
+      (request) => request.url === "/api/jobs" && request.method === "POST",
+    );
+    const intent = JSON.parse(post?.body ?? "{}") as Record<string, unknown>;
+    expect(intent.channel).toBe("filedrop");
+    expect(intent.inputCsv).toBeUndefined();
+    expect(intent.inputFile).toEqual(COHORT_FILE);
+
+    // The result completes the run on the appliance's endpoint.
+    await vi.waitFor(() =>
+      expect(
+        api.captured.some(
+          (request) => request.url === "/api/jobs/job-9/events",
+        ),
+      ).toBe(true),
+    );
+    api.emitEvent({ v: 1, type: "result", resultWritten: true });
+    api.closeEvents();
+    await expect
+      .element(page.getByRole("heading", { level: 1 }))
+      .toHaveTextContent("Exchange complete");
+  });
+
+  test("the coverage sweep posts the mounted-file freshness reference", async () => {
+    const api = stubJobApi();
+    window.location.hash = await encodeToken(FILEDROP_ENDPOINT);
+    mount(createElement(AcceptorBench));
+
+    await userEvent.click(
+      page.getByRole("button", { name: "Continue: consent & your file" }),
+    );
+    await page.getByRole("button", { name: "Select cohort.csv" }).click();
+    await page.getByRole("button", { name: "Use this file" }).click();
+    await expect.element(page.getByText("Selected")).toBeInTheDocument();
+
+    // The bench's coverage provider posts to the appliance sweep with the file's
+    // profiled freshness pair (no inline content).
+    await vi.waitFor(() => {
+      expect(
+        api.captured.some(
+          (request) =>
+            request.url === "/api/jobs/inputs/coverage" &&
+            request.method === "POST",
+        ),
+      ).toBe(true);
+    });
+    const post = api.captured.find(
+      (request) => request.url === "/api/jobs/inputs/coverage",
+    );
+    const body = JSON.parse(post?.body ?? "{}") as Record<string, unknown>;
+    expect(body.name).toBe("cohort.csv");
+    expect(body.sizeBytes).toBe(COHORT_FILE.sizeBytes);
+    expect(body.modifiedAt).toBe(COHORT_FILE.modifiedAt);
+  });
+
+  test("a listing refresh that finds a changed size/mtime shows the drift notice", async () => {
+    const api = stubJobApi();
+    window.location.hash = await encodeToken(FILEDROP_ENDPOINT);
+    mount(createElement(AcceptorBench));
+
+    await userEvent.click(
+      page.getByRole("button", { name: "Continue: consent & your file" }),
+    );
+    await page.getByRole("button", { name: "Select cohort.csv" }).click();
+    await page.getByRole("button", { name: "Use this file" }).click();
+    await expect.element(page.getByText("Selected")).toBeInTheDocument();
+
+    // The file changes on disk (size and mtime), then the operator refreshes.
+    api.setListing({
+      configured: true,
+      totalEntries: 1,
+      truncated: false,
+      files: [
+        { ...COHORT_FILE, sizeBytes: 9000, modifiedAt: 1_700_000_999_000 },
+      ],
+    });
+    await page.getByRole("button", { name: "Refresh" }).click();
+    await expect
+      .element(
+        page.getByText("This file changed on disk since you profiled it"),
+      )
+      .toBeInTheDocument();
+  });
+
+  test("re-profiling the committed file re-commits and still reaches the columns step", async () => {
+    stubJobApi();
+    window.location.hash = await encodeToken(FILEDROP_ENDPOINT);
+    mount(createElement(AcceptorBench));
+
+    await userEvent.click(
+      page.getByRole("button", { name: "Continue: consent & your file" }),
+    );
+    await page.getByRole("button", { name: "Select cohort.csv" }).click();
+    await page.getByRole("button", { name: "Use this file" }).click();
+    await expect.element(page.getByText("Selected")).toBeInTheDocument();
+
+    // The committed row offers a re-profile; with the same columns it re-commits
+    // through the acceptor's own commit path (reconcile-vs-reseed) without stranding
+    // the intake, and the gate still advances to the columns step.
+    await page.getByRole("button", { name: "Re-profile cohort.csv" }).click();
+    await page.getByRole("button", { name: "Use this file" }).click();
+    await expect.element(page.getByText("Selected")).toBeInTheDocument();
+
+    await userEvent.click(page.getByRole("checkbox"));
+    await userEvent.fill(page.getByLabelText("Your name"), "Sam Alvarez");
+    await userEvent.click(
+      page.getByRole("button", { name: "Accept and continue" }),
+    );
+    await expect
+      .element(page.getByRole("heading", { name: "Confirm your columns" }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("All 2 keys can match"))
+      .toBeInTheDocument();
+  });
+});
+
+describe("console acceptor unsupported-channel state", () => {
+  test("a webrtc invitation is blocked before consent, naming what the appliance can run", async () => {
+    stubJobApi();
+    window.location.hash = await encodeToken(WEBRTC_ENDPOINT);
+    mount(createElement(AcceptorBench));
+
+    // The terms still render (transparency), but the appliance cannot run an in-tab
+    // WebRTC exchange, so the honest block replaces the Continue action.
+    await expect
+      .element(page.getByText("Invitation from County Health Department"))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText(ACCEPT_UNSUPPORTED_TITLE))
+      .toBeInTheDocument();
+    expect(
+      page
+        .getByRole("button", { name: "Continue: consent & your file" })
+        .query(),
+    ).toBeNull();
+  });
+});

--- a/apps/web/test/unit/benchAcceptorModel.test.ts
+++ b/apps/web/test/unit/benchAcceptorModel.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from "vitest";
 
 import {
   ACCEPTOR_SEND_FORWARD_REFERENCE,
-  ACCEPT_UNSUPPORTED_MESSAGE,
   ACCEPT_UNSUPPORTED_TITLE,
+  acceptUnsupportedMessage,
   acceptorConsentName,
   acceptorConsentReady,
   acceptorDoneLedgerRows,
@@ -437,18 +437,20 @@ describe("acceptor legal-agreement display", () => {
 });
 
 describe("applianceRunsAccept", () => {
-  test("the appliance runs a filedrop accept (a server job over the mounted file)", () => {
-    expect(applianceRunsAccept("filedrop")).toBe(true);
-  });
-
   test("the appliance cannot run a webrtc accept (no in-tab exchange yet)", () => {
     expect(applianceRunsAccept("webrtc")).toBe(false);
   });
 
-  test("the unsupported copy names what the appliance CAN run so it is not a dead end", () => {
+  test("the appliance cannot run a filedrop accept (its server job polls a private per-job directory the partner cannot reach)", () => {
+    expect(applianceRunsAccept("filedrop")).toBe(false);
+  });
+
+  test("the unsupported copy points each channel at where it CAN run so it is not a dead end", () => {
     expect(ACCEPT_UNSUPPORTED_TITLE.length).toBeGreaterThan(0);
-    // The body must point the operator at the shared-directory path the appliance
-    // does run, not merely refuse.
-    expect(ACCEPT_UNSUPPORTED_MESSAGE).toContain("shared-directory");
+    // A WebRTC accept needs a browser; the copy points at a web deployment.
+    expect(acceptUnsupportedMessage("webrtc")).toContain("web app");
+    // A file-drop accept runs in the command-line tool, which reaches the partner's
+    // shared directory the appliance cannot.
+    expect(acceptUnsupportedMessage("filedrop")).toContain("command-line tool");
   });
 });

--- a/apps/web/test/unit/benchAcceptorModel.test.ts
+++ b/apps/web/test/unit/benchAcceptorModel.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "vitest";
 
 import {
   ACCEPTOR_SEND_FORWARD_REFERENCE,
+  ACCEPT_UNSUPPORTED_MESSAGE,
+  ACCEPT_UNSUPPORTED_TITLE,
   acceptorConsentName,
   acceptorConsentReady,
   acceptorDoneLedgerRows,
@@ -11,6 +13,7 @@ import {
   acceptorLegalAgreementDisplay,
   acceptorRailFacts,
   acceptorSpine,
+  applianceRunsAccept,
   invitingPartyName,
 } from "@bench/acceptorModel";
 
@@ -430,5 +433,22 @@ describe("acceptor legal-agreement display", () => {
     expect(
       acceptorLegalAgreementDisplay(makeToken({ legalAgreement: undefined })),
     ).toBeUndefined();
+  });
+});
+
+describe("applianceRunsAccept", () => {
+  test("the appliance runs a filedrop accept (a server job over the mounted file)", () => {
+    expect(applianceRunsAccept("filedrop")).toBe(true);
+  });
+
+  test("the appliance cannot run a webrtc accept (no in-tab exchange yet)", () => {
+    expect(applianceRunsAccept("webrtc")).toBe(false);
+  });
+
+  test("the unsupported copy names what the appliance CAN run so it is not a dead end", () => {
+    expect(ACCEPT_UNSUPPORTED_TITLE.length).toBeGreaterThan(0);
+    // The body must point the operator at the shared-directory path the appliance
+    // does run, not merely refuse.
+    expect(ACCEPT_UNSUPPORTED_MESSAGE).toContain("shared-directory");
   });
 });

--- a/apps/web/test/unit/benchAcceptorServerJob.test.ts
+++ b/apps/web/test/unit/benchAcceptorServerJob.test.ts
@@ -77,7 +77,7 @@ function configFor() {
     token,
     acceptorName: "Accepting Org",
     edits,
-    inputCsv,
+    inputSource: { kind: "inline", csv: inputCsv },
   });
 }
 
@@ -112,11 +112,30 @@ describe("acceptorServerJobConfig", () => {
     );
   });
 
-  test("carries the acceptor's raw CSV text and the token's shared secret verbatim", () => {
+  test("carries the acceptor's inline CSV source and the token's shared secret verbatim", () => {
     const config = configFor();
 
     expect(config.inputSource).toEqual({ kind: "inline", csv: inputCsv });
     expect(config.sharedSecret).toBe(token.sharedSecret);
+  });
+
+  test("threads a console workFile reference through as the input source verbatim", () => {
+    // The console accept sources from the operator-mounted file: the driver config
+    // carries only the reference (name + profiled freshness pair), never content, so
+    // the appliance's create can resolve and freshness-check the mounted file.
+    const workFile = {
+      kind: "workFile" as const,
+      name: "clients.csv",
+      sizeBytes: 4096,
+      modifiedAt: 1_700_000_000_000,
+    };
+    const config = acceptorServerJobConfig({
+      token,
+      acceptorName: "Accepting Org",
+      edits,
+      inputSource: workFile,
+    });
+    expect(config.inputSource).toEqual(workFile);
   });
 
   test("rides the filedrop transport: the accept guard admits no sftp endpoint", () => {
@@ -182,7 +201,7 @@ describe("acceptorServerJobConfig received-payload lock-in", () => {
       token: tokenWith(disclosed),
       acceptorName: "Accepting Org",
       edits,
-      inputCsv,
+      inputSource: { kind: "inline", csv: inputCsv },
     });
   }
 


### PR DESCRIPTION
## Summary

Bring the console acceptor onto the same server-file intake as the inviter, and gate the accept seat honestly: an invitation whose channel the appliance cannot run today surfaces an explicit unsupported state at the review step, before consent, instead of a doomed run.

Implements [214995311](https://github.com/orgs/georgetown-mdi/projects/9/views/1?pane=issue&itemId=214995311). Stacked on #532 (WP5); merge after it.

## Changes

- AcceptorBench.tsx: server-file picker intake behind the consent gate; the input-source union through launch; the appliance file-assurance line; the unsupported-channel review-step state.
- acceptorModel.ts: `applianceRunsAccept` exhaustive over the accept channels (webrtc and filedrop both unrunnable on console today) with honest per-channel copy pointing at what does run each type.
- useAcceptorExchange.ts, AcceptorCleaningStep.tsx, AcceptorExchangeSection.tsx: launch-union threading, profiled columnSamples + console pending copy, the channel-aware create-failure recovery.

## Background

A review round proved (adversarially verified) that every filedrop invitation necessarily carries an external locator the appliance's per-job rendezvous never consults, so every console filedrop accept was a doomed run -- the old test's success was mock-injected. The gate now blocks both unrunnable channels; the retained intake is dormant groundwork the interconnectivity follow-up lights up. The four intake-polish findings from that round are superseded by the gate and tracked to the interconnectivity item.

## Test plan

Ran: web unit (1483) and browser suites locally; typecheck/lint/format. Assembled stack boots to HTTP 200.
New tests cover: the gate against a locator-bearing filedrop fixture and a webrtc fixture (no Continue button, honest copy), and the launch-union threading.

## Checklist

- [x] Docs: enumerated docs/ and docs/spec/ -- n/a: console UI behind isConsoleBuild(); no documented behavior changes beyond the stacked docs PRs.
- [x] CHANGELOG.md [Unreleased] updated -- n/a: UI slice of the unreleased console appliance.
- [x] Security review -- independent review of the partner-reachable accept gate done (no findings; the gate is fail-closed, schema-validated before it sees the channel, and no navigation bypass forms a launch).