### PR TITLE
Document the three applications and console scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,16 @@ It is a npm workspaces monorepo (`packages/core`, `apps/cli`, `apps/web`); apps 
 
 **Read `CONTRIBUTING.md` before your first edit or commit.** It holds the build/test/dev reference and every coding and commit convention (enforced by CI and review), none of it repeated here. This file is only the complement: project operations and agent-specific rules.
 
+## Applications
+
+Three applications make up psilink's surface:
+
+- **Public web application** (`apps/web`, deployed to Elastic Beanstalk): conducts WebRTC exchanges only, all data handling in the browser (the server only delivers the code). It owns the recurring-exchange management interface -- recurring exchanges in browser storage, run on a schedule as a PWA.
+- **Command line application** (`apps/cli`, containerized): conducts SFTP and synced-folder (filedrop) exchanges only. Connecting it to the web application awaits a Node.js WebRTC implementation and a WebSocket-to-TCP proxy, both out of scope.
+- **Console**: a local management GUI for the containerized CLI, repurposing the web application's machinery. It lowers the friction of the CLI -- writing a config and setting the right arguments -- so an operator runs one exchange, conducted either by invoking the CLI or by the Node server running it directly. It runs on the same machine, used by the same person, that conducts the exchange: a web server, but not shared beyond the host. It operates on one mounted working directory holding a single exchange's config, secret, input, and results; only one exchange's resources are mounted at a time.
+
+The console is NOT a store of named connections, a recurring-exchange or scheduling interface (that lives in the public web app; the CLI schedules from the command line), a multi-exchange job manager, or a network-shared management service with an access-control perimeter over the operator. The operator is the machine's own user; the only untrusted input is the remote partner's invitation content, which the exchange protocol already protects.
+
 ## Commands
 
 Non-obvious ones (full reference in `CONTRIBUTING.md`):

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -18,7 +18,7 @@ The parameters necessary to execute an exchange are written down into a JSON or 
 
 # Architecture
 
-The linkage protocol, exchange agreements, and communication layer described in this document are built into a single library whose functionality is exposed to users through two applications, one delivered in the web browser and one used through the command line.
+The linkage protocol, exchange agreements, and communication layer described in this document are built into a single library whose functionality is exposed to users through three applications: a public web application delivered in the browser, a command line application, and a local console that puts a browser-based management interface in front of the command line application.
 
 When adopting the software, program officers are likely to first conduct exchanges with the web application in order to establish the business case for using the software, either by operating on previously established data sharing agreements or running a PSI-C algorithm to measure the size of shared membership. This bootstrapping process allows for setting and exporting exchange parameters, which can be handed off to IT professionals who can automate the procedure. They are likely to use the command line application as it can be more easily integrated with other data processes, such as exporting the data to be shared and ingesting the data received.
 
@@ -39,6 +39,12 @@ Starting an exchange walks the inviter through a short, guided flow: choose your
 Accepting an invitation opens the partner's deep link and walks the acceptor through reviewing the invitation's terms, consenting to them (an explicit acknowledgement and a typed name, with the inviter's legal agreement shown for agreement when one is attached), confirming which of the acceptor's own columns take part, and running the exchange. The invitation's secret travels in the link's URL fragment and is never sent to a server; the two parties rendezvous over the peer-coordination (PeerJS) signaling server the web application itself hosts, deriving their peer identifiers from that shared secret.
 
 Verifying a receipt checks a completed exchange's self-attested record against its verification keys, entirely in the browser, so a party can confirm its own disclosure record without uploading anything.
+
+## Web console
+
+The web console is a browser-based management interface for the command line application, run on the operator's own machine. It reuses the web application's machinery -- served locally as a web server bound to the host, used by the same person who conducts the exchange and not shared beyond that host -- to remove the friction of driving the CLI by hand: authoring a configuration and supplying the right arguments. From it an operator runs a single SFTP or synced-folder exchange, which the console conducts either by invoking the CLI or by running it directly in the server process.
+
+The console works on one mounted working directory at a time, holding that one exchange's configuration, secret, input, and results. It is not a directory of saved connections, a scheduler or recurring-exchange manager -- recurring exchanges live in the web application, and the command line application is scheduled from the command line -- a manager of many exchanges at once, or a network service that fronts the operator behind an access-control perimeter. The operator is the host's own user, and the one untrusted input, the partner's invitation, is already covered by the exchange protocol's own protections. The published Docker image runs the console when started with `serve`; how it is enabled and deployed is in [DEPLOYMENT.md](DEPLOYMENT.md#server-job-api), its single-party trust boundary in [SECURITY_DESIGN.md](SECURITY_DESIGN.md#single-party-appliance-trust-boundary), and the server-side job API's wire contract in [SERVER_JOB_API.md](spec/SERVER_JOB_API.md).
 
 # User journey
 


### PR DESCRIPTION
## Summary

Define psilink's three applications and the console's scope in the durable docs, so contributors and agents share one understanding of what the console is: a local, single-person, single-exchange GUI that lowers the friction of running one CLI exchange from one mounted working directory -- not a management service.

## Changes

- CLAUDE.md: an `## Applications` section naming the public web app (WebRTC, in-browser, owns the recurring-exchange interface), the containerized CLI (SFTP and synced-folder only), and the console (local GUI facilitating one CLI exchange), with a tight statement of what the console is not.
- docs/DESIGN.md: the architecture overview names three applications and gains a `## Web console` subsection at the overview tier, linking to the deployment and security docs rather than repeating them.

## Test plan

Ran: npm run linkcheck (52 files), typecheck/lint/format. Documentation only.
New tests cover: n/a -- doc-only.

## Background

Several existing docs (README, DEPLOYMENT, SECURITY_DESIGN, MANAGED_EXCHANGE, and the job-API spec) still describe the console with a multi-exchange, network-shared framing. Those follow the implementation, which is being simplified toward this scope; they are tracked for reconciliation as that work lands and are intentionally not touched here.

## Checklist

- [x] Docs: enumerated docs/ and docs/spec/ -- this PR is the docs change (CLAUDE.md, docs/DESIGN.md); it establishes the scope definition and links to existing pages without altering their behavior descriptions.
- [x] CHANGELOG.md [Unreleased] updated -- n/a: doc-only, no user-facing feature or breaking change.
- [x] Security review -- n/a: documentation only; no code, crypto, credential, auth, or disclosure surface touched.